### PR TITLE
Allow joining SyncPlay groups via Discord invites

### DIFF
--- a/jellyfin_mpv_shim/player.py
+++ b/jellyfin_mpv_shim/player.py
@@ -28,7 +28,7 @@ mpv_log = logging.getLogger("mpv")
 discord_presence = False
 if settings.discord_presence:
     try:
-        from .rich_presence import send_presence, clear_presence
+        from .rich_presence import register_join_event, send_presence, clear_presence
 
         discord_presence = True
     except Exception:
@@ -180,6 +180,9 @@ class PlayerManager(object):
         )
         self.menu = OSDMenu(self, self._player)
         self.syncplay = SyncPlayManager(self)
+
+        if discord_presence:
+            register_join_event(self.syncplay.discord_join_group)
 
         if hasattr(self._player, "osc"):
             self._player.osc = settings.enable_osc
@@ -860,6 +863,7 @@ class PlayerManager(object):
                     player.playback_time,
                     player.duration,
                     not player.pause,
+                    self.syncplay.current_group,
                 )
             except Exception:
                 log.error("Could not send Discord Rich Presence.", exc_info=True)

--- a/jellyfin_mpv_shim/rich_presence.py
+++ b/jellyfin_mpv_shim/rich_presence.py
@@ -1,9 +1,13 @@
-from pypresence import Presence
+from pypresence import Client
 import time
 
 client_id = "743296148592263240"
-RPC = Presence(client_id)
-RPC.connect()
+RPC = Client(client_id)
+RPC.start()
+
+
+def register_join_event(syncplay_join_group: callable):
+    RPC.register_event('activity_join', syncplay_join_group)
 
 
 def send_presence(
@@ -12,6 +16,7 @@ def send_presence(
     playback_time: float = None,
     duration: float = None,
     playing: bool = False,
+    syncplay_group: str = None,
 ):
     small_image = "play-dark3" if playing else None
     start = None
@@ -19,7 +24,7 @@ def send_presence(
     if playback_time is not None and duration is not None and playing:
         start = int(time.time() - playback_time)
         end = int(start + duration)
-    RPC.update(
+    RPC.set_activity(
         state=subtitle,
         details=title,
         instance=False,
@@ -28,8 +33,11 @@ def send_presence(
         end=end,
         large_text="Jellyfin",
         small_image=small_image,
+        party_id=str(hash(syncplay_group)),
+        party_size=[1, 100],
+        join=syncplay_group,
     )
 
 
 def clear_presence():
-    RPC.clear()
+    RPC.clear_activity()

--- a/jellyfin_mpv_shim/syncplay.py
+++ b/jellyfin_mpv_shim/syncplay.py
@@ -590,6 +590,10 @@ class SyncPlayManager:
     def join_group(self, group_id: str):
         self.client.jellyfin.join_sync_play(group_id)
 
+    def discord_join_group(self, join_secret):
+        self.enable_sync_play(False)
+        self.client.jellyfin.join_sync_play(join_secret["secret"])
+
     def menu_join_group(self):
         group = self.menu.menu_list[self.menu.menu_selection][2]
         self.menu.hide_menu()


### PR DESCRIPTION
With this, you can send Discord invites, while being in a SyncPlay group. Others can then join the group in Discord.
This idea was suggested in #148

Unfortunately, joining only works if there's already a video playing, as the rich-presence needs to be updated for pypresence to process the join event.