### PR TITLE
Systemd service to start jellyfin-mpv-shim

### DIFF
--- a/jellyfin-mpv-shim.service
+++ b/jellyfin-mpv-shim.service
@@ -1,0 +1,18 @@
+[Unit]
+Description=Jellyfin MPV Shim - MPV Cast Client for Jellyfin
+StartLimitIntervalSec=60
+StartLimitBurst=4
+
+[Service]
+ExecStart=%h/.local/bin/jellyfin-mpv-shim
+Restart=on-failure
+RestartSec=1
+
+# Hardening
+SystemCallArchitectures=native
+MemoryDenyWriteExecute=true
+NoNewPrivileges=true
+
+[Install]
+WantedBy=default.target
+


### PR DESCRIPTION
Here is a proposal for a systemd unit to manage the jellyfin-mpv-shim. I use it on a media player without keyboard access. It may be of interest for #174.

It's far from perfect:
- it assumes an installation in ~/.local/bin, which should be the case when installed with pip{x},
- if the Jellyfin server is not launched, it does not work because it wants to interactively create a new connection, but systemd is not noticed since the process is not killed.

I don't know how to deal properly with the first issue, but it's not really a problem.

For second one, my workaround is the following. I add a condition in order to check if my Jellyfin server is accessible

    ExecCondition=bash -c "curl --fail http://jellyfin || exit 255"; echo $?

(the bashism is used to get a proper exit code for systemd). But unfortunately the URL is hard-coded...

A proper way to fix this issue would be to have a command line argument which exits the shim when the connection fails, instead of asking the user to create a new one. I will try to work on this point, but the command line processing is rather primitive for now.

