### PR TITLE
switch to "user-data" property for storing values

### DIFF
--- a/jellyfin_mpv_shim/trickplay-osc.lua
+++ b/jellyfin_mpv_shim/trickplay-osc.lua
@@ -2237,13 +2237,12 @@ function update_margins()
         reset_margins()
     end
 
-    utils.shared_script_property_set("osc-margins",
-        string.format("%f,%f,%f,%f", margins.l, margins.r, margins.t, margins.b))
+    mp.set_property("user-data/osc-margins", string.format("%f,%f,%f,%f", margins.l, margins.r, margins.t, margins.b))
 end
 
 function shutdown()
     reset_margins()
-    utils.shared_script_property_set("osc-margins", nil)
+    mp.set_property("user-data/osc-margins", nil)
 end
 
 --
@@ -2907,7 +2906,7 @@ function visibility_mode(mode, no_osd)
     end
 
     user_opts.visibility = mode
-    utils.shared_script_property_set("osc-visibility", mode)
+    mp.set_property("user-data/osc-visibility", mode)
 
     if not no_osd and tonumber(mp.get_property("osd-level")) >= 1 then
         mp.osd_message("OSC visibility: " .. mode)
@@ -2939,7 +2938,7 @@ function idlescreen_visibility(mode, no_osd)
         user_opts.idlescreen = false
     end
 
-    utils.shared_script_property_set("osc-idlescreen", mode)
+    mp.set_property("user-data/osc-idlescreen", mode)
 
     if not no_osd and tonumber(mp.get_property("osd-level")) >= 1 then
         mp.osd_message("OSC logo visibility: " .. tostring(mode))


### PR DESCRIPTION
mpv-player/mpv@86b498e removed deprecated utils.shared_script_property_set. Since deprecation was ignored for years, it eventually broke jellyfin-mpv-shim.

Fixes #376