### PR TITLE
make shim logger configurable

### DIFF
--- a/jellyfin_mpv_shim/gui_mgr.py
+++ b/jellyfin_mpv_shim/gui_mgr.py
@@ -11,7 +11,7 @@ from .constants import USER_APP_NAME, APP_NAME
 from .conffile import confdir
 from .clients import clientManager
 from .utils import get_resource
-from .log_utils import CustomFormatter
+from .log_utils import CustomFormatter, root_logger
 from .i18n import _
 
 log = logging.getLogger("gui_mgr")
@@ -52,7 +52,6 @@ except KeyError:
 
 # Setup a log handler for log items.
 log_cache = deque([], 1000)
-root_logger = logging.getLogger("")
 
 
 class GUILogHandler(logging.Handler):

--- a/jellyfin_mpv_shim/log_utils.py
+++ b/jellyfin_mpv_shim/log_utils.py
@@ -12,7 +12,7 @@ bad_patterns = (
 
 sanitize_logs = False
 root_logger = logging.getLogger("")
-root_logger.level = logging.DEBUG
+root_logger.level = logging.INFO
 
 
 def sanitize(message):
@@ -52,14 +52,20 @@ def enable_sanitization():
     sanitize_logs = True
 
 
-def configure_log(destination):
+def configure_log(destination, level: str="info"):
+    lvl = logging.getLevelNamesMapping()[level.upper()]
+
     handler = logging.StreamHandler(destination)
     handler.setFormatter(CustomFormatter())
+    handler.setLevel(lvl)
     root_logger.addHandler(handler)
 
 
-def configure_log_file(destination: str):
+def configure_log_file(destination: str, level: str="info"):
+    lvl = logging.getLevelNamesMapping()[level.upper()]
+
     handler = logging.FileHandler(destination, mode="w")
     # Never allow logging API keys to a file.
     handler.setFormatter(CustomFormatter(True))
+    handler.setLevel(lvl)
     root_logger.addHandler(handler)

--- a/jellyfin_mpv_shim/mpv_shim.py
+++ b/jellyfin_mpv_shim/mpv_shim.py
@@ -10,10 +10,8 @@ from . import i18n
 from .conf import settings
 from .clients import clientManager
 from .constants import APP_NAME
-from .log_utils import configure_log, enable_sanitization, configure_log_file
+from .log_utils import configure_log, configure_log_file, enable_sanitization, root_logger
 
-configure_log(sys.stdout)
-log = logging.getLogger("")
 logging.getLogger("requests").setLevel(logging.CRITICAL)
 
 
@@ -25,9 +23,12 @@ def main():
     if settings.sanitize_output:
         enable_sanitization()
 
+    configure_log(sys.stdout, settings.mpv_log_level)
     if settings.write_logs:
         log_file = conffile.get(APP_NAME, "log.txt")
-        configure_log_file(log_file)
+        configure_log_file(log_file, settings.mpv_log_level)
+    
+    log = root_logger
 
     if sys.platform.startswith("darwin"):
         multiprocessing.set_start_method("forkserver")


### PR DESCRIPTION
Use mpv_log_level to set shim logger level too.
That should remove excessive chatter from pings to the server.

Set level to INFO by default. During normal operations people don't need to have debug enabled.

Fixes #372