### PR TITLE
set title to USER_APP_NAME

### DIFF
--- a/jellyfin_mpv_shim/gui_mgr.py
+++ b/jellyfin_mpv_shim/gui_mgr.py
@@ -460,7 +460,7 @@ class STrayProcess(Process):
             MenuItem(_("Quit"), die),
         ]
 
-        icon = Icon(USER_APP_NAME, menu=Menu(*menu_items))
+        icon = Icon(APP_NAME, title=USER_APP_NAME, menu=Menu(*menu_items))
         icon.icon = Image.open(get_resource("systray.png"))
         self.icon_stop = icon.stop
 


### PR DESCRIPTION
`title` is the real display name, not `name`.  
If `title` not provided, tray entry will be named as executable.

With this change, it will be consistently "Jellyfin MPV Shim".