### PR TITLE
Add processing delay during startup

### DIFF
--- a/jellyfin_mpv_shim/clients.py
+++ b/jellyfin_mpv_shim/clients.py
@@ -220,6 +220,8 @@ class ClientManager(object):
         client.start(websocket=True)
 
         client.jellyfin.post_capabilities(CAPABILITIES)
+        # Small delay so the server has time to process request
+        time.sleep(3)
         return self.validate_client(client)
 
     def remove_client(self, uuid: str):


### PR DESCRIPTION
Fixes #390 

Several users reporting that a 1 second sleep is enough, but 3 seconds won't hurt anything and gives more time for those rare users running their servers on literal potatoes.