### PR TITLE
Two small OpenBSD support improvements

### DIFF
--- a/jellyfin_mpv_shim/conffile.py
+++ b/jellyfin_mpv_shim/conffile.py
@@ -24,6 +24,7 @@ def win32(app: str):
 
 confdirs = (
     ("linux", posix),
+    ("openbsd", posix),
     ("win32", win32),
     ("cygwin", posix),
     (

--- a/jellyfin_mpv_shim/gui_mgr.py
+++ b/jellyfin_mpv_shim/gui_mgr.py
@@ -24,7 +24,7 @@ def _show_file_darwin(path: str):
     subprocess.Popen(["open", path])
 
 
-def _show_file_linux(path: str):
+def _show_file_xdg(path: str):
     subprocess.Popen(["xdg-open", path])
 
 
@@ -33,14 +33,18 @@ def _show_file_win32(path: str):
 
 
 _show_file_func = {
-    "darwin": _show_file_darwin,
-    "linux": _show_file_linux,
-    "win32": _show_file_win32,
-    "cygwin": _show_file_win32,
+    "darwin":  _show_file_darwin,
+    "linux":   _show_file_xdg,
+    "openbsd": _show_file_xdg,
+    "win32":   _show_file_win32,
+    "cygwin":  _show_file_win32,
 }
 
 try:
-    show_file = _show_file_func[sys.platform]
+    show_file = None
+    for platform, func in _show_file_func.items():
+        if sys.platform.startswith(platform):
+            show_file = func
 
     def open_config():
         show_file(confdir(APP_NAME))


### PR DESCRIPTION
This PR:

 - Modifies `conffile.py` to allow OpenBSD to use the `posix` configuration file locations
 - Modifies `gui_mgr.py` to allow OpenBSD to use the `xdg-open` command for opening files
 - Renames `_show_file_linux` to `_show_file_xdg` given it is now shared between Linux and OpenBSD
 - Updates `show_file` in `gui_mgr.py` to be set based on a matching platform prefix, instead of just an explicit match, as OpenBSD values for `sys.platform` are values like `openbsd7` rather than `openbsd`. Other platforms likely behave the same way.