### PR TITLE
Make main halt event work on non-glibc systems

### DIFF
--- a/jellyfin_mpv_shim/mpv_shim.py
+++ b/jellyfin_mpv_shim/mpv_shim.py
@@ -99,7 +99,8 @@ def main():
             halt = Event()
             user_interface.stop_callback = halt.set
             try:
-                halt.wait()
+                while not halt.wait(timeout=1):
+                    pass
             except KeyboardInterrupt:
                 print("")
                 log.info("Stopping services...")
@@ -109,7 +110,6 @@ def main():
         actionThread.stop()
         clientManager.stop()
         user_interface.stop()
-
 
 if __name__ == "__main__":
     main()


### PR DESCRIPTION
On non-glibc systems, event.wait() is not guaranteed to return on keyboard interrupt.

There is some further context in this [SO question](https://stackoverflow.com/questions/51083939/why-can-pythons-event-wait-be-interrupted-by-signals-on-some-systems-but-not), the short version is the syscall used by Python internally during event.wait() only optionally returns on interrupt per POSIX. On glibc systems, the syscall will be interrupted by Control+C, so event.wait() works as expected by this program. The effect on other operating systems (such as OpenBSD, and likely others) is that event.wait() will continue to wait even if Control+C is pressed.

This small change sets a timeout on the wait, and loops indefinitely until the program is interrupted. This allows the progrram an opportunity to catch KeyboardInterrupt, even on systems with the syscall blocks indefinitely and won't be interrupted by Control+C. I have tested this on OpenBSD and it works as expected.