### PR TITLE
Catch exceptions from pystray

### DIFF
--- a/jellyfin_mpv_shim/gui_mgr.py
+++ b/jellyfin_mpv_shim/gui_mgr.py
@@ -466,7 +466,10 @@ class STrayProcess(Process):
             icon.visible = True
             self.r_queue.put(("ready", None))
 
-        icon.run(setup=setup)
+        try:
+            icon.run(setup=setup)
+        except Exception:
+            pass
         self.r_queue.put(("die", None))
 
 


### PR DESCRIPTION
Currently if pystray throws any exceptions, the exception is passed through but not caught.
Without catching systray exceptions, the systray icon can be removed (i.e. by selecting Quit from the menu) without signalling to the rest of the program that it should shut down.

This happens for example if you run jellyfin-mpv-shim on a system which does not have a notifications daemon registered with dbus, pystray emits an exception when it tries to remove any lingering notifications. This fails, and jellyfin-mpv-shim is left without a systray icon, but still running in the background.

With this patch, a systray exception will gracefully terminate jellyfin-mpv-shim. It would be possible to selectively target individual exceptions which would trigger this behaviour, however looking at the other times where exceptions are caught in the codebase the `try/except/pass` patterns seems fairly widely used, so I went with that.