### PR TITLE
Bug Fix: Prevent false “not connected” state after MPV Shim restart

### DIFF
--- a/jellyfin_mpv_shim/clients.py
+++ b/jellyfin_mpv_shim/clients.py
@@ -185,9 +185,7 @@ class ClientManager(object):
         return False
 
     def validate_client(self, client: "JellyfinClient", dry_run=False):
-        client_list = client.jellyfin.sessions(
-            params={"ControllableByUserId": "{UserId}"}
-        )
+        client_list = client.jellyfin.sessions()
 
         if client_list is None:
             log.warning(


### PR DESCRIPTION
This pull request fixes a bug where MPV Shim disconnects itself immediately after starting, even though the WebSocket connection is successfully established.

The problem occurs in validate_client(), which fetches the session list using the ControllableByUserId filter. Right after a restart, Jellyfin has not yet fully registered the new session or attached the UserId. As a result, the filtered /Sessions query returns an empty list, causing the client to falsely assume it is not connected and to close the WebSocket.

This change removes the ControllableByUserId filter from the initial session query. Instead, the code checks for the presence of the correct DeviceId in the full session list. This avoids premature disconnects while still preserving the integrity of the session verification.

Tested across multiple restarts. The client now stays available in Jellyfin's “Play to” list after each restart, and playback functionality remains unchanged.