### PR TITLE
gen_pkg: change shebang to support nixos

### DIFF
--- a/gen_pkg.sh
+++ b/gen_pkg.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # This script:
 # - Checks the current version
 # - Verifies all versions match and are newer
@@ -7,7 +7,7 @@
 # - Generates locales
 # - Builds the python package
 
-cd "$(dirname "$0")"
+cd "$(dirname "$0")" || exit 1
 
 function download_compat {
     if [[ "$AZ_CACHE" != "" ]]


### PR DESCRIPTION
/bin/bash doesn't exist on my linux distribution nixos. /usr/bin/env should be universal.

did a quickfix suggested by shellcheck as well.

I asked the IA "claude" to update the script to work with plain /bin/sh but it's riskier (more changes), see at https://github.com/teto/jellyfin-mpv-shim/commit/4c9dee4186a664fb532f25af5998a6ab026a0bc9 