### PR TITLE
fix: prevent menu crash during stream initialization

### DIFF
--- a/jellyfin_mpv_shim/player.py
+++ b/jellyfin_mpv_shim/player.py
@@ -298,6 +298,9 @@ class PlayerManager(object):
 
         @keypress(settings.kb_menu)
         def menu_open():
+            if self.do_not_handle_pause:
+                self._player.show_text(_("Please wait, loading..."), 1000, 1)
+                return
             if not self.menu.is_menu_shown:
                 self.menu.show_menu()
             else:


### PR DESCRIPTION
# Fix: Prevent Menu Crash During Stream Initialization

## Summary

Fixes MPV crash when opening the menu (default 'c' key) within ~2 seconds of stream reload, particularly after changing bandwidth settings in the transcode quality menu.

## Problem

When users changed the bandwidth limit via the menu, the stream would reload. If the user pressed 'c' to open the menu before the video had been playing for about 2 seconds, MPV would crash. Waiting for the stream to fully initialize allowed the menu to work normally.

### Root Cause

The crash occurred because:
1. Stream reload triggers `_play_media()` which sets `do_not_handle_pause = True`
2. MPV starts loading the new stream at line 593: `self._player.play(self.url)`
3. Code waits for duration property to become available (lines 594-600), typically ~2 seconds
4. During this initialization window, if user presses 'c', the menu code runs
5. Menu calls `show_text()` and accesses player properties while MPV is incompletely initialized
6. This causes MPV to crash due to operations on an inconsistent player state

The `do_not_handle_pause` flag was intended to prevent event handlers from running during initialization, but it didn't block the menu key handler.

## Solution

Added a guard check in the menu key handler (`player.py` lines 300-305):

```python
@keypress(settings.kb_menu)
def menu_open():
    if self.do_not_handle_pause:
        self._player.show_text(_("Please wait, loading..."), 1000, 1)
        return
    if not self.menu.is_menu_shown:
        self.menu.show_menu()
    else:
        self.menu.hide_menu()
```

### Behavior

- If menu is opened during stream initialization, user sees "Please wait, loading..." for 1 second
- Menu doesn't open (preventing the crash)
- User can press 'c' again once stream is fully loaded
- Normal menu operation is unaffected after initialization completes

## Testing

1. Start playing high-bitrate content (e.g., 45mbps source)
2. Press 'c' to open menu
3. Change transcode quality (e.g., to 10mbps)
4. Immediately press 'c' (within 2 seconds)
5. **Expected**: See "Please wait, loading..." message, no crash
6. Wait 2-3 seconds, press 'c' again
7. **Expected**: Menu opens normally

## Impact

- **User-facing**: Eliminates crash during stream reloads, provides clear feedback
- **Code changes**: Minimal - 3 lines added to existing key handler
- **Performance**: No impact - simple flag check
- **Compatibility**: No breaking changes, works with all existing configurations

## Related Issues

Fixes crash when streaming transcoded content and attempting to open menu during stream initialization phase.
