### PR TITLE
fix: make Pillow optional dependency with graceful degradation

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -37,6 +37,7 @@ Current Dependencies:
  - `python-mpv` - Provides `libmpv` playback backend.
  - `python-mpv-jsonipc` - Provides `mpv` playback backend. (First-Party)
  - `jellyfin-apiclient-python` - Provides API client to Jellyfin. (First-Party)
+ - `pillow` - Provides image processing for trickplay thumbnails and systray icon. (Optional)
  - `pywin32` - Allows window management on Windows. (Optional)
  - `pystray` - Provides systray icon. (Optional)
  - `tkinter` - Provides GUI for adding servers and viewing logs. (Optional)

--- a/jellyfin_mpv_shim/bifdecode.py
+++ b/jellyfin_mpv_shim/bifdecode.py
@@ -1,9 +1,18 @@
 #!/usr/bin/env python3
 from io import BytesIO
-from PIL import Image
+
+try:
+    from PIL import Image
+    PIL_AVAILABLE = True
+except ImportError:
+    PIL_AVAILABLE = False
+    Image = None
 
 
 def decompress_tiles(width, height, tile_width, tile_height, count, tiles, fh):
+    if not PIL_AVAILABLE:
+        raise ImportError("Pillow (PIL) is required for trickplay thumbnails. Install with: pip install pillow")
+    
     image_count = 0
 
     for image in tiles:
@@ -31,6 +40,9 @@ def decompress_tiles(width, height, tile_width, tile_height, count, tiles, fh):
 
 
 def decompress_bif(images, fh):
+    if not PIL_AVAILABLE:
+        raise ImportError("Pillow (PIL) is required for trickplay thumbnails. Install with: pip install pillow")
+    
     height = None
     width = None
     image_count = 0

--- a/jellyfin_mpv_shim/bifdecode.py
+++ b/jellyfin_mpv_shim/bifdecode.py
@@ -3,6 +3,7 @@ from io import BytesIO
 
 try:
     from PIL import Image
+
     PIL_AVAILABLE = True
 except ImportError:
     PIL_AVAILABLE = False
@@ -11,8 +12,10 @@ except ImportError:
 
 def decompress_tiles(width, height, tile_width, tile_height, count, tiles, fh):
     if not PIL_AVAILABLE:
-        raise ImportError("Pillow (PIL) is required for trickplay thumbnails. Install with: pip install pillow")
-    
+        raise ImportError(
+            "Pillow (PIL) is required for trickplay thumbnails. Install with: pip install pillow"
+        )
+
     image_count = 0
 
     for image in tiles:
@@ -41,8 +44,10 @@ def decompress_tiles(width, height, tile_width, tile_height, count, tiles, fh):
 
 def decompress_bif(images, fh):
     if not PIL_AVAILABLE:
-        raise ImportError("Pillow (PIL) is required for trickplay thumbnails. Install with: pip install pillow")
-    
+        raise ImportError(
+            "Pillow (PIL) is required for trickplay thumbnails. Install with: pip install pillow"
+        )
+
     height = None
     width = None
     image_count = 0

--- a/jellyfin_mpv_shim/trickplay.py
+++ b/jellyfin_mpv_shim/trickplay.py
@@ -4,9 +4,15 @@ import logging
 import math
 
 from .conf import settings
-from . import bifdecode
 from . import conffile
 from .constants import APP_NAME
+
+try:
+    from . import bifdecode
+    BIFDECODE_AVAILABLE = bifdecode.PIL_AVAILABLE
+except ImportError:
+    BIFDECODE_AVAILABLE = False
+    bifdecode = None
 
 log = logging.getLogger("trickplay")
 img_file = conffile.get(APP_NAME, "raw_images.bin")
@@ -36,6 +42,10 @@ class TrickPlay(threading.Thread):
             os.remove(img_file)
 
     def run(self):
+        if not BIFDECODE_AVAILABLE:
+            log.warning("Trickplay thumbnails disabled: Pillow (PIL) not available. Install with: pip install pillow")
+            return
+        
         while not self.halt:
             self.trigger.wait()
             self.trigger.clear()

--- a/jellyfin_mpv_shim/trickplay.py
+++ b/jellyfin_mpv_shim/trickplay.py
@@ -9,6 +9,7 @@ from .constants import APP_NAME
 
 try:
     from . import bifdecode
+
     BIFDECODE_AVAILABLE = bifdecode.PIL_AVAILABLE
 except ImportError:
     BIFDECODE_AVAILABLE = False
@@ -43,9 +44,11 @@ class TrickPlay(threading.Thread):
 
     def run(self):
         if not BIFDECODE_AVAILABLE:
-            log.warning("Trickplay thumbnails disabled: Pillow (PIL) not available. Install with: pip install pillow")
+            log.warning(
+                "Trickplay thumbnails disabled: Pillow (PIL) not available. Install with: pip install pillow"
+            )
             return
-        
+
         while not self.halt:
             self.trigger.wait()
             self.trigger.clear()


### PR DESCRIPTION
# Fix: Make Pillow Optional Dependency with Graceful Degradation

## Summary
Makes Pillow a truly optional dependency that gracefully degrades when unavailable, fixing the issue where trickplay feature would crash on import if Pillow wasn't installed.

## Problem
- Pillow was marked as optional in `setup.py` under the `gui` extra
- However, `bifdecode.py` imported PIL directly without error handling
- This caused the application to fail on startup if Pillow wasn't installed
- Violated project philosophy: "All features requiring GUI/dependencies must be optional and gracefully degrade if unavailable"

## Solution
- Added try/except for PIL import in `bifdecode.py` with `PIL_AVAILABLE` flag
- Added graceful degradation in `trickplay.py` when Pillow is unavailable
- Clear error messages instruct users: `pip install pillow`
- Updated `CONTRIBUTING.md` to document Pillow as optional dependency
- Trickplay thumbnails now degrade gracefully without breaking CLI mode

## Changes
- `jellyfin_mpv_shim/bifdecode.py`: Conditional PIL import with availability check
- `jellyfin_mpv_shim/trickplay.py`: Early return with warning when Pillow unavailable
- `CONTRIBUTING.md`: Added Pillow to optional dependencies list

## Testing
- ✅ Application starts without Pillow installed
- ✅ Clear warning message logged: "Trickplay thumbnails disabled: Pillow (PIL) not available"
- ✅ CLI mode works perfectly without Pillow
- ✅ Helpful error message if trickplay functions called: "Install with: pip install pillow"

## Behavior
**Without Pillow:**
- App starts normally
- Trickplay disabled with warning
- CLI mode fully functional

**With Pillow:**
- All features work as before
- Trickplay thumbnails enabled
- System tray icon works
