### PR TITLE
fix: Improve Keyboard Interrupt Handling for Graceful Shutdown

### DIFF
--- a/jellyfin_mpv_shim/action_thread.py
+++ b/jellyfin_mpv_shim/action_thread.py
@@ -18,8 +18,12 @@ class ActionThread(threading.Thread):
     def run(self):
         force_next = False
         while not self.halt:
-            if playerManager.is_active() or force_next:
-                playerManager.update()
+            try:
+                if playerManager.is_active() or force_next:
+                    playerManager.update()
+            except (BrokenPipeError, OSError):
+                # MPV terminated, exit gracefully
+                break
 
             force_next = False
             if self.trigger.wait(1):

--- a/jellyfin_mpv_shim/mpv_shim.py
+++ b/jellyfin_mpv_shim/mpv_shim.py
@@ -105,10 +105,15 @@ def main():
                 print("")
                 log.info("Stopping services...")
     finally:
-        playerManager.terminate()
+        # Stop threads first to prevent them from accessing MPV during shutdown
+        log.debug("Stopping timeline and action threads...")
         timelineManager.stop()
         actionThread.stop()
+        log.debug("Terminating player...")
+        playerManager.terminate()
+        log.debug("Stopping client manager...")
         clientManager.stop()
+        log.debug("Stopping user interface...")
         user_interface.stop()
 
 if __name__ == "__main__":

--- a/jellyfin_mpv_shim/mpv_shim.py
+++ b/jellyfin_mpv_shim/mpv_shim.py
@@ -105,6 +105,8 @@ def main():
                 print("")
                 log.info("Stopping services...")
     finally:
+        # Mark player as shutting down to prevent further operations
+        playerManager.shutdown()
         # Stop threads first to prevent them from accessing MPV during shutdown
         log.debug("Stopping timeline and action threads...")
         timelineManager.stop()

--- a/jellyfin_mpv_shim/player.py
+++ b/jellyfin_mpv_shim/player.py
@@ -497,9 +497,7 @@ class PlayerManager(object):
             and self._video is not None
             and playback_time is not None
         ):
-            ready_to_skip, intro = self._video.get_current_intro(
-                playback_time
-            )
+            ready_to_skip, intro = self._video.get_current_intro(playback_time)
 
             if intro is not None:
                 should_prompt = (
@@ -1031,11 +1029,7 @@ class PlayerManager(object):
         if self._shutdown_flag:
             return
         playback_abort = self._safe_get_property("playback_abort", True)
-        if (
-            self.should_send_timeline
-            and self._video
-            and not playback_abort
-        ):
+        if self.should_send_timeline and self._video and not playback_abort:
             self._video.client.jellyfin.session_progress(self.get_timeline_options())
             try:
                 if self.syncplay.is_enabled():

--- a/jellyfin_mpv_shim/player.py
+++ b/jellyfin_mpv_shim/player.py
@@ -461,6 +461,9 @@ class PlayerManager(object):
     # This ensures the task executes outside
     # of an event handler, which causes a crash.
     def put_task(self, func, *args):
+        if self._shutdown_flag:
+            log.debug("Ignoring task during shutdown")
+            return
         self.evt_queue.put([func, args])
         if self.action_trigger:
             self.action_trigger.set()
@@ -468,6 +471,8 @@ class PlayerManager(object):
     # Trigger the timeline to update all
     # clients immediately.
     def timeline_handle(self):
+        if self._shutdown_flag:
+            return
         if self.timeline_trigger:
             self.timeline_trigger.set()
 

--- a/jellyfin_mpv_shim/player.py
+++ b/jellyfin_mpv_shim/player.py
@@ -1073,7 +1073,6 @@ class PlayerManager(object):
             self._player.keep_open = self._video.parent.has_next
 
     def terminate(self):
-        self._shutdown_flag = True
         self.stop()
         if is_using_ext_mpv:
             try:
@@ -1083,6 +1082,10 @@ class PlayerManager(object):
 
         if self.trickplay:
             self.trickplay.stop()
+
+    def shutdown(self):
+        """Mark player as shutting down to prevent further operations."""
+        self._shutdown_flag = True
 
     def get_seek_times(self):
         if self._jf_settings is None:

--- a/jellyfin_mpv_shim/timeline.py
+++ b/jellyfin_mpv_shim/timeline.py
@@ -35,7 +35,10 @@ class TimelineManager(threading.Thread):
                     if self.is_idle and settings.idle_ended_cmd:
                         os.system(settings.idle_ended_cmd)
                     self.delay_idle()
-                if self.idleTimer.elapsed() > settings.idle_cmd_delay and not self.is_idle:
+                if (
+                    self.idleTimer.elapsed() > settings.idle_cmd_delay
+                    and not self.is_idle
+                ):
                     if (
                         settings.idle_when_paused
                         and settings.stop_idle

--- a/jellyfin_mpv_shim/timeline.py
+++ b/jellyfin_mpv_shim/timeline.py
@@ -27,23 +27,28 @@ class TimelineManager(threading.Thread):
 
     def run(self):
         while not self.halt:
-            if playerManager.is_active() and (
-                not settings.idle_when_paused or not playerManager.is_paused()
-            ):
-                self.send_timeline()
-                if self.is_idle and settings.idle_ended_cmd:
-                    os.system(settings.idle_ended_cmd)
-                self.delay_idle()
-            if self.idleTimer.elapsed() > settings.idle_cmd_delay and not self.is_idle:
-                if (
-                    settings.idle_when_paused
-                    and settings.stop_idle
-                    and playerManager.has_video()
+            try:
+                if playerManager.is_active() and (
+                    not settings.idle_when_paused or not playerManager.is_paused()
                 ):
-                    playerManager.stop()
-                if settings.idle_cmd:
-                    os.system(settings.idle_cmd)
-                self.is_idle = True
+                    self.send_timeline()
+                    if self.is_idle and settings.idle_ended_cmd:
+                        os.system(settings.idle_ended_cmd)
+                    self.delay_idle()
+                if self.idleTimer.elapsed() > settings.idle_cmd_delay and not self.is_idle:
+                    if (
+                        settings.idle_when_paused
+                        and settings.stop_idle
+                        and playerManager.has_video()
+                    ):
+                        playerManager.stop()
+                    if settings.idle_cmd:
+                        os.system(settings.idle_cmd)
+                    self.is_idle = True
+            except (BrokenPipeError, OSError):
+                # MPV terminated, exit gracefully
+                log.debug("MPV connection lost, timeline thread exiting")
+                break
             if self.trigger.wait(5):
                 self.trigger.clear()
 


### PR DESCRIPTION
# Fix: Improve Keyboard Interrupt Handling for Graceful Shutdown

## Summary

Fixes keyboard interrupt (Ctrl-C) handling to enable graceful shutdown with a single interrupt instead of requiring multiple presses and generating `BrokenPipeError` exceptions.

## Problem

- Required **3+ Ctrl-C presses** to terminate
- Generated `BrokenPipeError` exceptions in background threads
- Race conditions between thread termination and MPV cleanup

## Solution

### Key Improvements

1. **Shutdown Flag Pattern** - Added `_shutdown_flag` with separate `shutdown()` method (called once on exit) vs `terminate()` (called for playback stop)
2. **Safe Property Access** - New `_safe_get_property()` handles `BrokenPipeError`/`OSError` gracefully
3. **Graceful Thread Exit** - Threads catch errors and exit cleanly when MPV connection lost
4. **Proper Shutdown Sequence** - `shutdown()` → stop threads → terminate MPV → cleanup
5. **Additional Shutdown Checks** - Added checks to `put_task()` and `timeline_handle()` to prevent operations during shutdown

### Critical Fix (Commit 2)

Initial implementation had a bug: `_shutdown_flag` was set in `terminate()`, causing zombie process that blocked new playback. Fixed by separating:
- `terminate()` - Stops MPV (can be called multiple times)
- `shutdown()` - Sets flag (called once on app exit)

### Additional Hardening (New Commits)

Added shutdown checks to prevent queued tasks and timeline triggers during shutdown:

```python
def put_task(self, func, *args):
    if self._shutdown_flag:
        log.debug("Ignoring task during shutdown")
        return
    # ... rest of method

def timeline_handle(self):
    if self._shutdown_flag:
        return
    # ... rest of method
```

## Changes

**4 files changed** (+94/-31 lines)

- `player.py` - Added shutdown flag, safe property access, `shutdown()` method, shutdown checks in `put_task()` and `timeline_handle()`
- `timeline.py` - Wrapped loop in try/except for graceful exit
- `action_thread.py` - Added error handling for clean termination
- `mpv_shim.py` - Call `shutdown()` before stopping threads

## Testing

- ✅ Single Ctrl-C cleanly exits application
- ✅ No `BrokenPipeError` exceptions
- ✅ Normal playback stop/start cycles work
- ✅ No zombie process
- ✅ No queued tasks executed during shutdown
- ✅ Clean shutdown during playback, paused, and stopped states

## Result

**Before:** 3+ Ctrl-C, exception spam, zombie process  
**After:** Single Ctrl-C, clean exit, proper shutdown ✨

## Compatibility

- ✅ Works with libmpv and external MPV backends
- ✅ Thread-safe with existing `@synchronous` decorators
- ✅ No breaking changes
