### PR TITLE
fix: respect mpv_ext_no_ovr setting for OSC control

### DIFF
--- a/jellyfin_mpv_shim/player.py
+++ b/jellyfin_mpv_shim/player.py
@@ -1104,6 +1104,8 @@ class PlayerManager(object):
         self._player.osd_font_size = font_size
 
     def enable_osc(self, enabled: bool):
+        if settings.mpv_ext and settings.mpv_ext_no_ovr:
+            return  # Don't override user's MPV config
         if settings.thumbnail_enable and self.trickplay:
             self.script_message(
                 "osc-visibility", "auto" if enabled else "never", "False"


### PR DESCRIPTION
## Summary
Fixes #471 - External MPV OSC hidden when launching with mpv-shim

## Problem
When using external MPV with `mpv_ext_no_ovr` enabled (to prevent mpv-shim from overriding user's MPV config), the OSC (On-Screen Controller) was being hidden on launch. Users had to manually run `cycle osc` in the MPV console to restore it, and the setting would reset on every new video.

The issue occurred because `enable_osc()` was unconditionally controlling OSC visibility based on thumbnail settings, even when the user explicitly configured mpv-shim to not override their MPV settings.

## Solution
Added a check in `enable_osc()` to respect the `mpv_ext_no_ovr` setting. When using external MPV with this setting enabled, mpv-shim now skips OSC control entirely, allowing the user's MPV configuration to take precedence.

## Changes
- Modified `PlayerManager.enable_osc()` in `player.py` to return early when `mpv_ext` and `mpv_ext_no_ovr` are both enabled
- Added inline comment explaining the behavior

## Testing
- Confirmed by issue reporter (@Asinin3) that the fix resolves the problem
- No OSC override occurs when using external MPV with `mpv_ext_no_ovr` enabled
- Existing functionality preserved for other configurations