### PR TITLE
fix(gui): force X11 backend for system tray to fix Wayland startup

### DIFF
--- a/jellyfin_mpv_shim/gui_mgr.py
+++ b/jellyfin_mpv_shim/gui_mgr.py
@@ -438,7 +438,19 @@ class STrayProcess(Process):
         Process.__init__(self)
 
     def run(self):
-        from pystray import Icon, MenuItem, Menu
+        import os
+
+        # Force X11 backend for GTK to fix Wayland startup issues
+        if "WAYLAND_DISPLAY" in os.environ:
+            del os.environ["WAYLAND_DISPLAY"]
+        os.environ["GDK_BACKEND"] = "x11"
+
+        try:
+            from pystray import Icon, MenuItem, Menu
+        except Exception as e:
+            log.error(f"Failed to import pystray: {e}")
+            self.r_queue.put(("die", None))
+            return
 
         def get_wrapper(command):
             def wrapper():


### PR DESCRIPTION
Unsets WAYLAND_DISPLAY and forces GDK_BACKEND=x11 before initializing the system tray process. This prevents the application from failing to start on Wayland environments due to pystray/GTK incompatibilities.

Since only the system tray runs via XWayland, MPV launches natively under Wayland, which correctly allows it to inhibit screen timeouts.

Tested the Flatpak

Workaround for #219