### PR TITLE
Add support for watching and listening RPC types

### DIFF
--- a/jellyfin_mpv_shim/player.py
+++ b/jellyfin_mpv_shim/player.py
@@ -1114,6 +1114,7 @@ class PlayerManager(object):
                     player.duration,
                     not player.pause,
                     self.syncplay.current_group,
+                    self._video.item.get("Type"),
                 )
             except Exception:
                 log.error("Could not send Discord Rich Presence.", exc_info=True)

--- a/jellyfin_mpv_shim/rich_presence.py
+++ b/jellyfin_mpv_shim/rich_presence.py
@@ -1,5 +1,6 @@
 from pypresence import Client
 import time
+from pypresence.types import ActivityType, StatusDisplayType
 
 client_id = "743296148592263240"
 RPC = Client(client_id)
@@ -17,6 +18,7 @@ def send_presence(
     duration: float = None,
     playing: bool = False,
     syncplay_group: str = None,
+    media_type: str = None,
 ):
     small_image = "play-dark3" if playing else None
     start = None
@@ -26,6 +28,8 @@ def send_presence(
         end = int(start + duration)
 
     payload = {
+        "activity_type": ActivityType.LISTENING if media_type and media_type == "Audio" else ActivityType.WATCHING,
+        "status_display_type": StatusDisplayType.DETAILS,
         "state": subtitle if subtitle else "Unknown Media",
         "details": title,
         "instance": False,


### PR DESCRIPTION
This PR modifies the activity type being given to discord rich presence to ActivityType.Watching and ActivityType.Listening, which was previous set to ActivityType.Playing which was the default to allow the metadata given to discord, such as timestamps of the media and more, to be acknowledged and displayed accordingly. Depending on the video type given to the Player, it uses Watching or Listening activity type.

Since "Watching(or the icon) Jellyfin MPV Shim" didn't feel quite right to me I have also changed the activity text to use the name of the media being played. This usually refers to the title of the show, title of the movie or the name of the song respectively