### PR TITLE
Fix H.265/HEVC not transcoding when both allow and prefer are active

### DIFF
--- a/jellyfin_mpv_shim/utils.py
+++ b/jellyfin_mpv_shim/utils.py
@@ -111,9 +111,9 @@ def get_profile(
 
     if settings.force_video_codec:
         transcode_codecs = settings.force_video_codec
-    elif settings.allow_transcode_to_h265 and not settings.transcode_hevc:
+    elif settings.allow_transcode_to_h265 and not settings.prefer_transcode_to_h265 and not settings.transcode_hevc:
         transcode_codecs = "h264,h265,hevc,mpeg4,mpeg2video"
-    elif settings.prefer_transcode_to_h265 and not settings.transcode_hevc:
+    elif settings.allow_transcode_to_h265 and settings.prefer_transcode_to_h265 and not settings.transcode_hevc:
         transcode_codecs = "h265,hevc,h264,mpeg4,mpeg2video"
     else:
         transcode_codecs = "h264,mpeg4,mpeg2video"


### PR DESCRIPTION
Previously, when setting both `allow_transcode_to_h265` and `prefer_transcode_to_h265` the program would basically ignore `prefer_transcode_to_h265` and just allow the codec to be used.

This commit checks both `prefer_transcode_to_h265` and `allow_transcode_to_h265` to see what codec should be allowed and preferred.

Fixes #530