### PR TITLE
fix: always send timeline updates when player is active

### DIFF
--- a/jellyfin_mpv_shim/timeline.py
+++ b/jellyfin_mpv_shim/timeline.py
@@ -27,14 +27,12 @@ class TimelineManager(threading.Thread):
 
     def run(self):
         while not self.halt:
-            if playerManager.is_active() and (
-                not settings.idle_when_paused or not playerManager.is_paused()
-            ):
-                if not playerManager.is_paused():
-                    self.send_timeline()
-                if self.is_idle and settings.idle_ended_cmd:
-                    os.system(settings.idle_ended_cmd)
-                self.delay_idle()
+            if playerManager.is_active():
+                self.send_timeline()
+                if not settings.idle_when_paused or not playerManager.is_paused():
+                    if self.is_idle and settings.idle_ended_cmd:
+                        os.system(settings.idle_ended_cmd)
+                    self.delay_idle()
             if self.idleTimer.elapsed() > settings.idle_cmd_delay and not self.is_idle:
                 if (
                     settings.idle_when_paused


### PR DESCRIPTION
When playback is paused for a while, cast clients (like the Jellyfin mobile app
or web UI) lose the ability to control playback. Resuming, seeking, or
stopping from the client no longer works. The clients don't see the paused 
playback at all. This appears to happen because the server loses track of the 
session when timeline updates stop being sent while paused.

The cause seems to be two separate guards in `timeline.py` that both end up
blocking `send_timeline()` during pause:

`timeline.py` line 30-34:

```python
if playerManager.is_active() and (          # outer guard
    not settings.idle_when_paused or not playerManager.is_paused()
):
    if not playerManager.is_paused():       # inner guard - also blocks send_timeline()
        self.send_timeline()
```

1. The outer condition ties `send_timeline()` to the `idle_when_paused`
   setting. This setting appears to be intended for idle command behaviour
   only, so it likely should not be controlling whether timeline updates
   are sent to the server.

2. The inner `if not playerManager.is_paused()` check blocks `send_timeline()`
   unconditionally, regardless of any config. This means the bug affects
   all users, even with default settings.

The fix separates these two concerns. `send_timeline()` now runs whenever the
player is active, regardless of pause state:


```python
if playerManager.is_active():
    self.send_timeline()
    if not settings.idle_when_paused or not playerManager.is_paused():
        if self.is_idle and settings.idle_ended_cmd:
            os.system(settings.idle_ended_cmd)
        self.delay_idle()
```

The `idle_when_paused` check is still there. It just only controls the
idle command behaviour (`delay_idle()`, `idle_ended_cmd`), which is what
it appears to have been intended for.
