### PR TITLE
Add missing global RPC reference in send_presence

### DIFF
--- a/jellyfin_mpv_shim/rich_presence.py
+++ b/jellyfin_mpv_shim/rich_presence.py
@@ -70,6 +70,7 @@ def send_presence(
         payload["party_size"] = [1, 100]
         payload["join"] = syncplay_group
 
+    global RPC
     try:
         RPC.set_activity(**payload)
     except Exception:


### PR DESCRIPTION
This PR adds a global RPC reference in the send_presence function which seems to be missing when introduced in commit ec0eaea7f1eaf656984fb77dd5e1f7aceebefcc4.

The change fixes what was mentioned in the [latest comment](https://github.com/jellyfin/jellyfin-mpv-shim/issues/334#issuecomment-4387724841) of #334 but doesn't fix the original cause of the issue but since the original cause seems to have been fixed a long ago (as it was because the original application at the time was deleted which as you can see isn't the issue anymore) I believe I should mention it here.