### PR TITLE
Revert #491

### DIFF
--- a/jellyfin_mpv_shim/player.py
+++ b/jellyfin_mpv_shim/player.py
@@ -151,7 +151,6 @@ class PlayerManager(object):
         self.fullscreen_disable = False
         self.update_check = UpdateChecker(self)
         self.is_in_intro = False
-        self.playback_time_before_seek = None
         self.trickplay = None
         self._mpv_alive = False
         # Last known playback position; used when MPV exits (e.g. OSC 'x'
@@ -427,20 +426,6 @@ class PlayerManager(object):
             if self.do_not_handle_pause:
                 return
 
-            # Handle intro skip for any forward seek (including custom key bindings)
-            if value:
-                # Seeking started - store current position
-                self.playback_time_before_seek = self._player.playback_time
-            else:
-                # Seeking ended - check if we should skip intro
-                if (
-                    self.is_in_intro
-                    and self.playback_time_before_seek is not None
-                    and self._player.playback_time is not None
-                    and self._player.playback_time > self.playback_time_before_seek
-                ):
-                    self.skip_intro()
-
             if self.syncplay.is_enabled():
                 play_time = self._player.playback_time
                 if (
@@ -558,9 +543,7 @@ class PlayerManager(object):
     def skip_intro(self):
         _, intro = self._video.get_current_intro(self._player.playback_time)
 
-        if not self._player.playback_abort:
-            self._player.command("seek", intro.end, "absolute")
-
+        self._player.playback_time = intro.end
         intro.has_triggered = True
         self.timeline_handle()
         self.is_in_intro = False
@@ -847,6 +830,8 @@ class PlayerManager(object):
                 if absolute:
                     if self.syncplay.is_enabled():
                         self.last_seek = offset
+                    if self.is_in_intro and offset > self._player.playback_time:
+                        self.skip_intro()
                     p2 = "absolute"
                     if exact:
                         p2 += "+exact"
@@ -854,6 +839,12 @@ class PlayerManager(object):
                 else:
                     if self.syncplay.is_enabled():
                         self.last_seek = self._player.playback_time + offset
+                    if (
+                        self.is_in_intro
+                        and self._player.playback_time + offset
+                        > self._player.playback_time
+                    ):
+                        self.skip_intro()
                     if exact:
                         self._player.command("seek", offset, "exact")
                     else:


### PR DESCRIPTION
Reverts the changes introduced in #491. Reposting my reasoning from the [original comment](https://github.com/jellyfin/jellyfin-mpv-shim/pull/491#issuecomment-4618083339):

> I liked the previous behavior. Sometimes I want to seek ahead instead of skipping completely (e.g. when there are "post-credit" scenes that are part of the credits which would normally be skipped over).
> 
> The previous behavior allowed me to perform both actions (skip completely when needed, or just seek ahead/back normally with the default right key).
> 
> I propose reverting this change as any enhancements should extend functionality, not limit what was already possible. With this change, I don't see a way to do both anymore.
> 
> It would have made more sense to introduce (or allow a custom) keymap specifically for skipping (e.g. how Netflix lets you skip by pressing "S", while seek works normally).