### PR TITLE
Add Quick Connect login support

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,6 +35,13 @@ URL to your server, for example `http://server_ip:8096` or `https://secure_domai
 include the subdirectory and port number if applicable. You can then cast your media
 from another Jellyfin application.
 
+If your account has no password (for example, users who sign in through an SSO provider), use
+**Quick Connect** instead of typing a password. In the GUI, enter the server URL and click
+**Quick Connect**; on the CLI, pass `--quick-connect` (optionally with `--server URL`). A code is
+shown — open Jellyfin in a browser where you are already signed in, go to your user menu →
+*Quick Connect*, and enter the code. Quick Connect must be enabled by an administrator on the
+server.
+
 The application runs with a notification icon by default. You can use this to edit the server settings,
 view the application log, open the config folder, and open the application menu. Unlike Plex MPV Shim,
 authorization tokens for your server are stored on your device, but you are able to cast to the player

--- a/jellyfin_mpv_shim/args.py
+++ b/jellyfin_mpv_shim/args.py
@@ -62,6 +62,13 @@ def _build_parser() -> argparse.ArgumentParser:
         help="password for --server (NOTE: visible to other processes via ps)",
     )
     parser.add_argument(
+        "--quick-connect",
+        dest="quick_connect",
+        action="store_true",
+        help="log in via Jellyfin Quick Connect instead of a password "
+        "(useful for SSO users); prompts for/uses only the server URL",
+    )
+    parser.add_argument(
         "command",
         nargs="*",
         choices=("add", "clear"),

--- a/jellyfin_mpv_shim/clients.py
+++ b/jellyfin_mpv_shim/clients.py
@@ -14,6 +14,9 @@ import logging
 import re
 import threading
 
+from datetime import datetime
+from urllib.parse import quote
+
 import socket
 import ipaddress
 from urllib.parse import urlparse
@@ -74,6 +77,19 @@ def is_local_subnet(host, local_ips, prefix_length=24):
 
 log = logging.getLogger("clients")
 path_regex = re.compile(r"^(https?://)?(?:(\[[^/]+\])|([^/:]+))(:[0-9]+)?(/.*)?$")
+
+# How often to poll the server while waiting for the user to authorize a
+# Quick Connect request, and how long to keep polling before giving up.
+QUICK_CONNECT_POLL_SECS = 3
+QUICK_CONNECT_TIMEOUT_SECS = 300
+
+
+class QuickConnectError(Exception):
+    """Raised when a Quick Connect login cannot be completed.
+
+    The message is user-facing (already translated) so callers can surface it
+    directly in the CLI or GUI.
+    """
 
 from typing import Optional
 
@@ -157,6 +173,25 @@ class ClientManager(object):
         # Re-login with updated credentials
         return self.login(server, username, password)
 
+    def _cli_quick_connect(self, server: str):
+        """Run a Quick Connect login from the terminal, printing the code."""
+
+        def show_code(code):
+            print(
+                _(
+                    "Open Jellyfin, go to your user menu -> Quick Connect, "
+                    "and enter this code:"
+                )
+            )
+            print("    " + code)
+            print(_("Waiting for authorization..."))
+
+        try:
+            return self.login_with_quick_connect(server, code_callback=show_code)
+        except QuickConnectError as e:
+            log.warning(str(e))
+            return False
+
     def cli_connect(self):
         from .args import get_args
         cli_commands = set(get_args().command or [])
@@ -164,6 +199,8 @@ class ClientManager(object):
         is_logged_in = self.try_connect()
         add_another = "add" in cli_commands
         clear_accounts = "clear" in cli_commands
+        use_quick_connect = get_args().quick_connect
+        server_arg = get_args().server
 
         cli_creds = self._get_cli_credential_args()
 
@@ -171,6 +208,16 @@ class ClientManager(object):
             log.info(_("Clearing all existing accounts."))
             self.remove_all_clients()
             is_logged_in = False
+
+        # Non-interactive Quick Connect: only the server URL is required.
+        if use_quick_connect and server_arg:
+            cli_creds = None
+            if not is_logged_in or add_another or clear_accounts:
+                if self._cli_quick_connect(server_arg):
+                    log.info(_("Successfully added server."))
+                    is_logged_in = True
+                else:
+                    log.warning(_("Adding server failed."))
 
         if cli_creds:
             server, username, password = cli_creds
@@ -194,13 +241,16 @@ class ClientManager(object):
 
         while not is_logged_in or add_another:
             server = input(_("Server URL: "))
-            username = input(_("Username: "))
-            try:
-                password = getpass(_("Password: "))
-            except (EOFError, OSError):
-                password = ""
+            if use_quick_connect:
+                is_logged_in = self._cli_quick_connect(server)
+            else:
+                username = input(_("Username: "))
+                try:
+                    password = getpass(_("Password: "))
+                except (EOFError, OSError):
+                    password = ""
 
-            is_logged_in = self.login(server, username, password)
+                is_logged_in = self.login(server, username, password)
 
             if is_logged_in:
                 log.info(_("Successfully added server."))
@@ -303,9 +353,8 @@ class ClientManager(object):
         with open(credentials_location, "w") as cf:
             json.dump(self.credentials, cf)
 
-    def login(
-        self, server: str, username: str, password: str, force_unique: bool = False
-    ):
+    @staticmethod
+    def _normalize_server(server: str) -> str:
         if server.endswith("/"):
             server = server[:-1]
 
@@ -322,26 +371,177 @@ class ClientManager(object):
             )
             port = ":8096"
 
-        server = "".join(filter(bool, (protocol, ipv6_host, ipv4_host, port, path)))
+        return "".join(filter(bool, (protocol, ipv6_host, ipv4_host, port, path)))
+
+    def _finalize_login(
+        self, client: "JellyfinClient", username: str, force_unique: bool = False
+    ):
+        """Stash a freshly-authenticated client into our credential store.
+
+        The client must already hold a valid AccessToken for its first server
+        (either from a password login or a Quick Connect exchange).
+        """
+        credentials = client.auth.credentials.get_credentials()
+        server = credentials["Servers"][0]
+        if force_unique:
+            server["uuid"] = server["Id"]
+        else:
+            server["uuid"] = str(uuid.uuid4())
+        server["username"] = username
+        if force_unique and server["Id"] in self.clients:
+            return True
+        self.connect_client(server)
+        self.credentials.append(server)
+        self.save_credentials()
+        return True
+
+    def login(
+        self, server: str, username: str, password: str, force_unique: bool = False
+    ):
+        server = self._normalize_server(server)
 
         client = self.client_factory()
         client.auth.connect_to_address(server)
         result = client.auth.login(server, username, password)
         if "AccessToken" in result:
-            credentials = client.auth.credentials.get_credentials()
-            server = credentials["Servers"][0]
-            if force_unique:
-                server["uuid"] = server["Id"]
-            else:
-                server["uuid"] = str(uuid.uuid4())
-            server["username"] = username
-            if force_unique and server["Id"] in self.clients:
-                return True
-            self.connect_client(server)
-            self.credentials.append(server)
-            self.save_credentials()
-            return True
+            return self._finalize_login(client, username, force_unique)
         return False
+
+    @staticmethod
+    def _qc_request(client, path, method="get", json_body=None):
+        """Issue a Quick Connect request reusing the client's device headers.
+
+        The connection manager's API/session carry the X-Emby-Authorization
+        device identity that the server ties the Quick Connect request to, so
+        we go through it rather than building a bare request.
+        """
+        api = client.auth.API
+        headers = api.get_default_headers()
+        data = None
+        if json_body is not None:
+            headers["Content-type"] = "application/json"
+            data = json.dumps(json_body)
+        address = client.auth.credentials.get_credentials()["Servers"][0]["address"]
+        return api.send_request(
+            address,
+            path,
+            method=method,
+            headers=headers,
+            data=data,
+            timeout=(5, 30),
+            session=client.auth.session,
+        )
+
+    def quick_connect_initiate(self, server: str):
+        """Start a Quick Connect request against ``server``.
+
+        Returns ``(client, secret, code)``. The ``code`` must be shown to the
+        user to enter in their (already authenticated) Jellyfin session.
+        Raises QuickConnectError if the server is unreachable or has Quick
+        Connect disabled.
+        """
+        server = self._normalize_server(server)
+        client = self.client_factory()
+        client.auth.connect_to_address(server)
+        if not client.auth.credentials.get_credentials().get("Servers"):
+            raise QuickConnectError(_("Could not connect to the server."))
+
+        enabled = self._qc_request(client, "QuickConnect/Enabled")
+        if enabled.status_code != 200 or not enabled.json():
+            raise QuickConnectError(_("Quick Connect is not enabled on this server."))
+
+        initiate = self._qc_request(client, "QuickConnect/Initiate", method="post")
+        if initiate.status_code != 200:
+            raise QuickConnectError(_("Could not start Quick Connect."))
+
+        data = initiate.json()
+        return client, data["Secret"], data["Code"]
+
+    def quick_connect_wait(self, client, secret: str, should_cancel=None):
+        """Poll until the Quick Connect request is authorized, then log in.
+
+        Returns True on success, False on timeout/cancellation/failure.
+        ``should_cancel`` is an optional callable polled between attempts.
+        """
+        deadline = time.time() + QUICK_CONNECT_TIMEOUT_SECS
+        authorized = False
+        while time.time() < deadline:
+            if should_cancel is not None and should_cancel():
+                return False
+            state = self._qc_request(
+                client, "QuickConnect/Connect?secret=" + quote(secret)
+            )
+            if state.status_code == 200 and state.json().get("Authenticated"):
+                authorized = True
+                break
+            time.sleep(QUICK_CONNECT_POLL_SECS)
+
+        if not authorized:
+            log.warning("Quick Connect timed out waiting for authorization.")
+            return False
+
+        auth = self._qc_request(
+            client,
+            "Users/AuthenticateWithQuickConnect",
+            method="post",
+            json_body={"Secret": secret},
+        )
+        if auth.status_code != 200:
+            log.warning(
+                "Quick Connect authentication failed with status %s.",
+                auth.status_code,
+            )
+            return False
+        result = auth.json()
+        if "AccessToken" not in result:
+            return False
+
+        self._store_quick_connect_credentials(client, result)
+        return self._finalize_login(client, result["User"]["Name"])
+
+    @staticmethod
+    def _store_quick_connect_credentials(client, data):
+        """Replicate ConnectionManager.login's credential bookkeeping.
+
+        The apiclient has no Quick Connect support, so after we obtain an
+        AuthenticationResult ourselves we have to record the token where the
+        rest of the client expects it before reusing the normal login tail.
+        """
+        cm = client.auth
+        credentials = cm.credentials.get_credentials()
+        cm.config.data["auth.user_id"] = data["User"]["Id"]
+        cm.config.data["auth.token"] = data["AccessToken"]
+
+        for server in credentials["Servers"]:
+            if server["Id"] == data["ServerId"]:
+                found_server = server
+                break
+        else:
+            raise QuickConnectError(_("Quick Connect returned an unknown server."))
+
+        found_server["DateLastAccessed"] = datetime.now().strftime(
+            "%Y-%m-%dT%H:%M:%SZ"
+        )
+        found_server["UserId"] = data["User"]["Id"]
+        found_server["AccessToken"] = data["AccessToken"]
+
+        cm.credentials.add_update_server(credentials["Servers"], found_server)
+        cm.credentials.add_update_user(
+            found_server, {"Id": data["User"]["Id"], "IsSignedInOffline": True}
+        )
+        cm.credentials.set_credentials(credentials)
+
+    def login_with_quick_connect(self, server: str, code_callback=None, should_cancel=None):
+        """High-level Quick Connect login.
+
+        Initiates the request, hands the user-facing code to ``code_callback``,
+        then blocks polling until authorized. Raises QuickConnectError on setup
+        failure; returns True/False from the wait phase.
+        """
+        client, secret, code = self.quick_connect_initiate(server)
+        if code_callback is not None:
+            code_callback(code)
+        return self.quick_connect_wait(client, secret, should_cancel=should_cancel)
 
     def validate_client(self, client: "JellyfinClient", dry_run=False):
         # Use the apiclient's lower-level _http to bound retries and timeout

--- a/jellyfin_mpv_shim/clients.py
+++ b/jellyfin_mpv_shim/clients.py
@@ -14,9 +14,6 @@ import logging
 import re
 import threading
 
-from datetime import datetime
-from urllib.parse import quote
-
 import socket
 import ipaddress
 from urllib.parse import urlparse
@@ -407,31 +404,6 @@ class ClientManager(object):
             return self._finalize_login(client, username, force_unique)
         return False
 
-    @staticmethod
-    def _qc_request(client, path, method="get", json_body=None):
-        """Issue a Quick Connect request reusing the client's device headers.
-
-        The connection manager's API/session carry the X-Emby-Authorization
-        device identity that the server ties the Quick Connect request to, so
-        we go through it rather than building a bare request.
-        """
-        api = client.auth.API
-        headers = api.get_default_headers()
-        data = None
-        if json_body is not None:
-            headers["Content-type"] = "application/json"
-            data = json.dumps(json_body)
-        address = client.auth.credentials.get_credentials()["Servers"][0]["address"]
-        return api.send_request(
-            address,
-            path,
-            method=method,
-            headers=headers,
-            data=data,
-            timeout=(5, 30),
-            session=client.auth.session,
-        )
-
     def quick_connect_initiate(self, server: str):
         """Start a Quick Connect request against ``server``.
 
@@ -443,18 +415,19 @@ class ClientManager(object):
         server = self._normalize_server(server)
         client = self.client_factory()
         client.auth.connect_to_address(server)
-        if not client.auth.credentials.get_credentials().get("Servers"):
+        servers = client.auth.credentials.get_credentials().get("Servers")
+        if not servers:
             raise QuickConnectError(_("Could not connect to the server."))
+        address = servers[0]["address"]
+        session = client.auth.session
 
-        enabled = self._qc_request(client, "QuickConnect/Enabled")
-        if enabled.status_code != 200 or not enabled.json():
+        if not client.auth.API.quick_connect_enabled(address, session):
             raise QuickConnectError(_("Quick Connect is not enabled on this server."))
 
-        initiate = self._qc_request(client, "QuickConnect/Initiate", method="post")
-        if initiate.status_code != 200:
+        data = client.auth.API.quick_connect_initiate(address, session)
+        if not data:
             raise QuickConnectError(_("Could not start Quick Connect."))
 
-        data = initiate.json()
         return client, data["Secret"], data["Code"]
 
     def quick_connect_wait(self, client, secret: str, should_cancel=None):
@@ -463,15 +436,16 @@ class ClientManager(object):
         Returns True on success, False on timeout/cancellation/failure.
         ``should_cancel`` is an optional callable polled between attempts.
         """
+        address = client.auth.credentials.get_credentials()["Servers"][0]["address"]
+        session = client.auth.session
+
         deadline = time.time() + QUICK_CONNECT_TIMEOUT_SECS
         authorized = False
         while time.time() < deadline:
             if should_cancel is not None and should_cancel():
                 return False
-            state = self._qc_request(
-                client, "QuickConnect/Connect?secret=" + quote(secret)
-            )
-            if state.status_code == 200 and state.json().get("Authenticated"):
+            state = client.auth.API.quick_connect_state(address, secret, session)
+            if state.get("Authenticated"):
                 authorized = True
                 break
             time.sleep(QUICK_CONNECT_POLL_SECS)
@@ -480,56 +454,12 @@ class ClientManager(object):
             log.warning("Quick Connect timed out waiting for authorization.")
             return False
 
-        auth = self._qc_request(
-            client,
-            "Users/AuthenticateWithQuickConnect",
-            method="post",
-            json_body={"Secret": secret},
-        )
-        if auth.status_code != 200:
-            log.warning(
-                "Quick Connect authentication failed with status %s.",
-                auth.status_code,
-            )
-            return False
-        result = auth.json()
+        result = client.auth.login_with_quick_connect(address, secret)
         if "AccessToken" not in result:
+            log.warning("Quick Connect authentication failed.")
             return False
 
-        self._store_quick_connect_credentials(client, result)
         return self._finalize_login(client, result["User"]["Name"])
-
-    @staticmethod
-    def _store_quick_connect_credentials(client, data):
-        """Replicate ConnectionManager.login's credential bookkeeping.
-
-        The apiclient has no Quick Connect support, so after we obtain an
-        AuthenticationResult ourselves we have to record the token where the
-        rest of the client expects it before reusing the normal login tail.
-        """
-        cm = client.auth
-        credentials = cm.credentials.get_credentials()
-        cm.config.data["auth.user_id"] = data["User"]["Id"]
-        cm.config.data["auth.token"] = data["AccessToken"]
-
-        for server in credentials["Servers"]:
-            if server["Id"] == data["ServerId"]:
-                found_server = server
-                break
-        else:
-            raise QuickConnectError(_("Quick Connect returned an unknown server."))
-
-        found_server["DateLastAccessed"] = datetime.now().strftime(
-            "%Y-%m-%dT%H:%M:%SZ"
-        )
-        found_server["UserId"] = data["User"]["Id"]
-        found_server["AccessToken"] = data["AccessToken"]
-
-        cm.credentials.add_update_server(credentials["Servers"], found_server)
-        cm.credentials.add_update_user(
-            found_server, {"Id": data["User"]["Id"], "IsSignedInOffline": True}
-        )
-        cm.credentials.set_credentials(credentials)
 
     def login_with_quick_connect(self, server: str, code_callback=None, should_cancel=None):
         """High-level Quick Connect login.

--- a/jellyfin_mpv_shim/gui_mgr.py
+++ b/jellyfin_mpv_shim/gui_mgr.py
@@ -9,7 +9,7 @@ import queue
 
 from .constants import USER_APP_NAME, APP_NAME
 from .conffile import confdir
-from .clients import clientManager
+from .clients import clientManager, QuickConnectError
 from .utils import get_resource
 from .log_utils import CustomFormatter, root_logger
 from .i18n import _
@@ -203,6 +203,21 @@ class PreferencesWindow(threading.Thread):
                 except Exception:
                     log.error("Error while adding server.", exc_info=True)
                     self.handle("error")
+            elif action == "quick_connect":
+                try:
+                    is_logged_in = clientManager.login_with_quick_connect(
+                        param,
+                        code_callback=lambda code: self.handle("qc_code", code),
+                    )
+                    if is_logged_in:
+                        self.handle("upd", clientManager.credentials)
+                    else:
+                        self.handle("error")
+                except QuickConnectError as e:
+                    self.handle("qc_error", str(e))
+                except Exception:
+                    log.error("Error during Quick Connect.", exc_info=True)
+                    self.handle("error")
             elif action == "remove":
                 clientManager.remove_client(param)
                 self.handle("upd", clientManager.credentials)
@@ -239,6 +254,8 @@ class PreferencesWindowProcess(Process):
         self.password = None
         self.add_button = None
         self.remove_button = None
+        self.quick_connect_button = None
+        self.qc_status = None
         Process.__init__(self)
 
     def update(self):
@@ -247,16 +264,28 @@ class PreferencesWindowProcess(Process):
                 action, param = self.queue.get_nowait()
                 if action == "upd":
                     self.update_servers(param)
-                    self.add_button.config(state=self.tk.NORMAL)
-                    self.remove_button.config(state=self.tk.NORMAL)
+                    self.qc_status.set("")
+                    self._enable_buttons()
                 elif action == "error":
+                    self.qc_status.set("")
                     self.messagebox.showerror(
                         _("Add Server"),
                         _(
                             "Could not add server.\nPlease check your connection information."
                         ),
                     )
-                    self.add_button.config(state=self.tk.NORMAL)
+                    self._enable_buttons()
+                elif action == "qc_code":
+                    self.qc_status.set(
+                        _(
+                            "Quick Connect code: {code}\n"
+                            "Enter it in Jellyfin under your user menu -> Quick Connect."
+                        ).format(code=param)
+                    )
+                elif action == "qc_error":
+                    self.qc_status.set("")
+                    self.messagebox.showerror(_("Quick Connect"), param)
+                    self._enable_buttons()
                 elif action == "die":
                     self.root.destroy()
                     self.root.quit()
@@ -264,6 +293,11 @@ class PreferencesWindowProcess(Process):
         except queue.Empty:
             pass
         self.root.after(100, self.update)
+
+    def _enable_buttons(self):
+        self.add_button.config(state=self.tk.NORMAL)
+        self.remove_button.config(state=self.tk.NORMAL)
+        self.quick_connect_button.config(state=self.tk.NORMAL)
 
     def update_servers(self, server_list):
         self.servers = server_list
@@ -330,6 +364,10 @@ class PreferencesWindowProcess(Process):
         password_box = ttk.Entry(c, textvariable=self.password, show="*")
         password_box.grid(column=2, row=2)
 
+        self.qc_status = tk.StringVar()
+        qc_status_label = ttk.Label(c, textvariable=self.qc_status, wraplength=240)
+        qc_status_label.grid(column=1, row=5, columnspan=2, sticky=tk.W)
+
         def add_server():
             self.add_button.config(state=tk.DISABLED)
             self.r_queue.put(
@@ -338,6 +376,18 @@ class PreferencesWindowProcess(Process):
                     (self.servername.get(), self.username.get(), self.password.get()),
                 )
             )
+
+        def quick_connect():
+            server = self.servername.get()
+            if not server:
+                self.messagebox.showerror(
+                    _("Quick Connect"), _("Please enter a server URL first.")
+                )
+                return
+            self.add_button.config(state=tk.DISABLED)
+            self.quick_connect_button.config(state=tk.DISABLED)
+            self.qc_status.set(_("Starting Quick Connect..."))
+            self.r_queue.put(("quick_connect", server))
 
         def remove_server():
             self.remove_button.config(state=tk.DISABLED)
@@ -348,6 +398,10 @@ class PreferencesWindowProcess(Process):
 
         self.add_button = ttk.Button(c, text=_("Add Server"), command=add_server)
         self.add_button.grid(column=2, row=3, pady=5, sticky=tk.E)
+        self.quick_connect_button = ttk.Button(
+            c, text=_("Quick Connect"), command=quick_connect
+        )
+        self.quick_connect_button.grid(column=1, row=3, pady=5, sticky=tk.W)
         self.remove_button = ttk.Button(
             c, text=_("Remove Server"), command=remove_server
         )

--- a/jellyfin_mpv_shim/messages/base.pot
+++ b/jellyfin_mpv_shim/messages/base.pot
@@ -5,7 +5,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2024-06-05 13:54-0400\n"
+"POT-Creation-Date: 2026-06-27 23:34+0200\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -43,105 +43,166 @@ msgstr ""
 msgid "Setting Current..."
 msgstr ""
 
-#: jellyfin_mpv_shim/clients.py:75
-msgid "Server URL: "
+#: jellyfin_mpv_shim/clients.py:181
+msgid "Open Jellyfin, go to your user menu -> Quick Connect, and enter this code:"
 msgstr ""
 
-#: jellyfin_mpv_shim/clients.py:76
-msgid "Username: "
+#: jellyfin_mpv_shim/clients.py:187
+msgid "Waiting for authorization..."
 msgstr ""
 
-#: jellyfin_mpv_shim/clients.py:77
-msgid "Password: "
+#: jellyfin_mpv_shim/clients.py:208
+msgid "Clearing all existing accounts."
 msgstr ""
 
-#: jellyfin_mpv_shim/clients.py:82
+#: jellyfin_mpv_shim/clients.py:217 jellyfin_mpv_shim/clients.py:238
+#: jellyfin_mpv_shim/clients.py:256
 msgid "Successfully added server."
 msgstr ""
 
-#: jellyfin_mpv_shim/clients.py:83
-msgid "Add another server?"
-msgstr ""
-
-#: jellyfin_mpv_shim/clients.py:86
+#: jellyfin_mpv_shim/clients.py:220 jellyfin_mpv_shim/clients.py:240
+#: jellyfin_mpv_shim/clients.py:260
 msgid "Adding server failed."
 msgstr ""
 
-#: jellyfin_mpv_shim/display_mirror/__init__.py:116
+#: jellyfin_mpv_shim/clients.py:227
+msgid "Account already exists. Updating credentials."
+msgstr ""
+
+#: jellyfin_mpv_shim/clients.py:229
+msgid "Successfully updated server credentials."
+msgstr ""
+
+#: jellyfin_mpv_shim/clients.py:232
+msgid "Updating server credentials failed."
+msgstr ""
+
+#: jellyfin_mpv_shim/clients.py:243
+msgid "Server URL: "
+msgstr ""
+
+#: jellyfin_mpv_shim/clients.py:247
+msgid "Username: "
+msgstr ""
+
+#: jellyfin_mpv_shim/clients.py:249
+msgid "Password: "
+msgstr ""
+
+#: jellyfin_mpv_shim/clients.py:257
+msgid "Add another server?"
+msgstr ""
+
+#: jellyfin_mpv_shim/clients.py:447
+msgid "Could not connect to the server."
+msgstr ""
+
+#: jellyfin_mpv_shim/clients.py:451
+msgid "Quick Connect is not enabled on this server."
+msgstr ""
+
+#: jellyfin_mpv_shim/clients.py:455
+msgid "Could not start Quick Connect."
+msgstr ""
+
+#: jellyfin_mpv_shim/clients.py:520
+msgid "Quick Connect returned an unknown server."
+msgstr ""
+
+#: jellyfin_mpv_shim/display_mirror.py:305
 msgid "Ready to cast"
 msgstr ""
 
-#: jellyfin_mpv_shim/display_mirror/__init__.py:118
-msgid "Select your media in Jellyfin and play it here"
+#: jellyfin_mpv_shim/display_mirror.py:306
+msgid "Select your media in Jellyfin and play it here."
 msgstr ""
 
-#: jellyfin_mpv_shim/gui_mgr.py:153
+#: jellyfin_mpv_shim/gui_mgr.py:157
 msgid "Application Log"
 msgstr ""
 
-#: jellyfin_mpv_shim/gui_mgr.py:245 jellyfin_mpv_shim/gui_mgr.py:335
+#: jellyfin_mpv_shim/gui_mgr.py:272 jellyfin_mpv_shim/gui_mgr.py:399
 msgid "Add Server"
 msgstr ""
 
-#: jellyfin_mpv_shim/gui_mgr.py:246
+#: jellyfin_mpv_shim/gui_mgr.py:273
 msgid ""
 "Could not add server.\n"
 "Please check your connection information."
 msgstr ""
 
-#: jellyfin_mpv_shim/gui_mgr.py:267
-msgid "Fail"
+#: jellyfin_mpv_shim/gui_mgr.py:280
+msgid ""
+"Quick Connect code: {code}\n"
+"Enter it in Jellyfin under your user menu -> Quick Connect."
 msgstr ""
 
-#: jellyfin_mpv_shim/gui_mgr.py:267
+#: jellyfin_mpv_shim/gui_mgr.py:287 jellyfin_mpv_shim/gui_mgr.py:384
+#: jellyfin_mpv_shim/gui_mgr.py:402
+msgid "Quick Connect"
+msgstr ""
+
+#: jellyfin_mpv_shim/gui_mgr.py:310
 msgid "Ok"
 msgstr ""
 
-#: jellyfin_mpv_shim/gui_mgr.py:280
+#: jellyfin_mpv_shim/gui_mgr.py:310
+msgid "Fail"
+msgstr ""
+
+#: jellyfin_mpv_shim/gui_mgr.py:323
 msgid "Server Configuration"
 msgstr ""
 
-#: jellyfin_mpv_shim/gui_mgr.py:303
+#: jellyfin_mpv_shim/gui_mgr.py:351
 msgid "Server:"
 msgstr ""
 
-#: jellyfin_mpv_shim/gui_mgr.py:308
+#: jellyfin_mpv_shim/gui_mgr.py:356
 msgid "Username:"
 msgstr ""
 
-#: jellyfin_mpv_shim/gui_mgr.py:313
+#: jellyfin_mpv_shim/gui_mgr.py:361
 msgid "Password:"
 msgstr ""
 
-#: jellyfin_mpv_shim/gui_mgr.py:338
+#: jellyfin_mpv_shim/gui_mgr.py:384
+msgid "Please enter a server URL first."
+msgstr ""
+
+#: jellyfin_mpv_shim/gui_mgr.py:389
+msgid "Starting Quick Connect..."
+msgstr ""
+
+#: jellyfin_mpv_shim/gui_mgr.py:406
 msgid "Remove Server"
 msgstr ""
 
-#: jellyfin_mpv_shim/gui_mgr.py:341
+#: jellyfin_mpv_shim/gui_mgr.py:409
 msgid "Close"
 msgstr ""
 
-#: jellyfin_mpv_shim/gui_mgr.py:454
+#: jellyfin_mpv_shim/gui_mgr.py:540
 msgid "Configure Servers"
 msgstr ""
 
-#: jellyfin_mpv_shim/gui_mgr.py:455
+#: jellyfin_mpv_shim/gui_mgr.py:541
 msgid "Show Console"
 msgstr ""
 
-#: jellyfin_mpv_shim/gui_mgr.py:456
+#: jellyfin_mpv_shim/gui_mgr.py:542
 msgid "Application Menu"
 msgstr ""
 
-#: jellyfin_mpv_shim/gui_mgr.py:457
+#: jellyfin_mpv_shim/gui_mgr.py:543
 msgid "Open Config Folder"
 msgstr ""
 
-#: jellyfin_mpv_shim/gui_mgr.py:458
+#: jellyfin_mpv_shim/gui_mgr.py:544
 msgid "Quit"
 msgstr ""
 
-#: jellyfin_mpv_shim/media.py:139
+#: jellyfin_mpv_shim/media.py:148
 msgid " (Transcode)"
 msgstr ""
 
@@ -201,249 +262,253 @@ msgstr ""
 msgid "Huge"
 msgstr ""
 
-#: jellyfin_mpv_shim/menu.py:130
+#: jellyfin_mpv_shim/menu.py:127
 msgid "Main Menu"
 msgstr ""
 
-#: jellyfin_mpv_shim/menu.py:136
+#: jellyfin_mpv_shim/menu.py:133
 msgid "Change Audio"
 msgstr ""
 
-#: jellyfin_mpv_shim/menu.py:137
+#: jellyfin_mpv_shim/menu.py:134
 msgid "Change Subtitles"
 msgstr ""
 
-#: jellyfin_mpv_shim/menu.py:138
+#: jellyfin_mpv_shim/menu.py:135
 msgid "Change Video Quality"
 msgstr ""
 
-#: jellyfin_mpv_shim/menu.py:139 jellyfin_mpv_shim/syncplay.py:634
+#: jellyfin_mpv_shim/menu.py:136 jellyfin_mpv_shim/syncplay.py:634
 msgid "SyncPlay"
 msgstr ""
 
-#: jellyfin_mpv_shim/menu.py:145
+#: jellyfin_mpv_shim/menu.py:142
 msgid "MPV Shim v{0} Release Info/Download"
 msgstr ""
 
-#: jellyfin_mpv_shim/menu.py:153
+#: jellyfin_mpv_shim/menu.py:150
 msgid "Change Video Playback Profile"
 msgstr ""
 
-#: jellyfin_mpv_shim/menu.py:158
+#: jellyfin_mpv_shim/menu.py:155
 msgid "Auto Set Audio/Subtitles (Entire Series)"
 msgstr ""
 
-#: jellyfin_mpv_shim/menu.py:163
+#: jellyfin_mpv_shim/menu.py:160
 msgid "Quit and Mark Unwatched"
 msgstr ""
 
-#: jellyfin_mpv_shim/menu.py:166
+#: jellyfin_mpv_shim/menu.py:163
 msgid "Screenshot"
 msgstr ""
 
-#: jellyfin_mpv_shim/menu.py:170
+#: jellyfin_mpv_shim/menu.py:167
 msgid "Video Playback Profiles"
 msgstr ""
 
-#: jellyfin_mpv_shim/menu.py:173
+#: jellyfin_mpv_shim/menu.py:170
 msgid "SVP Settings"
 msgstr ""
 
-#: jellyfin_mpv_shim/menu.py:177 jellyfin_mpv_shim/menu.py:521
+#: jellyfin_mpv_shim/menu.py:174 jellyfin_mpv_shim/menu.py:526
 msgid "Video Preferences"
 msgstr ""
 
-#: jellyfin_mpv_shim/menu.py:178 jellyfin_mpv_shim/menu.py:544
+#: jellyfin_mpv_shim/menu.py:175 jellyfin_mpv_shim/menu.py:549
 msgid "Player Preferences"
 msgstr ""
 
-#: jellyfin_mpv_shim/menu.py:179
+#: jellyfin_mpv_shim/menu.py:176
 msgid "Close Menu"
 msgstr ""
 
-#: jellyfin_mpv_shim/menu.py:261
+#: jellyfin_mpv_shim/menu.py:266
 msgid "Select Audio Track"
 msgstr ""
 
-#: jellyfin_mpv_shim/menu.py:298
+#: jellyfin_mpv_shim/menu.py:303
 msgid "Select Subtitle Track"
 msgstr ""
 
-#: jellyfin_mpv_shim/menu.py:306
+#: jellyfin_mpv_shim/menu.py:311
 msgid "None"
 msgstr ""
 
-#: jellyfin_mpv_shim/menu.py:345
+#: jellyfin_mpv_shim/menu.py:350
 msgid "Select Transcode Quality"
 msgstr ""
 
-#: jellyfin_mpv_shim/menu.py:346
+#: jellyfin_mpv_shim/menu.py:351
 msgid "Maximum"
 msgstr ""
 
-#: jellyfin_mpv_shim/menu.py:346 jellyfin_mpv_shim/menu.py:423
+#: jellyfin_mpv_shim/menu.py:351 jellyfin_mpv_shim/menu.py:428
 msgid "No Transcode"
 msgstr ""
 
-#: jellyfin_mpv_shim/menu.py:382
+#: jellyfin_mpv_shim/menu.py:387
 msgid "Select Audio/Subtitle for Series"
 msgstr ""
 
-#: jellyfin_mpv_shim/menu.py:384
+#: jellyfin_mpv_shim/menu.py:389
 msgid "English Audio"
 msgstr ""
 
-#: jellyfin_mpv_shim/menu.py:386
+#: jellyfin_mpv_shim/menu.py:391
 msgid "Japanese Audio w/ English Subtitles"
 msgstr ""
 
-#: jellyfin_mpv_shim/menu.py:391
+#: jellyfin_mpv_shim/menu.py:396
 msgid "Manual by Track Index (Less Reliable)"
 msgstr ""
 
-#: jellyfin_mpv_shim/menu.py:421
+#: jellyfin_mpv_shim/menu.py:426
 msgid "Select Default Transcode Profile"
 msgstr ""
 
-#: jellyfin_mpv_shim/menu.py:456
+#: jellyfin_mpv_shim/menu.py:461
 msgid "Select Subtitle Color"
 msgstr ""
 
-#: jellyfin_mpv_shim/menu.py:465
+#: jellyfin_mpv_shim/menu.py:470
 msgid "Select Subtitle Size"
 msgstr ""
 
-#: jellyfin_mpv_shim/menu.py:475
+#: jellyfin_mpv_shim/menu.py:480
 msgid "Select Subtitle Position"
 msgstr ""
 
-#: jellyfin_mpv_shim/menu.py:477
+#: jellyfin_mpv_shim/menu.py:482
 msgid "Bottom"
 msgstr ""
 
-#: jellyfin_mpv_shim/menu.py:478
+#: jellyfin_mpv_shim/menu.py:483
 msgid "Top"
 msgstr ""
 
-#: jellyfin_mpv_shim/menu.py:479
+#: jellyfin_mpv_shim/menu.py:484
 msgid "Middle"
 msgstr ""
 
-#: jellyfin_mpv_shim/menu.py:486
+#: jellyfin_mpv_shim/menu.py:491
 msgid "Remote Transcode Quality: {0:0.1f} Mbps"
 msgstr ""
 
-#: jellyfin_mpv_shim/menu.py:492
+#: jellyfin_mpv_shim/menu.py:497
 msgid "Subtitle Size: {0}"
 msgstr ""
 
-#: jellyfin_mpv_shim/menu.py:496
+#: jellyfin_mpv_shim/menu.py:501
 msgid "Subtitle Position: {0}"
 msgstr ""
 
-#: jellyfin_mpv_shim/menu.py:500
+#: jellyfin_mpv_shim/menu.py:505
 msgid "Subtitle Color: {0}"
 msgstr ""
 
-#: jellyfin_mpv_shim/menu.py:505
+#: jellyfin_mpv_shim/menu.py:510
 msgid "Transcode Hi10p to 8bit"
 msgstr ""
 
-#: jellyfin_mpv_shim/menu.py:506
+#: jellyfin_mpv_shim/menu.py:511
 msgid "Transcode HDR"
 msgstr ""
 
-#: jellyfin_mpv_shim/menu.py:507
+#: jellyfin_mpv_shim/menu.py:512
 msgid "Direct Paths"
 msgstr ""
 
-#: jellyfin_mpv_shim/menu.py:508
+#: jellyfin_mpv_shim/menu.py:513
 msgid "Disable Direct Play"
 msgstr ""
 
-#: jellyfin_mpv_shim/menu.py:514
+#: jellyfin_mpv_shim/menu.py:519
 msgid "Video Profile Subtype: {0}"
 msgstr ""
 
-#: jellyfin_mpv_shim/menu.py:525
+#: jellyfin_mpv_shim/menu.py:530
 msgid "Video Profile Subtype"
 msgstr ""
 
-#: jellyfin_mpv_shim/menu.py:546
+#: jellyfin_mpv_shim/menu.py:551
 msgid "Auto Play"
 msgstr ""
 
-#: jellyfin_mpv_shim/menu.py:547
+#: jellyfin_mpv_shim/menu.py:552
 msgid "Auto Fullscreen"
 msgstr ""
 
-#: jellyfin_mpv_shim/menu.py:548
+#: jellyfin_mpv_shim/menu.py:553
 msgid "Media Key Seek"
 msgstr ""
 
-#: jellyfin_mpv_shim/menu.py:549
+#: jellyfin_mpv_shim/menu.py:554
 msgid "Use Web Seek Pref"
 msgstr ""
 
-#: jellyfin_mpv_shim/menu.py:550
+#: jellyfin_mpv_shim/menu.py:555
 msgid "Display Mirroring"
 msgstr ""
 
-#: jellyfin_mpv_shim/menu.py:551
+#: jellyfin_mpv_shim/menu.py:556
 msgid "Write Logs to File"
 msgstr ""
 
-#: jellyfin_mpv_shim/menu.py:552
+#: jellyfin_mpv_shim/menu.py:557
 msgid "Check for Updates"
 msgstr ""
 
-#: jellyfin_mpv_shim/menu.py:554
+#: jellyfin_mpv_shim/menu.py:559
 msgid "Discord Rich Presence"
 msgstr ""
 
-#: jellyfin_mpv_shim/menu.py:556
+#: jellyfin_mpv_shim/menu.py:561
 msgid "Always Skip Intros"
 msgstr ""
 
-#: jellyfin_mpv_shim/menu.py:557
+#: jellyfin_mpv_shim/menu.py:562
 msgid "Ask to Skip Intros"
 msgstr ""
 
-#: jellyfin_mpv_shim/menu.py:558
+#: jellyfin_mpv_shim/menu.py:564
 msgid "Always Skip Credits"
 msgstr ""
 
-#: jellyfin_mpv_shim/menu.py:559
+#: jellyfin_mpv_shim/menu.py:567
 msgid "Ask to Skip Credits"
 msgstr ""
 
-#: jellyfin_mpv_shim/menu.py:561
+#: jellyfin_mpv_shim/menu.py:570
 msgid "Enable thumbnail previews"
 msgstr ""
 
-#: jellyfin_mpv_shim/player.py:487
+#: jellyfin_mpv_shim/player.py:329
+msgid "Please wait, loading..."
+msgstr ""
+
+#: jellyfin_mpv_shim/player.py:601
 msgid "Skipped Credits"
 msgstr ""
 
-#: jellyfin_mpv_shim/player.py:487
+#: jellyfin_mpv_shim/player.py:603
 msgid "Skipped Intro"
 msgstr ""
 
-#: jellyfin_mpv_shim/player.py:490
+#: jellyfin_mpv_shim/player.py:617
 msgid "Seek to Skip Credits"
 msgstr ""
 
-#: jellyfin_mpv_shim/player.py:490
+#: jellyfin_mpv_shim/player.py:619
 msgid "Seek to Skip Intro"
 msgstr ""
 
-#: jellyfin_mpv_shim/player.py:598
+#: jellyfin_mpv_shim/player.py:742
 msgid ""
 "Your remote video is transcoding!\n"
 "Press c to adjust bandwidth settings if this is not needed."
 msgstr ""
 
-#: jellyfin_mpv_shim/player.py:965
+#: jellyfin_mpv_shim/player.py:1153
 msgid "Season {0} - Episode {1}"
 msgstr ""
 
@@ -473,11 +538,11 @@ msgid "Retry"
 msgstr ""
 
 #: jellyfin_mpv_shim/svp_integration.py:180
-msgid "Enable SVP"
+msgid "SVP is Disabled"
 msgstr ""
 
 #: jellyfin_mpv_shim/svp_integration.py:180
-msgid "SVP is Disabled"
+msgid "Enable SVP"
 msgstr ""
 
 #: jellyfin_mpv_shim/syncplay.py:21
@@ -546,11 +611,11 @@ msgid ""
 "Open menu (press c) for details."
 msgstr ""
 
-#: jellyfin_mpv_shim/utils.py:307
+#: jellyfin_mpv_shim/utils.py:331
 msgid "Unkn"
 msgstr ""
 
-#: jellyfin_mpv_shim/utils.py:308
+#: jellyfin_mpv_shim/utils.py:332
 msgid " Forced"
 msgstr ""
 

--- a/jellyfin_mpv_shim/messages/base.pot
+++ b/jellyfin_mpv_shim/messages/base.pot
@@ -5,7 +5,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2026-06-27 23:34+0200\n"
+"POT-Creation-Date: 2026-06-28 21:15+0200\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -43,70 +43,66 @@ msgstr ""
 msgid "Setting Current..."
 msgstr ""
 
-#: jellyfin_mpv_shim/clients.py:181
+#: jellyfin_mpv_shim/clients.py:178
 msgid "Open Jellyfin, go to your user menu -> Quick Connect, and enter this code:"
 msgstr ""
 
-#: jellyfin_mpv_shim/clients.py:187
+#: jellyfin_mpv_shim/clients.py:184
 msgid "Waiting for authorization..."
 msgstr ""
 
-#: jellyfin_mpv_shim/clients.py:208
+#: jellyfin_mpv_shim/clients.py:205
 msgid "Clearing all existing accounts."
 msgstr ""
 
-#: jellyfin_mpv_shim/clients.py:217 jellyfin_mpv_shim/clients.py:238
-#: jellyfin_mpv_shim/clients.py:256
+#: jellyfin_mpv_shim/clients.py:214 jellyfin_mpv_shim/clients.py:235
+#: jellyfin_mpv_shim/clients.py:253
 msgid "Successfully added server."
 msgstr ""
 
-#: jellyfin_mpv_shim/clients.py:220 jellyfin_mpv_shim/clients.py:240
-#: jellyfin_mpv_shim/clients.py:260
+#: jellyfin_mpv_shim/clients.py:217 jellyfin_mpv_shim/clients.py:237
+#: jellyfin_mpv_shim/clients.py:257
 msgid "Adding server failed."
 msgstr ""
 
-#: jellyfin_mpv_shim/clients.py:227
+#: jellyfin_mpv_shim/clients.py:224
 msgid "Account already exists. Updating credentials."
 msgstr ""
 
-#: jellyfin_mpv_shim/clients.py:229
+#: jellyfin_mpv_shim/clients.py:226
 msgid "Successfully updated server credentials."
 msgstr ""
 
-#: jellyfin_mpv_shim/clients.py:232
+#: jellyfin_mpv_shim/clients.py:229
 msgid "Updating server credentials failed."
 msgstr ""
 
-#: jellyfin_mpv_shim/clients.py:243
+#: jellyfin_mpv_shim/clients.py:240
 msgid "Server URL: "
 msgstr ""
 
-#: jellyfin_mpv_shim/clients.py:247
+#: jellyfin_mpv_shim/clients.py:244
 msgid "Username: "
 msgstr ""
 
-#: jellyfin_mpv_shim/clients.py:249
+#: jellyfin_mpv_shim/clients.py:246
 msgid "Password: "
 msgstr ""
 
-#: jellyfin_mpv_shim/clients.py:257
+#: jellyfin_mpv_shim/clients.py:254
 msgid "Add another server?"
 msgstr ""
 
-#: jellyfin_mpv_shim/clients.py:447
+#: jellyfin_mpv_shim/clients.py:420
 msgid "Could not connect to the server."
 msgstr ""
 
-#: jellyfin_mpv_shim/clients.py:451
+#: jellyfin_mpv_shim/clients.py:425
 msgid "Quick Connect is not enabled on this server."
 msgstr ""
 
-#: jellyfin_mpv_shim/clients.py:455
+#: jellyfin_mpv_shim/clients.py:429
 msgid "Could not start Quick Connect."
-msgstr ""
-
-#: jellyfin_mpv_shim/clients.py:520
-msgid "Quick Connect returned an unknown server."
 msgstr ""
 
 #: jellyfin_mpv_shim/display_mirror.py:305

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,7 +17,7 @@ classifiers = [
 dynamic = ["version"]
 dependencies = [
     "python-mpv>=1.0.8",
-    "jellyfin-apiclient-python>=1.12.0",
+    "jellyfin-apiclient-python>=1.13.0",
     "python-mpv-jsonipc>=1.2.2",
     "requests",
 ]


### PR DESCRIPTION
## Summary

Adds support for logging in via Jellyfin's native **Quick Connect**, alongside the existing username/password flow.

Instead of typing a password, you enter the server URL, receive a short code, and approve it from any session that is already signed in to Jellyfin (web or mobile). This is more convenient for everyone — no entering passwords on a separate device — and it is also the only practical way in for accounts that have no local password (for example, users who sign in through an SSO/OpenID provider), who currently cannot use the shim at all.

Quick Connect must be enabled on the server (admin setting); the feature degrades gracefully when it is not.

## What's included

- **CLI:** a `--quick-connect` flag, both non-interactive (with `--server URL`) and in the interactive add flow. The code is printed and the client waits for authorization.
- **GUI:** a **Quick Connect** button in the server preferences window that shows the code and live status.
- **Core:** implements the flow directly (`QuickConnect/Enabled` → `Initiate` → poll `Connect` → `Users/AuthenticateWithQuickConnect`), since `jellyfin-apiclient-python` does not expose Quick Connect. It reuses the connection manager's existing session and credential bookkeeping, then the normal post-login path, so stored credentials are identical to a password login.
- **Docs/i18n:** README updated; `base.pot` regenerated with the new strings.

## Notes

- No new dependencies (uses `requests`, already required).
- Clear, translated error messages when Quick Connect is disabled or the server is unreachable.