### PR TITLE
feat: just set user-data/media-source/Path, for auto applying profile

### DIFF
--- a/jellyfin_mpv_shim/player.py
+++ b/jellyfin_mpv_shim/player.py
@@ -2,6 +2,7 @@ import logging
 import os
 import sys
 import time
+import json
 
 import platform
 
@@ -682,6 +683,7 @@ class PlayerManager(object):
             # noinspection PyUnresolvedReferences
             self.get_webview().hide()
 
+        self._player.command("set_property", "user-data/media-source/Path", video.media_source["Path"])
         self._player.play(self.url)
         if not wait_property(
             self._player, "duration", lambda x: x is not None, settings.playback_timeout


### PR DESCRIPTION
#### Summary

This PR injects the original file path of the `media_source` into mpv's `user-data` property (`user-data/media-source/Path`) upon file playback initialization.

#### Motivation

Currently, when playing streams via Jellyfin MPV Shim, mpv only receives the HTTP streaming URL (e.g., `http://.../Items/.../Download`). This makes it impossible for users to target specific media libraries (such as `Anime` or `Movies`) within their `mpv.conf` or `profiles.conf` using conditional profiles (`profile-cond`).

By exposing the original server-side file path to `user-data/media-source/Path`, users can now easily write conditional automation rules in their `profiles.conf` based on folder names or media types.