### PR TITLE
Fix: require Python 3.9 or newer

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,7 +9,7 @@ readme = "README.md"
 authors = [{ name = "Izzie Walton", email = "izzie@iwalton.com" }]
 license = "GPL-3.0-or-later"
 license-files = ["LICENSE.md"]
-requires-python = ">=3.7"
+requires-python = ">=3.9"
 classifiers = [
     "Programming Language :: Python :: 3",
     "Operating System :: OS Independent",


### PR DESCRIPTION
The dependency python-mpv v1.0.8 (`python-mpv>=1.0.8`) itself requires a minimum of Python 3.9. This PR bumps MPV shim's version to also require a minimum of Python 3.9. 

Before this PR, I was unable to `uv run jellyfin-mpv-shim` due to the dependency resolution failing.
```sh
$ uv run jellyfin-mpv-shim
  × No solution found when resolving dependencies for split (markers:
  │ python_full_version >= '3.7' and python_full_version < '3.9'):
  ╰─▶ Because the requested Python version (>=3.7) does not satisfy
      Python>=3.9 and python-mpv==1.0.8 depends on Python>=3.9, we can
      conclude that python-mpv==1.0.8 cannot be used.
      And because only python-mpv<=1.0.8 is available, we can conclude that
      python-mpv>=1.0.8 cannot be used.
      And because your project depends on python-mpv>=1.0.8 and your project
      requires jellyfin-mpv-shim[all], we can conclude that your project's
      requirements are unsatisfiable.

hint: While the active Python version is 3.14, the resolution failed for other Python versions supported by your project. Consider limiting your project's supported Python versions using `requires-python`.
hint: The `requires-python` value (>=3.7) includes Python versions that are not supported by your dependencies (e.g., python-mpv==1.0.8 only supports >=3.9). Consider using a more restrictive `requires-python` value (like >=3.9).  
``` 