### PR TITLE
Remove enable_gui footgun from main settings UI (#576)

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -180,6 +180,9 @@ You can use the config file to enable and disable features.
 - `fullscreen` - Fullscreen the player when starting playback. Default: `false`
   - The library browser and the player share one window, so playback no longer takes over the screen unless you ask it to.
 - `enable_gui` - Enable the system tray icon and GUI features. Default: `true`
+  - Turning this off puts the app in command-line mode: no window, no system tray and no settings screen, so on Windows the only way back is editing `conf.json` by hand. It is listed under "Advanced" in the settings form for that reason.
+  - It is *not* how you get MPV's own on-screen controls back — set `osc_style` to `mpv` (or `default`) and leave this on.
+  - For the classic "sit in the background and play what is cast to me" setup, enable `close_to_tray` (or `allow_background` where there is no tray), `start_minimized` and `fullscreen`; closing the video with `q` or the back button returns to waiting.
 - `browser_fullscreen` - Run the in-window library browser fullscreen. Default: `false`
   - Browsing is a desktop activity, so it opens windowed even when `fullscreen` is set. `fullscreen` still applies when playback starts.
   - Toggling fullscreen in the player (`f`, or the on-screen control) is remembered: it writes `browser_fullscreen` while browsing and `fullscreen` while something is playing.
@@ -243,6 +246,8 @@ You can use the config file to enable and disable features.
 - `use_web_seek` - Use the seek times set in Jellyfin web for arrow key seek. Default: `false`
 - `headless` - Cast-target mode: show the "Ready to cast" screen instead of the library, and make the library unreachable from this machine. Default: `false`
   - Not a security boundary — see [Cast-target mode](../README.md#cast-target-mode-headless).
+  - Settings goes with the library. With no system tray icon there is nothing left to turn it off from, so it is listed under "Advanced" in the settings form and the way back is editing `conf.json`.
+  - You don't need it for the ordinary "wait in the background until something casts to me" setup — that is `close_to_tray` (or `allow_background`), `start_minimized` and `fullscreen`.
   - (Replaces `display_mirroring`. Mirroring itself is now always on and needs no setting; a stale `display_mirroring` entry in your config is ignored.)
 - `screenshot_menu` - Allow taking screenshots from menu. Default: `true`
 - `check_updates` - Check for updates via GitHub. Default: `true`

--- a/jellyfin_mpv_shim/messages/af/LC_MESSAGES/base.po
+++ b/jellyfin_mpv_shim/messages/af/LC_MESSAGES/base.po
@@ -5,7 +5,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2026-07-25 17:21-0400\n"
+"POT-Creation-Date: 2026-07-26 12:03-0400\n"
 "PO-Revision-Date: 2026-03-04 23:20+0000\n"
 "Last-Translator: Eugene <eugclass@gmail.com>\n"
 "Language-Team: Afrikaans <https://translate.jellyfin.org/projects/jellyfin/"
@@ -252,7 +252,7 @@ msgid "Select Subtitle Track"
 msgstr "Kies sub titels"
 
 #: jellyfin_mpv_shim/menu.py:341
-#: jellyfin_mpv_shim/mpvtk_browser/home_sections.py:102
+#: jellyfin_mpv_shim/mpvtk_browser/home_sections.py:103
 #: jellyfin_mpv_shim/osc_bridge.py:81 jellyfin_mpv_shim/osc_bridge.py:82
 #: jellyfin_mpv_shim/osc_bridge.py:104 jellyfin_mpv_shim/osc_bridge.py:140
 msgid "None"
@@ -403,7 +403,7 @@ msgstr "Vra om Krediete te Oorslaan"
 msgid "Enable thumbnail previews"
 msgstr "Aktiveer duimnaalvoorskoue"
 
-#: jellyfin_mpv_shim/menu.py:609 jellyfin_mpv_shim/mpvtk_browser/config.py:186
+#: jellyfin_mpv_shim/menu.py:609 jellyfin_mpv_shim/mpvtk_browser/config.py:195
 #: jellyfin_mpv_shim/mpvtk_browser/hud.py:375
 msgid "Night Mode (Auto Volume Adj)"
 msgstr ""
@@ -702,310 +702,334 @@ msgstr ""
 msgid "Or switch to another user"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/cast.py:317
+#: jellyfin_mpv_shim/mpvtk_browser/cast.py:314
 msgid "Ready to cast"
 msgstr "Klaar om te gooi"
 
-#: jellyfin_mpv_shim/mpvtk_browser/cast.py:318
+#: jellyfin_mpv_shim/mpvtk_browser/cast.py:315
 #, fuzzy
 #| msgid "Select your media in Jellyfin and play it here"
 msgid "Select your media in Jellyfin and play it here."
 msgstr "Kies u media en speel dit hier"
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:74
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:83
 msgid "Interface"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:83
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:92
 msgid "Playback"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:88
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:97
 msgid "Audio"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:92
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:101
 msgid "Subtitles & Languages"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:97
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:106
 #, fuzzy
 #| msgid " (Transcode)"
 msgid "Transcoding"
 msgstr " (Transkodeer )"
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:102
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:111
 msgid "Video Enhancement"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:104
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:113
 #, fuzzy
 #| msgid "Seek to Skip Credits"
 msgid "Skip Intro / Credits"
 msgstr "Soek om Krediete te Oorslaan"
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:107
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:116
 msgid "Library Browser"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:109
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:118
 msgid "Downloads"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:128
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:137
 msgid "Jellyfin UI"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:129
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:138
 msgid "MPV UI with thumbnails"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:130
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:139
 msgid "MPV built-in default"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:133
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:142
 msgid "Follow display"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:134
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:143
 msgid "100% (no scaling)"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:135
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:144
 msgid "125%"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:136
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:145
 msgid "150%"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:137
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:146
 msgid "200%"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:140
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:149
 msgid "Automatic (recommended)"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:141
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:150
 msgid "Vulkan"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:142
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:151
 msgid "Direct3D 11 (Windows only)"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:143
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:152
 msgid "OpenGL (compatibility)"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:146
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:155
 msgid "Default (auto)"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:147
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:156
 msgid "Force Stereo"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:148
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:157
 msgid "Optical Surround"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:149
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:158
 msgid "HDMI Passthrough"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:152
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:161
 msgid "Unset"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:153
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:162
 msgid "Dubbed (shows only)"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:154
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:163
 msgid "Subbed (shows only)"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:155
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:164
 msgid "Dubbed (all)"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:156
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:165
 msgid "Subbed (all)"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:157
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:166
 msgid "Custom (set in config)"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:162
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:171
 msgid "Download Folder"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:163
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:172
 msgid "Prefer Downloaded Copy"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:164
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:173
 msgid "Automatically Download Upcoming Episodes"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:165
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:174
 msgid "Include Next Up"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:166
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:175
 msgid "Next Up Entries to Consider"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:167
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:176
 msgid "Episodes to Keep Ahead (0 = off)"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:168
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:177
 msgid "Storage Limit for Automatic Downloads (GB)"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:169
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:178
 #, fuzzy
 #| msgid "Remove Server"
 msgid "Delete Automatic Downloads Once Watched"
 msgstr "Verwyder Server"
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:170
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:179
 msgid "Delete Unwatched After (days, 0 = never)"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:171
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:180
 msgid "Check Every (minutes)"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:172
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:181
 msgid "Close to Tray (keep running)"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:173
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:182
 msgid "Keep Running in Background"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:174
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:183
 msgid "Remember Window Size"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:175
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:184
 msgid "Player Controls Style"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:176
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:185
 msgid "Show What You're Watching in Discord"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:177
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:186
 msgid "Interface Scale"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:178
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:187
 msgid "Cast-target mode (no library browsing)"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:179
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:188
 msgid "Casting Opens the Library Browser"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:180
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:189
 msgid "Fullscreen Library Browser"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:181
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:190
 msgid "Always Bind Arrow Keys to Player Controls"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:182
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:191
 msgid "Player Controls Activation Key"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:183
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:192
 msgid "Audio Output Mode"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:184
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:193
 msgid "Audio Output Device"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:185
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:194
 msgid "Take the Device Exclusively"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:187
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:196
 #, fuzzy
 #| msgid "Video Playback Profiles"
 msgid "Enable Video Playback Profiles"
 msgstr "Video Weergawe Profiele"
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:188
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:197
 #, fuzzy
 #| msgid "New Group"
 msgid "Profile Group"
 msgstr "Nuwe Groep"
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:189
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:198
 msgid "Remember Last Used Profile"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:190
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:199
 msgid "Graphics API for Shaders"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:191
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:200
 msgid "Pass Through AC3"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:192
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:201
 msgid "Pass Through DTS"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:193
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:202
 msgid "Pass Through E-AC3"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:194
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:203
 msgid "Pass Through DTS-HD"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:195
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:204
 msgid "Pass Through TrueHD"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:196
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:205
 msgid "Re-encode Others to AC3"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:202
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:213
 msgid ""
-"MPV keybinds are used by default. Press ENTER to drive the player controls "
-"by keyboard."
+"With \"Start Minimized\" and \"Fullscreen\" this is the classic cast-target "
+"setup: the app waits out of the way, plays fullscreen when something casts "
+"to it, and goes back to waiting when the video ends or you press Q."
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:204
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:227
+msgid ""
+"Off means command-line mode: no window, no system tray and no settings "
+"screen, so the only way back is editing conf.json by hand. It is not how you "
+"get MPV's own on-screen controls — \"Player Controls Style\" under Interface "
+"does that."
+msgstr ""
+
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:234
+msgid ""
+"Show only what is cast to this machine — the library, including this "
+"settings screen, can't be reached from here. Without a system tray icon the "
+"only way back is editing conf.json. For the classic cast-target setup you "
+"want the Interface settings instead; this is for a shared TV nobody should "
+"be able to browse from."
+msgstr ""
+
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:240
+msgid ""
+"Requires restart to change. MPV keybinds are used by default. Press ENTER to "
+"drive the player controls by keyboard."
+msgstr ""
+
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:242
 msgid ""
 "Pixels one wheel notch scrolls. The scrollbar glides while the content snaps "
 "to the nearest row, so a trackpad or trackball no longer overshoots. Raise "
 "it to scroll faster, lower it for finer control."
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:209
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:247
 msgid ""
 "Make each wheel notch jump exactly one row (or one home-screen section) "
 "instead of gliding. Turn this on if you prefer the older stepped scrolling."
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:217
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:255
 msgid "Discord Rich Presence. Takes effect after a restart."
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:219
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:257
 msgid ""
 "Leave this to Default unless setting up passthrough. Note some audio servers "
 "like Pipewire don't like passthrough and will need to be disabled for a card "
@@ -1013,57 +1037,57 @@ msgid ""
 "silence otherwise, but results may vary."
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:225
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:263
 msgid ""
 "Stop anything else using the device while playing. Needed for passthrough on "
 "some systems, and it means other applications will be silent."
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:228
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:266
 msgid ""
 "Page the library and music tile grids instead of scrolling: each page is one "
 "screenful with First / Previous / Next / Last controls and a page number you "
 "can type into. Easier than precise scrolling on a trackpad."
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:232
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:270
 msgid ""
 "Takes effect after a restart. \"Follow display\" uses the scale your desktop "
 "reports, which is 100% on X11."
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:234
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:272
 msgid ""
 "\"Default\" changes nothing and lets MPV (and your own mpv.conf) decide. "
 "Pick a mode only if you are sending audio to a receiver."
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:237
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:275
 msgid ""
 "Audio your receiver can't be sent directly is encoded to AC3, which is the "
 "only way surround fits down an optical cable. Turn this off if the encoder "
 "causes audio delay — those tracks become stereo instead."
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:242
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:280
 msgid ""
 "\"hq\" offers heavier profiles. Pick it if you have a fast graphics card."
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:244
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:282
 msgid ""
 "Leave on Automatic unless video breaks when a profile is loaded. This only "
 "applies while a profile is active, and OpenGL can cost you HDR output."
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:248
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:286
 msgid ""
 "Evens out loud effects and quiet dialogue. This turns passthrough off while "
 "it is enabled, because the volume has to be adjusted before your receiver "
 "gets the audio."
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:330
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:368
 msgid "Advanced"
 msgstr ""
 
@@ -1289,7 +1313,7 @@ msgid "Automatic"
 msgstr "Outomaties"
 
 #: jellyfin_mpv_shim/mpvtk_browser/downloads.py:51
-#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1355
+#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1288
 msgid "Episodes"
 msgstr ""
 
@@ -1298,7 +1322,7 @@ msgid "Season %s"
 msgstr ""
 
 #: jellyfin_mpv_shim/mpvtk_browser/downloads.py:52
-#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1351
+#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1284
 msgid "Specials"
 msgstr ""
 
@@ -1323,7 +1347,7 @@ msgid "Failed"
 msgstr "Misluk"
 
 #: jellyfin_mpv_shim/mpvtk_browser/downloads.py:185
-#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1105
+#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1038
 msgid "Playlist"
 msgstr ""
 
@@ -1335,30 +1359,30 @@ msgstr ""
 msgid "Movies & Videos"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/home_sections.py:103
+#: jellyfin_mpv_shim/mpvtk_browser/home_sections.py:104
 msgid "My Media"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/home_sections.py:104
-#: jellyfin_mpv_shim/mpvtk_browser/repository.py:352
+#: jellyfin_mpv_shim/mpvtk_browser/home_sections.py:105
+#: jellyfin_mpv_shim/mpvtk_browser/repository.py:350
 msgid "Continue Watching"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/home_sections.py:105
-#: jellyfin_mpv_shim/mpvtk_browser/repository.py:359
+#: jellyfin_mpv_shim/mpvtk_browser/home_sections.py:106
+#: jellyfin_mpv_shim/mpvtk_browser/repository.py:357
 msgid "Continue Listening"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/home_sections.py:106
-#: jellyfin_mpv_shim/mpvtk_browser/repository.py:366
+#: jellyfin_mpv_shim/mpvtk_browser/home_sections.py:107
+#: jellyfin_mpv_shim/mpvtk_browser/repository.py:364
 msgid "Next Up"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/home_sections.py:107
+#: jellyfin_mpv_shim/mpvtk_browser/home_sections.py:108
 msgid "Recently Added"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/home_sections.py:108
+#: jellyfin_mpv_shim/mpvtk_browser/home_sections.py:109
 msgid "Live TV"
 msgstr ""
 
@@ -1611,52 +1635,52 @@ msgstr ""
 "Kon nie server byvoeg nie.\n"
 "Gaan u na verbindingsinligting toe."
 
-#: jellyfin_mpv_shim/mpvtk_browser/repository.py:390
+#: jellyfin_mpv_shim/mpvtk_browser/repository.py:386
 msgid "On Now"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/repository.py:411
+#: jellyfin_mpv_shim/mpvtk_browser/repository.py:407
 msgid "Latest %s"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1119
+#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1052
 msgid "Downloaded"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1138
+#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1071
 msgid "Movies"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1143
+#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1076
 msgid "Videos"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1147
+#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1080
 msgid "TV Shows"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1151
+#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1084
 msgid "Playlists"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1168
-#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1441
+#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1101
+#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1374
 msgid "Series"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1212
+#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1145
 msgid "Downloaded Movies"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1216
+#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1149
 msgid "Downloaded Videos"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1220
+#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1153
 msgid "Downloaded Shows"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1353
+#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1286
 msgid "Season %d"
 msgstr ""
 

--- a/jellyfin_mpv_shim/messages/am/LC_MESSAGES/base.po
+++ b/jellyfin_mpv_shim/messages/am/LC_MESSAGES/base.po
@@ -5,7 +5,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2026-07-25 17:21-0400\n"
+"POT-Creation-Date: 2026-07-26 12:03-0400\n"
 "PO-Revision-Date: 2026-03-08 09:12+0000\n"
 "Last-Translator: Jack Ward <jack200114@hotmail.com>\n"
 "Language-Team: Amharic <https://translate.jellyfin.org/projects/jellyfin/"
@@ -242,7 +242,7 @@ msgid "Select Subtitle Track"
 msgstr ""
 
 #: jellyfin_mpv_shim/menu.py:341
-#: jellyfin_mpv_shim/mpvtk_browser/home_sections.py:102
+#: jellyfin_mpv_shim/mpvtk_browser/home_sections.py:103
 #: jellyfin_mpv_shim/osc_bridge.py:81 jellyfin_mpv_shim/osc_bridge.py:82
 #: jellyfin_mpv_shim/osc_bridge.py:104 jellyfin_mpv_shim/osc_bridge.py:140
 msgid "None"
@@ -393,7 +393,7 @@ msgstr ""
 msgid "Enable thumbnail previews"
 msgstr ""
 
-#: jellyfin_mpv_shim/menu.py:609 jellyfin_mpv_shim/mpvtk_browser/config.py:186
+#: jellyfin_mpv_shim/menu.py:609 jellyfin_mpv_shim/mpvtk_browser/config.py:195
 #: jellyfin_mpv_shim/mpvtk_browser/hud.py:375
 msgid "Night Mode (Auto Volume Adj)"
 msgstr ""
@@ -658,298 +658,322 @@ msgstr ""
 msgid "Or switch to another user"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/cast.py:317
+#: jellyfin_mpv_shim/mpvtk_browser/cast.py:314
 msgid "Ready to cast"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/cast.py:318
+#: jellyfin_mpv_shim/mpvtk_browser/cast.py:315
 msgid "Select your media in Jellyfin and play it here."
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:74
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:83
 msgid "Interface"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:83
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:92
 msgid "Playback"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:88
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:97
 msgid "Audio"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:92
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:101
 msgid "Subtitles & Languages"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:97
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:106
 msgid "Transcoding"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:102
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:111
 msgid "Video Enhancement"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:104
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:113
 msgid "Skip Intro / Credits"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:107
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:116
 msgid "Library Browser"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:109
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:118
 msgid "Downloads"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:128
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:137
 msgid "Jellyfin UI"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:129
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:138
 msgid "MPV UI with thumbnails"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:130
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:139
 msgid "MPV built-in default"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:133
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:142
 msgid "Follow display"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:134
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:143
 msgid "100% (no scaling)"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:135
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:144
 msgid "125%"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:136
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:145
 msgid "150%"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:137
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:146
 msgid "200%"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:140
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:149
 msgid "Automatic (recommended)"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:141
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:150
 msgid "Vulkan"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:142
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:151
 msgid "Direct3D 11 (Windows only)"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:143
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:152
 msgid "OpenGL (compatibility)"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:146
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:155
 msgid "Default (auto)"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:147
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:156
 msgid "Force Stereo"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:148
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:157
 msgid "Optical Surround"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:149
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:158
 msgid "HDMI Passthrough"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:152
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:161
 msgid "Unset"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:153
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:162
 msgid "Dubbed (shows only)"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:154
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:163
 msgid "Subbed (shows only)"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:155
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:164
 msgid "Dubbed (all)"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:156
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:165
 msgid "Subbed (all)"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:157
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:166
 msgid "Custom (set in config)"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:162
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:171
 msgid "Download Folder"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:163
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:172
 msgid "Prefer Downloaded Copy"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:164
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:173
 msgid "Automatically Download Upcoming Episodes"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:165
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:174
 msgid "Include Next Up"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:166
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:175
 msgid "Next Up Entries to Consider"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:167
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:176
 msgid "Episodes to Keep Ahead (0 = off)"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:168
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:177
 msgid "Storage Limit for Automatic Downloads (GB)"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:169
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:178
 msgid "Delete Automatic Downloads Once Watched"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:170
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:179
 msgid "Delete Unwatched After (days, 0 = never)"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:171
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:180
 msgid "Check Every (minutes)"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:172
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:181
 msgid "Close to Tray (keep running)"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:173
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:182
 msgid "Keep Running in Background"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:174
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:183
 msgid "Remember Window Size"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:175
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:184
 msgid "Player Controls Style"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:176
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:185
 msgid "Show What You're Watching in Discord"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:177
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:186
 msgid "Interface Scale"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:178
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:187
 msgid "Cast-target mode (no library browsing)"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:179
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:188
 msgid "Casting Opens the Library Browser"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:180
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:189
 msgid "Fullscreen Library Browser"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:181
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:190
 msgid "Always Bind Arrow Keys to Player Controls"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:182
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:191
 msgid "Player Controls Activation Key"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:183
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:192
 msgid "Audio Output Mode"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:184
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:193
 msgid "Audio Output Device"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:185
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:194
 msgid "Take the Device Exclusively"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:187
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:196
 msgid "Enable Video Playback Profiles"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:188
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:197
 msgid "Profile Group"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:189
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:198
 msgid "Remember Last Used Profile"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:190
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:199
 msgid "Graphics API for Shaders"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:191
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:200
 msgid "Pass Through AC3"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:192
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:201
 msgid "Pass Through DTS"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:193
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:202
 msgid "Pass Through E-AC3"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:194
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:203
 msgid "Pass Through DTS-HD"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:195
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:204
 msgid "Pass Through TrueHD"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:196
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:205
 msgid "Re-encode Others to AC3"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:202
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:213
 msgid ""
-"MPV keybinds are used by default. Press ENTER to drive the player controls "
-"by keyboard."
+"With \"Start Minimized\" and \"Fullscreen\" this is the classic cast-target "
+"setup: the app waits out of the way, plays fullscreen when something casts "
+"to it, and goes back to waiting when the video ends or you press Q."
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:204
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:227
+msgid ""
+"Off means command-line mode: no window, no system tray and no settings "
+"screen, so the only way back is editing conf.json by hand. It is not how you "
+"get MPV's own on-screen controls — \"Player Controls Style\" under Interface "
+"does that."
+msgstr ""
+
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:234
+msgid ""
+"Show only what is cast to this machine — the library, including this "
+"settings screen, can't be reached from here. Without a system tray icon the "
+"only way back is editing conf.json. For the classic cast-target setup you "
+"want the Interface settings instead; this is for a shared TV nobody should "
+"be able to browse from."
+msgstr ""
+
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:240
+msgid ""
+"Requires restart to change. MPV keybinds are used by default. Press ENTER to "
+"drive the player controls by keyboard."
+msgstr ""
+
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:242
 msgid ""
 "Pixels one wheel notch scrolls. The scrollbar glides while the content snaps "
 "to the nearest row, so a trackpad or trackball no longer overshoots. Raise "
 "it to scroll faster, lower it for finer control."
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:209
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:247
 msgid ""
 "Make each wheel notch jump exactly one row (or one home-screen section) "
 "instead of gliding. Turn this on if you prefer the older stepped scrolling."
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:217
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:255
 msgid "Discord Rich Presence. Takes effect after a restart."
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:219
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:257
 msgid ""
 "Leave this to Default unless setting up passthrough. Note some audio servers "
 "like Pipewire don't like passthrough and will need to be disabled for a card "
@@ -957,57 +981,57 @@ msgid ""
 "silence otherwise, but results may vary."
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:225
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:263
 msgid ""
 "Stop anything else using the device while playing. Needed for passthrough on "
 "some systems, and it means other applications will be silent."
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:228
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:266
 msgid ""
 "Page the library and music tile grids instead of scrolling: each page is one "
 "screenful with First / Previous / Next / Last controls and a page number you "
 "can type into. Easier than precise scrolling on a trackpad."
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:232
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:270
 msgid ""
 "Takes effect after a restart. \"Follow display\" uses the scale your desktop "
 "reports, which is 100% on X11."
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:234
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:272
 msgid ""
 "\"Default\" changes nothing and lets MPV (and your own mpv.conf) decide. "
 "Pick a mode only if you are sending audio to a receiver."
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:237
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:275
 msgid ""
 "Audio your receiver can't be sent directly is encoded to AC3, which is the "
 "only way surround fits down an optical cable. Turn this off if the encoder "
 "causes audio delay — those tracks become stereo instead."
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:242
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:280
 msgid ""
 "\"hq\" offers heavier profiles. Pick it if you have a fast graphics card."
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:244
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:282
 msgid ""
 "Leave on Automatic unless video breaks when a profile is loaded. This only "
 "applies while a profile is active, and OpenGL can cost you HDR output."
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:248
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:286
 msgid ""
 "Evens out loud effects and quiet dialogue. This turns passthrough off while "
 "it is enabled, because the volume has to be adjusted before your receiver "
 "gets the audio."
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:330
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:368
 msgid "Advanced"
 msgstr ""
 
@@ -1185,7 +1209,7 @@ msgid "Automatic"
 msgstr ""
 
 #: jellyfin_mpv_shim/mpvtk_browser/downloads.py:51
-#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1355
+#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1288
 msgid "Episodes"
 msgstr ""
 
@@ -1194,7 +1218,7 @@ msgid "Season %s"
 msgstr ""
 
 #: jellyfin_mpv_shim/mpvtk_browser/downloads.py:52
-#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1351
+#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1284
 msgid "Specials"
 msgstr ""
 
@@ -1215,7 +1239,7 @@ msgid "Failed"
 msgstr ""
 
 #: jellyfin_mpv_shim/mpvtk_browser/downloads.py:185
-#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1105
+#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1038
 msgid "Playlist"
 msgstr ""
 
@@ -1227,30 +1251,30 @@ msgstr ""
 msgid "Movies & Videos"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/home_sections.py:103
+#: jellyfin_mpv_shim/mpvtk_browser/home_sections.py:104
 msgid "My Media"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/home_sections.py:104
-#: jellyfin_mpv_shim/mpvtk_browser/repository.py:352
+#: jellyfin_mpv_shim/mpvtk_browser/home_sections.py:105
+#: jellyfin_mpv_shim/mpvtk_browser/repository.py:350
 msgid "Continue Watching"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/home_sections.py:105
-#: jellyfin_mpv_shim/mpvtk_browser/repository.py:359
+#: jellyfin_mpv_shim/mpvtk_browser/home_sections.py:106
+#: jellyfin_mpv_shim/mpvtk_browser/repository.py:357
 msgid "Continue Listening"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/home_sections.py:106
-#: jellyfin_mpv_shim/mpvtk_browser/repository.py:366
+#: jellyfin_mpv_shim/mpvtk_browser/home_sections.py:107
+#: jellyfin_mpv_shim/mpvtk_browser/repository.py:364
 msgid "Next Up"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/home_sections.py:107
+#: jellyfin_mpv_shim/mpvtk_browser/home_sections.py:108
 msgid "Recently Added"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/home_sections.py:108
+#: jellyfin_mpv_shim/mpvtk_browser/home_sections.py:109
 msgid "Live TV"
 msgstr ""
 
@@ -1463,52 +1487,52 @@ msgstr ""
 msgid "Could not load this page."
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/repository.py:390
+#: jellyfin_mpv_shim/mpvtk_browser/repository.py:386
 msgid "On Now"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/repository.py:411
+#: jellyfin_mpv_shim/mpvtk_browser/repository.py:407
 msgid "Latest %s"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1119
+#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1052
 msgid "Downloaded"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1138
+#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1071
 msgid "Movies"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1143
+#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1076
 msgid "Videos"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1147
+#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1080
 msgid "TV Shows"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1151
+#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1084
 msgid "Playlists"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1168
-#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1441
+#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1101
+#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1374
 msgid "Series"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1212
+#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1145
 msgid "Downloaded Movies"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1216
+#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1149
 msgid "Downloaded Videos"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1220
+#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1153
 msgid "Downloaded Shows"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1353
+#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1286
 msgid "Season %d"
 msgstr ""
 

--- a/jellyfin_mpv_shim/messages/ar/LC_MESSAGES/base.po
+++ b/jellyfin_mpv_shim/messages/ar/LC_MESSAGES/base.po
@@ -5,9 +5,9 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2026-07-25 17:21-0400\n"
-"PO-Revision-Date: 2026-07-26 15:36+0000\n"
-"Last-Translator: Translation expert <eleceng4ever@hotmail.com>\n"
+"POT-Creation-Date: 2026-07-26 12:03-0400\n"
+"PO-Revision-Date: 2026-05-15 14:08+0000\n"
+"Last-Translator: Ziad El Kalali <ziadad@hotmail.fr>\n"
 "Language-Team: Arabic <https://translate.jellyfin.org/projects/jellyfin/"
 "jellyfin-mpv-shim/ar/>\n"
 "Language: ar\n"
@@ -75,12 +75,16 @@ msgid "Account already exists. Updating credentials."
 msgstr "الحساب موجود فعلا. تحديث الاعتمادات."
 
 #: jellyfin_mpv_shim/clients.py:302
+#, fuzzy
+#| msgid "Successfully added server."
 msgid "Successfully updated server credentials."
-msgstr "تم تحديث اعتمادات الخادم بنجاح."
+msgstr "نجاح إضافة الخادم."
 
 #: jellyfin_mpv_shim/clients.py:305
+#, fuzzy
+#| msgid "Adding server failed."
 msgid "Updating server credentials failed."
-msgstr "فشل تحديث اعتمادات الخادم."
+msgstr "فشل إضافة الخادم."
 
 #: jellyfin_mpv_shim/clients.py:316
 msgid "Server URL: "
@@ -99,8 +103,14 @@ msgid "Add another server?"
 msgstr "إضافة خادم آخر؟"
 
 #: jellyfin_mpv_shim/clients.py:617
+#, fuzzy
+#| msgid ""
+#| "Could not add server.\n"
+#| "Please check your connection information."
 msgid "Could not connect to the server."
-msgstr "تعذر التواصل مع الخادم."
+msgstr ""
+"تعذرت إضافة الخادم.\n"
+"يرجى التحقق من معلومات الاتصال الخاصة بك."
 
 #: jellyfin_mpv_shim/clients.py:622
 msgid "Quick Connect is not enabled on this server."
@@ -193,7 +203,7 @@ msgstr "تغيير جودة الفيديو"
 #: jellyfin_mpv_shim/mpvtk_browser/window_chrome.py:148
 #: jellyfin_mpv_shim/syncplay.py:740
 msgid "SyncPlay"
-msgstr "تشغيل متزامن"
+msgstr "SyncPlay"
 
 #: jellyfin_mpv_shim/menu.py:163
 msgid "MPV Shim v{0} Release Info/Download"
@@ -243,7 +253,7 @@ msgid "Select Subtitle Track"
 msgstr "تحديد مقطع الترجمة"
 
 #: jellyfin_mpv_shim/menu.py:341
-#: jellyfin_mpv_shim/mpvtk_browser/home_sections.py:102
+#: jellyfin_mpv_shim/mpvtk_browser/home_sections.py:103
 #: jellyfin_mpv_shim/osc_bridge.py:81 jellyfin_mpv_shim/osc_bridge.py:82
 #: jellyfin_mpv_shim/osc_bridge.py:104 jellyfin_mpv_shim/osc_bridge.py:140
 msgid "None"
@@ -394,7 +404,7 @@ msgstr "اسأل لتخطي الخاتمة"
 msgid "Enable thumbnail previews"
 msgstr "تمكين الصور المصغرة للمعاينة"
 
-#: jellyfin_mpv_shim/menu.py:609 jellyfin_mpv_shim/mpvtk_browser/config.py:186
+#: jellyfin_mpv_shim/menu.py:609 jellyfin_mpv_shim/mpvtk_browser/config.py:195
 #: jellyfin_mpv_shim/mpvtk_browser/hud.py:375
 msgid "Night Mode (Auto Volume Adj)"
 msgstr "النمط الليلي (ضبط صوت تلقائي)"
@@ -416,8 +426,10 @@ msgid "First page"
 msgstr "أول صفحة"
 
 #: jellyfin_mpv_shim/mpvtk_browser/app.py:746
+#, fuzzy
+#| msgid "Successfully added server."
 msgid "Previous page"
-msgstr "صفحة سابقة"
+msgstr "نجاح إضافة الخادم."
 
 #: jellyfin_mpv_shim/mpvtk_browser/app.py:747
 msgid "Next page"
@@ -464,8 +476,14 @@ msgstr "إعادة المحاولة"
 
 #: jellyfin_mpv_shim/mpvtk_browser/app.py:1811
 #: jellyfin_mpv_shim/mpvtk_browser/app.py:1813
+#, fuzzy
+#| msgid ""
+#| "Could not add server.\n"
+#| "Please check your connection information."
 msgid "Still can't reach the server."
-msgstr "لا يزال الوصول للخادم متعذرا."
+msgstr ""
+"تعذرت إضافة الخادم.\n"
+"يرجى التحقق من معلومات الاتصال الخاصة بك."
 
 #: jellyfin_mpv_shim/mpvtk_browser/auth.py:73
 msgid "Switch to %s"
@@ -498,8 +516,10 @@ msgid "Incorrect PIN."
 msgstr "رمز خاطئ."
 
 #: jellyfin_mpv_shim/mpvtk_browser/auth.py:123
+#, fuzzy
+#| msgid "Server:"
 msgid "Set PIN for %s"
-msgstr "حدد الرمز لأجل %s"
+msgstr "الخادم:"
 
 #: jellyfin_mpv_shim/mpvtk_browser/auth.py:128
 msgid "Current PIN"
@@ -519,8 +539,10 @@ msgid "Require this PIN at startup"
 msgstr "هذا الرمز مطلوب عند البدء"
 
 #: jellyfin_mpv_shim/mpvtk_browser/auth.py:141
+#, fuzzy
+#| msgid "Remove Server"
 msgid "Remove PIN"
-msgstr "حذف الرمز"
+msgstr "حذف الخادم"
 
 #: jellyfin_mpv_shim/mpvtk_browser/auth.py:147
 msgid "Save"
@@ -555,8 +577,10 @@ msgid "Connect to Jellyfin"
 msgstr "التوصيل لـ Jellyfin"
 
 #: jellyfin_mpv_shim/mpvtk_browser/auth.py:248
+#, fuzzy
+#| msgid "Successfully added server."
 msgid "Previously added servers"
-msgstr "خوادم مضافة سابقا"
+msgstr "نجاح إضافة الخادم."
 
 #: jellyfin_mpv_shim/mpvtk_browser/auth.py:255
 msgid "Use"
@@ -572,20 +596,28 @@ msgid "Enter this code in the Jellyfin app or web client:"
 msgstr "ادخل هذا الرمز في تطبيقJellyfin أو عميل ويب:"
 
 #: jellyfin_mpv_shim/mpvtk_browser/auth.py:276
+#, fuzzy
+#| msgid "SVP Settings"
 msgid "Requesting…"
-msgstr "طلب…"
+msgstr "إعدادات SVP"
 
 #: jellyfin_mpv_shim/mpvtk_browser/auth.py:287
+#, fuzzy
+#| msgid "Server URL: "
 msgid "Server URL"
-msgstr "URL الخادم"
+msgstr "عنوان الخادم: "
 
 #: jellyfin_mpv_shim/mpvtk_browser/auth.py:288
+#, fuzzy
+#| msgid "Username:"
 msgid "Username"
-msgstr "اسم المستخدم"
+msgstr "اسم المستخدم:"
 
 #: jellyfin_mpv_shim/mpvtk_browser/auth.py:289
+#, fuzzy
+#| msgid "Password:"
 msgid "Password"
-msgstr "كلمة العبور"
+msgstr "كلمة السر:"
 
 #: jellyfin_mpv_shim/mpvtk_browser/auth.py:291
 msgid "Use Quick Connect"
@@ -600,8 +632,14 @@ msgid "Enter the server URL first."
 msgstr "ادخل عنوان الخادم أولا."
 
 #: jellyfin_mpv_shim/mpvtk_browser/auth.py:330
+#, fuzzy
+#| msgid ""
+#| "Could not add server.\n"
+#| "Please check your connection information."
 msgid "Contacting the server…"
-msgstr "التوصال مع الخادم…"
+msgstr ""
+"تعذرت إضافة الخادم.\n"
+"يرجى التحقق من معلومات الاتصال الخاصة بك."
 
 #: jellyfin_mpv_shim/mpvtk_browser/auth.py:339
 msgid "Waiting for approval…"
@@ -616,8 +654,14 @@ msgid "Connecting…"
 msgstr "توصيل…"
 
 #: jellyfin_mpv_shim/mpvtk_browser/auth.py:382
+#, fuzzy
+#| msgid ""
+#| "Could not add server.\n"
+#| "Please check your connection information."
 msgid "Could not connect. Please check your details."
-msgstr "تعذرت التواصل مع الخادم. يرجى مراجعة تفاصيلك."
+msgstr ""
+"تعذرت إضافة الخادم.\n"
+"يرجى التحقق من معلومات الاتصال الخاصة بك."
 
 #: jellyfin_mpv_shim/mpvtk_browser/auth.py:409
 msgid "Locked"
@@ -659,304 +703,334 @@ msgstr "فتح"
 msgid "Or switch to another user"
 msgstr "أو التحويل لمستخدم آخر"
 
-#: jellyfin_mpv_shim/mpvtk_browser/cast.py:317
+#: jellyfin_mpv_shim/mpvtk_browser/cast.py:314
 msgid "Ready to cast"
 msgstr "جاهز للإرسال"
 
-#: jellyfin_mpv_shim/mpvtk_browser/cast.py:318
+#: jellyfin_mpv_shim/mpvtk_browser/cast.py:315
+#, fuzzy
+#| msgid "Select your media in Jellyfin and play it here"
 msgid "Select your media in Jellyfin and play it here."
-msgstr "اختر الوسائط الخاصة بك في Jellyfin وقم بتشغيلها هنا."
+msgstr "حدد الوسائط الخاصة بك في Jellyfin وقم بتشغيلها هنا"
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:74
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:83
 msgid "Interface"
 msgstr "واجهة"
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:83
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:92
 msgid "Playback"
 msgstr "تشغيل سابق"
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:88
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:97
 msgid "Audio"
 msgstr "صوت"
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:92
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:101
 msgid "Subtitles & Languages"
 msgstr "ترجمات و لغات"
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:97
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:106
+#, fuzzy
+#| msgid " (Transcode)"
 msgid "Transcoding"
-msgstr "الترميز"
+msgstr " (ترميز)"
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:102
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:111
 msgid "Video Enhancement"
 msgstr "تحسين الفيديو"
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:104
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:113
+#, fuzzy
+#| msgid "Seek to Skip Credits"
 msgid "Skip Intro / Credits"
-msgstr "تجاوز المقدمة / شارة النهاية"
+msgstr "قم بالتنقل لتتخطى الخاتمة"
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:107
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:116
 msgid "Library Browser"
 msgstr "مستعرض المكتبة"
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:109
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:118
 msgid "Downloads"
 msgstr "تحميلات"
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:128
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:137
 msgid "Jellyfin UI"
 msgstr "واجهة Jellyfin"
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:129
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:138
 msgid "MPV UI with thumbnails"
 msgstr "واجهة MPV مع صور مصغرة"
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:130
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:139
 msgid "MPV built-in default"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:133
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:142
 msgid "Follow display"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:134
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:143
 msgid "100% (no scaling)"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:135
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:144
 msgid "125%"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:136
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:145
 msgid "150%"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:137
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:146
 msgid "200%"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:140
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:149
 msgid "Automatic (recommended)"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:141
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:150
 msgid "Vulkan"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:142
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:151
 msgid "Direct3D 11 (Windows only)"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:143
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:152
 msgid "OpenGL (compatibility)"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:146
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:155
 msgid "Default (auto)"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:147
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:156
 msgid "Force Stereo"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:148
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:157
 msgid "Optical Surround"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:149
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:158
 msgid "HDMI Passthrough"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:152
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:161
 msgid "Unset"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:153
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:162
 msgid "Dubbed (shows only)"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:154
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:163
 msgid "Subbed (shows only)"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:155
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:164
 msgid "Dubbed (all)"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:156
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:165
 msgid "Subbed (all)"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:157
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:166
 msgid "Custom (set in config)"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:162
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:171
 msgid "Download Folder"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:163
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:172
 msgid "Prefer Downloaded Copy"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:164
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:173
 msgid "Automatically Download Upcoming Episodes"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:165
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:174
 msgid "Include Next Up"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:166
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:175
 msgid "Next Up Entries to Consider"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:167
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:176
 msgid "Episodes to Keep Ahead (0 = off)"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:168
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:177
 msgid "Storage Limit for Automatic Downloads (GB)"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:169
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:178
 #, fuzzy
 #| msgid "Remove Server"
 msgid "Delete Automatic Downloads Once Watched"
 msgstr "حذف الخادم"
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:170
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:179
 msgid "Delete Unwatched After (days, 0 = never)"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:171
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:180
 msgid "Check Every (minutes)"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:172
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:181
 msgid "Close to Tray (keep running)"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:173
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:182
 msgid "Keep Running in Background"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:174
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:183
 msgid "Remember Window Size"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:175
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:184
 msgid "Player Controls Style"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:176
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:185
 msgid "Show What You're Watching in Discord"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:177
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:186
 msgid "Interface Scale"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:178
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:187
 msgid "Cast-target mode (no library browsing)"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:179
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:188
 msgid "Casting Opens the Library Browser"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:180
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:189
 msgid "Fullscreen Library Browser"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:181
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:190
 msgid "Always Bind Arrow Keys to Player Controls"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:182
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:191
 msgid "Player Controls Activation Key"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:183
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:192
 msgid "Audio Output Mode"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:184
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:193
 msgid "Audio Output Device"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:185
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:194
 msgid "Take the Device Exclusively"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:187
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:196
 #, fuzzy
 #| msgid "Video Playback Profiles"
 msgid "Enable Video Playback Profiles"
 msgstr "أوضاع تشغيل الفيديو"
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:188
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:197
 #, fuzzy
 #| msgid "New Group"
 msgid "Profile Group"
 msgstr "مجموعة جديدة"
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:189
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:198
 msgid "Remember Last Used Profile"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:190
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:199
 msgid "Graphics API for Shaders"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:191
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:200
 msgid "Pass Through AC3"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:192
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:201
 msgid "Pass Through DTS"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:193
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:202
 msgid "Pass Through E-AC3"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:194
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:203
 msgid "Pass Through DTS-HD"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:195
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:204
 msgid "Pass Through TrueHD"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:196
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:205
 msgid "Re-encode Others to AC3"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:202
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:213
 msgid ""
-"MPV keybinds are used by default. Press ENTER to drive the player controls "
-"by keyboard."
+"With \"Start Minimized\" and \"Fullscreen\" this is the classic cast-target "
+"setup: the app waits out of the way, plays fullscreen when something casts "
+"to it, and goes back to waiting when the video ends or you press Q."
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:204
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:227
+msgid ""
+"Off means command-line mode: no window, no system tray and no settings "
+"screen, so the only way back is editing conf.json by hand. It is not how you "
+"get MPV's own on-screen controls — \"Player Controls Style\" under Interface "
+"does that."
+msgstr ""
+
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:234
+msgid ""
+"Show only what is cast to this machine — the library, including this "
+"settings screen, can't be reached from here. Without a system tray icon the "
+"only way back is editing conf.json. For the classic cast-target setup you "
+"want the Interface settings instead; this is for a shared TV nobody should "
+"be able to browse from."
+msgstr ""
+
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:240
+msgid ""
+"Requires restart to change. MPV keybinds are used by default. Press ENTER to "
+"drive the player controls by keyboard."
+msgstr ""
+
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:242
 msgid ""
 "Pixels one wheel notch scrolls. The scrollbar glides while the content snaps "
 "to the nearest row, so a trackpad or trackball no longer overshoots. Raise "
 "it to scroll faster, lower it for finer control."
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:209
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:247
 msgid ""
 "Make each wheel notch jump exactly one row (or one home-screen section) "
 "instead of gliding. Turn this on if you prefer the older stepped scrolling."
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:217
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:255
 msgid "Discord Rich Presence. Takes effect after a restart."
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:219
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:257
 msgid ""
 "Leave this to Default unless setting up passthrough. Note some audio servers "
 "like Pipewire don't like passthrough and will need to be disabled for a card "
@@ -964,57 +1038,57 @@ msgid ""
 "silence otherwise, but results may vary."
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:225
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:263
 msgid ""
 "Stop anything else using the device while playing. Needed for passthrough on "
 "some systems, and it means other applications will be silent."
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:228
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:266
 msgid ""
 "Page the library and music tile grids instead of scrolling: each page is one "
 "screenful with First / Previous / Next / Last controls and a page number you "
 "can type into. Easier than precise scrolling on a trackpad."
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:232
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:270
 msgid ""
 "Takes effect after a restart. \"Follow display\" uses the scale your desktop "
 "reports, which is 100% on X11."
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:234
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:272
 msgid ""
 "\"Default\" changes nothing and lets MPV (and your own mpv.conf) decide. "
 "Pick a mode only if you are sending audio to a receiver."
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:237
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:275
 msgid ""
 "Audio your receiver can't be sent directly is encoded to AC3, which is the "
 "only way surround fits down an optical cable. Turn this off if the encoder "
 "causes audio delay — those tracks become stereo instead."
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:242
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:280
 msgid ""
 "\"hq\" offers heavier profiles. Pick it if you have a fast graphics card."
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:244
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:282
 msgid ""
 "Leave on Automatic unless video breaks when a profile is loaded. This only "
 "applies while a profile is active, and OpenGL can cost you HDR output."
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:248
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:286
 msgid ""
 "Evens out loud effects and quiet dialogue. This turns passthrough off while "
 "it is enabled, because the volume has to be adjusted before your receiver "
 "gets the audio."
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:330
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:368
 msgid "Advanced"
 msgstr ""
 
@@ -1043,8 +1117,10 @@ msgid "Private (only you can see it)"
 msgstr ""
 
 #: jellyfin_mpv_shim/mpvtk_browser/dialogs.py:120
+#, fuzzy
+#| msgid "Remove Server"
 msgid "Collections…"
-msgstr "مختارات…"
+msgstr "حذف الخادم"
 
 #: jellyfin_mpv_shim/mpvtk_browser/dialogs.py:123
 #: jellyfin_mpv_shim/mpvtk_browser/dialogs.py:169
@@ -1059,12 +1135,16 @@ msgid "Add to Collection"
 msgstr "حذف الخادم"
 
 #: jellyfin_mpv_shim/mpvtk_browser/dialogs.py:153
+#, fuzzy
+#| msgid "Remove Server"
 msgid "No collections yet."
-msgstr "لا توجد مختارات بعد."
+msgstr "حذف الخادم"
 
 #: jellyfin_mpv_shim/mpvtk_browser/dialogs.py:156
+#, fuzzy
+#| msgid "Username: "
 msgid "New collection name…"
-msgstr "اسم مختارات جديد…"
+msgstr "اسم المستخدم: "
 
 #: jellyfin_mpv_shim/mpvtk_browser/dialogs.py:166
 #: jellyfin_mpv_shim/mpvtk_browser/hud.py:393
@@ -1074,13 +1154,21 @@ msgid "Back"
 msgstr ""
 
 #: jellyfin_mpv_shim/mpvtk_browser/dialogs.py:253
+#, fuzzy
+#| msgid ""
+#| "Could not add server.\n"
+#| "Please check your connection information."
 msgid "Could not check what needs downloading."
-msgstr "تعذرت فحص المطلوب تحميله."
+msgstr ""
+"تعذرت إضافة الخادم.\n"
+"يرجى التحقق من معلومات الاتصال الخاصة بك."
 
 #: jellyfin_mpv_shim/mpvtk_browser/dialogs.py:270
 #: jellyfin_mpv_shim/mpvtk_browser/dialogs.py:303
+#, fuzzy
+#| msgid "SVP Settings"
 msgid "Estimating…"
-msgstr "تقدير…"
+msgstr "إعدادات SVP"
 
 #: jellyfin_mpv_shim/mpvtk_browser/dialogs.py:272
 msgid "%(count)d items · %(size)s"
@@ -1144,8 +1232,10 @@ msgid "Clipboard"
 msgstr ""
 
 #: jellyfin_mpv_shim/mpvtk_browser/dialogs.py:449
+#, fuzzy
+#| msgid "{0} has joined."
 msgid "%s (joined)"
-msgstr "%s (انضم)"
+msgstr "{0} قد انضم."
 
 #: jellyfin_mpv_shim/mpvtk_browser/dialogs.py:450
 #, fuzzy
@@ -1154,8 +1244,10 @@ msgid "Group"
 msgstr "مجموعة جديدة"
 
 #: jellyfin_mpv_shim/mpvtk_browser/dialogs.py:461
+#, fuzzy
+#| msgid "New Group"
 msgid "No active groups."
-msgstr "لا مجموعات نشطة."
+msgstr "مجموعة جديدة"
 
 #: jellyfin_mpv_shim/mpvtk_browser/dialogs.py:464
 #: jellyfin_mpv_shim/mpvtk_browser/hud.py:425
@@ -1174,16 +1266,34 @@ msgid "Refresh"
 msgstr ""
 
 #: jellyfin_mpv_shim/mpvtk_browser/dialogs.py:494
+#, fuzzy
+#| msgid ""
+#| "Could not add server.\n"
+#| "Please check your connection information."
 msgid "Could not join the SyncPlay group."
-msgstr "تعذر الانضمام إلى مجموعة SyncPlay."
+msgstr ""
+"تعذرت إضافة الخادم.\n"
+"يرجى التحقق من معلومات الاتصال الخاصة بك."
 
 #: jellyfin_mpv_shim/mpvtk_browser/dialogs.py:499
+#, fuzzy
+#| msgid ""
+#| "Could not add server.\n"
+#| "Please check your connection information."
 msgid "Could not create the SyncPlay group."
-msgstr "تعذر تكوين مجموعة SyncPlay."
+msgstr ""
+"تعذرت إضافة الخادم.\n"
+"يرجى التحقق من معلومات الاتصال الخاصة بك."
 
 #: jellyfin_mpv_shim/mpvtk_browser/dialogs.py:504
+#, fuzzy
+#| msgid ""
+#| "Could not add server.\n"
+#| "Please check your connection information."
 msgid "Could not leave the SyncPlay group."
-msgstr "تعذرت مغادرة مجموعة SyncPlay."
+msgstr ""
+"تعذرت إضافة الخادم.\n"
+"يرجى التحقق من معلومات الاتصال الخاصة بك."
 
 #: jellyfin_mpv_shim/mpvtk_browser/downloads.py:23
 #, fuzzy
@@ -1204,7 +1314,7 @@ msgid "Automatic"
 msgstr "آلي"
 
 #: jellyfin_mpv_shim/mpvtk_browser/downloads.py:51
-#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1355
+#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1288
 msgid "Episodes"
 msgstr ""
 
@@ -1213,7 +1323,7 @@ msgid "Season %s"
 msgstr ""
 
 #: jellyfin_mpv_shim/mpvtk_browser/downloads.py:52
-#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1351
+#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1284
 msgid "Specials"
 msgstr ""
 
@@ -1238,7 +1348,7 @@ msgid "Failed"
 msgstr "فشل"
 
 #: jellyfin_mpv_shim/mpvtk_browser/downloads.py:185
-#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1105
+#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1038
 msgid "Playlist"
 msgstr ""
 
@@ -1250,30 +1360,30 @@ msgstr ""
 msgid "Movies & Videos"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/home_sections.py:103
+#: jellyfin_mpv_shim/mpvtk_browser/home_sections.py:104
 msgid "My Media"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/home_sections.py:104
-#: jellyfin_mpv_shim/mpvtk_browser/repository.py:352
+#: jellyfin_mpv_shim/mpvtk_browser/home_sections.py:105
+#: jellyfin_mpv_shim/mpvtk_browser/repository.py:350
 msgid "Continue Watching"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/home_sections.py:105
-#: jellyfin_mpv_shim/mpvtk_browser/repository.py:359
+#: jellyfin_mpv_shim/mpvtk_browser/home_sections.py:106
+#: jellyfin_mpv_shim/mpvtk_browser/repository.py:357
 msgid "Continue Listening"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/home_sections.py:106
-#: jellyfin_mpv_shim/mpvtk_browser/repository.py:366
+#: jellyfin_mpv_shim/mpvtk_browser/home_sections.py:107
+#: jellyfin_mpv_shim/mpvtk_browser/repository.py:364
 msgid "Next Up"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/home_sections.py:107
+#: jellyfin_mpv_shim/mpvtk_browser/home_sections.py:108
 msgid "Recently Added"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/home_sections.py:108
+#: jellyfin_mpv_shim/mpvtk_browser/home_sections.py:109
 msgid "Live TV"
 msgstr ""
 
@@ -1364,8 +1474,10 @@ msgid "Previous"
 msgstr ""
 
 #: jellyfin_mpv_shim/mpvtk_browser/hud.py:569
+#, fuzzy
+#| msgid "Successfully added server."
 msgid "Previous Chapter"
-msgstr "فصل سابق"
+msgstr "نجاح إضافة الخادم."
 
 #: jellyfin_mpv_shim/mpvtk_browser/hud.py:574
 msgid "Back 10 Seconds"
@@ -1399,8 +1511,10 @@ msgstr ""
 
 #: jellyfin_mpv_shim/mpvtk_browser/hud.py:637
 #: jellyfin_mpv_shim/mpvtk_browser/window_chrome.py:150
+#, fuzzy
+#| msgid "SVP Settings"
 msgid "Settings"
-msgstr "إعدادات"
+msgstr "إعدادات SVP"
 
 #: jellyfin_mpv_shim/mpvtk_browser/hud.py:641
 #, fuzzy
@@ -1414,8 +1528,10 @@ msgid "Those items could not be added to the queue."
 msgstr ""
 
 #: jellyfin_mpv_shim/mpvtk_browser/item_actions.py:337
+#, fuzzy
+#| msgid "Remove Server"
 msgid "Delete the downloaded copy of %s?"
-msgstr "حذف النسخة المنزلة من %s؟"
+msgstr "حذف الخادم"
 
 #: jellyfin_mpv_shim/mpvtk_browser/item_actions.py:339
 msgid "Delete"
@@ -1520,52 +1636,52 @@ msgstr ""
 "تعذرت إضافة الخادم.\n"
 "يرجى التحقق من معلومات الاتصال الخاصة بك."
 
-#: jellyfin_mpv_shim/mpvtk_browser/repository.py:390
+#: jellyfin_mpv_shim/mpvtk_browser/repository.py:386
 msgid "On Now"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/repository.py:411
+#: jellyfin_mpv_shim/mpvtk_browser/repository.py:407
 msgid "Latest %s"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1119
+#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1052
 msgid "Downloaded"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1138
+#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1071
 msgid "Movies"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1143
+#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1076
 msgid "Videos"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1147
+#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1080
 msgid "TV Shows"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1151
+#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1084
 msgid "Playlists"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1168
-#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1441
+#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1101
+#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1374
 msgid "Series"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1212
+#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1145
 msgid "Downloaded Movies"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1216
+#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1149
 msgid "Downloaded Videos"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1220
+#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1153
 msgid "Downloaded Shows"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1353
+#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1286
 msgid "Season %d"
 msgstr ""
 

--- a/jellyfin_mpv_shim/messages/az/LC_MESSAGES/base.po
+++ b/jellyfin_mpv_shim/messages/az/LC_MESSAGES/base.po
@@ -5,7 +5,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2026-07-25 17:21-0400\n"
+"POT-Creation-Date: 2026-07-26 12:03-0400\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: Automatically generated\n"
 "Language-Team: none\n"
@@ -240,7 +240,7 @@ msgid "Select Subtitle Track"
 msgstr ""
 
 #: jellyfin_mpv_shim/menu.py:341
-#: jellyfin_mpv_shim/mpvtk_browser/home_sections.py:102
+#: jellyfin_mpv_shim/mpvtk_browser/home_sections.py:103
 #: jellyfin_mpv_shim/osc_bridge.py:81 jellyfin_mpv_shim/osc_bridge.py:82
 #: jellyfin_mpv_shim/osc_bridge.py:104 jellyfin_mpv_shim/osc_bridge.py:140
 msgid "None"
@@ -391,7 +391,7 @@ msgstr ""
 msgid "Enable thumbnail previews"
 msgstr ""
 
-#: jellyfin_mpv_shim/menu.py:609 jellyfin_mpv_shim/mpvtk_browser/config.py:186
+#: jellyfin_mpv_shim/menu.py:609 jellyfin_mpv_shim/mpvtk_browser/config.py:195
 #: jellyfin_mpv_shim/mpvtk_browser/hud.py:375
 msgid "Night Mode (Auto Volume Adj)"
 msgstr ""
@@ -656,298 +656,322 @@ msgstr ""
 msgid "Or switch to another user"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/cast.py:317
+#: jellyfin_mpv_shim/mpvtk_browser/cast.py:314
 msgid "Ready to cast"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/cast.py:318
+#: jellyfin_mpv_shim/mpvtk_browser/cast.py:315
 msgid "Select your media in Jellyfin and play it here."
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:74
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:83
 msgid "Interface"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:83
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:92
 msgid "Playback"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:88
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:97
 msgid "Audio"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:92
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:101
 msgid "Subtitles & Languages"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:97
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:106
 msgid "Transcoding"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:102
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:111
 msgid "Video Enhancement"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:104
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:113
 msgid "Skip Intro / Credits"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:107
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:116
 msgid "Library Browser"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:109
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:118
 msgid "Downloads"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:128
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:137
 msgid "Jellyfin UI"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:129
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:138
 msgid "MPV UI with thumbnails"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:130
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:139
 msgid "MPV built-in default"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:133
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:142
 msgid "Follow display"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:134
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:143
 msgid "100% (no scaling)"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:135
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:144
 msgid "125%"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:136
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:145
 msgid "150%"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:137
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:146
 msgid "200%"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:140
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:149
 msgid "Automatic (recommended)"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:141
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:150
 msgid "Vulkan"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:142
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:151
 msgid "Direct3D 11 (Windows only)"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:143
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:152
 msgid "OpenGL (compatibility)"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:146
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:155
 msgid "Default (auto)"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:147
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:156
 msgid "Force Stereo"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:148
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:157
 msgid "Optical Surround"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:149
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:158
 msgid "HDMI Passthrough"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:152
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:161
 msgid "Unset"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:153
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:162
 msgid "Dubbed (shows only)"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:154
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:163
 msgid "Subbed (shows only)"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:155
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:164
 msgid "Dubbed (all)"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:156
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:165
 msgid "Subbed (all)"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:157
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:166
 msgid "Custom (set in config)"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:162
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:171
 msgid "Download Folder"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:163
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:172
 msgid "Prefer Downloaded Copy"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:164
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:173
 msgid "Automatically Download Upcoming Episodes"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:165
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:174
 msgid "Include Next Up"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:166
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:175
 msgid "Next Up Entries to Consider"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:167
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:176
 msgid "Episodes to Keep Ahead (0 = off)"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:168
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:177
 msgid "Storage Limit for Automatic Downloads (GB)"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:169
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:178
 msgid "Delete Automatic Downloads Once Watched"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:170
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:179
 msgid "Delete Unwatched After (days, 0 = never)"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:171
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:180
 msgid "Check Every (minutes)"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:172
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:181
 msgid "Close to Tray (keep running)"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:173
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:182
 msgid "Keep Running in Background"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:174
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:183
 msgid "Remember Window Size"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:175
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:184
 msgid "Player Controls Style"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:176
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:185
 msgid "Show What You're Watching in Discord"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:177
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:186
 msgid "Interface Scale"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:178
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:187
 msgid "Cast-target mode (no library browsing)"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:179
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:188
 msgid "Casting Opens the Library Browser"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:180
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:189
 msgid "Fullscreen Library Browser"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:181
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:190
 msgid "Always Bind Arrow Keys to Player Controls"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:182
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:191
 msgid "Player Controls Activation Key"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:183
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:192
 msgid "Audio Output Mode"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:184
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:193
 msgid "Audio Output Device"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:185
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:194
 msgid "Take the Device Exclusively"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:187
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:196
 msgid "Enable Video Playback Profiles"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:188
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:197
 msgid "Profile Group"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:189
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:198
 msgid "Remember Last Used Profile"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:190
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:199
 msgid "Graphics API for Shaders"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:191
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:200
 msgid "Pass Through AC3"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:192
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:201
 msgid "Pass Through DTS"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:193
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:202
 msgid "Pass Through E-AC3"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:194
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:203
 msgid "Pass Through DTS-HD"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:195
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:204
 msgid "Pass Through TrueHD"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:196
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:205
 msgid "Re-encode Others to AC3"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:202
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:213
 msgid ""
-"MPV keybinds are used by default. Press ENTER to drive the player controls "
-"by keyboard."
+"With \"Start Minimized\" and \"Fullscreen\" this is the classic cast-target "
+"setup: the app waits out of the way, plays fullscreen when something casts "
+"to it, and goes back to waiting when the video ends or you press Q."
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:204
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:227
+msgid ""
+"Off means command-line mode: no window, no system tray and no settings "
+"screen, so the only way back is editing conf.json by hand. It is not how you "
+"get MPV's own on-screen controls — \"Player Controls Style\" under Interface "
+"does that."
+msgstr ""
+
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:234
+msgid ""
+"Show only what is cast to this machine — the library, including this "
+"settings screen, can't be reached from here. Without a system tray icon the "
+"only way back is editing conf.json. For the classic cast-target setup you "
+"want the Interface settings instead; this is for a shared TV nobody should "
+"be able to browse from."
+msgstr ""
+
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:240
+msgid ""
+"Requires restart to change. MPV keybinds are used by default. Press ENTER to "
+"drive the player controls by keyboard."
+msgstr ""
+
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:242
 msgid ""
 "Pixels one wheel notch scrolls. The scrollbar glides while the content snaps "
 "to the nearest row, so a trackpad or trackball no longer overshoots. Raise "
 "it to scroll faster, lower it for finer control."
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:209
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:247
 msgid ""
 "Make each wheel notch jump exactly one row (or one home-screen section) "
 "instead of gliding. Turn this on if you prefer the older stepped scrolling."
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:217
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:255
 msgid "Discord Rich Presence. Takes effect after a restart."
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:219
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:257
 msgid ""
 "Leave this to Default unless setting up passthrough. Note some audio servers "
 "like Pipewire don't like passthrough and will need to be disabled for a card "
@@ -955,57 +979,57 @@ msgid ""
 "silence otherwise, but results may vary."
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:225
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:263
 msgid ""
 "Stop anything else using the device while playing. Needed for passthrough on "
 "some systems, and it means other applications will be silent."
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:228
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:266
 msgid ""
 "Page the library and music tile grids instead of scrolling: each page is one "
 "screenful with First / Previous / Next / Last controls and a page number you "
 "can type into. Easier than precise scrolling on a trackpad."
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:232
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:270
 msgid ""
 "Takes effect after a restart. \"Follow display\" uses the scale your desktop "
 "reports, which is 100% on X11."
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:234
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:272
 msgid ""
 "\"Default\" changes nothing and lets MPV (and your own mpv.conf) decide. "
 "Pick a mode only if you are sending audio to a receiver."
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:237
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:275
 msgid ""
 "Audio your receiver can't be sent directly is encoded to AC3, which is the "
 "only way surround fits down an optical cable. Turn this off if the encoder "
 "causes audio delay — those tracks become stereo instead."
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:242
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:280
 msgid ""
 "\"hq\" offers heavier profiles. Pick it if you have a fast graphics card."
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:244
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:282
 msgid ""
 "Leave on Automatic unless video breaks when a profile is loaded. This only "
 "applies while a profile is active, and OpenGL can cost you HDR output."
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:248
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:286
 msgid ""
 "Evens out loud effects and quiet dialogue. This turns passthrough off while "
 "it is enabled, because the volume has to be adjusted before your receiver "
 "gets the audio."
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:330
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:368
 msgid "Advanced"
 msgstr ""
 
@@ -1183,7 +1207,7 @@ msgid "Automatic"
 msgstr ""
 
 #: jellyfin_mpv_shim/mpvtk_browser/downloads.py:51
-#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1355
+#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1288
 msgid "Episodes"
 msgstr ""
 
@@ -1192,7 +1216,7 @@ msgid "Season %s"
 msgstr ""
 
 #: jellyfin_mpv_shim/mpvtk_browser/downloads.py:52
-#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1351
+#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1284
 msgid "Specials"
 msgstr ""
 
@@ -1213,7 +1237,7 @@ msgid "Failed"
 msgstr ""
 
 #: jellyfin_mpv_shim/mpvtk_browser/downloads.py:185
-#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1105
+#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1038
 msgid "Playlist"
 msgstr ""
 
@@ -1225,30 +1249,30 @@ msgstr ""
 msgid "Movies & Videos"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/home_sections.py:103
+#: jellyfin_mpv_shim/mpvtk_browser/home_sections.py:104
 msgid "My Media"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/home_sections.py:104
-#: jellyfin_mpv_shim/mpvtk_browser/repository.py:352
+#: jellyfin_mpv_shim/mpvtk_browser/home_sections.py:105
+#: jellyfin_mpv_shim/mpvtk_browser/repository.py:350
 msgid "Continue Watching"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/home_sections.py:105
-#: jellyfin_mpv_shim/mpvtk_browser/repository.py:359
+#: jellyfin_mpv_shim/mpvtk_browser/home_sections.py:106
+#: jellyfin_mpv_shim/mpvtk_browser/repository.py:357
 msgid "Continue Listening"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/home_sections.py:106
-#: jellyfin_mpv_shim/mpvtk_browser/repository.py:366
+#: jellyfin_mpv_shim/mpvtk_browser/home_sections.py:107
+#: jellyfin_mpv_shim/mpvtk_browser/repository.py:364
 msgid "Next Up"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/home_sections.py:107
+#: jellyfin_mpv_shim/mpvtk_browser/home_sections.py:108
 msgid "Recently Added"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/home_sections.py:108
+#: jellyfin_mpv_shim/mpvtk_browser/home_sections.py:109
 msgid "Live TV"
 msgstr ""
 
@@ -1453,52 +1477,52 @@ msgstr ""
 msgid "Could not load this page."
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/repository.py:390
+#: jellyfin_mpv_shim/mpvtk_browser/repository.py:386
 msgid "On Now"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/repository.py:411
+#: jellyfin_mpv_shim/mpvtk_browser/repository.py:407
 msgid "Latest %s"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1119
+#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1052
 msgid "Downloaded"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1138
+#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1071
 msgid "Movies"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1143
+#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1076
 msgid "Videos"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1147
+#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1080
 msgid "TV Shows"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1151
+#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1084
 msgid "Playlists"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1168
-#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1441
+#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1101
+#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1374
 msgid "Series"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1212
+#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1145
 msgid "Downloaded Movies"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1216
+#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1149
 msgid "Downloaded Videos"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1220
+#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1153
 msgid "Downloaded Shows"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1353
+#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1286
 msgid "Season %d"
 msgstr ""
 

--- a/jellyfin_mpv_shim/messages/base.pot
+++ b/jellyfin_mpv_shim/messages/base.pot
@@ -5,7 +5,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2026-07-25 17:21-0400\n"
+"POT-Creation-Date: 2026-07-26 12:03-0400\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -239,7 +239,7 @@ msgid "Select Subtitle Track"
 msgstr ""
 
 #: jellyfin_mpv_shim/menu.py:341
-#: jellyfin_mpv_shim/mpvtk_browser/home_sections.py:102
+#: jellyfin_mpv_shim/mpvtk_browser/home_sections.py:103
 #: jellyfin_mpv_shim/osc_bridge.py:81 jellyfin_mpv_shim/osc_bridge.py:82
 #: jellyfin_mpv_shim/osc_bridge.py:104 jellyfin_mpv_shim/osc_bridge.py:140
 msgid "None"
@@ -390,7 +390,7 @@ msgstr ""
 msgid "Enable thumbnail previews"
 msgstr ""
 
-#: jellyfin_mpv_shim/menu.py:609 jellyfin_mpv_shim/mpvtk_browser/config.py:186
+#: jellyfin_mpv_shim/menu.py:609 jellyfin_mpv_shim/mpvtk_browser/config.py:195
 #: jellyfin_mpv_shim/mpvtk_browser/hud.py:375
 msgid "Night Mode (Auto Volume Adj)"
 msgstr ""
@@ -655,327 +655,339 @@ msgstr ""
 msgid "Or switch to another user"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/cast.py:317
+#: jellyfin_mpv_shim/mpvtk_browser/cast.py:314
 msgid "Ready to cast"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/cast.py:318
+#: jellyfin_mpv_shim/mpvtk_browser/cast.py:315
 msgid "Select your media in Jellyfin and play it here."
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:74
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:83
 msgid "Interface"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:83
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:92
 msgid "Playback"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:88
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:97
 msgid "Audio"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:92
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:101
 msgid "Subtitles & Languages"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:97
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:106
 msgid "Transcoding"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:102
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:111
 msgid "Video Enhancement"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:104
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:113
 msgid "Skip Intro / Credits"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:107
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:116
 msgid "Library Browser"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:109
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:118
 msgid "Downloads"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:128
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:137
 msgid "Jellyfin UI"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:129
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:138
 msgid "MPV UI with thumbnails"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:130
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:139
 msgid "MPV built-in default"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:133
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:142
 msgid "Follow display"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:134
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:143
 msgid "100% (no scaling)"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:135
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:144
 msgid "125%"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:136
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:145
 msgid "150%"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:137
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:146
 msgid "200%"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:140
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:149
 msgid "Automatic (recommended)"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:141
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:150
 msgid "Vulkan"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:142
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:151
 msgid "Direct3D 11 (Windows only)"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:143
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:152
 msgid "OpenGL (compatibility)"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:146
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:155
 msgid "Default (auto)"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:147
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:156
 msgid "Force Stereo"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:148
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:157
 msgid "Optical Surround"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:149
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:158
 msgid "HDMI Passthrough"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:152
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:161
 msgid "Unset"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:153
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:162
 msgid "Dubbed (shows only)"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:154
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:163
 msgid "Subbed (shows only)"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:155
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:164
 msgid "Dubbed (all)"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:156
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:165
 msgid "Subbed (all)"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:157
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:166
 msgid "Custom (set in config)"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:162
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:171
 msgid "Download Folder"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:163
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:172
 msgid "Prefer Downloaded Copy"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:164
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:173
 msgid "Automatically Download Upcoming Episodes"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:165
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:174
 msgid "Include Next Up"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:166
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:175
 msgid "Next Up Entries to Consider"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:167
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:176
 msgid "Episodes to Keep Ahead (0 = off)"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:168
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:177
 msgid "Storage Limit for Automatic Downloads (GB)"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:169
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:178
 msgid "Delete Automatic Downloads Once Watched"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:170
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:179
 msgid "Delete Unwatched After (days, 0 = never)"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:171
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:180
 msgid "Check Every (minutes)"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:172
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:181
 msgid "Close to Tray (keep running)"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:173
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:182
 msgid "Keep Running in Background"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:174
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:183
 msgid "Remember Window Size"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:175
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:184
 msgid "Player Controls Style"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:176
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:185
 msgid "Show What You're Watching in Discord"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:177
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:186
 msgid "Interface Scale"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:178
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:187
 msgid "Cast-target mode (no library browsing)"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:179
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:188
 msgid "Casting Opens the Library Browser"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:180
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:189
 msgid "Fullscreen Library Browser"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:181
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:190
 msgid "Always Bind Arrow Keys to Player Controls"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:182
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:191
 msgid "Player Controls Activation Key"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:183
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:192
 msgid "Audio Output Mode"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:184
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:193
 msgid "Audio Output Device"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:185
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:194
 msgid "Take the Device Exclusively"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:187
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:196
 msgid "Enable Video Playback Profiles"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:188
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:197
 msgid "Profile Group"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:189
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:198
 msgid "Remember Last Used Profile"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:190
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:199
 msgid "Graphics API for Shaders"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:191
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:200
 msgid "Pass Through AC3"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:192
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:201
 msgid "Pass Through DTS"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:193
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:202
 msgid "Pass Through E-AC3"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:194
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:203
 msgid "Pass Through DTS-HD"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:195
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:204
 msgid "Pass Through TrueHD"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:196
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:205
 msgid "Re-encode Others to AC3"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:202
-msgid "MPV keybinds are used by default. Press ENTER to drive the player controls by keyboard."
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:213
+msgid "With \"Start Minimized\" and \"Fullscreen\" this is the classic cast-target setup: the app waits out of the way, plays fullscreen when something casts to it, and goes back to waiting when the video ends or you press Q."
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:204
-msgid "Pixels one wheel notch scrolls. The scrollbar glides while the content snaps to the nearest row, so a trackpad or trackball no longer overshoots. Raise it to scroll faster, lower it for finer control."
-msgstr ""
-
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:209
-msgid "Make each wheel notch jump exactly one row (or one home-screen section) instead of gliding. Turn this on if you prefer the older stepped scrolling."
-msgstr ""
-
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:217
-msgid "Discord Rich Presence. Takes effect after a restart."
-msgstr ""
-
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:219
-msgid "Leave this to Default unless setting up passthrough. Note some audio servers like Pipewire don't like passthrough and will need to be disabled for a card before it'll let *any* audio through in passthrough mode. In my tests I got silence otherwise, but results may vary."
-msgstr ""
-
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:225
-msgid "Stop anything else using the device while playing. Needed for passthrough on some systems, and it means other applications will be silent."
-msgstr ""
-
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:228
-msgid "Page the library and music tile grids instead of scrolling: each page is one screenful with First / Previous / Next / Last controls and a page number you can type into. Easier than precise scrolling on a trackpad."
-msgstr ""
-
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:232
-msgid "Takes effect after a restart. \"Follow display\" uses the scale your desktop reports, which is 100% on X11."
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:227
+msgid "Off means command-line mode: no window, no system tray and no settings screen, so the only way back is editing conf.json by hand. It is not how you get MPV's own on-screen controls — \"Player Controls Style\" under Interface does that."
 msgstr ""
 
 #: jellyfin_mpv_shim/mpvtk_browser/config.py:234
-msgid "\"Default\" changes nothing and lets MPV (and your own mpv.conf) decide. Pick a mode only if you are sending audio to a receiver."
+msgid "Show only what is cast to this machine — the library, including this settings screen, can't be reached from here. Without a system tray icon the only way back is editing conf.json. For the classic cast-target setup you want the Interface settings instead; this is for a shared TV nobody should be able to browse from."
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:237
-msgid "Audio your receiver can't be sent directly is encoded to AC3, which is the only way surround fits down an optical cable. Turn this off if the encoder causes audio delay — those tracks become stereo instead."
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:240
+msgid "Requires restart to change. MPV keybinds are used by default. Press ENTER to drive the player controls by keyboard."
 msgstr ""
 
 #: jellyfin_mpv_shim/mpvtk_browser/config.py:242
+msgid "Pixels one wheel notch scrolls. The scrollbar glides while the content snaps to the nearest row, so a trackpad or trackball no longer overshoots. Raise it to scroll faster, lower it for finer control."
+msgstr ""
+
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:247
+msgid "Make each wheel notch jump exactly one row (or one home-screen section) instead of gliding. Turn this on if you prefer the older stepped scrolling."
+msgstr ""
+
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:255
+msgid "Discord Rich Presence. Takes effect after a restart."
+msgstr ""
+
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:257
+msgid "Leave this to Default unless setting up passthrough. Note some audio servers like Pipewire don't like passthrough and will need to be disabled for a card before it'll let *any* audio through in passthrough mode. In my tests I got silence otherwise, but results may vary."
+msgstr ""
+
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:263
+msgid "Stop anything else using the device while playing. Needed for passthrough on some systems, and it means other applications will be silent."
+msgstr ""
+
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:266
+msgid "Page the library and music tile grids instead of scrolling: each page is one screenful with First / Previous / Next / Last controls and a page number you can type into. Easier than precise scrolling on a trackpad."
+msgstr ""
+
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:270
+msgid "Takes effect after a restart. \"Follow display\" uses the scale your desktop reports, which is 100% on X11."
+msgstr ""
+
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:272
+msgid "\"Default\" changes nothing and lets MPV (and your own mpv.conf) decide. Pick a mode only if you are sending audio to a receiver."
+msgstr ""
+
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:275
+msgid "Audio your receiver can't be sent directly is encoded to AC3, which is the only way surround fits down an optical cable. Turn this off if the encoder causes audio delay — those tracks become stereo instead."
+msgstr ""
+
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:280
 msgid "\"hq\" offers heavier profiles. Pick it if you have a fast graphics card."
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:244
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:282
 msgid "Leave on Automatic unless video breaks when a profile is loaded. This only applies while a profile is active, and OpenGL can cost you HDR output."
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:248
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:286
 msgid "Evens out loud effects and quiet dialogue. This turns passthrough off while it is enabled, because the volume has to be adjusted before your receiver gets the audio."
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:330
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:368
 msgid "Advanced"
 msgstr ""
 
@@ -1151,7 +1163,7 @@ msgid "Automatic"
 msgstr ""
 
 #: jellyfin_mpv_shim/mpvtk_browser/downloads.py:51
-#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1355
+#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1288
 msgid "Episodes"
 msgstr ""
 
@@ -1160,7 +1172,7 @@ msgid "Season %s"
 msgstr ""
 
 #: jellyfin_mpv_shim/mpvtk_browser/downloads.py:52
-#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1351
+#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1284
 msgid "Specials"
 msgstr ""
 
@@ -1181,7 +1193,7 @@ msgid "Failed"
 msgstr ""
 
 #: jellyfin_mpv_shim/mpvtk_browser/downloads.py:185
-#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1105
+#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1038
 msgid "Playlist"
 msgstr ""
 
@@ -1193,30 +1205,30 @@ msgstr ""
 msgid "Movies & Videos"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/home_sections.py:103
+#: jellyfin_mpv_shim/mpvtk_browser/home_sections.py:104
 msgid "My Media"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/home_sections.py:104
-#: jellyfin_mpv_shim/mpvtk_browser/repository.py:352
+#: jellyfin_mpv_shim/mpvtk_browser/home_sections.py:105
+#: jellyfin_mpv_shim/mpvtk_browser/repository.py:350
 msgid "Continue Watching"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/home_sections.py:105
-#: jellyfin_mpv_shim/mpvtk_browser/repository.py:359
+#: jellyfin_mpv_shim/mpvtk_browser/home_sections.py:106
+#: jellyfin_mpv_shim/mpvtk_browser/repository.py:357
 msgid "Continue Listening"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/home_sections.py:106
-#: jellyfin_mpv_shim/mpvtk_browser/repository.py:366
+#: jellyfin_mpv_shim/mpvtk_browser/home_sections.py:107
+#: jellyfin_mpv_shim/mpvtk_browser/repository.py:364
 msgid "Next Up"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/home_sections.py:107
+#: jellyfin_mpv_shim/mpvtk_browser/home_sections.py:108
 msgid "Recently Added"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/home_sections.py:108
+#: jellyfin_mpv_shim/mpvtk_browser/home_sections.py:109
 msgid "Live TV"
 msgstr ""
 
@@ -1421,52 +1433,52 @@ msgstr ""
 msgid "Could not load this page."
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/repository.py:390
+#: jellyfin_mpv_shim/mpvtk_browser/repository.py:386
 msgid "On Now"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/repository.py:411
+#: jellyfin_mpv_shim/mpvtk_browser/repository.py:407
 msgid "Latest %s"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1119
+#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1052
 msgid "Downloaded"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1138
+#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1071
 msgid "Movies"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1143
+#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1076
 msgid "Videos"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1147
+#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1080
 msgid "TV Shows"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1151
+#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1084
 msgid "Playlists"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1168
-#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1441
+#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1101
+#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1374
 msgid "Series"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1212
+#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1145
 msgid "Downloaded Movies"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1216
+#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1149
 msgid "Downloaded Videos"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1220
+#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1153
 msgid "Downloaded Shows"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1353
+#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1286
 msgid "Season %d"
 msgstr ""
 

--- a/jellyfin_mpv_shim/messages/be/LC_MESSAGES/base.po
+++ b/jellyfin_mpv_shim/messages/be/LC_MESSAGES/base.po
@@ -5,7 +5,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2026-07-25 17:21-0400\n"
+"POT-Creation-Date: 2026-07-26 12:03-0400\n"
 "PO-Revision-Date: 2026-06-29 09:08+0000\n"
 "Last-Translator: Pavel Miniutka <pavel.miniutka@gmail.com>\n"
 "Language-Team: Belarusian <https://translate.jellyfin.org/projects/jellyfin/"
@@ -247,7 +247,7 @@ msgid "Select Subtitle Track"
 msgstr "Выбраць дарожку субцітраў"
 
 #: jellyfin_mpv_shim/menu.py:341
-#: jellyfin_mpv_shim/mpvtk_browser/home_sections.py:102
+#: jellyfin_mpv_shim/mpvtk_browser/home_sections.py:103
 #: jellyfin_mpv_shim/osc_bridge.py:81 jellyfin_mpv_shim/osc_bridge.py:82
 #: jellyfin_mpv_shim/osc_bridge.py:104 jellyfin_mpv_shim/osc_bridge.py:140
 msgid "None"
@@ -398,7 +398,7 @@ msgstr "Патыцца, ці прапускаць цітры"
 msgid "Enable thumbnail previews"
 msgstr "Уключыць папярэдні прагляд мініяцюр"
 
-#: jellyfin_mpv_shim/menu.py:609 jellyfin_mpv_shim/mpvtk_browser/config.py:186
+#: jellyfin_mpv_shim/menu.py:609 jellyfin_mpv_shim/mpvtk_browser/config.py:195
 #: jellyfin_mpv_shim/mpvtk_browser/hud.py:375
 msgid "Night Mode (Auto Volume Adj)"
 msgstr ""
@@ -683,310 +683,334 @@ msgstr ""
 msgid "Or switch to another user"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/cast.py:317
+#: jellyfin_mpv_shim/mpvtk_browser/cast.py:314
 msgid "Ready to cast"
 msgstr "Гатовы да перадачы"
 
-#: jellyfin_mpv_shim/mpvtk_browser/cast.py:318
+#: jellyfin_mpv_shim/mpvtk_browser/cast.py:315
 #, fuzzy
 #| msgid "Select your media in Jellyfin and play it here"
 msgid "Select your media in Jellyfin and play it here."
 msgstr "Выберыце свой медыяфайл у Jellyfin і прайграйце яго тут"
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:74
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:83
 msgid "Interface"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:83
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:92
 msgid "Playback"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:88
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:97
 msgid "Audio"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:92
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:101
 msgid "Subtitles & Languages"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:97
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:106
 #, fuzzy
 #| msgid " (Transcode)"
 msgid "Transcoding"
 msgstr " (Перакадзіраваць)"
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:102
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:111
 msgid "Video Enhancement"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:104
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:113
 #, fuzzy
 #| msgid "Seek to Skip Credits"
 msgid "Skip Intro / Credits"
 msgstr "Прапусціць цітры"
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:107
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:116
 msgid "Library Browser"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:109
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:118
 msgid "Downloads"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:128
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:137
 msgid "Jellyfin UI"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:129
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:138
 msgid "MPV UI with thumbnails"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:130
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:139
 msgid "MPV built-in default"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:133
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:142
 msgid "Follow display"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:134
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:143
 msgid "100% (no scaling)"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:135
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:144
 msgid "125%"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:136
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:145
 msgid "150%"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:137
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:146
 msgid "200%"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:140
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:149
 msgid "Automatic (recommended)"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:141
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:150
 msgid "Vulkan"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:142
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:151
 msgid "Direct3D 11 (Windows only)"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:143
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:152
 msgid "OpenGL (compatibility)"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:146
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:155
 msgid "Default (auto)"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:147
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:156
 msgid "Force Stereo"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:148
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:157
 msgid "Optical Surround"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:149
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:158
 msgid "HDMI Passthrough"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:152
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:161
 msgid "Unset"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:153
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:162
 msgid "Dubbed (shows only)"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:154
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:163
 msgid "Subbed (shows only)"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:155
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:164
 msgid "Dubbed (all)"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:156
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:165
 msgid "Subbed (all)"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:157
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:166
 msgid "Custom (set in config)"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:162
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:171
 msgid "Download Folder"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:163
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:172
 msgid "Prefer Downloaded Copy"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:164
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:173
 msgid "Automatically Download Upcoming Episodes"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:165
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:174
 msgid "Include Next Up"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:166
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:175
 msgid "Next Up Entries to Consider"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:167
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:176
 msgid "Episodes to Keep Ahead (0 = off)"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:168
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:177
 msgid "Storage Limit for Automatic Downloads (GB)"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:169
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:178
 #, fuzzy
 #| msgid "Auto Play"
 msgid "Delete Automatic Downloads Once Watched"
 msgstr "Аўтапрайграванне"
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:170
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:179
 msgid "Delete Unwatched After (days, 0 = never)"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:171
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:180
 msgid "Check Every (minutes)"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:172
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:181
 msgid "Close to Tray (keep running)"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:173
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:182
 msgid "Keep Running in Background"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:174
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:183
 msgid "Remember Window Size"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:175
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:184
 msgid "Player Controls Style"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:176
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:185
 msgid "Show What You're Watching in Discord"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:177
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:186
 msgid "Interface Scale"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:178
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:187
 msgid "Cast-target mode (no library browsing)"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:179
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:188
 msgid "Casting Opens the Library Browser"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:180
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:189
 msgid "Fullscreen Library Browser"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:181
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:190
 msgid "Always Bind Arrow Keys to Player Controls"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:182
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:191
 msgid "Player Controls Activation Key"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:183
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:192
 msgid "Audio Output Mode"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:184
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:193
 msgid "Audio Output Device"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:185
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:194
 msgid "Take the Device Exclusively"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:187
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:196
 #, fuzzy
 #| msgid "Video Playback Profiles"
 msgid "Enable Video Playback Profiles"
 msgstr "Профілі прайгравання відэа"
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:188
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:197
 #, fuzzy
 #| msgid "New Group"
 msgid "Profile Group"
 msgstr "Новая група"
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:189
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:198
 msgid "Remember Last Used Profile"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:190
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:199
 msgid "Graphics API for Shaders"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:191
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:200
 msgid "Pass Through AC3"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:192
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:201
 msgid "Pass Through DTS"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:193
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:202
 msgid "Pass Through E-AC3"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:194
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:203
 msgid "Pass Through DTS-HD"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:195
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:204
 msgid "Pass Through TrueHD"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:196
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:205
 msgid "Re-encode Others to AC3"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:202
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:213
 msgid ""
-"MPV keybinds are used by default. Press ENTER to drive the player controls "
-"by keyboard."
+"With \"Start Minimized\" and \"Fullscreen\" this is the classic cast-target "
+"setup: the app waits out of the way, plays fullscreen when something casts "
+"to it, and goes back to waiting when the video ends or you press Q."
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:204
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:227
+msgid ""
+"Off means command-line mode: no window, no system tray and no settings "
+"screen, so the only way back is editing conf.json by hand. It is not how you "
+"get MPV's own on-screen controls — \"Player Controls Style\" under Interface "
+"does that."
+msgstr ""
+
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:234
+msgid ""
+"Show only what is cast to this machine — the library, including this "
+"settings screen, can't be reached from here. Without a system tray icon the "
+"only way back is editing conf.json. For the classic cast-target setup you "
+"want the Interface settings instead; this is for a shared TV nobody should "
+"be able to browse from."
+msgstr ""
+
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:240
+msgid ""
+"Requires restart to change. MPV keybinds are used by default. Press ENTER to "
+"drive the player controls by keyboard."
+msgstr ""
+
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:242
 msgid ""
 "Pixels one wheel notch scrolls. The scrollbar glides while the content snaps "
 "to the nearest row, so a trackpad or trackball no longer overshoots. Raise "
 "it to scroll faster, lower it for finer control."
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:209
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:247
 msgid ""
 "Make each wheel notch jump exactly one row (or one home-screen section) "
 "instead of gliding. Turn this on if you prefer the older stepped scrolling."
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:217
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:255
 msgid "Discord Rich Presence. Takes effect after a restart."
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:219
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:257
 msgid ""
 "Leave this to Default unless setting up passthrough. Note some audio servers "
 "like Pipewire don't like passthrough and will need to be disabled for a card "
@@ -994,57 +1018,57 @@ msgid ""
 "silence otherwise, but results may vary."
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:225
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:263
 msgid ""
 "Stop anything else using the device while playing. Needed for passthrough on "
 "some systems, and it means other applications will be silent."
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:228
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:266
 msgid ""
 "Page the library and music tile grids instead of scrolling: each page is one "
 "screenful with First / Previous / Next / Last controls and a page number you "
 "can type into. Easier than precise scrolling on a trackpad."
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:232
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:270
 msgid ""
 "Takes effect after a restart. \"Follow display\" uses the scale your desktop "
 "reports, which is 100% on X11."
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:234
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:272
 msgid ""
 "\"Default\" changes nothing and lets MPV (and your own mpv.conf) decide. "
 "Pick a mode only if you are sending audio to a receiver."
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:237
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:275
 msgid ""
 "Audio your receiver can't be sent directly is encoded to AC3, which is the "
 "only way surround fits down an optical cable. Turn this off if the encoder "
 "causes audio delay — those tracks become stereo instead."
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:242
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:280
 msgid ""
 "\"hq\" offers heavier profiles. Pick it if you have a fast graphics card."
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:244
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:282
 msgid ""
 "Leave on Automatic unless video breaks when a profile is loaded. This only "
 "applies while a profile is active, and OpenGL can cost you HDR output."
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:248
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:286
 msgid ""
 "Evens out loud effects and quiet dialogue. This turns passthrough off while "
 "it is enabled, because the volume has to be adjusted before your receiver "
 "gets the audio."
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:330
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:368
 msgid "Advanced"
 msgstr ""
 
@@ -1244,7 +1268,7 @@ msgid "Automatic"
 msgstr "Аўтаматычна"
 
 #: jellyfin_mpv_shim/mpvtk_browser/downloads.py:51
-#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1355
+#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1288
 msgid "Episodes"
 msgstr ""
 
@@ -1253,7 +1277,7 @@ msgid "Season %s"
 msgstr ""
 
 #: jellyfin_mpv_shim/mpvtk_browser/downloads.py:52
-#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1351
+#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1284
 msgid "Specials"
 msgstr ""
 
@@ -1278,7 +1302,7 @@ msgid "Failed"
 msgstr "Няўдача"
 
 #: jellyfin_mpv_shim/mpvtk_browser/downloads.py:185
-#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1105
+#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1038
 msgid "Playlist"
 msgstr ""
 
@@ -1290,30 +1314,30 @@ msgstr ""
 msgid "Movies & Videos"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/home_sections.py:103
+#: jellyfin_mpv_shim/mpvtk_browser/home_sections.py:104
 msgid "My Media"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/home_sections.py:104
-#: jellyfin_mpv_shim/mpvtk_browser/repository.py:352
+#: jellyfin_mpv_shim/mpvtk_browser/home_sections.py:105
+#: jellyfin_mpv_shim/mpvtk_browser/repository.py:350
 msgid "Continue Watching"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/home_sections.py:105
-#: jellyfin_mpv_shim/mpvtk_browser/repository.py:359
+#: jellyfin_mpv_shim/mpvtk_browser/home_sections.py:106
+#: jellyfin_mpv_shim/mpvtk_browser/repository.py:357
 msgid "Continue Listening"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/home_sections.py:106
-#: jellyfin_mpv_shim/mpvtk_browser/repository.py:366
+#: jellyfin_mpv_shim/mpvtk_browser/home_sections.py:107
+#: jellyfin_mpv_shim/mpvtk_browser/repository.py:364
 msgid "Next Up"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/home_sections.py:107
+#: jellyfin_mpv_shim/mpvtk_browser/home_sections.py:108
 msgid "Recently Added"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/home_sections.py:108
+#: jellyfin_mpv_shim/mpvtk_browser/home_sections.py:109
 msgid "Live TV"
 msgstr ""
 
@@ -1546,52 +1570,52 @@ msgstr ""
 msgid "Could not load this page."
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/repository.py:390
+#: jellyfin_mpv_shim/mpvtk_browser/repository.py:386
 msgid "On Now"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/repository.py:411
+#: jellyfin_mpv_shim/mpvtk_browser/repository.py:407
 msgid "Latest %s"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1119
+#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1052
 msgid "Downloaded"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1138
+#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1071
 msgid "Movies"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1143
+#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1076
 msgid "Videos"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1147
+#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1080
 msgid "TV Shows"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1151
+#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1084
 msgid "Playlists"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1168
-#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1441
+#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1101
+#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1374
 msgid "Series"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1212
+#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1145
 msgid "Downloaded Movies"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1216
+#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1149
 msgid "Downloaded Videos"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1220
+#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1153
 msgid "Downloaded Shows"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1353
+#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1286
 msgid "Season %d"
 msgstr ""
 

--- a/jellyfin_mpv_shim/messages/bg/LC_MESSAGES/base.po
+++ b/jellyfin_mpv_shim/messages/bg/LC_MESSAGES/base.po
@@ -5,7 +5,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2026-07-25 17:21-0400\n"
+"POT-Creation-Date: 2026-07-26 12:03-0400\n"
 "PO-Revision-Date: 2026-04-29 16:08+0000\n"
 "Last-Translator: d0nizam <dzhaid.nizam@gmail.com>\n"
 "Language-Team: Bulgarian <https://translate.jellyfin.org/projects/jellyfin/"
@@ -252,7 +252,7 @@ msgid "Select Subtitle Track"
 msgstr "Избери субтитри"
 
 #: jellyfin_mpv_shim/menu.py:341
-#: jellyfin_mpv_shim/mpvtk_browser/home_sections.py:102
+#: jellyfin_mpv_shim/mpvtk_browser/home_sections.py:103
 #: jellyfin_mpv_shim/osc_bridge.py:81 jellyfin_mpv_shim/osc_bridge.py:82
 #: jellyfin_mpv_shim/osc_bridge.py:104 jellyfin_mpv_shim/osc_bridge.py:140
 msgid "None"
@@ -403,7 +403,7 @@ msgstr "Питай за пропуск на надписите"
 msgid "Enable thumbnail previews"
 msgstr "Активиране преглед на миниатюрни визуализации"
 
-#: jellyfin_mpv_shim/menu.py:609 jellyfin_mpv_shim/mpvtk_browser/config.py:186
+#: jellyfin_mpv_shim/menu.py:609 jellyfin_mpv_shim/mpvtk_browser/config.py:195
 #: jellyfin_mpv_shim/mpvtk_browser/hud.py:375
 msgid "Night Mode (Auto Volume Adj)"
 msgstr ""
@@ -702,310 +702,334 @@ msgstr ""
 msgid "Or switch to another user"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/cast.py:317
+#: jellyfin_mpv_shim/mpvtk_browser/cast.py:314
 msgid "Ready to cast"
 msgstr "Готов да предава"
 
-#: jellyfin_mpv_shim/mpvtk_browser/cast.py:318
+#: jellyfin_mpv_shim/mpvtk_browser/cast.py:315
 #, fuzzy
 #| msgid "Select your media in Jellyfin and play it here"
 msgid "Select your media in Jellyfin and play it here."
 msgstr "Избери своята медия в Джелифин и я пусни тук"
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:74
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:83
 msgid "Interface"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:83
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:92
 msgid "Playback"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:88
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:97
 msgid "Audio"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:92
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:101
 msgid "Subtitles & Languages"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:97
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:106
 #, fuzzy
 #| msgid " (Transcode)"
 msgid "Transcoding"
 msgstr " (Транскодиране)"
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:102
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:111
 msgid "Video Enhancement"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:104
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:113
 #, fuzzy
 #| msgid "Seek to Skip Credits"
 msgid "Skip Intro / Credits"
 msgstr "Търсене за пропускане на надписите"
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:107
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:116
 msgid "Library Browser"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:109
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:118
 msgid "Downloads"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:128
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:137
 msgid "Jellyfin UI"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:129
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:138
 msgid "MPV UI with thumbnails"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:130
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:139
 msgid "MPV built-in default"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:133
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:142
 msgid "Follow display"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:134
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:143
 msgid "100% (no scaling)"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:135
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:144
 msgid "125%"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:136
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:145
 msgid "150%"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:137
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:146
 msgid "200%"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:140
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:149
 msgid "Automatic (recommended)"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:141
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:150
 msgid "Vulkan"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:142
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:151
 msgid "Direct3D 11 (Windows only)"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:143
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:152
 msgid "OpenGL (compatibility)"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:146
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:155
 msgid "Default (auto)"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:147
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:156
 msgid "Force Stereo"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:148
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:157
 msgid "Optical Surround"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:149
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:158
 msgid "HDMI Passthrough"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:152
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:161
 msgid "Unset"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:153
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:162
 msgid "Dubbed (shows only)"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:154
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:163
 msgid "Subbed (shows only)"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:155
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:164
 msgid "Dubbed (all)"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:156
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:165
 msgid "Subbed (all)"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:157
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:166
 msgid "Custom (set in config)"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:162
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:171
 msgid "Download Folder"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:163
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:172
 msgid "Prefer Downloaded Copy"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:164
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:173
 msgid "Automatically Download Upcoming Episodes"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:165
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:174
 msgid "Include Next Up"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:166
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:175
 msgid "Next Up Entries to Consider"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:167
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:176
 msgid "Episodes to Keep Ahead (0 = off)"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:168
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:177
 msgid "Storage Limit for Automatic Downloads (GB)"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:169
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:178
 #, fuzzy
 #| msgid "Remove Server"
 msgid "Delete Automatic Downloads Once Watched"
 msgstr "Отдалечен сървър"
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:170
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:179
 msgid "Delete Unwatched After (days, 0 = never)"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:171
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:180
 msgid "Check Every (minutes)"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:172
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:181
 msgid "Close to Tray (keep running)"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:173
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:182
 msgid "Keep Running in Background"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:174
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:183
 msgid "Remember Window Size"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:175
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:184
 msgid "Player Controls Style"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:176
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:185
 msgid "Show What You're Watching in Discord"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:177
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:186
 msgid "Interface Scale"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:178
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:187
 msgid "Cast-target mode (no library browsing)"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:179
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:188
 msgid "Casting Opens the Library Browser"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:180
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:189
 msgid "Fullscreen Library Browser"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:181
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:190
 msgid "Always Bind Arrow Keys to Player Controls"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:182
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:191
 msgid "Player Controls Activation Key"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:183
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:192
 msgid "Audio Output Mode"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:184
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:193
 msgid "Audio Output Device"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:185
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:194
 msgid "Take the Device Exclusively"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:187
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:196
 #, fuzzy
 #| msgid "Video Playback Profiles"
 msgid "Enable Video Playback Profiles"
 msgstr "Профили за възпроизвеждане на видеото"
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:188
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:197
 #, fuzzy
 #| msgid "New Group"
 msgid "Profile Group"
 msgstr "Нова група"
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:189
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:198
 msgid "Remember Last Used Profile"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:190
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:199
 msgid "Graphics API for Shaders"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:191
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:200
 msgid "Pass Through AC3"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:192
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:201
 msgid "Pass Through DTS"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:193
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:202
 msgid "Pass Through E-AC3"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:194
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:203
 msgid "Pass Through DTS-HD"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:195
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:204
 msgid "Pass Through TrueHD"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:196
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:205
 msgid "Re-encode Others to AC3"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:202
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:213
 msgid ""
-"MPV keybinds are used by default. Press ENTER to drive the player controls "
-"by keyboard."
+"With \"Start Minimized\" and \"Fullscreen\" this is the classic cast-target "
+"setup: the app waits out of the way, plays fullscreen when something casts "
+"to it, and goes back to waiting when the video ends or you press Q."
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:204
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:227
+msgid ""
+"Off means command-line mode: no window, no system tray and no settings "
+"screen, so the only way back is editing conf.json by hand. It is not how you "
+"get MPV's own on-screen controls — \"Player Controls Style\" under Interface "
+"does that."
+msgstr ""
+
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:234
+msgid ""
+"Show only what is cast to this machine — the library, including this "
+"settings screen, can't be reached from here. Without a system tray icon the "
+"only way back is editing conf.json. For the classic cast-target setup you "
+"want the Interface settings instead; this is for a shared TV nobody should "
+"be able to browse from."
+msgstr ""
+
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:240
+msgid ""
+"Requires restart to change. MPV keybinds are used by default. Press ENTER to "
+"drive the player controls by keyboard."
+msgstr ""
+
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:242
 msgid ""
 "Pixels one wheel notch scrolls. The scrollbar glides while the content snaps "
 "to the nearest row, so a trackpad or trackball no longer overshoots. Raise "
 "it to scroll faster, lower it for finer control."
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:209
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:247
 msgid ""
 "Make each wheel notch jump exactly one row (or one home-screen section) "
 "instead of gliding. Turn this on if you prefer the older stepped scrolling."
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:217
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:255
 msgid "Discord Rich Presence. Takes effect after a restart."
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:219
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:257
 msgid ""
 "Leave this to Default unless setting up passthrough. Note some audio servers "
 "like Pipewire don't like passthrough and will need to be disabled for a card "
@@ -1013,57 +1037,57 @@ msgid ""
 "silence otherwise, but results may vary."
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:225
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:263
 msgid ""
 "Stop anything else using the device while playing. Needed for passthrough on "
 "some systems, and it means other applications will be silent."
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:228
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:266
 msgid ""
 "Page the library and music tile grids instead of scrolling: each page is one "
 "screenful with First / Previous / Next / Last controls and a page number you "
 "can type into. Easier than precise scrolling on a trackpad."
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:232
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:270
 msgid ""
 "Takes effect after a restart. \"Follow display\" uses the scale your desktop "
 "reports, which is 100% on X11."
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:234
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:272
 msgid ""
 "\"Default\" changes nothing and lets MPV (and your own mpv.conf) decide. "
 "Pick a mode only if you are sending audio to a receiver."
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:237
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:275
 msgid ""
 "Audio your receiver can't be sent directly is encoded to AC3, which is the "
 "only way surround fits down an optical cable. Turn this off if the encoder "
 "causes audio delay — those tracks become stereo instead."
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:242
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:280
 msgid ""
 "\"hq\" offers heavier profiles. Pick it if you have a fast graphics card."
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:244
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:282
 msgid ""
 "Leave on Automatic unless video breaks when a profile is loaded. This only "
 "applies while a profile is active, and OpenGL can cost you HDR output."
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:248
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:286
 msgid ""
 "Evens out loud effects and quiet dialogue. This turns passthrough off while "
 "it is enabled, because the volume has to be adjusted before your receiver "
 "gets the audio."
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:330
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:368
 msgid "Advanced"
 msgstr ""
 
@@ -1289,7 +1313,7 @@ msgid "Automatic"
 msgstr "Автоматично"
 
 #: jellyfin_mpv_shim/mpvtk_browser/downloads.py:51
-#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1355
+#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1288
 msgid "Episodes"
 msgstr ""
 
@@ -1298,7 +1322,7 @@ msgid "Season %s"
 msgstr ""
 
 #: jellyfin_mpv_shim/mpvtk_browser/downloads.py:52
-#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1351
+#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1284
 msgid "Specials"
 msgstr ""
 
@@ -1323,7 +1347,7 @@ msgid "Failed"
 msgstr "Грешка"
 
 #: jellyfin_mpv_shim/mpvtk_browser/downloads.py:185
-#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1105
+#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1038
 msgid "Playlist"
 msgstr ""
 
@@ -1335,30 +1359,30 @@ msgstr ""
 msgid "Movies & Videos"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/home_sections.py:103
+#: jellyfin_mpv_shim/mpvtk_browser/home_sections.py:104
 msgid "My Media"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/home_sections.py:104
-#: jellyfin_mpv_shim/mpvtk_browser/repository.py:352
+#: jellyfin_mpv_shim/mpvtk_browser/home_sections.py:105
+#: jellyfin_mpv_shim/mpvtk_browser/repository.py:350
 msgid "Continue Watching"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/home_sections.py:105
-#: jellyfin_mpv_shim/mpvtk_browser/repository.py:359
+#: jellyfin_mpv_shim/mpvtk_browser/home_sections.py:106
+#: jellyfin_mpv_shim/mpvtk_browser/repository.py:357
 msgid "Continue Listening"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/home_sections.py:106
-#: jellyfin_mpv_shim/mpvtk_browser/repository.py:366
+#: jellyfin_mpv_shim/mpvtk_browser/home_sections.py:107
+#: jellyfin_mpv_shim/mpvtk_browser/repository.py:364
 msgid "Next Up"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/home_sections.py:107
+#: jellyfin_mpv_shim/mpvtk_browser/home_sections.py:108
 msgid "Recently Added"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/home_sections.py:108
+#: jellyfin_mpv_shim/mpvtk_browser/home_sections.py:109
 msgid "Live TV"
 msgstr ""
 
@@ -1611,52 +1635,52 @@ msgstr ""
 "Не може да бъде добавен сървър.\n"
 "Моля,проверете информацията за връзката."
 
-#: jellyfin_mpv_shim/mpvtk_browser/repository.py:390
+#: jellyfin_mpv_shim/mpvtk_browser/repository.py:386
 msgid "On Now"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/repository.py:411
+#: jellyfin_mpv_shim/mpvtk_browser/repository.py:407
 msgid "Latest %s"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1119
+#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1052
 msgid "Downloaded"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1138
+#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1071
 msgid "Movies"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1143
+#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1076
 msgid "Videos"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1147
+#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1080
 msgid "TV Shows"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1151
+#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1084
 msgid "Playlists"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1168
-#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1441
+#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1101
+#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1374
 msgid "Series"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1212
+#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1145
 msgid "Downloaded Movies"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1216
+#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1149
 msgid "Downloaded Videos"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1220
+#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1153
 msgid "Downloaded Shows"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1353
+#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1286
 msgid "Season %d"
 msgstr ""
 

--- a/jellyfin_mpv_shim/messages/bn/LC_MESSAGES/base.po
+++ b/jellyfin_mpv_shim/messages/bn/LC_MESSAGES/base.po
@@ -5,7 +5,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2026-07-25 17:21-0400\n"
+"POT-Creation-Date: 2026-07-26 12:03-0400\n"
 "PO-Revision-Date: 2026-05-20 10:59+0000\n"
 "Last-Translator: Sarker Siam <siamsarker36@gmail.com>\n"
 "Language-Team: Bengali <https://translate.jellyfin.org/projects/jellyfin/"
@@ -252,7 +252,7 @@ msgid "Select Subtitle Track"
 msgstr "সাবটাইটেল ট্র্যাক নির্বাচন করুন"
 
 #: jellyfin_mpv_shim/menu.py:341
-#: jellyfin_mpv_shim/mpvtk_browser/home_sections.py:102
+#: jellyfin_mpv_shim/mpvtk_browser/home_sections.py:103
 #: jellyfin_mpv_shim/osc_bridge.py:81 jellyfin_mpv_shim/osc_bridge.py:82
 #: jellyfin_mpv_shim/osc_bridge.py:104 jellyfin_mpv_shim/osc_bridge.py:140
 msgid "None"
@@ -403,7 +403,7 @@ msgstr "ক্রেডিট স্কিপ করতে জিজ্ঞাস
 msgid "Enable thumbnail previews"
 msgstr "থাম্বনেইল প্রিভিউ সক্ষম করুন"
 
-#: jellyfin_mpv_shim/menu.py:609 jellyfin_mpv_shim/mpvtk_browser/config.py:186
+#: jellyfin_mpv_shim/menu.py:609 jellyfin_mpv_shim/mpvtk_browser/config.py:195
 #: jellyfin_mpv_shim/mpvtk_browser/hud.py:375
 msgid "Night Mode (Auto Volume Adj)"
 msgstr ""
@@ -702,310 +702,334 @@ msgstr ""
 msgid "Or switch to another user"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/cast.py:317
+#: jellyfin_mpv_shim/mpvtk_browser/cast.py:314
 msgid "Ready to cast"
 msgstr "কাস্ট করার জন্য প্রস্তুত"
 
-#: jellyfin_mpv_shim/mpvtk_browser/cast.py:318
+#: jellyfin_mpv_shim/mpvtk_browser/cast.py:315
 #, fuzzy
 #| msgid "Select your media in Jellyfin and play it here"
 msgid "Select your media in Jellyfin and play it here."
 msgstr "জেলিফিনে আপনার মিডিয়া নির্বাচন করুন এবং এখানে তা চালান"
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:74
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:83
 msgid "Interface"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:83
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:92
 msgid "Playback"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:88
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:97
 msgid "Audio"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:92
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:101
 msgid "Subtitles & Languages"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:97
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:106
 #, fuzzy
 #| msgid " (Transcode)"
 msgid "Transcoding"
 msgstr " (ট্রান্সকোড)"
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:102
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:111
 msgid "Video Enhancement"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:104
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:113
 #, fuzzy
 #| msgid "Seek to Skip Credits"
 msgid "Skip Intro / Credits"
 msgstr "ক্রেডিট স্কিপ করতে সিক করুন"
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:107
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:116
 msgid "Library Browser"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:109
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:118
 msgid "Downloads"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:128
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:137
 msgid "Jellyfin UI"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:129
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:138
 msgid "MPV UI with thumbnails"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:130
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:139
 msgid "MPV built-in default"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:133
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:142
 msgid "Follow display"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:134
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:143
 msgid "100% (no scaling)"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:135
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:144
 msgid "125%"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:136
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:145
 msgid "150%"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:137
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:146
 msgid "200%"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:140
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:149
 msgid "Automatic (recommended)"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:141
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:150
 msgid "Vulkan"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:142
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:151
 msgid "Direct3D 11 (Windows only)"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:143
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:152
 msgid "OpenGL (compatibility)"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:146
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:155
 msgid "Default (auto)"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:147
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:156
 msgid "Force Stereo"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:148
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:157
 msgid "Optical Surround"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:149
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:158
 msgid "HDMI Passthrough"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:152
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:161
 msgid "Unset"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:153
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:162
 msgid "Dubbed (shows only)"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:154
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:163
 msgid "Subbed (shows only)"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:155
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:164
 msgid "Dubbed (all)"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:156
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:165
 msgid "Subbed (all)"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:157
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:166
 msgid "Custom (set in config)"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:162
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:171
 msgid "Download Folder"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:163
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:172
 msgid "Prefer Downloaded Copy"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:164
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:173
 msgid "Automatically Download Upcoming Episodes"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:165
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:174
 msgid "Include Next Up"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:166
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:175
 msgid "Next Up Entries to Consider"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:167
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:176
 msgid "Episodes to Keep Ahead (0 = off)"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:168
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:177
 msgid "Storage Limit for Automatic Downloads (GB)"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:169
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:178
 #, fuzzy
 #| msgid "Remove Server"
 msgid "Delete Automatic Downloads Once Watched"
 msgstr "সার্ভার মুছে ফেলুন"
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:170
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:179
 msgid "Delete Unwatched After (days, 0 = never)"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:171
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:180
 msgid "Check Every (minutes)"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:172
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:181
 msgid "Close to Tray (keep running)"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:173
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:182
 msgid "Keep Running in Background"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:174
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:183
 msgid "Remember Window Size"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:175
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:184
 msgid "Player Controls Style"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:176
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:185
 msgid "Show What You're Watching in Discord"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:177
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:186
 msgid "Interface Scale"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:178
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:187
 msgid "Cast-target mode (no library browsing)"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:179
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:188
 msgid "Casting Opens the Library Browser"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:180
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:189
 msgid "Fullscreen Library Browser"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:181
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:190
 msgid "Always Bind Arrow Keys to Player Controls"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:182
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:191
 msgid "Player Controls Activation Key"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:183
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:192
 msgid "Audio Output Mode"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:184
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:193
 msgid "Audio Output Device"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:185
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:194
 msgid "Take the Device Exclusively"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:187
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:196
 #, fuzzy
 #| msgid "Video Playback Profiles"
 msgid "Enable Video Playback Profiles"
 msgstr "ভিডিও প্লেব্যাক প্রোফাইলসমূহ"
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:188
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:197
 #, fuzzy
 #| msgid "New Group"
 msgid "Profile Group"
 msgstr "নতুন গ্রুপ"
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:189
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:198
 msgid "Remember Last Used Profile"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:190
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:199
 msgid "Graphics API for Shaders"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:191
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:200
 msgid "Pass Through AC3"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:192
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:201
 msgid "Pass Through DTS"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:193
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:202
 msgid "Pass Through E-AC3"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:194
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:203
 msgid "Pass Through DTS-HD"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:195
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:204
 msgid "Pass Through TrueHD"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:196
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:205
 msgid "Re-encode Others to AC3"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:202
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:213
 msgid ""
-"MPV keybinds are used by default. Press ENTER to drive the player controls "
-"by keyboard."
+"With \"Start Minimized\" and \"Fullscreen\" this is the classic cast-target "
+"setup: the app waits out of the way, plays fullscreen when something casts "
+"to it, and goes back to waiting when the video ends or you press Q."
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:204
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:227
+msgid ""
+"Off means command-line mode: no window, no system tray and no settings "
+"screen, so the only way back is editing conf.json by hand. It is not how you "
+"get MPV's own on-screen controls — \"Player Controls Style\" under Interface "
+"does that."
+msgstr ""
+
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:234
+msgid ""
+"Show only what is cast to this machine — the library, including this "
+"settings screen, can't be reached from here. Without a system tray icon the "
+"only way back is editing conf.json. For the classic cast-target setup you "
+"want the Interface settings instead; this is for a shared TV nobody should "
+"be able to browse from."
+msgstr ""
+
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:240
+msgid ""
+"Requires restart to change. MPV keybinds are used by default. Press ENTER to "
+"drive the player controls by keyboard."
+msgstr ""
+
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:242
 msgid ""
 "Pixels one wheel notch scrolls. The scrollbar glides while the content snaps "
 "to the nearest row, so a trackpad or trackball no longer overshoots. Raise "
 "it to scroll faster, lower it for finer control."
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:209
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:247
 msgid ""
 "Make each wheel notch jump exactly one row (or one home-screen section) "
 "instead of gliding. Turn this on if you prefer the older stepped scrolling."
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:217
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:255
 msgid "Discord Rich Presence. Takes effect after a restart."
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:219
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:257
 msgid ""
 "Leave this to Default unless setting up passthrough. Note some audio servers "
 "like Pipewire don't like passthrough and will need to be disabled for a card "
@@ -1013,57 +1037,57 @@ msgid ""
 "silence otherwise, but results may vary."
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:225
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:263
 msgid ""
 "Stop anything else using the device while playing. Needed for passthrough on "
 "some systems, and it means other applications will be silent."
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:228
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:266
 msgid ""
 "Page the library and music tile grids instead of scrolling: each page is one "
 "screenful with First / Previous / Next / Last controls and a page number you "
 "can type into. Easier than precise scrolling on a trackpad."
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:232
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:270
 msgid ""
 "Takes effect after a restart. \"Follow display\" uses the scale your desktop "
 "reports, which is 100% on X11."
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:234
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:272
 msgid ""
 "\"Default\" changes nothing and lets MPV (and your own mpv.conf) decide. "
 "Pick a mode only if you are sending audio to a receiver."
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:237
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:275
 msgid ""
 "Audio your receiver can't be sent directly is encoded to AC3, which is the "
 "only way surround fits down an optical cable. Turn this off if the encoder "
 "causes audio delay — those tracks become stereo instead."
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:242
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:280
 msgid ""
 "\"hq\" offers heavier profiles. Pick it if you have a fast graphics card."
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:244
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:282
 msgid ""
 "Leave on Automatic unless video breaks when a profile is loaded. This only "
 "applies while a profile is active, and OpenGL can cost you HDR output."
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:248
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:286
 msgid ""
 "Evens out loud effects and quiet dialogue. This turns passthrough off while "
 "it is enabled, because the volume has to be adjusted before your receiver "
 "gets the audio."
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:330
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:368
 msgid "Advanced"
 msgstr ""
 
@@ -1289,7 +1313,7 @@ msgid "Automatic"
 msgstr "স্বয়ংক্রিয়"
 
 #: jellyfin_mpv_shim/mpvtk_browser/downloads.py:51
-#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1355
+#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1288
 msgid "Episodes"
 msgstr ""
 
@@ -1298,7 +1322,7 @@ msgid "Season %s"
 msgstr ""
 
 #: jellyfin_mpv_shim/mpvtk_browser/downloads.py:52
-#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1351
+#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1284
 msgid "Specials"
 msgstr ""
 
@@ -1323,7 +1347,7 @@ msgid "Failed"
 msgstr "ব্যর্থ"
 
 #: jellyfin_mpv_shim/mpvtk_browser/downloads.py:185
-#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1105
+#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1038
 msgid "Playlist"
 msgstr ""
 
@@ -1335,30 +1359,30 @@ msgstr ""
 msgid "Movies & Videos"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/home_sections.py:103
+#: jellyfin_mpv_shim/mpvtk_browser/home_sections.py:104
 msgid "My Media"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/home_sections.py:104
-#: jellyfin_mpv_shim/mpvtk_browser/repository.py:352
+#: jellyfin_mpv_shim/mpvtk_browser/home_sections.py:105
+#: jellyfin_mpv_shim/mpvtk_browser/repository.py:350
 msgid "Continue Watching"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/home_sections.py:105
-#: jellyfin_mpv_shim/mpvtk_browser/repository.py:359
+#: jellyfin_mpv_shim/mpvtk_browser/home_sections.py:106
+#: jellyfin_mpv_shim/mpvtk_browser/repository.py:357
 msgid "Continue Listening"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/home_sections.py:106
-#: jellyfin_mpv_shim/mpvtk_browser/repository.py:366
+#: jellyfin_mpv_shim/mpvtk_browser/home_sections.py:107
+#: jellyfin_mpv_shim/mpvtk_browser/repository.py:364
 msgid "Next Up"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/home_sections.py:107
+#: jellyfin_mpv_shim/mpvtk_browser/home_sections.py:108
 msgid "Recently Added"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/home_sections.py:108
+#: jellyfin_mpv_shim/mpvtk_browser/home_sections.py:109
 msgid "Live TV"
 msgstr ""
 
@@ -1611,52 +1635,52 @@ msgstr ""
 "সার্ভার সংযুক্তি সম্ভব হয়নি.\n"
 "দয়া করে আপনার কানেকশনের তথ্য পর্যালোচনা করুন।"
 
-#: jellyfin_mpv_shim/mpvtk_browser/repository.py:390
+#: jellyfin_mpv_shim/mpvtk_browser/repository.py:386
 msgid "On Now"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/repository.py:411
+#: jellyfin_mpv_shim/mpvtk_browser/repository.py:407
 msgid "Latest %s"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1119
+#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1052
 msgid "Downloaded"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1138
+#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1071
 msgid "Movies"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1143
+#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1076
 msgid "Videos"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1147
+#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1080
 msgid "TV Shows"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1151
+#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1084
 msgid "Playlists"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1168
-#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1441
+#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1101
+#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1374
 msgid "Series"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1212
+#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1145
 msgid "Downloaded Movies"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1216
+#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1149
 msgid "Downloaded Videos"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1220
+#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1153
 msgid "Downloaded Shows"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1353
+#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1286
 msgid "Season %d"
 msgstr ""
 

--- a/jellyfin_mpv_shim/messages/br/LC_MESSAGES/base.po
+++ b/jellyfin_mpv_shim/messages/br/LC_MESSAGES/base.po
@@ -5,7 +5,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2026-07-25 17:21-0400\n"
+"POT-Creation-Date: 2026-07-26 12:03-0400\n"
 "PO-Revision-Date: 2026-05-23 07:46+0000\n"
 "Last-Translator: Klomer <florent.grouin+jellyfin@gmail.com>\n"
 "Language-Team: Breton <https://translate.jellyfin.org/projects/jellyfin/"
@@ -256,7 +256,7 @@ msgid "Select Subtitle Track"
 msgstr ""
 
 #: jellyfin_mpv_shim/menu.py:341
-#: jellyfin_mpv_shim/mpvtk_browser/home_sections.py:102
+#: jellyfin_mpv_shim/mpvtk_browser/home_sections.py:103
 #: jellyfin_mpv_shim/osc_bridge.py:81 jellyfin_mpv_shim/osc_bridge.py:82
 #: jellyfin_mpv_shim/osc_bridge.py:104 jellyfin_mpv_shim/osc_bridge.py:140
 msgid "None"
@@ -407,7 +407,7 @@ msgstr ""
 msgid "Enable thumbnail previews"
 msgstr ""
 
-#: jellyfin_mpv_shim/menu.py:609 jellyfin_mpv_shim/mpvtk_browser/config.py:186
+#: jellyfin_mpv_shim/menu.py:609 jellyfin_mpv_shim/mpvtk_browser/config.py:195
 #: jellyfin_mpv_shim/mpvtk_browser/hud.py:375
 msgid "Night Mode (Auto Volume Adj)"
 msgstr ""
@@ -704,302 +704,326 @@ msgstr ""
 msgid "Or switch to another user"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/cast.py:317
+#: jellyfin_mpv_shim/mpvtk_browser/cast.py:314
 msgid "Ready to cast"
 msgstr "Prest da skignañ"
 
-#: jellyfin_mpv_shim/mpvtk_browser/cast.py:318
+#: jellyfin_mpv_shim/mpvtk_browser/cast.py:315
 #, fuzzy
 #| msgid "Select your media in Jellyfin and play it here"
 msgid "Select your media in Jellyfin and play it here."
 msgstr "Choazit ho media e-barzh Jellyfin ha lennit anezhañ amañ"
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:74
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:83
 msgid "Interface"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:83
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:92
 msgid "Playback"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:88
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:97
 msgid "Audio"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:92
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:101
 msgid "Subtitles & Languages"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:97
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:106
 msgid "Transcoding"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:102
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:111
 msgid "Video Enhancement"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:104
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:113
 msgid "Skip Intro / Credits"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:107
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:116
 msgid "Library Browser"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:109
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:118
 msgid "Downloads"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:128
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:137
 msgid "Jellyfin UI"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:129
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:138
 msgid "MPV UI with thumbnails"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:130
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:139
 msgid "MPV built-in default"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:133
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:142
 msgid "Follow display"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:134
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:143
 msgid "100% (no scaling)"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:135
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:144
 msgid "125%"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:136
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:145
 msgid "150%"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:137
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:146
 msgid "200%"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:140
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:149
 msgid "Automatic (recommended)"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:141
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:150
 msgid "Vulkan"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:142
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:151
 msgid "Direct3D 11 (Windows only)"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:143
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:152
 msgid "OpenGL (compatibility)"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:146
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:155
 msgid "Default (auto)"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:147
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:156
 msgid "Force Stereo"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:148
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:157
 msgid "Optical Surround"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:149
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:158
 msgid "HDMI Passthrough"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:152
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:161
 msgid "Unset"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:153
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:162
 msgid "Dubbed (shows only)"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:154
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:163
 msgid "Subbed (shows only)"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:155
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:164
 msgid "Dubbed (all)"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:156
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:165
 msgid "Subbed (all)"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:157
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:166
 msgid "Custom (set in config)"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:162
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:171
 msgid "Download Folder"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:163
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:172
 msgid "Prefer Downloaded Copy"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:164
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:173
 msgid "Automatically Download Upcoming Episodes"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:165
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:174
 msgid "Include Next Up"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:166
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:175
 msgid "Next Up Entries to Consider"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:167
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:176
 msgid "Episodes to Keep Ahead (0 = off)"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:168
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:177
 msgid "Storage Limit for Automatic Downloads (GB)"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:169
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:178
 #, fuzzy
 #| msgid "Remove Server"
 msgid "Delete Automatic Downloads Once Watched"
 msgstr "Dilemel ar Servijer"
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:170
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:179
 msgid "Delete Unwatched After (days, 0 = never)"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:171
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:180
 msgid "Check Every (minutes)"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:172
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:181
 msgid "Close to Tray (keep running)"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:173
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:182
 msgid "Keep Running in Background"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:174
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:183
 msgid "Remember Window Size"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:175
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:184
 msgid "Player Controls Style"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:176
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:185
 msgid "Show What You're Watching in Discord"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:177
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:186
 msgid "Interface Scale"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:178
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:187
 msgid "Cast-target mode (no library browsing)"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:179
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:188
 msgid "Casting Opens the Library Browser"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:180
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:189
 msgid "Fullscreen Library Browser"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:181
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:190
 msgid "Always Bind Arrow Keys to Player Controls"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:182
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:191
 msgid "Player Controls Activation Key"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:183
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:192
 msgid "Audio Output Mode"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:184
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:193
 msgid "Audio Output Device"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:185
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:194
 msgid "Take the Device Exclusively"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:187
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:196
 msgid "Enable Video Playback Profiles"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:188
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:197
 msgid "Profile Group"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:189
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:198
 msgid "Remember Last Used Profile"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:190
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:199
 msgid "Graphics API for Shaders"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:191
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:200
 msgid "Pass Through AC3"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:192
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:201
 msgid "Pass Through DTS"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:193
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:202
 msgid "Pass Through E-AC3"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:194
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:203
 msgid "Pass Through DTS-HD"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:195
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:204
 msgid "Pass Through TrueHD"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:196
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:205
 msgid "Re-encode Others to AC3"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:202
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:213
 msgid ""
-"MPV keybinds are used by default. Press ENTER to drive the player controls "
-"by keyboard."
+"With \"Start Minimized\" and \"Fullscreen\" this is the classic cast-target "
+"setup: the app waits out of the way, plays fullscreen when something casts "
+"to it, and goes back to waiting when the video ends or you press Q."
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:204
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:227
+msgid ""
+"Off means command-line mode: no window, no system tray and no settings "
+"screen, so the only way back is editing conf.json by hand. It is not how you "
+"get MPV's own on-screen controls — \"Player Controls Style\" under Interface "
+"does that."
+msgstr ""
+
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:234
+msgid ""
+"Show only what is cast to this machine — the library, including this "
+"settings screen, can't be reached from here. Without a system tray icon the "
+"only way back is editing conf.json. For the classic cast-target setup you "
+"want the Interface settings instead; this is for a shared TV nobody should "
+"be able to browse from."
+msgstr ""
+
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:240
+msgid ""
+"Requires restart to change. MPV keybinds are used by default. Press ENTER to "
+"drive the player controls by keyboard."
+msgstr ""
+
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:242
 msgid ""
 "Pixels one wheel notch scrolls. The scrollbar glides while the content snaps "
 "to the nearest row, so a trackpad or trackball no longer overshoots. Raise "
 "it to scroll faster, lower it for finer control."
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:209
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:247
 msgid ""
 "Make each wheel notch jump exactly one row (or one home-screen section) "
 "instead of gliding. Turn this on if you prefer the older stepped scrolling."
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:217
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:255
 msgid "Discord Rich Presence. Takes effect after a restart."
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:219
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:257
 msgid ""
 "Leave this to Default unless setting up passthrough. Note some audio servers "
 "like Pipewire don't like passthrough and will need to be disabled for a card "
@@ -1007,57 +1031,57 @@ msgid ""
 "silence otherwise, but results may vary."
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:225
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:263
 msgid ""
 "Stop anything else using the device while playing. Needed for passthrough on "
 "some systems, and it means other applications will be silent."
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:228
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:266
 msgid ""
 "Page the library and music tile grids instead of scrolling: each page is one "
 "screenful with First / Previous / Next / Last controls and a page number you "
 "can type into. Easier than precise scrolling on a trackpad."
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:232
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:270
 msgid ""
 "Takes effect after a restart. \"Follow display\" uses the scale your desktop "
 "reports, which is 100% on X11."
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:234
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:272
 msgid ""
 "\"Default\" changes nothing and lets MPV (and your own mpv.conf) decide. "
 "Pick a mode only if you are sending audio to a receiver."
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:237
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:275
 msgid ""
 "Audio your receiver can't be sent directly is encoded to AC3, which is the "
 "only way surround fits down an optical cable. Turn this off if the encoder "
 "causes audio delay — those tracks become stereo instead."
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:242
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:280
 msgid ""
 "\"hq\" offers heavier profiles. Pick it if you have a fast graphics card."
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:244
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:282
 msgid ""
 "Leave on Automatic unless video breaks when a profile is loaded. This only "
 "applies while a profile is active, and OpenGL can cost you HDR output."
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:248
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:286
 msgid ""
 "Evens out loud effects and quiet dialogue. This turns passthrough off while "
 "it is enabled, because the volume has to be adjusted before your receiver "
 "gets the audio."
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:330
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:368
 msgid "Advanced"
 msgstr ""
 
@@ -1271,7 +1295,7 @@ msgid "Automatic"
 msgstr ""
 
 #: jellyfin_mpv_shim/mpvtk_browser/downloads.py:51
-#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1355
+#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1288
 msgid "Episodes"
 msgstr ""
 
@@ -1280,7 +1304,7 @@ msgid "Season %s"
 msgstr ""
 
 #: jellyfin_mpv_shim/mpvtk_browser/downloads.py:52
-#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1351
+#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1284
 msgid "Specials"
 msgstr ""
 
@@ -1305,7 +1329,7 @@ msgid "Failed"
 msgstr "C'hwitadenn"
 
 #: jellyfin_mpv_shim/mpvtk_browser/downloads.py:185
-#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1105
+#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1038
 msgid "Playlist"
 msgstr ""
 
@@ -1317,30 +1341,30 @@ msgstr ""
 msgid "Movies & Videos"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/home_sections.py:103
+#: jellyfin_mpv_shim/mpvtk_browser/home_sections.py:104
 msgid "My Media"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/home_sections.py:104
-#: jellyfin_mpv_shim/mpvtk_browser/repository.py:352
+#: jellyfin_mpv_shim/mpvtk_browser/home_sections.py:105
+#: jellyfin_mpv_shim/mpvtk_browser/repository.py:350
 msgid "Continue Watching"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/home_sections.py:105
-#: jellyfin_mpv_shim/mpvtk_browser/repository.py:359
+#: jellyfin_mpv_shim/mpvtk_browser/home_sections.py:106
+#: jellyfin_mpv_shim/mpvtk_browser/repository.py:357
 msgid "Continue Listening"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/home_sections.py:106
-#: jellyfin_mpv_shim/mpvtk_browser/repository.py:366
+#: jellyfin_mpv_shim/mpvtk_browser/home_sections.py:107
+#: jellyfin_mpv_shim/mpvtk_browser/repository.py:364
 msgid "Next Up"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/home_sections.py:107
+#: jellyfin_mpv_shim/mpvtk_browser/home_sections.py:108
 msgid "Recently Added"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/home_sections.py:108
+#: jellyfin_mpv_shim/mpvtk_browser/home_sections.py:109
 msgid "Live TV"
 msgstr ""
 
@@ -1581,52 +1605,52 @@ msgstr ""
 "Ouzhpennañ ar servijer dibosupl.\n"
 "Trugarez da wiriañ titouroù ar c'hennask."
 
-#: jellyfin_mpv_shim/mpvtk_browser/repository.py:390
+#: jellyfin_mpv_shim/mpvtk_browser/repository.py:386
 msgid "On Now"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/repository.py:411
+#: jellyfin_mpv_shim/mpvtk_browser/repository.py:407
 msgid "Latest %s"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1119
+#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1052
 msgid "Downloaded"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1138
+#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1071
 msgid "Movies"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1143
+#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1076
 msgid "Videos"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1147
+#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1080
 msgid "TV Shows"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1151
+#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1084
 msgid "Playlists"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1168
-#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1441
+#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1101
+#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1374
 msgid "Series"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1212
+#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1145
 msgid "Downloaded Movies"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1216
+#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1149
 msgid "Downloaded Videos"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1220
+#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1153
 msgid "Downloaded Shows"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1353
+#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1286
 msgid "Season %d"
 msgstr ""
 

--- a/jellyfin_mpv_shim/messages/bs/LC_MESSAGES/base.po
+++ b/jellyfin_mpv_shim/messages/bs/LC_MESSAGES/base.po
@@ -5,7 +5,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2026-07-25 17:21-0400\n"
+"POT-Creation-Date: 2026-07-26 12:03-0400\n"
 "PO-Revision-Date: 2026-04-17 12:45+0000\n"
 "Last-Translator: SecularSteve <fairfull.playing@gmail.com>\n"
 "Language-Team: Bosnian <https://translate.jellyfin.org/projects/jellyfin/"
@@ -253,7 +253,7 @@ msgid "Select Subtitle Track"
 msgstr "Odaberite stazu titlova"
 
 #: jellyfin_mpv_shim/menu.py:341
-#: jellyfin_mpv_shim/mpvtk_browser/home_sections.py:102
+#: jellyfin_mpv_shim/mpvtk_browser/home_sections.py:103
 #: jellyfin_mpv_shim/osc_bridge.py:81 jellyfin_mpv_shim/osc_bridge.py:82
 #: jellyfin_mpv_shim/osc_bridge.py:104 jellyfin_mpv_shim/osc_bridge.py:140
 msgid "None"
@@ -404,7 +404,7 @@ msgstr "Zatraži preskakanje odjavne špice"
 msgid "Enable thumbnail previews"
 msgstr "Omogući pregled minijatura"
 
-#: jellyfin_mpv_shim/menu.py:609 jellyfin_mpv_shim/mpvtk_browser/config.py:186
+#: jellyfin_mpv_shim/menu.py:609 jellyfin_mpv_shim/mpvtk_browser/config.py:195
 #: jellyfin_mpv_shim/mpvtk_browser/hud.py:375
 msgid "Night Mode (Auto Volume Adj)"
 msgstr ""
@@ -703,310 +703,334 @@ msgstr ""
 msgid "Or switch to another user"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/cast.py:317
+#: jellyfin_mpv_shim/mpvtk_browser/cast.py:314
 msgid "Ready to cast"
 msgstr "Spremno za glasanje"
 
-#: jellyfin_mpv_shim/mpvtk_browser/cast.py:318
+#: jellyfin_mpv_shim/mpvtk_browser/cast.py:315
 #, fuzzy
 #| msgid "Select your media in Jellyfin and play it here"
 msgid "Select your media in Jellyfin and play it here."
 msgstr "Odaberite svoj medij u Jellyfinu i reproducirajte ga ovdje"
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:74
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:83
 msgid "Interface"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:83
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:92
 msgid "Playback"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:88
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:97
 msgid "Audio"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:92
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:101
 msgid "Subtitles & Languages"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:97
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:106
 #, fuzzy
 #| msgid " (Transcode)"
 msgid "Transcoding"
 msgstr " (Transkodiraj)"
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:102
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:111
 msgid "Video Enhancement"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:104
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:113
 #, fuzzy
 #| msgid "Seek to Skip Credits"
 msgid "Skip Intro / Credits"
 msgstr "Pokušaj preskočiti odjavne titlove"
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:107
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:116
 msgid "Library Browser"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:109
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:118
 msgid "Downloads"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:128
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:137
 msgid "Jellyfin UI"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:129
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:138
 msgid "MPV UI with thumbnails"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:130
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:139
 msgid "MPV built-in default"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:133
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:142
 msgid "Follow display"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:134
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:143
 msgid "100% (no scaling)"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:135
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:144
 msgid "125%"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:136
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:145
 msgid "150%"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:137
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:146
 msgid "200%"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:140
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:149
 msgid "Automatic (recommended)"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:141
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:150
 msgid "Vulkan"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:142
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:151
 msgid "Direct3D 11 (Windows only)"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:143
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:152
 msgid "OpenGL (compatibility)"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:146
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:155
 msgid "Default (auto)"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:147
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:156
 msgid "Force Stereo"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:148
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:157
 msgid "Optical Surround"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:149
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:158
 msgid "HDMI Passthrough"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:152
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:161
 msgid "Unset"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:153
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:162
 msgid "Dubbed (shows only)"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:154
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:163
 msgid "Subbed (shows only)"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:155
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:164
 msgid "Dubbed (all)"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:156
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:165
 msgid "Subbed (all)"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:157
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:166
 msgid "Custom (set in config)"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:162
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:171
 msgid "Download Folder"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:163
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:172
 msgid "Prefer Downloaded Copy"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:164
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:173
 msgid "Automatically Download Upcoming Episodes"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:165
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:174
 msgid "Include Next Up"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:166
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:175
 msgid "Next Up Entries to Consider"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:167
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:176
 msgid "Episodes to Keep Ahead (0 = off)"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:168
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:177
 msgid "Storage Limit for Automatic Downloads (GB)"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:169
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:178
 #, fuzzy
 #| msgid "Remove Server"
 msgid "Delete Automatic Downloads Once Watched"
 msgstr "Ukloni server"
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:170
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:179
 msgid "Delete Unwatched After (days, 0 = never)"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:171
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:180
 msgid "Check Every (minutes)"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:172
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:181
 msgid "Close to Tray (keep running)"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:173
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:182
 msgid "Keep Running in Background"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:174
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:183
 msgid "Remember Window Size"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:175
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:184
 msgid "Player Controls Style"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:176
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:185
 msgid "Show What You're Watching in Discord"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:177
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:186
 msgid "Interface Scale"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:178
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:187
 msgid "Cast-target mode (no library browsing)"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:179
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:188
 msgid "Casting Opens the Library Browser"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:180
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:189
 msgid "Fullscreen Library Browser"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:181
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:190
 msgid "Always Bind Arrow Keys to Player Controls"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:182
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:191
 msgid "Player Controls Activation Key"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:183
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:192
 msgid "Audio Output Mode"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:184
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:193
 msgid "Audio Output Device"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:185
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:194
 msgid "Take the Device Exclusively"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:187
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:196
 #, fuzzy
 #| msgid "Video Playback Profiles"
 msgid "Enable Video Playback Profiles"
 msgstr "Profili za reprodukciju videa"
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:188
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:197
 #, fuzzy
 #| msgid "New Group"
 msgid "Profile Group"
 msgstr "Nova grupa"
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:189
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:198
 msgid "Remember Last Used Profile"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:190
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:199
 msgid "Graphics API for Shaders"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:191
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:200
 msgid "Pass Through AC3"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:192
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:201
 msgid "Pass Through DTS"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:193
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:202
 msgid "Pass Through E-AC3"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:194
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:203
 msgid "Pass Through DTS-HD"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:195
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:204
 msgid "Pass Through TrueHD"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:196
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:205
 msgid "Re-encode Others to AC3"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:202
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:213
 msgid ""
-"MPV keybinds are used by default. Press ENTER to drive the player controls "
-"by keyboard."
+"With \"Start Minimized\" and \"Fullscreen\" this is the classic cast-target "
+"setup: the app waits out of the way, plays fullscreen when something casts "
+"to it, and goes back to waiting when the video ends or you press Q."
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:204
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:227
+msgid ""
+"Off means command-line mode: no window, no system tray and no settings "
+"screen, so the only way back is editing conf.json by hand. It is not how you "
+"get MPV's own on-screen controls — \"Player Controls Style\" under Interface "
+"does that."
+msgstr ""
+
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:234
+msgid ""
+"Show only what is cast to this machine — the library, including this "
+"settings screen, can't be reached from here. Without a system tray icon the "
+"only way back is editing conf.json. For the classic cast-target setup you "
+"want the Interface settings instead; this is for a shared TV nobody should "
+"be able to browse from."
+msgstr ""
+
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:240
+msgid ""
+"Requires restart to change. MPV keybinds are used by default. Press ENTER to "
+"drive the player controls by keyboard."
+msgstr ""
+
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:242
 msgid ""
 "Pixels one wheel notch scrolls. The scrollbar glides while the content snaps "
 "to the nearest row, so a trackpad or trackball no longer overshoots. Raise "
 "it to scroll faster, lower it for finer control."
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:209
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:247
 msgid ""
 "Make each wheel notch jump exactly one row (or one home-screen section) "
 "instead of gliding. Turn this on if you prefer the older stepped scrolling."
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:217
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:255
 msgid "Discord Rich Presence. Takes effect after a restart."
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:219
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:257
 msgid ""
 "Leave this to Default unless setting up passthrough. Note some audio servers "
 "like Pipewire don't like passthrough and will need to be disabled for a card "
@@ -1014,57 +1038,57 @@ msgid ""
 "silence otherwise, but results may vary."
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:225
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:263
 msgid ""
 "Stop anything else using the device while playing. Needed for passthrough on "
 "some systems, and it means other applications will be silent."
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:228
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:266
 msgid ""
 "Page the library and music tile grids instead of scrolling: each page is one "
 "screenful with First / Previous / Next / Last controls and a page number you "
 "can type into. Easier than precise scrolling on a trackpad."
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:232
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:270
 msgid ""
 "Takes effect after a restart. \"Follow display\" uses the scale your desktop "
 "reports, which is 100% on X11."
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:234
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:272
 msgid ""
 "\"Default\" changes nothing and lets MPV (and your own mpv.conf) decide. "
 "Pick a mode only if you are sending audio to a receiver."
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:237
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:275
 msgid ""
 "Audio your receiver can't be sent directly is encoded to AC3, which is the "
 "only way surround fits down an optical cable. Turn this off if the encoder "
 "causes audio delay — those tracks become stereo instead."
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:242
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:280
 msgid ""
 "\"hq\" offers heavier profiles. Pick it if you have a fast graphics card."
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:244
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:282
 msgid ""
 "Leave on Automatic unless video breaks when a profile is loaded. This only "
 "applies while a profile is active, and OpenGL can cost you HDR output."
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:248
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:286
 msgid ""
 "Evens out loud effects and quiet dialogue. This turns passthrough off while "
 "it is enabled, because the volume has to be adjusted before your receiver "
 "gets the audio."
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:330
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:368
 msgid "Advanced"
 msgstr ""
 
@@ -1290,7 +1314,7 @@ msgid "Automatic"
 msgstr "Automatski"
 
 #: jellyfin_mpv_shim/mpvtk_browser/downloads.py:51
-#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1355
+#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1288
 msgid "Episodes"
 msgstr ""
 
@@ -1299,7 +1323,7 @@ msgid "Season %s"
 msgstr ""
 
 #: jellyfin_mpv_shim/mpvtk_browser/downloads.py:52
-#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1351
+#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1284
 msgid "Specials"
 msgstr ""
 
@@ -1324,7 +1348,7 @@ msgid "Failed"
 msgstr "Neuspjeh"
 
 #: jellyfin_mpv_shim/mpvtk_browser/downloads.py:185
-#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1105
+#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1038
 msgid "Playlist"
 msgstr ""
 
@@ -1336,30 +1360,30 @@ msgstr ""
 msgid "Movies & Videos"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/home_sections.py:103
+#: jellyfin_mpv_shim/mpvtk_browser/home_sections.py:104
 msgid "My Media"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/home_sections.py:104
-#: jellyfin_mpv_shim/mpvtk_browser/repository.py:352
+#: jellyfin_mpv_shim/mpvtk_browser/home_sections.py:105
+#: jellyfin_mpv_shim/mpvtk_browser/repository.py:350
 msgid "Continue Watching"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/home_sections.py:105
-#: jellyfin_mpv_shim/mpvtk_browser/repository.py:359
+#: jellyfin_mpv_shim/mpvtk_browser/home_sections.py:106
+#: jellyfin_mpv_shim/mpvtk_browser/repository.py:357
 msgid "Continue Listening"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/home_sections.py:106
-#: jellyfin_mpv_shim/mpvtk_browser/repository.py:366
+#: jellyfin_mpv_shim/mpvtk_browser/home_sections.py:107
+#: jellyfin_mpv_shim/mpvtk_browser/repository.py:364
 msgid "Next Up"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/home_sections.py:107
+#: jellyfin_mpv_shim/mpvtk_browser/home_sections.py:108
 msgid "Recently Added"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/home_sections.py:108
+#: jellyfin_mpv_shim/mpvtk_browser/home_sections.py:109
 msgid "Live TV"
 msgstr ""
 
@@ -1612,52 +1636,52 @@ msgstr ""
 "Nije moguće dodati server.\n"
 "Provjerite podatke o vezi."
 
-#: jellyfin_mpv_shim/mpvtk_browser/repository.py:390
+#: jellyfin_mpv_shim/mpvtk_browser/repository.py:386
 msgid "On Now"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/repository.py:411
+#: jellyfin_mpv_shim/mpvtk_browser/repository.py:407
 msgid "Latest %s"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1119
+#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1052
 msgid "Downloaded"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1138
+#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1071
 msgid "Movies"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1143
+#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1076
 msgid "Videos"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1147
+#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1080
 msgid "TV Shows"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1151
+#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1084
 msgid "Playlists"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1168
-#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1441
+#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1101
+#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1374
 msgid "Series"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1212
+#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1145
 msgid "Downloaded Movies"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1216
+#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1149
 msgid "Downloaded Videos"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1220
+#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1153
 msgid "Downloaded Shows"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1353
+#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1286
 msgid "Season %d"
 msgstr ""
 

--- a/jellyfin_mpv_shim/messages/ca/LC_MESSAGES/base.po
+++ b/jellyfin_mpv_shim/messages/ca/LC_MESSAGES/base.po
@@ -5,7 +5,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2026-07-25 17:21-0400\n"
+"POT-Creation-Date: 2026-07-26 12:03-0400\n"
 "PO-Revision-Date: 2026-06-10 22:10+0000\n"
 "Last-Translator: Gargotaire <gargots@gmail.com>\n"
 "Language-Team: Catalan <https://translate.jellyfin.org/projects/jellyfin/"
@@ -252,7 +252,7 @@ msgid "Select Subtitle Track"
 msgstr "Selecciona una pista de subtítols"
 
 #: jellyfin_mpv_shim/menu.py:341
-#: jellyfin_mpv_shim/mpvtk_browser/home_sections.py:102
+#: jellyfin_mpv_shim/mpvtk_browser/home_sections.py:103
 #: jellyfin_mpv_shim/osc_bridge.py:81 jellyfin_mpv_shim/osc_bridge.py:82
 #: jellyfin_mpv_shim/osc_bridge.py:104 jellyfin_mpv_shim/osc_bridge.py:140
 msgid "None"
@@ -403,7 +403,7 @@ msgstr "Demana saltar els crèdits"
 msgid "Enable thumbnail previews"
 msgstr "Activa la vista prèvia de les miniatures"
 
-#: jellyfin_mpv_shim/menu.py:609 jellyfin_mpv_shim/mpvtk_browser/config.py:186
+#: jellyfin_mpv_shim/menu.py:609 jellyfin_mpv_shim/mpvtk_browser/config.py:195
 #: jellyfin_mpv_shim/mpvtk_browser/hud.py:375
 msgid "Night Mode (Auto Volume Adj)"
 msgstr ""
@@ -702,311 +702,335 @@ msgstr ""
 msgid "Or switch to another user"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/cast.py:317
+#: jellyfin_mpv_shim/mpvtk_browser/cast.py:314
 msgid "Ready to cast"
 msgstr "Preparat per a transmetre"
 
-#: jellyfin_mpv_shim/mpvtk_browser/cast.py:318
+#: jellyfin_mpv_shim/mpvtk_browser/cast.py:315
 #, fuzzy
 #| msgid "Select your media in Jellyfin and play it here"
 msgid "Select your media in Jellyfin and play it here."
 msgstr ""
 "Seleccioneu el vostre contingut multimèdia a Jellyfin i reproduïu-lo aquí"
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:74
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:83
 msgid "Interface"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:83
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:92
 msgid "Playback"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:88
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:97
 msgid "Audio"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:92
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:101
 msgid "Subtitles & Languages"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:97
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:106
 #, fuzzy
 #| msgid " (Transcode)"
 msgid "Transcoding"
 msgstr " (Transcodifica)"
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:102
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:111
 msgid "Video Enhancement"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:104
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:113
 #, fuzzy
 #| msgid "Seek to Skip Credits"
 msgid "Skip Intro / Credits"
 msgstr "Demana saltar els crèdits"
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:107
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:116
 msgid "Library Browser"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:109
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:118
 msgid "Downloads"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:128
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:137
 msgid "Jellyfin UI"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:129
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:138
 msgid "MPV UI with thumbnails"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:130
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:139
 msgid "MPV built-in default"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:133
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:142
 msgid "Follow display"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:134
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:143
 msgid "100% (no scaling)"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:135
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:144
 msgid "125%"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:136
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:145
 msgid "150%"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:137
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:146
 msgid "200%"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:140
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:149
 msgid "Automatic (recommended)"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:141
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:150
 msgid "Vulkan"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:142
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:151
 msgid "Direct3D 11 (Windows only)"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:143
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:152
 msgid "OpenGL (compatibility)"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:146
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:155
 msgid "Default (auto)"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:147
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:156
 msgid "Force Stereo"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:148
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:157
 msgid "Optical Surround"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:149
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:158
 msgid "HDMI Passthrough"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:152
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:161
 msgid "Unset"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:153
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:162
 msgid "Dubbed (shows only)"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:154
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:163
 msgid "Subbed (shows only)"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:155
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:164
 msgid "Dubbed (all)"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:156
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:165
 msgid "Subbed (all)"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:157
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:166
 msgid "Custom (set in config)"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:162
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:171
 msgid "Download Folder"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:163
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:172
 msgid "Prefer Downloaded Copy"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:164
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:173
 msgid "Automatically Download Upcoming Episodes"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:165
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:174
 msgid "Include Next Up"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:166
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:175
 msgid "Next Up Entries to Consider"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:167
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:176
 msgid "Episodes to Keep Ahead (0 = off)"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:168
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:177
 msgid "Storage Limit for Automatic Downloads (GB)"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:169
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:178
 #, fuzzy
 #| msgid "Remove Server"
 msgid "Delete Automatic Downloads Once Watched"
 msgstr "Elimina el servidor"
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:170
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:179
 msgid "Delete Unwatched After (days, 0 = never)"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:171
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:180
 msgid "Check Every (minutes)"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:172
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:181
 msgid "Close to Tray (keep running)"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:173
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:182
 msgid "Keep Running in Background"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:174
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:183
 msgid "Remember Window Size"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:175
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:184
 msgid "Player Controls Style"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:176
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:185
 msgid "Show What You're Watching in Discord"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:177
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:186
 msgid "Interface Scale"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:178
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:187
 msgid "Cast-target mode (no library browsing)"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:179
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:188
 msgid "Casting Opens the Library Browser"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:180
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:189
 msgid "Fullscreen Library Browser"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:181
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:190
 msgid "Always Bind Arrow Keys to Player Controls"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:182
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:191
 msgid "Player Controls Activation Key"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:183
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:192
 msgid "Audio Output Mode"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:184
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:193
 msgid "Audio Output Device"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:185
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:194
 msgid "Take the Device Exclusively"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:187
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:196
 #, fuzzy
 #| msgid "Video Playback Profiles"
 msgid "Enable Video Playback Profiles"
 msgstr "Perfils de reproducció de vídeo"
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:188
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:197
 #, fuzzy
 #| msgid "New Group"
 msgid "Profile Group"
 msgstr "Grup nou"
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:189
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:198
 msgid "Remember Last Used Profile"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:190
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:199
 msgid "Graphics API for Shaders"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:191
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:200
 msgid "Pass Through AC3"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:192
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:201
 msgid "Pass Through DTS"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:193
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:202
 msgid "Pass Through E-AC3"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:194
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:203
 msgid "Pass Through DTS-HD"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:195
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:204
 msgid "Pass Through TrueHD"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:196
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:205
 msgid "Re-encode Others to AC3"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:202
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:213
 msgid ""
-"MPV keybinds are used by default. Press ENTER to drive the player controls "
-"by keyboard."
+"With \"Start Minimized\" and \"Fullscreen\" this is the classic cast-target "
+"setup: the app waits out of the way, plays fullscreen when something casts "
+"to it, and goes back to waiting when the video ends or you press Q."
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:204
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:227
+msgid ""
+"Off means command-line mode: no window, no system tray and no settings "
+"screen, so the only way back is editing conf.json by hand. It is not how you "
+"get MPV's own on-screen controls — \"Player Controls Style\" under Interface "
+"does that."
+msgstr ""
+
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:234
+msgid ""
+"Show only what is cast to this machine — the library, including this "
+"settings screen, can't be reached from here. Without a system tray icon the "
+"only way back is editing conf.json. For the classic cast-target setup you "
+"want the Interface settings instead; this is for a shared TV nobody should "
+"be able to browse from."
+msgstr ""
+
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:240
+msgid ""
+"Requires restart to change. MPV keybinds are used by default. Press ENTER to "
+"drive the player controls by keyboard."
+msgstr ""
+
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:242
 msgid ""
 "Pixels one wheel notch scrolls. The scrollbar glides while the content snaps "
 "to the nearest row, so a trackpad or trackball no longer overshoots. Raise "
 "it to scroll faster, lower it for finer control."
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:209
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:247
 msgid ""
 "Make each wheel notch jump exactly one row (or one home-screen section) "
 "instead of gliding. Turn this on if you prefer the older stepped scrolling."
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:217
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:255
 msgid "Discord Rich Presence. Takes effect after a restart."
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:219
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:257
 msgid ""
 "Leave this to Default unless setting up passthrough. Note some audio servers "
 "like Pipewire don't like passthrough and will need to be disabled for a card "
@@ -1014,57 +1038,57 @@ msgid ""
 "silence otherwise, but results may vary."
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:225
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:263
 msgid ""
 "Stop anything else using the device while playing. Needed for passthrough on "
 "some systems, and it means other applications will be silent."
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:228
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:266
 msgid ""
 "Page the library and music tile grids instead of scrolling: each page is one "
 "screenful with First / Previous / Next / Last controls and a page number you "
 "can type into. Easier than precise scrolling on a trackpad."
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:232
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:270
 msgid ""
 "Takes effect after a restart. \"Follow display\" uses the scale your desktop "
 "reports, which is 100% on X11."
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:234
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:272
 msgid ""
 "\"Default\" changes nothing and lets MPV (and your own mpv.conf) decide. "
 "Pick a mode only if you are sending audio to a receiver."
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:237
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:275
 msgid ""
 "Audio your receiver can't be sent directly is encoded to AC3, which is the "
 "only way surround fits down an optical cable. Turn this off if the encoder "
 "causes audio delay — those tracks become stereo instead."
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:242
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:280
 msgid ""
 "\"hq\" offers heavier profiles. Pick it if you have a fast graphics card."
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:244
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:282
 msgid ""
 "Leave on Automatic unless video breaks when a profile is loaded. This only "
 "applies while a profile is active, and OpenGL can cost you HDR output."
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:248
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:286
 msgid ""
 "Evens out loud effects and quiet dialogue. This turns passthrough off while "
 "it is enabled, because the volume has to be adjusted before your receiver "
 "gets the audio."
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:330
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:368
 msgid "Advanced"
 msgstr ""
 
@@ -1290,7 +1314,7 @@ msgid "Automatic"
 msgstr "Automàtic"
 
 #: jellyfin_mpv_shim/mpvtk_browser/downloads.py:51
-#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1355
+#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1288
 msgid "Episodes"
 msgstr ""
 
@@ -1299,7 +1323,7 @@ msgid "Season %s"
 msgstr ""
 
 #: jellyfin_mpv_shim/mpvtk_browser/downloads.py:52
-#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1351
+#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1284
 msgid "Specials"
 msgstr ""
 
@@ -1324,7 +1348,7 @@ msgid "Failed"
 msgstr "Fallada"
 
 #: jellyfin_mpv_shim/mpvtk_browser/downloads.py:185
-#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1105
+#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1038
 msgid "Playlist"
 msgstr ""
 
@@ -1336,30 +1360,30 @@ msgstr ""
 msgid "Movies & Videos"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/home_sections.py:103
+#: jellyfin_mpv_shim/mpvtk_browser/home_sections.py:104
 msgid "My Media"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/home_sections.py:104
-#: jellyfin_mpv_shim/mpvtk_browser/repository.py:352
+#: jellyfin_mpv_shim/mpvtk_browser/home_sections.py:105
+#: jellyfin_mpv_shim/mpvtk_browser/repository.py:350
 msgid "Continue Watching"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/home_sections.py:105
-#: jellyfin_mpv_shim/mpvtk_browser/repository.py:359
+#: jellyfin_mpv_shim/mpvtk_browser/home_sections.py:106
+#: jellyfin_mpv_shim/mpvtk_browser/repository.py:357
 msgid "Continue Listening"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/home_sections.py:106
-#: jellyfin_mpv_shim/mpvtk_browser/repository.py:366
+#: jellyfin_mpv_shim/mpvtk_browser/home_sections.py:107
+#: jellyfin_mpv_shim/mpvtk_browser/repository.py:364
 msgid "Next Up"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/home_sections.py:107
+#: jellyfin_mpv_shim/mpvtk_browser/home_sections.py:108
 msgid "Recently Added"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/home_sections.py:108
+#: jellyfin_mpv_shim/mpvtk_browser/home_sections.py:109
 msgid "Live TV"
 msgstr ""
 
@@ -1612,52 +1636,52 @@ msgstr ""
 "No s'ha pogut afegir el servidor.\n"
 "Comproveu la informació de la connexió."
 
-#: jellyfin_mpv_shim/mpvtk_browser/repository.py:390
+#: jellyfin_mpv_shim/mpvtk_browser/repository.py:386
 msgid "On Now"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/repository.py:411
+#: jellyfin_mpv_shim/mpvtk_browser/repository.py:407
 msgid "Latest %s"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1119
+#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1052
 msgid "Downloaded"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1138
+#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1071
 msgid "Movies"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1143
+#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1076
 msgid "Videos"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1147
+#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1080
 msgid "TV Shows"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1151
+#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1084
 msgid "Playlists"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1168
-#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1441
+#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1101
+#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1374
 msgid "Series"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1212
+#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1145
 msgid "Downloaded Movies"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1216
+#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1149
 msgid "Downloaded Videos"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1220
+#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1153
 msgid "Downloaded Shows"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1353
+#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1286
 msgid "Season %d"
 msgstr ""
 

--- a/jellyfin_mpv_shim/messages/ckb/LC_MESSAGES/base.po
+++ b/jellyfin_mpv_shim/messages/ckb/LC_MESSAGES/base.po
@@ -5,7 +5,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2026-07-25 17:21-0400\n"
+"POT-Creation-Date: 2026-07-26 12:03-0400\n"
 "PO-Revision-Date: 2025-07-26 19:21+0000\n"
 "Last-Translator: Djwarf <djwar.fettah@outlook.com>\n"
 "Language-Team: Kurdish (Central) <https://translate.jellyfin.org/projects/"
@@ -252,7 +252,7 @@ msgid "Select Subtitle Track"
 msgstr "دیاریکردنی بەشەژێرنووس"
 
 #: jellyfin_mpv_shim/menu.py:341
-#: jellyfin_mpv_shim/mpvtk_browser/home_sections.py:102
+#: jellyfin_mpv_shim/mpvtk_browser/home_sections.py:103
 #: jellyfin_mpv_shim/osc_bridge.py:81 jellyfin_mpv_shim/osc_bridge.py:82
 #: jellyfin_mpv_shim/osc_bridge.py:104 jellyfin_mpv_shim/osc_bridge.py:140
 msgid "None"
@@ -407,7 +407,7 @@ msgstr "داوابکە بۆ پەڕاندنی سەرەتاکان"
 msgid "Enable thumbnail previews"
 msgstr "لابردنی وێنەی بچووكی پێشبینین"
 
-#: jellyfin_mpv_shim/menu.py:609 jellyfin_mpv_shim/mpvtk_browser/config.py:186
+#: jellyfin_mpv_shim/menu.py:609 jellyfin_mpv_shim/mpvtk_browser/config.py:195
 #: jellyfin_mpv_shim/mpvtk_browser/hud.py:375
 msgid "Night Mode (Auto Volume Adj)"
 msgstr ""
@@ -706,308 +706,332 @@ msgstr ""
 msgid "Or switch to another user"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/cast.py:317
+#: jellyfin_mpv_shim/mpvtk_browser/cast.py:314
 msgid "Ready to cast"
 msgstr "ئامادەیە بۆ پەخشکردن"
 
-#: jellyfin_mpv_shim/mpvtk_browser/cast.py:318
+#: jellyfin_mpv_shim/mpvtk_browser/cast.py:315
 #, fuzzy
 #| msgid "Select your media in Jellyfin and play it here"
 msgid "Select your media in Jellyfin and play it here."
 msgstr "میدیای خۆت هەڵبژێرە لە جێلی فین وە کاری پێ بکە لێرە"
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:74
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:83
 msgid "Interface"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:83
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:92
 msgid "Playback"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:88
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:97
 msgid "Audio"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:92
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:101
 msgid "Subtitles & Languages"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:97
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:106
 #, fuzzy
 #| msgid " (Transcode)"
 msgid "Transcoding"
 msgstr " (تڕانسکۆد)"
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:102
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:111
 msgid "Video Enhancement"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:104
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:113
 #, fuzzy
 #| msgid "Seek to Skip Intro"
 msgid "Skip Intro / Credits"
 msgstr "گواستنەوە بۆ پەڕاندنی سەرەتا"
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:107
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:116
 msgid "Library Browser"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:109
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:118
 msgid "Downloads"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:128
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:137
 msgid "Jellyfin UI"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:129
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:138
 msgid "MPV UI with thumbnails"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:130
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:139
 msgid "MPV built-in default"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:133
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:142
 msgid "Follow display"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:134
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:143
 msgid "100% (no scaling)"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:135
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:144
 msgid "125%"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:136
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:145
 msgid "150%"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:137
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:146
 msgid "200%"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:140
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:149
 msgid "Automatic (recommended)"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:141
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:150
 msgid "Vulkan"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:142
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:151
 msgid "Direct3D 11 (Windows only)"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:143
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:152
 msgid "OpenGL (compatibility)"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:146
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:155
 msgid "Default (auto)"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:147
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:156
 msgid "Force Stereo"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:148
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:157
 msgid "Optical Surround"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:149
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:158
 msgid "HDMI Passthrough"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:152
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:161
 msgid "Unset"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:153
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:162
 msgid "Dubbed (shows only)"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:154
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:163
 msgid "Subbed (shows only)"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:155
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:164
 msgid "Dubbed (all)"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:156
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:165
 msgid "Subbed (all)"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:157
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:166
 msgid "Custom (set in config)"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:162
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:171
 msgid "Download Folder"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:163
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:172
 msgid "Prefer Downloaded Copy"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:164
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:173
 msgid "Automatically Download Upcoming Episodes"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:165
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:174
 msgid "Include Next Up"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:166
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:175
 msgid "Next Up Entries to Consider"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:167
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:176
 msgid "Episodes to Keep Ahead (0 = off)"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:168
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:177
 msgid "Storage Limit for Automatic Downloads (GB)"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:169
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:178
 #, fuzzy
 #| msgid "Remove Server"
 msgid "Delete Automatic Downloads Once Watched"
 msgstr "لابردنی ڕاژە"
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:170
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:179
 msgid "Delete Unwatched After (days, 0 = never)"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:171
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:180
 msgid "Check Every (minutes)"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:172
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:181
 msgid "Close to Tray (keep running)"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:173
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:182
 msgid "Keep Running in Background"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:174
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:183
 msgid "Remember Window Size"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:175
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:184
 msgid "Player Controls Style"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:176
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:185
 msgid "Show What You're Watching in Discord"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:177
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:186
 msgid "Interface Scale"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:178
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:187
 msgid "Cast-target mode (no library browsing)"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:179
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:188
 msgid "Casting Opens the Library Browser"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:180
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:189
 msgid "Fullscreen Library Browser"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:181
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:190
 msgid "Always Bind Arrow Keys to Player Controls"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:182
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:191
 msgid "Player Controls Activation Key"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:183
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:192
 msgid "Audio Output Mode"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:184
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:193
 msgid "Audio Output Device"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:185
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:194
 msgid "Take the Device Exclusively"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:187
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:196
 #, fuzzy
 #| msgid "Video Playback Profiles"
 msgid "Enable Video Playback Profiles"
 msgstr "لاڕووی خستنەوەسەری ڤیدیۆ"
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:188
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:197
 msgid "Profile Group"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:189
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:198
 msgid "Remember Last Used Profile"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:190
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:199
 msgid "Graphics API for Shaders"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:191
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:200
 msgid "Pass Through AC3"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:192
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:201
 msgid "Pass Through DTS"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:193
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:202
 msgid "Pass Through E-AC3"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:194
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:203
 msgid "Pass Through DTS-HD"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:195
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:204
 msgid "Pass Through TrueHD"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:196
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:205
 msgid "Re-encode Others to AC3"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:202
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:213
 msgid ""
-"MPV keybinds are used by default. Press ENTER to drive the player controls "
-"by keyboard."
+"With \"Start Minimized\" and \"Fullscreen\" this is the classic cast-target "
+"setup: the app waits out of the way, plays fullscreen when something casts "
+"to it, and goes back to waiting when the video ends or you press Q."
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:204
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:227
+msgid ""
+"Off means command-line mode: no window, no system tray and no settings "
+"screen, so the only way back is editing conf.json by hand. It is not how you "
+"get MPV's own on-screen controls — \"Player Controls Style\" under Interface "
+"does that."
+msgstr ""
+
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:234
+msgid ""
+"Show only what is cast to this machine — the library, including this "
+"settings screen, can't be reached from here. Without a system tray icon the "
+"only way back is editing conf.json. For the classic cast-target setup you "
+"want the Interface settings instead; this is for a shared TV nobody should "
+"be able to browse from."
+msgstr ""
+
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:240
+msgid ""
+"Requires restart to change. MPV keybinds are used by default. Press ENTER to "
+"drive the player controls by keyboard."
+msgstr ""
+
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:242
 msgid ""
 "Pixels one wheel notch scrolls. The scrollbar glides while the content snaps "
 "to the nearest row, so a trackpad or trackball no longer overshoots. Raise "
 "it to scroll faster, lower it for finer control."
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:209
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:247
 msgid ""
 "Make each wheel notch jump exactly one row (or one home-screen section) "
 "instead of gliding. Turn this on if you prefer the older stepped scrolling."
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:217
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:255
 msgid "Discord Rich Presence. Takes effect after a restart."
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:219
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:257
 msgid ""
 "Leave this to Default unless setting up passthrough. Note some audio servers "
 "like Pipewire don't like passthrough and will need to be disabled for a card "
@@ -1015,57 +1039,57 @@ msgid ""
 "silence otherwise, but results may vary."
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:225
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:263
 msgid ""
 "Stop anything else using the device while playing. Needed for passthrough on "
 "some systems, and it means other applications will be silent."
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:228
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:266
 msgid ""
 "Page the library and music tile grids instead of scrolling: each page is one "
 "screenful with First / Previous / Next / Last controls and a page number you "
 "can type into. Easier than precise scrolling on a trackpad."
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:232
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:270
 msgid ""
 "Takes effect after a restart. \"Follow display\" uses the scale your desktop "
 "reports, which is 100% on X11."
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:234
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:272
 msgid ""
 "\"Default\" changes nothing and lets MPV (and your own mpv.conf) decide. "
 "Pick a mode only if you are sending audio to a receiver."
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:237
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:275
 msgid ""
 "Audio your receiver can't be sent directly is encoded to AC3, which is the "
 "only way surround fits down an optical cable. Turn this off if the encoder "
 "causes audio delay — those tracks become stereo instead."
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:242
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:280
 msgid ""
 "\"hq\" offers heavier profiles. Pick it if you have a fast graphics card."
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:244
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:282
 msgid ""
 "Leave on Automatic unless video breaks when a profile is loaded. This only "
 "applies while a profile is active, and OpenGL can cost you HDR output."
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:248
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:286
 msgid ""
 "Evens out loud effects and quiet dialogue. This turns passthrough off while "
 "it is enabled, because the volume has to be adjusted before your receiver "
 "gets the audio."
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:330
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:368
 msgid "Advanced"
 msgstr ""
 
@@ -1283,7 +1307,7 @@ msgid "Automatic"
 msgstr "خۆکارانە"
 
 #: jellyfin_mpv_shim/mpvtk_browser/downloads.py:51
-#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1355
+#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1288
 msgid "Episodes"
 msgstr ""
 
@@ -1292,7 +1316,7 @@ msgid "Season %s"
 msgstr ""
 
 #: jellyfin_mpv_shim/mpvtk_browser/downloads.py:52
-#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1351
+#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1284
 msgid "Specials"
 msgstr ""
 
@@ -1317,7 +1341,7 @@ msgid "Failed"
 msgstr "شکست"
 
 #: jellyfin_mpv_shim/mpvtk_browser/downloads.py:185
-#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1105
+#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1038
 msgid "Playlist"
 msgstr ""
 
@@ -1329,30 +1353,30 @@ msgstr ""
 msgid "Movies & Videos"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/home_sections.py:103
+#: jellyfin_mpv_shim/mpvtk_browser/home_sections.py:104
 msgid "My Media"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/home_sections.py:104
-#: jellyfin_mpv_shim/mpvtk_browser/repository.py:352
+#: jellyfin_mpv_shim/mpvtk_browser/home_sections.py:105
+#: jellyfin_mpv_shim/mpvtk_browser/repository.py:350
 msgid "Continue Watching"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/home_sections.py:105
-#: jellyfin_mpv_shim/mpvtk_browser/repository.py:359
+#: jellyfin_mpv_shim/mpvtk_browser/home_sections.py:106
+#: jellyfin_mpv_shim/mpvtk_browser/repository.py:357
 msgid "Continue Listening"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/home_sections.py:106
-#: jellyfin_mpv_shim/mpvtk_browser/repository.py:366
+#: jellyfin_mpv_shim/mpvtk_browser/home_sections.py:107
+#: jellyfin_mpv_shim/mpvtk_browser/repository.py:364
 msgid "Next Up"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/home_sections.py:107
+#: jellyfin_mpv_shim/mpvtk_browser/home_sections.py:108
 msgid "Recently Added"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/home_sections.py:108
+#: jellyfin_mpv_shim/mpvtk_browser/home_sections.py:109
 msgid "Live TV"
 msgstr ""
 
@@ -1605,52 +1629,52 @@ msgstr ""
 "ناتوانرا ڕاژە زیاد بکرێ. \n"
 "تکایە هێڵی ئینتەرنێتەکەت بپشکنەوە."
 
-#: jellyfin_mpv_shim/mpvtk_browser/repository.py:390
+#: jellyfin_mpv_shim/mpvtk_browser/repository.py:386
 msgid "On Now"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/repository.py:411
+#: jellyfin_mpv_shim/mpvtk_browser/repository.py:407
 msgid "Latest %s"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1119
+#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1052
 msgid "Downloaded"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1138
+#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1071
 msgid "Movies"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1143
+#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1076
 msgid "Videos"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1147
+#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1080
 msgid "TV Shows"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1151
+#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1084
 msgid "Playlists"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1168
-#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1441
+#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1101
+#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1374
 msgid "Series"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1212
+#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1145
 msgid "Downloaded Movies"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1216
+#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1149
 msgid "Downloaded Videos"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1220
+#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1153
 msgid "Downloaded Shows"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1353
+#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1286
 msgid "Season %d"
 msgstr ""
 

--- a/jellyfin_mpv_shim/messages/cs/LC_MESSAGES/base.po
+++ b/jellyfin_mpv_shim/messages/cs/LC_MESSAGES/base.po
@@ -5,7 +5,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2026-07-25 17:21-0400\n"
+"POT-Creation-Date: 2026-07-26 12:03-0400\n"
 "PO-Revision-Date: 2026-06-08 11:26+0000\n"
 "Last-Translator: Fjuro <fjuro@users.noreply.translate.jellyfin.org>\n"
 "Language-Team: Czech <https://translate.jellyfin.org/projects/jellyfin/"
@@ -252,7 +252,7 @@ msgid "Select Subtitle Track"
 msgstr "Vybrat stopu titulků"
 
 #: jellyfin_mpv_shim/menu.py:341
-#: jellyfin_mpv_shim/mpvtk_browser/home_sections.py:102
+#: jellyfin_mpv_shim/mpvtk_browser/home_sections.py:103
 #: jellyfin_mpv_shim/osc_bridge.py:81 jellyfin_mpv_shim/osc_bridge.py:82
 #: jellyfin_mpv_shim/osc_bridge.py:104 jellyfin_mpv_shim/osc_bridge.py:140
 msgid "None"
@@ -403,7 +403,7 @@ msgstr "Zeptat se, zda přeskočit závěrečné titulky"
 msgid "Enable thumbnail previews"
 msgstr "Zobrazit náhledy na časové ose"
 
-#: jellyfin_mpv_shim/menu.py:609 jellyfin_mpv_shim/mpvtk_browser/config.py:186
+#: jellyfin_mpv_shim/menu.py:609 jellyfin_mpv_shim/mpvtk_browser/config.py:195
 #: jellyfin_mpv_shim/mpvtk_browser/hud.py:375
 msgid "Night Mode (Auto Volume Adj)"
 msgstr ""
@@ -702,310 +702,334 @@ msgstr ""
 msgid "Or switch to another user"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/cast.py:317
+#: jellyfin_mpv_shim/mpvtk_browser/cast.py:314
 msgid "Ready to cast"
 msgstr "Připraveno k projekci"
 
-#: jellyfin_mpv_shim/mpvtk_browser/cast.py:318
+#: jellyfin_mpv_shim/mpvtk_browser/cast.py:315
 #, fuzzy
 #| msgid "Select your media in Jellyfin and play it here"
 msgid "Select your media in Jellyfin and play it here."
 msgstr "V aplikaci Jellyfin vyberte, co chcete přehrát"
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:74
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:83
 msgid "Interface"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:83
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:92
 msgid "Playback"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:88
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:97
 msgid "Audio"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:92
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:101
 msgid "Subtitles & Languages"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:97
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:106
 #, fuzzy
 #| msgid " (Transcode)"
 msgid "Transcoding"
 msgstr " (Překódovat)"
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:102
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:111
 msgid "Video Enhancement"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:104
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:113
 #, fuzzy
 #| msgid "Seek to Skip Credits"
 msgid "Skip Intro / Credits"
 msgstr "Přeskočit závěrečné titulky"
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:107
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:116
 msgid "Library Browser"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:109
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:118
 msgid "Downloads"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:128
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:137
 msgid "Jellyfin UI"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:129
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:138
 msgid "MPV UI with thumbnails"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:130
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:139
 msgid "MPV built-in default"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:133
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:142
 msgid "Follow display"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:134
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:143
 msgid "100% (no scaling)"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:135
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:144
 msgid "125%"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:136
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:145
 msgid "150%"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:137
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:146
 msgid "200%"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:140
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:149
 msgid "Automatic (recommended)"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:141
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:150
 msgid "Vulkan"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:142
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:151
 msgid "Direct3D 11 (Windows only)"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:143
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:152
 msgid "OpenGL (compatibility)"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:146
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:155
 msgid "Default (auto)"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:147
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:156
 msgid "Force Stereo"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:148
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:157
 msgid "Optical Surround"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:149
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:158
 msgid "HDMI Passthrough"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:152
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:161
 msgid "Unset"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:153
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:162
 msgid "Dubbed (shows only)"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:154
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:163
 msgid "Subbed (shows only)"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:155
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:164
 msgid "Dubbed (all)"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:156
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:165
 msgid "Subbed (all)"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:157
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:166
 msgid "Custom (set in config)"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:162
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:171
 msgid "Download Folder"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:163
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:172
 msgid "Prefer Downloaded Copy"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:164
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:173
 msgid "Automatically Download Upcoming Episodes"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:165
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:174
 msgid "Include Next Up"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:166
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:175
 msgid "Next Up Entries to Consider"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:167
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:176
 msgid "Episodes to Keep Ahead (0 = off)"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:168
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:177
 msgid "Storage Limit for Automatic Downloads (GB)"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:169
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:178
 #, fuzzy
 #| msgid "Remove Server"
 msgid "Delete Automatic Downloads Once Watched"
 msgstr "Vzdálený server"
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:170
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:179
 msgid "Delete Unwatched After (days, 0 = never)"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:171
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:180
 msgid "Check Every (minutes)"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:172
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:181
 msgid "Close to Tray (keep running)"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:173
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:182
 msgid "Keep Running in Background"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:174
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:183
 msgid "Remember Window Size"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:175
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:184
 msgid "Player Controls Style"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:176
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:185
 msgid "Show What You're Watching in Discord"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:177
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:186
 msgid "Interface Scale"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:178
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:187
 msgid "Cast-target mode (no library browsing)"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:179
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:188
 msgid "Casting Opens the Library Browser"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:180
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:189
 msgid "Fullscreen Library Browser"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:181
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:190
 msgid "Always Bind Arrow Keys to Player Controls"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:182
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:191
 msgid "Player Controls Activation Key"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:183
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:192
 msgid "Audio Output Mode"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:184
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:193
 msgid "Audio Output Device"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:185
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:194
 msgid "Take the Device Exclusively"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:187
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:196
 #, fuzzy
 #| msgid "Video Playback Profiles"
 msgid "Enable Video Playback Profiles"
 msgstr "Profily přehrávání videa"
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:188
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:197
 #, fuzzy
 #| msgid "New Group"
 msgid "Profile Group"
 msgstr "Nová skupina"
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:189
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:198
 msgid "Remember Last Used Profile"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:190
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:199
 msgid "Graphics API for Shaders"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:191
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:200
 msgid "Pass Through AC3"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:192
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:201
 msgid "Pass Through DTS"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:193
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:202
 msgid "Pass Through E-AC3"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:194
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:203
 msgid "Pass Through DTS-HD"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:195
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:204
 msgid "Pass Through TrueHD"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:196
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:205
 msgid "Re-encode Others to AC3"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:202
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:213
 msgid ""
-"MPV keybinds are used by default. Press ENTER to drive the player controls "
-"by keyboard."
+"With \"Start Minimized\" and \"Fullscreen\" this is the classic cast-target "
+"setup: the app waits out of the way, plays fullscreen when something casts "
+"to it, and goes back to waiting when the video ends or you press Q."
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:204
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:227
+msgid ""
+"Off means command-line mode: no window, no system tray and no settings "
+"screen, so the only way back is editing conf.json by hand. It is not how you "
+"get MPV's own on-screen controls — \"Player Controls Style\" under Interface "
+"does that."
+msgstr ""
+
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:234
+msgid ""
+"Show only what is cast to this machine — the library, including this "
+"settings screen, can't be reached from here. Without a system tray icon the "
+"only way back is editing conf.json. For the classic cast-target setup you "
+"want the Interface settings instead; this is for a shared TV nobody should "
+"be able to browse from."
+msgstr ""
+
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:240
+msgid ""
+"Requires restart to change. MPV keybinds are used by default. Press ENTER to "
+"drive the player controls by keyboard."
+msgstr ""
+
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:242
 msgid ""
 "Pixels one wheel notch scrolls. The scrollbar glides while the content snaps "
 "to the nearest row, so a trackpad or trackball no longer overshoots. Raise "
 "it to scroll faster, lower it for finer control."
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:209
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:247
 msgid ""
 "Make each wheel notch jump exactly one row (or one home-screen section) "
 "instead of gliding. Turn this on if you prefer the older stepped scrolling."
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:217
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:255
 msgid "Discord Rich Presence. Takes effect after a restart."
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:219
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:257
 msgid ""
 "Leave this to Default unless setting up passthrough. Note some audio servers "
 "like Pipewire don't like passthrough and will need to be disabled for a card "
@@ -1013,57 +1037,57 @@ msgid ""
 "silence otherwise, but results may vary."
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:225
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:263
 msgid ""
 "Stop anything else using the device while playing. Needed for passthrough on "
 "some systems, and it means other applications will be silent."
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:228
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:266
 msgid ""
 "Page the library and music tile grids instead of scrolling: each page is one "
 "screenful with First / Previous / Next / Last controls and a page number you "
 "can type into. Easier than precise scrolling on a trackpad."
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:232
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:270
 msgid ""
 "Takes effect after a restart. \"Follow display\" uses the scale your desktop "
 "reports, which is 100% on X11."
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:234
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:272
 msgid ""
 "\"Default\" changes nothing and lets MPV (and your own mpv.conf) decide. "
 "Pick a mode only if you are sending audio to a receiver."
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:237
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:275
 msgid ""
 "Audio your receiver can't be sent directly is encoded to AC3, which is the "
 "only way surround fits down an optical cable. Turn this off if the encoder "
 "causes audio delay — those tracks become stereo instead."
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:242
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:280
 msgid ""
 "\"hq\" offers heavier profiles. Pick it if you have a fast graphics card."
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:244
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:282
 msgid ""
 "Leave on Automatic unless video breaks when a profile is loaded. This only "
 "applies while a profile is active, and OpenGL can cost you HDR output."
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:248
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:286
 msgid ""
 "Evens out loud effects and quiet dialogue. This turns passthrough off while "
 "it is enabled, because the volume has to be adjusted before your receiver "
 "gets the audio."
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:330
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:368
 msgid "Advanced"
 msgstr ""
 
@@ -1289,7 +1313,7 @@ msgid "Automatic"
 msgstr "Automaticky"
 
 #: jellyfin_mpv_shim/mpvtk_browser/downloads.py:51
-#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1355
+#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1288
 msgid "Episodes"
 msgstr ""
 
@@ -1298,7 +1322,7 @@ msgid "Season %s"
 msgstr ""
 
 #: jellyfin_mpv_shim/mpvtk_browser/downloads.py:52
-#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1351
+#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1284
 msgid "Specials"
 msgstr ""
 
@@ -1323,7 +1347,7 @@ msgid "Failed"
 msgstr "Selhání"
 
 #: jellyfin_mpv_shim/mpvtk_browser/downloads.py:185
-#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1105
+#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1038
 msgid "Playlist"
 msgstr ""
 
@@ -1335,30 +1359,30 @@ msgstr ""
 msgid "Movies & Videos"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/home_sections.py:103
+#: jellyfin_mpv_shim/mpvtk_browser/home_sections.py:104
 msgid "My Media"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/home_sections.py:104
-#: jellyfin_mpv_shim/mpvtk_browser/repository.py:352
+#: jellyfin_mpv_shim/mpvtk_browser/home_sections.py:105
+#: jellyfin_mpv_shim/mpvtk_browser/repository.py:350
 msgid "Continue Watching"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/home_sections.py:105
-#: jellyfin_mpv_shim/mpvtk_browser/repository.py:359
+#: jellyfin_mpv_shim/mpvtk_browser/home_sections.py:106
+#: jellyfin_mpv_shim/mpvtk_browser/repository.py:357
 msgid "Continue Listening"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/home_sections.py:106
-#: jellyfin_mpv_shim/mpvtk_browser/repository.py:366
+#: jellyfin_mpv_shim/mpvtk_browser/home_sections.py:107
+#: jellyfin_mpv_shim/mpvtk_browser/repository.py:364
 msgid "Next Up"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/home_sections.py:107
+#: jellyfin_mpv_shim/mpvtk_browser/home_sections.py:108
 msgid "Recently Added"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/home_sections.py:108
+#: jellyfin_mpv_shim/mpvtk_browser/home_sections.py:109
 msgid "Live TV"
 msgstr ""
 
@@ -1611,52 +1635,52 @@ msgstr ""
 "Server nebylo možné přidat.\n"
 "Zkontrolujte informace o připojení."
 
-#: jellyfin_mpv_shim/mpvtk_browser/repository.py:390
+#: jellyfin_mpv_shim/mpvtk_browser/repository.py:386
 msgid "On Now"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/repository.py:411
+#: jellyfin_mpv_shim/mpvtk_browser/repository.py:407
 msgid "Latest %s"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1119
+#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1052
 msgid "Downloaded"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1138
+#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1071
 msgid "Movies"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1143
+#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1076
 msgid "Videos"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1147
+#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1080
 msgid "TV Shows"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1151
+#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1084
 msgid "Playlists"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1168
-#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1441
+#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1101
+#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1374
 msgid "Series"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1212
+#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1145
 msgid "Downloaded Movies"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1216
+#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1149
 msgid "Downloaded Videos"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1220
+#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1153
 msgid "Downloaded Shows"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1353
+#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1286
 msgid "Season %d"
 msgstr ""
 

--- a/jellyfin_mpv_shim/messages/cy/LC_MESSAGES/base.po
+++ b/jellyfin_mpv_shim/messages/cy/LC_MESSAGES/base.po
@@ -5,7 +5,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2026-07-25 17:21-0400\n"
+"POT-Creation-Date: 2026-07-26 12:03-0400\n"
 "PO-Revision-Date: 2026-01-09 22:16+0000\n"
 "Last-Translator: SilentSkies <toby.taylor400@outlook.com>\n"
 "Language-Team: Welsh <https://translate.jellyfin.org/projects/jellyfin/"
@@ -253,7 +253,7 @@ msgid "Select Subtitle Track"
 msgstr "Dewiswch Trac Isdeitl"
 
 #: jellyfin_mpv_shim/menu.py:341
-#: jellyfin_mpv_shim/mpvtk_browser/home_sections.py:102
+#: jellyfin_mpv_shim/mpvtk_browser/home_sections.py:103
 #: jellyfin_mpv_shim/osc_bridge.py:81 jellyfin_mpv_shim/osc_bridge.py:82
 #: jellyfin_mpv_shim/osc_bridge.py:104 jellyfin_mpv_shim/osc_bridge.py:140
 msgid "None"
@@ -408,7 +408,7 @@ msgstr "Gofynnwch i Hepgor Intros"
 msgid "Enable thumbnail previews"
 msgstr "Galluogi rhagolwg mân-luniau"
 
-#: jellyfin_mpv_shim/menu.py:609 jellyfin_mpv_shim/mpvtk_browser/config.py:186
+#: jellyfin_mpv_shim/menu.py:609 jellyfin_mpv_shim/mpvtk_browser/config.py:195
 #: jellyfin_mpv_shim/mpvtk_browser/hud.py:375
 msgid "Night Mode (Auto Volume Adj)"
 msgstr ""
@@ -707,310 +707,334 @@ msgstr ""
 msgid "Or switch to another user"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/cast.py:317
+#: jellyfin_mpv_shim/mpvtk_browser/cast.py:314
 msgid "Ready to cast"
 msgstr "Barod i gastio"
 
-#: jellyfin_mpv_shim/mpvtk_browser/cast.py:318
+#: jellyfin_mpv_shim/mpvtk_browser/cast.py:315
 #, fuzzy
 #| msgid "Select your media in Jellyfin and play it here"
 msgid "Select your media in Jellyfin and play it here."
 msgstr "Dewiswch eich cyfryngau yn Jellyfin a'i chwarae yma"
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:74
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:83
 msgid "Interface"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:83
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:92
 msgid "Playback"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:88
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:97
 msgid "Audio"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:92
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:101
 msgid "Subtitles & Languages"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:97
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:106
 #, fuzzy
 #| msgid " (Transcode)"
 msgid "Transcoding"
 msgstr " (Trawsgodio)"
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:102
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:111
 msgid "Video Enhancement"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:104
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:113
 #, fuzzy
 #| msgid "Seek to Skip Intro"
 msgid "Skip Intro / Credits"
 msgstr "Ceisio Hepgor y Cyflwyniad"
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:107
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:116
 msgid "Library Browser"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:109
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:118
 msgid "Downloads"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:128
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:137
 msgid "Jellyfin UI"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:129
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:138
 msgid "MPV UI with thumbnails"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:130
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:139
 msgid "MPV built-in default"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:133
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:142
 msgid "Follow display"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:134
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:143
 msgid "100% (no scaling)"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:135
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:144
 msgid "125%"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:136
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:145
 msgid "150%"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:137
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:146
 msgid "200%"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:140
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:149
 msgid "Automatic (recommended)"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:141
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:150
 msgid "Vulkan"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:142
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:151
 msgid "Direct3D 11 (Windows only)"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:143
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:152
 msgid "OpenGL (compatibility)"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:146
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:155
 msgid "Default (auto)"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:147
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:156
 msgid "Force Stereo"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:148
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:157
 msgid "Optical Surround"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:149
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:158
 msgid "HDMI Passthrough"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:152
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:161
 msgid "Unset"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:153
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:162
 msgid "Dubbed (shows only)"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:154
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:163
 msgid "Subbed (shows only)"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:155
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:164
 msgid "Dubbed (all)"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:156
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:165
 msgid "Subbed (all)"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:157
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:166
 msgid "Custom (set in config)"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:162
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:171
 msgid "Download Folder"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:163
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:172
 msgid "Prefer Downloaded Copy"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:164
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:173
 msgid "Automatically Download Upcoming Episodes"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:165
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:174
 msgid "Include Next Up"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:166
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:175
 msgid "Next Up Entries to Consider"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:167
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:176
 msgid "Episodes to Keep Ahead (0 = off)"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:168
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:177
 msgid "Storage Limit for Automatic Downloads (GB)"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:169
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:178
 #, fuzzy
 #| msgid "Remove Server"
 msgid "Delete Automatic Downloads Once Watched"
 msgstr "Dileu Gweinydd"
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:170
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:179
 msgid "Delete Unwatched After (days, 0 = never)"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:171
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:180
 msgid "Check Every (minutes)"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:172
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:181
 msgid "Close to Tray (keep running)"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:173
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:182
 msgid "Keep Running in Background"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:174
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:183
 msgid "Remember Window Size"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:175
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:184
 msgid "Player Controls Style"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:176
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:185
 msgid "Show What You're Watching in Discord"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:177
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:186
 msgid "Interface Scale"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:178
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:187
 msgid "Cast-target mode (no library browsing)"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:179
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:188
 msgid "Casting Opens the Library Browser"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:180
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:189
 msgid "Fullscreen Library Browser"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:181
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:190
 msgid "Always Bind Arrow Keys to Player Controls"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:182
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:191
 msgid "Player Controls Activation Key"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:183
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:192
 msgid "Audio Output Mode"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:184
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:193
 msgid "Audio Output Device"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:185
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:194
 msgid "Take the Device Exclusively"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:187
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:196
 #, fuzzy
 #| msgid "Video Playback Profiles"
 msgid "Enable Video Playback Profiles"
 msgstr "Proffiliau Chwarae"
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:188
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:197
 #, fuzzy
 #| msgid "New Group"
 msgid "Profile Group"
 msgstr "Grwp Newydd"
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:189
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:198
 msgid "Remember Last Used Profile"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:190
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:199
 msgid "Graphics API for Shaders"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:191
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:200
 msgid "Pass Through AC3"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:192
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:201
 msgid "Pass Through DTS"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:193
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:202
 msgid "Pass Through E-AC3"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:194
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:203
 msgid "Pass Through DTS-HD"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:195
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:204
 msgid "Pass Through TrueHD"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:196
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:205
 msgid "Re-encode Others to AC3"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:202
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:213
 msgid ""
-"MPV keybinds are used by default. Press ENTER to drive the player controls "
-"by keyboard."
+"With \"Start Minimized\" and \"Fullscreen\" this is the classic cast-target "
+"setup: the app waits out of the way, plays fullscreen when something casts "
+"to it, and goes back to waiting when the video ends or you press Q."
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:204
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:227
+msgid ""
+"Off means command-line mode: no window, no system tray and no settings "
+"screen, so the only way back is editing conf.json by hand. It is not how you "
+"get MPV's own on-screen controls — \"Player Controls Style\" under Interface "
+"does that."
+msgstr ""
+
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:234
+msgid ""
+"Show only what is cast to this machine — the library, including this "
+"settings screen, can't be reached from here. Without a system tray icon the "
+"only way back is editing conf.json. For the classic cast-target setup you "
+"want the Interface settings instead; this is for a shared TV nobody should "
+"be able to browse from."
+msgstr ""
+
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:240
+msgid ""
+"Requires restart to change. MPV keybinds are used by default. Press ENTER to "
+"drive the player controls by keyboard."
+msgstr ""
+
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:242
 msgid ""
 "Pixels one wheel notch scrolls. The scrollbar glides while the content snaps "
 "to the nearest row, so a trackpad or trackball no longer overshoots. Raise "
 "it to scroll faster, lower it for finer control."
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:209
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:247
 msgid ""
 "Make each wheel notch jump exactly one row (or one home-screen section) "
 "instead of gliding. Turn this on if you prefer the older stepped scrolling."
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:217
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:255
 msgid "Discord Rich Presence. Takes effect after a restart."
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:219
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:257
 msgid ""
 "Leave this to Default unless setting up passthrough. Note some audio servers "
 "like Pipewire don't like passthrough and will need to be disabled for a card "
@@ -1018,57 +1042,57 @@ msgid ""
 "silence otherwise, but results may vary."
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:225
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:263
 msgid ""
 "Stop anything else using the device while playing. Needed for passthrough on "
 "some systems, and it means other applications will be silent."
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:228
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:266
 msgid ""
 "Page the library and music tile grids instead of scrolling: each page is one "
 "screenful with First / Previous / Next / Last controls and a page number you "
 "can type into. Easier than precise scrolling on a trackpad."
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:232
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:270
 msgid ""
 "Takes effect after a restart. \"Follow display\" uses the scale your desktop "
 "reports, which is 100% on X11."
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:234
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:272
 msgid ""
 "\"Default\" changes nothing and lets MPV (and your own mpv.conf) decide. "
 "Pick a mode only if you are sending audio to a receiver."
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:237
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:275
 msgid ""
 "Audio your receiver can't be sent directly is encoded to AC3, which is the "
 "only way surround fits down an optical cable. Turn this off if the encoder "
 "causes audio delay — those tracks become stereo instead."
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:242
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:280
 msgid ""
 "\"hq\" offers heavier profiles. Pick it if you have a fast graphics card."
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:244
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:282
 msgid ""
 "Leave on Automatic unless video breaks when a profile is loaded. This only "
 "applies while a profile is active, and OpenGL can cost you HDR output."
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:248
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:286
 msgid ""
 "Evens out loud effects and quiet dialogue. This turns passthrough off while "
 "it is enabled, because the volume has to be adjusted before your receiver "
 "gets the audio."
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:330
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:368
 msgid "Advanced"
 msgstr ""
 
@@ -1294,7 +1318,7 @@ msgid "Automatic"
 msgstr "Awtomatig"
 
 #: jellyfin_mpv_shim/mpvtk_browser/downloads.py:51
-#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1355
+#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1288
 msgid "Episodes"
 msgstr ""
 
@@ -1303,7 +1327,7 @@ msgid "Season %s"
 msgstr ""
 
 #: jellyfin_mpv_shim/mpvtk_browser/downloads.py:52
-#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1351
+#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1284
 msgid "Specials"
 msgstr ""
 
@@ -1328,7 +1352,7 @@ msgid "Failed"
 msgstr "Methu"
 
 #: jellyfin_mpv_shim/mpvtk_browser/downloads.py:185
-#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1105
+#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1038
 msgid "Playlist"
 msgstr ""
 
@@ -1340,30 +1364,30 @@ msgstr ""
 msgid "Movies & Videos"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/home_sections.py:103
+#: jellyfin_mpv_shim/mpvtk_browser/home_sections.py:104
 msgid "My Media"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/home_sections.py:104
-#: jellyfin_mpv_shim/mpvtk_browser/repository.py:352
+#: jellyfin_mpv_shim/mpvtk_browser/home_sections.py:105
+#: jellyfin_mpv_shim/mpvtk_browser/repository.py:350
 msgid "Continue Watching"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/home_sections.py:105
-#: jellyfin_mpv_shim/mpvtk_browser/repository.py:359
+#: jellyfin_mpv_shim/mpvtk_browser/home_sections.py:106
+#: jellyfin_mpv_shim/mpvtk_browser/repository.py:357
 msgid "Continue Listening"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/home_sections.py:106
-#: jellyfin_mpv_shim/mpvtk_browser/repository.py:366
+#: jellyfin_mpv_shim/mpvtk_browser/home_sections.py:107
+#: jellyfin_mpv_shim/mpvtk_browser/repository.py:364
 msgid "Next Up"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/home_sections.py:107
+#: jellyfin_mpv_shim/mpvtk_browser/home_sections.py:108
 msgid "Recently Added"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/home_sections.py:108
+#: jellyfin_mpv_shim/mpvtk_browser/home_sections.py:109
 msgid "Live TV"
 msgstr ""
 
@@ -1616,52 +1640,52 @@ msgstr ""
 "Methu ychwanegu gweinydd.\n"
 "Gwiriwch eich gwybodaeth cyswllt."
 
-#: jellyfin_mpv_shim/mpvtk_browser/repository.py:390
+#: jellyfin_mpv_shim/mpvtk_browser/repository.py:386
 msgid "On Now"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/repository.py:411
+#: jellyfin_mpv_shim/mpvtk_browser/repository.py:407
 msgid "Latest %s"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1119
+#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1052
 msgid "Downloaded"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1138
+#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1071
 msgid "Movies"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1143
+#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1076
 msgid "Videos"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1147
+#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1080
 msgid "TV Shows"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1151
+#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1084
 msgid "Playlists"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1168
-#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1441
+#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1101
+#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1374
 msgid "Series"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1212
+#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1145
 msgid "Downloaded Movies"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1216
+#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1149
 msgid "Downloaded Videos"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1220
+#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1153
 msgid "Downloaded Shows"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1353
+#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1286
 msgid "Season %d"
 msgstr ""
 

--- a/jellyfin_mpv_shim/messages/da/LC_MESSAGES/base.po
+++ b/jellyfin_mpv_shim/messages/da/LC_MESSAGES/base.po
@@ -5,7 +5,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2026-07-25 17:21-0400\n"
+"POT-Creation-Date: 2026-07-26 12:03-0400\n"
 "PO-Revision-Date: 2026-07-06 01:00+0000\n"
 "Last-Translator: Ulrik <ulrik.johansen@me.com>\n"
 "Language-Team: Danish <https://translate.jellyfin.org/projects/jellyfin/"
@@ -246,7 +246,7 @@ msgid "Select Subtitle Track"
 msgstr "Vælg undertekstspor"
 
 #: jellyfin_mpv_shim/menu.py:341
-#: jellyfin_mpv_shim/mpvtk_browser/home_sections.py:102
+#: jellyfin_mpv_shim/mpvtk_browser/home_sections.py:103
 #: jellyfin_mpv_shim/osc_bridge.py:81 jellyfin_mpv_shim/osc_bridge.py:82
 #: jellyfin_mpv_shim/osc_bridge.py:104 jellyfin_mpv_shim/osc_bridge.py:140
 msgid "None"
@@ -397,7 +397,7 @@ msgstr "Spørg om at springe rulletekster over"
 msgid "Enable thumbnail previews"
 msgstr "Aktivér forhåndsvisning af miniaturer"
 
-#: jellyfin_mpv_shim/menu.py:609 jellyfin_mpv_shim/mpvtk_browser/config.py:186
+#: jellyfin_mpv_shim/menu.py:609 jellyfin_mpv_shim/mpvtk_browser/config.py:195
 #: jellyfin_mpv_shim/mpvtk_browser/hud.py:375
 msgid "Night Mode (Auto Volume Adj)"
 msgstr ""
@@ -682,310 +682,334 @@ msgstr ""
 msgid "Or switch to another user"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/cast.py:317
+#: jellyfin_mpv_shim/mpvtk_browser/cast.py:314
 msgid "Ready to cast"
 msgstr "Klar til at caste"
 
-#: jellyfin_mpv_shim/mpvtk_browser/cast.py:318
+#: jellyfin_mpv_shim/mpvtk_browser/cast.py:315
 #, fuzzy
 #| msgid "Select your media in Jellyfin and play it here"
 msgid "Select your media in Jellyfin and play it here."
 msgstr "Vælg dine medier i Jellyfin, og afspil dem her"
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:74
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:83
 msgid "Interface"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:83
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:92
 msgid "Playback"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:88
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:97
 msgid "Audio"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:92
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:101
 msgid "Subtitles & Languages"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:97
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:106
 #, fuzzy
 #| msgid " (Transcode)"
 msgid "Transcoding"
 msgstr " (Transkodning)"
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:102
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:111
 msgid "Video Enhancement"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:104
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:113
 #, fuzzy
 #| msgid "Seek to Skip Credits"
 msgid "Skip Intro / Credits"
 msgstr "Spol til Spring over rulletekster"
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:107
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:116
 msgid "Library Browser"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:109
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:118
 msgid "Downloads"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:128
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:137
 msgid "Jellyfin UI"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:129
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:138
 msgid "MPV UI with thumbnails"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:130
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:139
 msgid "MPV built-in default"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:133
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:142
 msgid "Follow display"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:134
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:143
 msgid "100% (no scaling)"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:135
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:144
 msgid "125%"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:136
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:145
 msgid "150%"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:137
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:146
 msgid "200%"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:140
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:149
 msgid "Automatic (recommended)"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:141
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:150
 msgid "Vulkan"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:142
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:151
 msgid "Direct3D 11 (Windows only)"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:143
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:152
 msgid "OpenGL (compatibility)"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:146
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:155
 msgid "Default (auto)"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:147
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:156
 msgid "Force Stereo"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:148
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:157
 msgid "Optical Surround"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:149
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:158
 msgid "HDMI Passthrough"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:152
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:161
 msgid "Unset"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:153
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:162
 msgid "Dubbed (shows only)"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:154
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:163
 msgid "Subbed (shows only)"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:155
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:164
 msgid "Dubbed (all)"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:156
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:165
 msgid "Subbed (all)"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:157
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:166
 msgid "Custom (set in config)"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:162
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:171
 msgid "Download Folder"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:163
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:172
 msgid "Prefer Downloaded Copy"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:164
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:173
 msgid "Automatically Download Upcoming Episodes"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:165
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:174
 msgid "Include Next Up"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:166
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:175
 msgid "Next Up Entries to Consider"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:167
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:176
 msgid "Episodes to Keep Ahead (0 = off)"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:168
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:177
 msgid "Storage Limit for Automatic Downloads (GB)"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:169
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:178
 #, fuzzy
 #| msgid "Auto Play"
 msgid "Delete Automatic Downloads Once Watched"
 msgstr "Automatisk afspilning"
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:170
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:179
 msgid "Delete Unwatched After (days, 0 = never)"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:171
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:180
 msgid "Check Every (minutes)"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:172
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:181
 msgid "Close to Tray (keep running)"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:173
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:182
 msgid "Keep Running in Background"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:174
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:183
 msgid "Remember Window Size"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:175
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:184
 msgid "Player Controls Style"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:176
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:185
 msgid "Show What You're Watching in Discord"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:177
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:186
 msgid "Interface Scale"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:178
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:187
 msgid "Cast-target mode (no library browsing)"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:179
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:188
 msgid "Casting Opens the Library Browser"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:180
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:189
 msgid "Fullscreen Library Browser"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:181
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:190
 msgid "Always Bind Arrow Keys to Player Controls"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:182
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:191
 msgid "Player Controls Activation Key"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:183
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:192
 msgid "Audio Output Mode"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:184
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:193
 msgid "Audio Output Device"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:185
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:194
 msgid "Take the Device Exclusively"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:187
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:196
 #, fuzzy
 #| msgid "Video Playback Profiles"
 msgid "Enable Video Playback Profiles"
 msgstr "Videoafspilningsprofil"
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:188
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:197
 #, fuzzy
 #| msgid "New Group"
 msgid "Profile Group"
 msgstr "Ny gruppe"
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:189
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:198
 msgid "Remember Last Used Profile"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:190
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:199
 msgid "Graphics API for Shaders"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:191
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:200
 msgid "Pass Through AC3"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:192
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:201
 msgid "Pass Through DTS"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:193
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:202
 msgid "Pass Through E-AC3"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:194
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:203
 msgid "Pass Through DTS-HD"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:195
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:204
 msgid "Pass Through TrueHD"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:196
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:205
 msgid "Re-encode Others to AC3"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:202
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:213
 msgid ""
-"MPV keybinds are used by default. Press ENTER to drive the player controls "
-"by keyboard."
+"With \"Start Minimized\" and \"Fullscreen\" this is the classic cast-target "
+"setup: the app waits out of the way, plays fullscreen when something casts "
+"to it, and goes back to waiting when the video ends or you press Q."
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:204
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:227
+msgid ""
+"Off means command-line mode: no window, no system tray and no settings "
+"screen, so the only way back is editing conf.json by hand. It is not how you "
+"get MPV's own on-screen controls — \"Player Controls Style\" under Interface "
+"does that."
+msgstr ""
+
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:234
+msgid ""
+"Show only what is cast to this machine — the library, including this "
+"settings screen, can't be reached from here. Without a system tray icon the "
+"only way back is editing conf.json. For the classic cast-target setup you "
+"want the Interface settings instead; this is for a shared TV nobody should "
+"be able to browse from."
+msgstr ""
+
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:240
+msgid ""
+"Requires restart to change. MPV keybinds are used by default. Press ENTER to "
+"drive the player controls by keyboard."
+msgstr ""
+
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:242
 msgid ""
 "Pixels one wheel notch scrolls. The scrollbar glides while the content snaps "
 "to the nearest row, so a trackpad or trackball no longer overshoots. Raise "
 "it to scroll faster, lower it for finer control."
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:209
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:247
 msgid ""
 "Make each wheel notch jump exactly one row (or one home-screen section) "
 "instead of gliding. Turn this on if you prefer the older stepped scrolling."
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:217
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:255
 msgid "Discord Rich Presence. Takes effect after a restart."
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:219
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:257
 msgid ""
 "Leave this to Default unless setting up passthrough. Note some audio servers "
 "like Pipewire don't like passthrough and will need to be disabled for a card "
@@ -993,57 +1017,57 @@ msgid ""
 "silence otherwise, but results may vary."
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:225
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:263
 msgid ""
 "Stop anything else using the device while playing. Needed for passthrough on "
 "some systems, and it means other applications will be silent."
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:228
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:266
 msgid ""
 "Page the library and music tile grids instead of scrolling: each page is one "
 "screenful with First / Previous / Next / Last controls and a page number you "
 "can type into. Easier than precise scrolling on a trackpad."
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:232
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:270
 msgid ""
 "Takes effect after a restart. \"Follow display\" uses the scale your desktop "
 "reports, which is 100% on X11."
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:234
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:272
 msgid ""
 "\"Default\" changes nothing and lets MPV (and your own mpv.conf) decide. "
 "Pick a mode only if you are sending audio to a receiver."
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:237
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:275
 msgid ""
 "Audio your receiver can't be sent directly is encoded to AC3, which is the "
 "only way surround fits down an optical cable. Turn this off if the encoder "
 "causes audio delay — those tracks become stereo instead."
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:242
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:280
 msgid ""
 "\"hq\" offers heavier profiles. Pick it if you have a fast graphics card."
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:244
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:282
 msgid ""
 "Leave on Automatic unless video breaks when a profile is loaded. This only "
 "applies while a profile is active, and OpenGL can cost you HDR output."
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:248
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:286
 msgid ""
 "Evens out loud effects and quiet dialogue. This turns passthrough off while "
 "it is enabled, because the volume has to be adjusted before your receiver "
 "gets the audio."
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:330
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:368
 msgid "Advanced"
 msgstr ""
 
@@ -1243,7 +1267,7 @@ msgid "Automatic"
 msgstr "Automatisk"
 
 #: jellyfin_mpv_shim/mpvtk_browser/downloads.py:51
-#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1355
+#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1288
 msgid "Episodes"
 msgstr ""
 
@@ -1252,7 +1276,7 @@ msgid "Season %s"
 msgstr ""
 
 #: jellyfin_mpv_shim/mpvtk_browser/downloads.py:52
-#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1351
+#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1284
 msgid "Specials"
 msgstr ""
 
@@ -1277,7 +1301,7 @@ msgid "Failed"
 msgstr "Fejl"
 
 #: jellyfin_mpv_shim/mpvtk_browser/downloads.py:185
-#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1105
+#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1038
 msgid "Playlist"
 msgstr ""
 
@@ -1289,30 +1313,30 @@ msgstr ""
 msgid "Movies & Videos"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/home_sections.py:103
+#: jellyfin_mpv_shim/mpvtk_browser/home_sections.py:104
 msgid "My Media"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/home_sections.py:104
-#: jellyfin_mpv_shim/mpvtk_browser/repository.py:352
+#: jellyfin_mpv_shim/mpvtk_browser/home_sections.py:105
+#: jellyfin_mpv_shim/mpvtk_browser/repository.py:350
 msgid "Continue Watching"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/home_sections.py:105
-#: jellyfin_mpv_shim/mpvtk_browser/repository.py:359
+#: jellyfin_mpv_shim/mpvtk_browser/home_sections.py:106
+#: jellyfin_mpv_shim/mpvtk_browser/repository.py:357
 msgid "Continue Listening"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/home_sections.py:106
-#: jellyfin_mpv_shim/mpvtk_browser/repository.py:366
+#: jellyfin_mpv_shim/mpvtk_browser/home_sections.py:107
+#: jellyfin_mpv_shim/mpvtk_browser/repository.py:364
 msgid "Next Up"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/home_sections.py:107
+#: jellyfin_mpv_shim/mpvtk_browser/home_sections.py:108
 msgid "Recently Added"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/home_sections.py:108
+#: jellyfin_mpv_shim/mpvtk_browser/home_sections.py:109
 msgid "Live TV"
 msgstr ""
 
@@ -1545,52 +1569,52 @@ msgstr ""
 msgid "Could not load this page."
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/repository.py:390
+#: jellyfin_mpv_shim/mpvtk_browser/repository.py:386
 msgid "On Now"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/repository.py:411
+#: jellyfin_mpv_shim/mpvtk_browser/repository.py:407
 msgid "Latest %s"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1119
+#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1052
 msgid "Downloaded"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1138
+#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1071
 msgid "Movies"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1143
+#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1076
 msgid "Videos"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1147
+#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1080
 msgid "TV Shows"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1151
+#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1084
 msgid "Playlists"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1168
-#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1441
+#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1101
+#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1374
 msgid "Series"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1212
+#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1145
 msgid "Downloaded Movies"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1216
+#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1149
 msgid "Downloaded Videos"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1220
+#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1153
 msgid "Downloaded Shows"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1353
+#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1286
 msgid "Season %d"
 msgstr ""
 

--- a/jellyfin_mpv_shim/messages/de/LC_MESSAGES/base.po
+++ b/jellyfin_mpv_shim/messages/de/LC_MESSAGES/base.po
@@ -5,7 +5,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2026-07-25 17:21-0400\n"
+"POT-Creation-Date: 2026-07-26 12:03-0400\n"
 "PO-Revision-Date: 2025-09-29 05:10+0000\n"
 "Last-Translator: Timo <timo.liebscher@outlook.de>\n"
 "Language-Team: German <https://translate.jellyfin.org/projects/jellyfin/"
@@ -252,7 +252,7 @@ msgid "Select Subtitle Track"
 msgstr "Untertitelspur wählen"
 
 #: jellyfin_mpv_shim/menu.py:341
-#: jellyfin_mpv_shim/mpvtk_browser/home_sections.py:102
+#: jellyfin_mpv_shim/mpvtk_browser/home_sections.py:103
 #: jellyfin_mpv_shim/osc_bridge.py:81 jellyfin_mpv_shim/osc_bridge.py:82
 #: jellyfin_mpv_shim/osc_bridge.py:104 jellyfin_mpv_shim/osc_bridge.py:140
 msgid "None"
@@ -403,7 +403,7 @@ msgstr "Nachfragen, ob Credits übersprungen werden sollen"
 msgid "Enable thumbnail previews"
 msgstr "Miniaturvorschauen aktivieren"
 
-#: jellyfin_mpv_shim/menu.py:609 jellyfin_mpv_shim/mpvtk_browser/config.py:186
+#: jellyfin_mpv_shim/menu.py:609 jellyfin_mpv_shim/mpvtk_browser/config.py:195
 #: jellyfin_mpv_shim/mpvtk_browser/hud.py:375
 msgid "Night Mode (Auto Volume Adj)"
 msgstr ""
@@ -702,310 +702,334 @@ msgstr ""
 msgid "Or switch to another user"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/cast.py:317
+#: jellyfin_mpv_shim/mpvtk_browser/cast.py:314
 msgid "Ready to cast"
 msgstr "Bereit zur Übertragung"
 
-#: jellyfin_mpv_shim/mpvtk_browser/cast.py:318
+#: jellyfin_mpv_shim/mpvtk_browser/cast.py:315
 #, fuzzy
 #| msgid "Select your media in Jellyfin and play it here"
 msgid "Select your media in Jellyfin and play it here."
 msgstr "Wähle deine Medien in Jellyfin und spiele sie hier ab"
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:74
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:83
 msgid "Interface"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:83
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:92
 msgid "Playback"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:88
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:97
 msgid "Audio"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:92
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:101
 msgid "Subtitles & Languages"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:97
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:106
 #, fuzzy
 #| msgid " (Transcode)"
 msgid "Transcoding"
 msgstr " (Transkodieren)"
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:102
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:111
 msgid "Video Enhancement"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:104
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:113
 #, fuzzy
 #| msgid "Seek to Skip Credits"
 msgid "Skip Intro / Credits"
 msgstr "Versuche, Credits zu überspringen"
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:107
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:116
 msgid "Library Browser"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:109
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:118
 msgid "Downloads"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:128
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:137
 msgid "Jellyfin UI"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:129
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:138
 msgid "MPV UI with thumbnails"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:130
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:139
 msgid "MPV built-in default"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:133
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:142
 msgid "Follow display"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:134
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:143
 msgid "100% (no scaling)"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:135
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:144
 msgid "125%"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:136
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:145
 msgid "150%"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:137
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:146
 msgid "200%"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:140
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:149
 msgid "Automatic (recommended)"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:141
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:150
 msgid "Vulkan"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:142
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:151
 msgid "Direct3D 11 (Windows only)"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:143
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:152
 msgid "OpenGL (compatibility)"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:146
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:155
 msgid "Default (auto)"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:147
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:156
 msgid "Force Stereo"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:148
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:157
 msgid "Optical Surround"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:149
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:158
 msgid "HDMI Passthrough"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:152
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:161
 msgid "Unset"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:153
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:162
 msgid "Dubbed (shows only)"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:154
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:163
 msgid "Subbed (shows only)"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:155
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:164
 msgid "Dubbed (all)"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:156
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:165
 msgid "Subbed (all)"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:157
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:166
 msgid "Custom (set in config)"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:162
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:171
 msgid "Download Folder"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:163
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:172
 msgid "Prefer Downloaded Copy"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:164
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:173
 msgid "Automatically Download Upcoming Episodes"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:165
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:174
 msgid "Include Next Up"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:166
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:175
 msgid "Next Up Entries to Consider"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:167
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:176
 msgid "Episodes to Keep Ahead (0 = off)"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:168
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:177
 msgid "Storage Limit for Automatic Downloads (GB)"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:169
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:178
 #, fuzzy
 #| msgid "Remove Server"
 msgid "Delete Automatic Downloads Once Watched"
 msgstr "Server entfernen"
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:170
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:179
 msgid "Delete Unwatched After (days, 0 = never)"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:171
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:180
 msgid "Check Every (minutes)"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:172
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:181
 msgid "Close to Tray (keep running)"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:173
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:182
 msgid "Keep Running in Background"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:174
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:183
 msgid "Remember Window Size"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:175
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:184
 msgid "Player Controls Style"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:176
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:185
 msgid "Show What You're Watching in Discord"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:177
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:186
 msgid "Interface Scale"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:178
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:187
 msgid "Cast-target mode (no library browsing)"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:179
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:188
 msgid "Casting Opens the Library Browser"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:180
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:189
 msgid "Fullscreen Library Browser"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:181
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:190
 msgid "Always Bind Arrow Keys to Player Controls"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:182
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:191
 msgid "Player Controls Activation Key"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:183
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:192
 msgid "Audio Output Mode"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:184
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:193
 msgid "Audio Output Device"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:185
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:194
 msgid "Take the Device Exclusively"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:187
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:196
 #, fuzzy
 #| msgid "Video Playback Profiles"
 msgid "Enable Video Playback Profiles"
 msgstr "Videowiedergabeprofile"
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:188
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:197
 #, fuzzy
 #| msgid "New Group"
 msgid "Profile Group"
 msgstr "Neue Gruppe"
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:189
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:198
 msgid "Remember Last Used Profile"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:190
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:199
 msgid "Graphics API for Shaders"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:191
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:200
 msgid "Pass Through AC3"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:192
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:201
 msgid "Pass Through DTS"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:193
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:202
 msgid "Pass Through E-AC3"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:194
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:203
 msgid "Pass Through DTS-HD"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:195
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:204
 msgid "Pass Through TrueHD"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:196
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:205
 msgid "Re-encode Others to AC3"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:202
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:213
 msgid ""
-"MPV keybinds are used by default. Press ENTER to drive the player controls "
-"by keyboard."
+"With \"Start Minimized\" and \"Fullscreen\" this is the classic cast-target "
+"setup: the app waits out of the way, plays fullscreen when something casts "
+"to it, and goes back to waiting when the video ends or you press Q."
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:204
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:227
+msgid ""
+"Off means command-line mode: no window, no system tray and no settings "
+"screen, so the only way back is editing conf.json by hand. It is not how you "
+"get MPV's own on-screen controls — \"Player Controls Style\" under Interface "
+"does that."
+msgstr ""
+
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:234
+msgid ""
+"Show only what is cast to this machine — the library, including this "
+"settings screen, can't be reached from here. Without a system tray icon the "
+"only way back is editing conf.json. For the classic cast-target setup you "
+"want the Interface settings instead; this is for a shared TV nobody should "
+"be able to browse from."
+msgstr ""
+
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:240
+msgid ""
+"Requires restart to change. MPV keybinds are used by default. Press ENTER to "
+"drive the player controls by keyboard."
+msgstr ""
+
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:242
 msgid ""
 "Pixels one wheel notch scrolls. The scrollbar glides while the content snaps "
 "to the nearest row, so a trackpad or trackball no longer overshoots. Raise "
 "it to scroll faster, lower it for finer control."
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:209
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:247
 msgid ""
 "Make each wheel notch jump exactly one row (or one home-screen section) "
 "instead of gliding. Turn this on if you prefer the older stepped scrolling."
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:217
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:255
 msgid "Discord Rich Presence. Takes effect after a restart."
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:219
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:257
 msgid ""
 "Leave this to Default unless setting up passthrough. Note some audio servers "
 "like Pipewire don't like passthrough and will need to be disabled for a card "
@@ -1013,57 +1037,57 @@ msgid ""
 "silence otherwise, but results may vary."
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:225
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:263
 msgid ""
 "Stop anything else using the device while playing. Needed for passthrough on "
 "some systems, and it means other applications will be silent."
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:228
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:266
 msgid ""
 "Page the library and music tile grids instead of scrolling: each page is one "
 "screenful with First / Previous / Next / Last controls and a page number you "
 "can type into. Easier than precise scrolling on a trackpad."
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:232
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:270
 msgid ""
 "Takes effect after a restart. \"Follow display\" uses the scale your desktop "
 "reports, which is 100% on X11."
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:234
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:272
 msgid ""
 "\"Default\" changes nothing and lets MPV (and your own mpv.conf) decide. "
 "Pick a mode only if you are sending audio to a receiver."
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:237
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:275
 msgid ""
 "Audio your receiver can't be sent directly is encoded to AC3, which is the "
 "only way surround fits down an optical cable. Turn this off if the encoder "
 "causes audio delay — those tracks become stereo instead."
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:242
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:280
 msgid ""
 "\"hq\" offers heavier profiles. Pick it if you have a fast graphics card."
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:244
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:282
 msgid ""
 "Leave on Automatic unless video breaks when a profile is loaded. This only "
 "applies while a profile is active, and OpenGL can cost you HDR output."
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:248
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:286
 msgid ""
 "Evens out loud effects and quiet dialogue. This turns passthrough off while "
 "it is enabled, because the volume has to be adjusted before your receiver "
 "gets the audio."
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:330
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:368
 msgid "Advanced"
 msgstr ""
 
@@ -1289,7 +1313,7 @@ msgid "Automatic"
 msgstr "Automatisch"
 
 #: jellyfin_mpv_shim/mpvtk_browser/downloads.py:51
-#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1355
+#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1288
 msgid "Episodes"
 msgstr ""
 
@@ -1298,7 +1322,7 @@ msgid "Season %s"
 msgstr ""
 
 #: jellyfin_mpv_shim/mpvtk_browser/downloads.py:52
-#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1351
+#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1284
 msgid "Specials"
 msgstr ""
 
@@ -1323,7 +1347,7 @@ msgid "Failed"
 msgstr "Fehler"
 
 #: jellyfin_mpv_shim/mpvtk_browser/downloads.py:185
-#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1105
+#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1038
 msgid "Playlist"
 msgstr ""
 
@@ -1335,30 +1359,30 @@ msgstr ""
 msgid "Movies & Videos"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/home_sections.py:103
+#: jellyfin_mpv_shim/mpvtk_browser/home_sections.py:104
 msgid "My Media"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/home_sections.py:104
-#: jellyfin_mpv_shim/mpvtk_browser/repository.py:352
+#: jellyfin_mpv_shim/mpvtk_browser/home_sections.py:105
+#: jellyfin_mpv_shim/mpvtk_browser/repository.py:350
 msgid "Continue Watching"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/home_sections.py:105
-#: jellyfin_mpv_shim/mpvtk_browser/repository.py:359
+#: jellyfin_mpv_shim/mpvtk_browser/home_sections.py:106
+#: jellyfin_mpv_shim/mpvtk_browser/repository.py:357
 msgid "Continue Listening"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/home_sections.py:106
-#: jellyfin_mpv_shim/mpvtk_browser/repository.py:366
+#: jellyfin_mpv_shim/mpvtk_browser/home_sections.py:107
+#: jellyfin_mpv_shim/mpvtk_browser/repository.py:364
 msgid "Next Up"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/home_sections.py:107
+#: jellyfin_mpv_shim/mpvtk_browser/home_sections.py:108
 msgid "Recently Added"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/home_sections.py:108
+#: jellyfin_mpv_shim/mpvtk_browser/home_sections.py:109
 msgid "Live TV"
 msgstr ""
 
@@ -1611,52 +1635,52 @@ msgstr ""
 "Server konnte nicht hinzugefügt werden.\n"
 "Bitte überprüfe deine Verbindungsinformationen."
 
-#: jellyfin_mpv_shim/mpvtk_browser/repository.py:390
+#: jellyfin_mpv_shim/mpvtk_browser/repository.py:386
 msgid "On Now"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/repository.py:411
+#: jellyfin_mpv_shim/mpvtk_browser/repository.py:407
 msgid "Latest %s"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1119
+#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1052
 msgid "Downloaded"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1138
+#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1071
 msgid "Movies"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1143
+#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1076
 msgid "Videos"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1147
+#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1080
 msgid "TV Shows"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1151
+#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1084
 msgid "Playlists"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1168
-#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1441
+#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1101
+#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1374
 msgid "Series"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1212
+#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1145
 msgid "Downloaded Movies"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1216
+#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1149
 msgid "Downloaded Videos"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1220
+#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1153
 msgid "Downloaded Shows"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1353
+#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1286
 msgid "Season %d"
 msgstr ""
 

--- a/jellyfin_mpv_shim/messages/dv/LC_MESSAGES/base.po
+++ b/jellyfin_mpv_shim/messages/dv/LC_MESSAGES/base.po
@@ -5,7 +5,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2026-07-25 17:21-0400\n"
+"POT-Creation-Date: 2026-07-26 12:03-0400\n"
 "PO-Revision-Date: 2026-06-21 23:00+0000\n"
 "Last-Translator: Naveed Ali Anwar <hello@naveedalianwar.com>\n"
 "Language-Team: Dhivehi <https://translate.jellyfin.org/projects/jellyfin/"
@@ -242,7 +242,7 @@ msgid "Select Subtitle Track"
 msgstr ""
 
 #: jellyfin_mpv_shim/menu.py:341
-#: jellyfin_mpv_shim/mpvtk_browser/home_sections.py:102
+#: jellyfin_mpv_shim/mpvtk_browser/home_sections.py:103
 #: jellyfin_mpv_shim/osc_bridge.py:81 jellyfin_mpv_shim/osc_bridge.py:82
 #: jellyfin_mpv_shim/osc_bridge.py:104 jellyfin_mpv_shim/osc_bridge.py:140
 msgid "None"
@@ -393,7 +393,7 @@ msgstr ""
 msgid "Enable thumbnail previews"
 msgstr ""
 
-#: jellyfin_mpv_shim/menu.py:609 jellyfin_mpv_shim/mpvtk_browser/config.py:186
+#: jellyfin_mpv_shim/menu.py:609 jellyfin_mpv_shim/mpvtk_browser/config.py:195
 #: jellyfin_mpv_shim/mpvtk_browser/hud.py:375
 msgid "Night Mode (Auto Volume Adj)"
 msgstr ""
@@ -660,298 +660,322 @@ msgstr ""
 msgid "Or switch to another user"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/cast.py:317
+#: jellyfin_mpv_shim/mpvtk_browser/cast.py:314
 msgid "Ready to cast"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/cast.py:318
+#: jellyfin_mpv_shim/mpvtk_browser/cast.py:315
 msgid "Select your media in Jellyfin and play it here."
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:74
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:83
 msgid "Interface"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:83
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:92
 msgid "Playback"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:88
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:97
 msgid "Audio"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:92
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:101
 msgid "Subtitles & Languages"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:97
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:106
 msgid "Transcoding"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:102
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:111
 msgid "Video Enhancement"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:104
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:113
 msgid "Skip Intro / Credits"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:107
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:116
 msgid "Library Browser"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:109
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:118
 msgid "Downloads"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:128
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:137
 msgid "Jellyfin UI"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:129
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:138
 msgid "MPV UI with thumbnails"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:130
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:139
 msgid "MPV built-in default"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:133
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:142
 msgid "Follow display"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:134
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:143
 msgid "100% (no scaling)"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:135
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:144
 msgid "125%"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:136
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:145
 msgid "150%"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:137
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:146
 msgid "200%"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:140
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:149
 msgid "Automatic (recommended)"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:141
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:150
 msgid "Vulkan"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:142
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:151
 msgid "Direct3D 11 (Windows only)"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:143
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:152
 msgid "OpenGL (compatibility)"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:146
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:155
 msgid "Default (auto)"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:147
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:156
 msgid "Force Stereo"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:148
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:157
 msgid "Optical Surround"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:149
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:158
 msgid "HDMI Passthrough"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:152
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:161
 msgid "Unset"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:153
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:162
 msgid "Dubbed (shows only)"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:154
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:163
 msgid "Subbed (shows only)"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:155
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:164
 msgid "Dubbed (all)"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:156
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:165
 msgid "Subbed (all)"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:157
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:166
 msgid "Custom (set in config)"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:162
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:171
 msgid "Download Folder"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:163
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:172
 msgid "Prefer Downloaded Copy"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:164
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:173
 msgid "Automatically Download Upcoming Episodes"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:165
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:174
 msgid "Include Next Up"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:166
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:175
 msgid "Next Up Entries to Consider"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:167
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:176
 msgid "Episodes to Keep Ahead (0 = off)"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:168
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:177
 msgid "Storage Limit for Automatic Downloads (GB)"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:169
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:178
 msgid "Delete Automatic Downloads Once Watched"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:170
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:179
 msgid "Delete Unwatched After (days, 0 = never)"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:171
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:180
 msgid "Check Every (minutes)"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:172
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:181
 msgid "Close to Tray (keep running)"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:173
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:182
 msgid "Keep Running in Background"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:174
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:183
 msgid "Remember Window Size"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:175
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:184
 msgid "Player Controls Style"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:176
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:185
 msgid "Show What You're Watching in Discord"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:177
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:186
 msgid "Interface Scale"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:178
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:187
 msgid "Cast-target mode (no library browsing)"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:179
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:188
 msgid "Casting Opens the Library Browser"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:180
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:189
 msgid "Fullscreen Library Browser"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:181
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:190
 msgid "Always Bind Arrow Keys to Player Controls"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:182
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:191
 msgid "Player Controls Activation Key"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:183
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:192
 msgid "Audio Output Mode"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:184
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:193
 msgid "Audio Output Device"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:185
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:194
 msgid "Take the Device Exclusively"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:187
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:196
 msgid "Enable Video Playback Profiles"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:188
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:197
 msgid "Profile Group"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:189
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:198
 msgid "Remember Last Used Profile"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:190
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:199
 msgid "Graphics API for Shaders"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:191
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:200
 msgid "Pass Through AC3"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:192
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:201
 msgid "Pass Through DTS"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:193
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:202
 msgid "Pass Through E-AC3"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:194
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:203
 msgid "Pass Through DTS-HD"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:195
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:204
 msgid "Pass Through TrueHD"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:196
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:205
 msgid "Re-encode Others to AC3"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:202
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:213
 msgid ""
-"MPV keybinds are used by default. Press ENTER to drive the player controls "
-"by keyboard."
+"With \"Start Minimized\" and \"Fullscreen\" this is the classic cast-target "
+"setup: the app waits out of the way, plays fullscreen when something casts "
+"to it, and goes back to waiting when the video ends or you press Q."
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:204
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:227
+msgid ""
+"Off means command-line mode: no window, no system tray and no settings "
+"screen, so the only way back is editing conf.json by hand. It is not how you "
+"get MPV's own on-screen controls — \"Player Controls Style\" under Interface "
+"does that."
+msgstr ""
+
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:234
+msgid ""
+"Show only what is cast to this machine — the library, including this "
+"settings screen, can't be reached from here. Without a system tray icon the "
+"only way back is editing conf.json. For the classic cast-target setup you "
+"want the Interface settings instead; this is for a shared TV nobody should "
+"be able to browse from."
+msgstr ""
+
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:240
+msgid ""
+"Requires restart to change. MPV keybinds are used by default. Press ENTER to "
+"drive the player controls by keyboard."
+msgstr ""
+
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:242
 msgid ""
 "Pixels one wheel notch scrolls. The scrollbar glides while the content snaps "
 "to the nearest row, so a trackpad or trackball no longer overshoots. Raise "
 "it to scroll faster, lower it for finer control."
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:209
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:247
 msgid ""
 "Make each wheel notch jump exactly one row (or one home-screen section) "
 "instead of gliding. Turn this on if you prefer the older stepped scrolling."
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:217
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:255
 msgid "Discord Rich Presence. Takes effect after a restart."
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:219
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:257
 msgid ""
 "Leave this to Default unless setting up passthrough. Note some audio servers "
 "like Pipewire don't like passthrough and will need to be disabled for a card "
@@ -959,57 +983,57 @@ msgid ""
 "silence otherwise, but results may vary."
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:225
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:263
 msgid ""
 "Stop anything else using the device while playing. Needed for passthrough on "
 "some systems, and it means other applications will be silent."
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:228
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:266
 msgid ""
 "Page the library and music tile grids instead of scrolling: each page is one "
 "screenful with First / Previous / Next / Last controls and a page number you "
 "can type into. Easier than precise scrolling on a trackpad."
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:232
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:270
 msgid ""
 "Takes effect after a restart. \"Follow display\" uses the scale your desktop "
 "reports, which is 100% on X11."
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:234
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:272
 msgid ""
 "\"Default\" changes nothing and lets MPV (and your own mpv.conf) decide. "
 "Pick a mode only if you are sending audio to a receiver."
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:237
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:275
 msgid ""
 "Audio your receiver can't be sent directly is encoded to AC3, which is the "
 "only way surround fits down an optical cable. Turn this off if the encoder "
 "causes audio delay — those tracks become stereo instead."
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:242
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:280
 msgid ""
 "\"hq\" offers heavier profiles. Pick it if you have a fast graphics card."
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:244
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:282
 msgid ""
 "Leave on Automatic unless video breaks when a profile is loaded. This only "
 "applies while a profile is active, and OpenGL can cost you HDR output."
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:248
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:286
 msgid ""
 "Evens out loud effects and quiet dialogue. This turns passthrough off while "
 "it is enabled, because the volume has to be adjusted before your receiver "
 "gets the audio."
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:330
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:368
 msgid "Advanced"
 msgstr ""
 
@@ -1187,7 +1211,7 @@ msgid "Automatic"
 msgstr ""
 
 #: jellyfin_mpv_shim/mpvtk_browser/downloads.py:51
-#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1355
+#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1288
 msgid "Episodes"
 msgstr ""
 
@@ -1196,7 +1220,7 @@ msgid "Season %s"
 msgstr ""
 
 #: jellyfin_mpv_shim/mpvtk_browser/downloads.py:52
-#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1351
+#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1284
 msgid "Specials"
 msgstr ""
 
@@ -1217,7 +1241,7 @@ msgid "Failed"
 msgstr ""
 
 #: jellyfin_mpv_shim/mpvtk_browser/downloads.py:185
-#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1105
+#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1038
 msgid "Playlist"
 msgstr ""
 
@@ -1229,30 +1253,30 @@ msgstr ""
 msgid "Movies & Videos"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/home_sections.py:103
+#: jellyfin_mpv_shim/mpvtk_browser/home_sections.py:104
 msgid "My Media"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/home_sections.py:104
-#: jellyfin_mpv_shim/mpvtk_browser/repository.py:352
+#: jellyfin_mpv_shim/mpvtk_browser/home_sections.py:105
+#: jellyfin_mpv_shim/mpvtk_browser/repository.py:350
 msgid "Continue Watching"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/home_sections.py:105
-#: jellyfin_mpv_shim/mpvtk_browser/repository.py:359
+#: jellyfin_mpv_shim/mpvtk_browser/home_sections.py:106
+#: jellyfin_mpv_shim/mpvtk_browser/repository.py:357
 msgid "Continue Listening"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/home_sections.py:106
-#: jellyfin_mpv_shim/mpvtk_browser/repository.py:366
+#: jellyfin_mpv_shim/mpvtk_browser/home_sections.py:107
+#: jellyfin_mpv_shim/mpvtk_browser/repository.py:364
 msgid "Next Up"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/home_sections.py:107
+#: jellyfin_mpv_shim/mpvtk_browser/home_sections.py:108
 msgid "Recently Added"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/home_sections.py:108
+#: jellyfin_mpv_shim/mpvtk_browser/home_sections.py:109
 msgid "Live TV"
 msgstr ""
 
@@ -1465,52 +1489,52 @@ msgstr ""
 msgid "Could not load this page."
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/repository.py:390
+#: jellyfin_mpv_shim/mpvtk_browser/repository.py:386
 msgid "On Now"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/repository.py:411
+#: jellyfin_mpv_shim/mpvtk_browser/repository.py:407
 msgid "Latest %s"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1119
+#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1052
 msgid "Downloaded"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1138
+#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1071
 msgid "Movies"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1143
+#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1076
 msgid "Videos"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1147
+#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1080
 msgid "TV Shows"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1151
+#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1084
 msgid "Playlists"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1168
-#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1441
+#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1101
+#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1374
 msgid "Series"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1212
+#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1145
 msgid "Downloaded Movies"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1216
+#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1149
 msgid "Downloaded Videos"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1220
+#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1153
 msgid "Downloaded Shows"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1353
+#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1286
 msgid "Season %d"
 msgstr ""
 

--- a/jellyfin_mpv_shim/messages/el/LC_MESSAGES/base.po
+++ b/jellyfin_mpv_shim/messages/el/LC_MESSAGES/base.po
@@ -5,7 +5,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2026-07-25 17:21-0400\n"
+"POT-Creation-Date: 2026-07-26 12:03-0400\n"
 "PO-Revision-Date: 2026-06-08 11:26+0000\n"
 "Last-Translator: Thunderstrike116 <thunderstrike116@gmail.com>\n"
 "Language-Team: Greek <https://translate.jellyfin.org/projects/jellyfin/"
@@ -252,7 +252,7 @@ msgid "Select Subtitle Track"
 msgstr "Επιλέξτε Κομμάτι Υπότιτλων"
 
 #: jellyfin_mpv_shim/menu.py:341
-#: jellyfin_mpv_shim/mpvtk_browser/home_sections.py:102
+#: jellyfin_mpv_shim/mpvtk_browser/home_sections.py:103
 #: jellyfin_mpv_shim/osc_bridge.py:81 jellyfin_mpv_shim/osc_bridge.py:82
 #: jellyfin_mpv_shim/osc_bridge.py:104 jellyfin_mpv_shim/osc_bridge.py:140
 msgid "None"
@@ -403,7 +403,7 @@ msgstr "Ερώτηση για παράλειψη τίτλων τέλους"
 msgid "Enable thumbnail previews"
 msgstr "Προεπισκόπηση μικρογραφίας ενεργή"
 
-#: jellyfin_mpv_shim/menu.py:609 jellyfin_mpv_shim/mpvtk_browser/config.py:186
+#: jellyfin_mpv_shim/menu.py:609 jellyfin_mpv_shim/mpvtk_browser/config.py:195
 #: jellyfin_mpv_shim/mpvtk_browser/hud.py:375
 msgid "Night Mode (Auto Volume Adj)"
 msgstr ""
@@ -702,310 +702,334 @@ msgstr ""
 msgid "Or switch to another user"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/cast.py:317
+#: jellyfin_mpv_shim/mpvtk_browser/cast.py:314
 msgid "Ready to cast"
 msgstr "Έτοιμο για μετάδοση"
 
-#: jellyfin_mpv_shim/mpvtk_browser/cast.py:318
+#: jellyfin_mpv_shim/mpvtk_browser/cast.py:315
 #, fuzzy
 #| msgid "Select your media in Jellyfin and play it here"
 msgid "Select your media in Jellyfin and play it here."
 msgstr "Επιλέξτε τα πολυμέσα σας στο Jellyfin και κάντε τα αναπαραγωγή εδώ"
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:74
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:83
 msgid "Interface"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:83
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:92
 msgid "Playback"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:88
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:97
 msgid "Audio"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:92
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:101
 msgid "Subtitles & Languages"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:97
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:106
 #, fuzzy
 #| msgid " (Transcode)"
 msgid "Transcoding"
 msgstr " (Διακωδικοποίηση)"
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:102
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:111
 msgid "Video Enhancement"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:104
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:113
 #, fuzzy
 #| msgid "Seek to Skip Credits"
 msgid "Skip Intro / Credits"
 msgstr "Προχωρήστε για να παραλείψετε τους τίτλους αρχής"
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:107
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:116
 msgid "Library Browser"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:109
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:118
 msgid "Downloads"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:128
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:137
 msgid "Jellyfin UI"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:129
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:138
 msgid "MPV UI with thumbnails"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:130
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:139
 msgid "MPV built-in default"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:133
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:142
 msgid "Follow display"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:134
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:143
 msgid "100% (no scaling)"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:135
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:144
 msgid "125%"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:136
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:145
 msgid "150%"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:137
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:146
 msgid "200%"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:140
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:149
 msgid "Automatic (recommended)"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:141
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:150
 msgid "Vulkan"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:142
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:151
 msgid "Direct3D 11 (Windows only)"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:143
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:152
 msgid "OpenGL (compatibility)"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:146
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:155
 msgid "Default (auto)"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:147
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:156
 msgid "Force Stereo"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:148
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:157
 msgid "Optical Surround"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:149
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:158
 msgid "HDMI Passthrough"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:152
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:161
 msgid "Unset"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:153
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:162
 msgid "Dubbed (shows only)"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:154
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:163
 msgid "Subbed (shows only)"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:155
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:164
 msgid "Dubbed (all)"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:156
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:165
 msgid "Subbed (all)"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:157
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:166
 msgid "Custom (set in config)"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:162
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:171
 msgid "Download Folder"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:163
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:172
 msgid "Prefer Downloaded Copy"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:164
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:173
 msgid "Automatically Download Upcoming Episodes"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:165
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:174
 msgid "Include Next Up"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:166
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:175
 msgid "Next Up Entries to Consider"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:167
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:176
 msgid "Episodes to Keep Ahead (0 = off)"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:168
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:177
 msgid "Storage Limit for Automatic Downloads (GB)"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:169
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:178
 #, fuzzy
 #| msgid "Remove Server"
 msgid "Delete Automatic Downloads Once Watched"
 msgstr "Κατάργηση Διακομιστή"
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:170
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:179
 msgid "Delete Unwatched After (days, 0 = never)"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:171
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:180
 msgid "Check Every (minutes)"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:172
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:181
 msgid "Close to Tray (keep running)"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:173
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:182
 msgid "Keep Running in Background"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:174
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:183
 msgid "Remember Window Size"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:175
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:184
 msgid "Player Controls Style"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:176
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:185
 msgid "Show What You're Watching in Discord"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:177
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:186
 msgid "Interface Scale"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:178
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:187
 msgid "Cast-target mode (no library browsing)"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:179
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:188
 msgid "Casting Opens the Library Browser"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:180
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:189
 msgid "Fullscreen Library Browser"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:181
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:190
 msgid "Always Bind Arrow Keys to Player Controls"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:182
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:191
 msgid "Player Controls Activation Key"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:183
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:192
 msgid "Audio Output Mode"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:184
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:193
 msgid "Audio Output Device"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:185
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:194
 msgid "Take the Device Exclusively"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:187
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:196
 #, fuzzy
 #| msgid "Video Playback Profiles"
 msgid "Enable Video Playback Profiles"
 msgstr "Προφίλ Αναπαραγωγής Βίντεο"
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:188
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:197
 #, fuzzy
 #| msgid "New Group"
 msgid "Profile Group"
 msgstr "Νέα Ομάδα"
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:189
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:198
 msgid "Remember Last Used Profile"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:190
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:199
 msgid "Graphics API for Shaders"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:191
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:200
 msgid "Pass Through AC3"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:192
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:201
 msgid "Pass Through DTS"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:193
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:202
 msgid "Pass Through E-AC3"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:194
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:203
 msgid "Pass Through DTS-HD"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:195
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:204
 msgid "Pass Through TrueHD"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:196
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:205
 msgid "Re-encode Others to AC3"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:202
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:213
 msgid ""
-"MPV keybinds are used by default. Press ENTER to drive the player controls "
-"by keyboard."
+"With \"Start Minimized\" and \"Fullscreen\" this is the classic cast-target "
+"setup: the app waits out of the way, plays fullscreen when something casts "
+"to it, and goes back to waiting when the video ends or you press Q."
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:204
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:227
+msgid ""
+"Off means command-line mode: no window, no system tray and no settings "
+"screen, so the only way back is editing conf.json by hand. It is not how you "
+"get MPV's own on-screen controls — \"Player Controls Style\" under Interface "
+"does that."
+msgstr ""
+
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:234
+msgid ""
+"Show only what is cast to this machine — the library, including this "
+"settings screen, can't be reached from here. Without a system tray icon the "
+"only way back is editing conf.json. For the classic cast-target setup you "
+"want the Interface settings instead; this is for a shared TV nobody should "
+"be able to browse from."
+msgstr ""
+
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:240
+msgid ""
+"Requires restart to change. MPV keybinds are used by default. Press ENTER to "
+"drive the player controls by keyboard."
+msgstr ""
+
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:242
 msgid ""
 "Pixels one wheel notch scrolls. The scrollbar glides while the content snaps "
 "to the nearest row, so a trackpad or trackball no longer overshoots. Raise "
 "it to scroll faster, lower it for finer control."
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:209
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:247
 msgid ""
 "Make each wheel notch jump exactly one row (or one home-screen section) "
 "instead of gliding. Turn this on if you prefer the older stepped scrolling."
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:217
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:255
 msgid "Discord Rich Presence. Takes effect after a restart."
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:219
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:257
 msgid ""
 "Leave this to Default unless setting up passthrough. Note some audio servers "
 "like Pipewire don't like passthrough and will need to be disabled for a card "
@@ -1013,57 +1037,57 @@ msgid ""
 "silence otherwise, but results may vary."
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:225
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:263
 msgid ""
 "Stop anything else using the device while playing. Needed for passthrough on "
 "some systems, and it means other applications will be silent."
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:228
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:266
 msgid ""
 "Page the library and music tile grids instead of scrolling: each page is one "
 "screenful with First / Previous / Next / Last controls and a page number you "
 "can type into. Easier than precise scrolling on a trackpad."
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:232
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:270
 msgid ""
 "Takes effect after a restart. \"Follow display\" uses the scale your desktop "
 "reports, which is 100% on X11."
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:234
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:272
 msgid ""
 "\"Default\" changes nothing and lets MPV (and your own mpv.conf) decide. "
 "Pick a mode only if you are sending audio to a receiver."
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:237
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:275
 msgid ""
 "Audio your receiver can't be sent directly is encoded to AC3, which is the "
 "only way surround fits down an optical cable. Turn this off if the encoder "
 "causes audio delay — those tracks become stereo instead."
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:242
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:280
 msgid ""
 "\"hq\" offers heavier profiles. Pick it if you have a fast graphics card."
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:244
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:282
 msgid ""
 "Leave on Automatic unless video breaks when a profile is loaded. This only "
 "applies while a profile is active, and OpenGL can cost you HDR output."
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:248
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:286
 msgid ""
 "Evens out loud effects and quiet dialogue. This turns passthrough off while "
 "it is enabled, because the volume has to be adjusted before your receiver "
 "gets the audio."
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:330
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:368
 msgid "Advanced"
 msgstr ""
 
@@ -1289,7 +1313,7 @@ msgid "Automatic"
 msgstr "Αυτόματα"
 
 #: jellyfin_mpv_shim/mpvtk_browser/downloads.py:51
-#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1355
+#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1288
 msgid "Episodes"
 msgstr ""
 
@@ -1298,7 +1322,7 @@ msgid "Season %s"
 msgstr ""
 
 #: jellyfin_mpv_shim/mpvtk_browser/downloads.py:52
-#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1351
+#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1284
 msgid "Specials"
 msgstr ""
 
@@ -1323,7 +1347,7 @@ msgid "Failed"
 msgstr "Αποτυχία"
 
 #: jellyfin_mpv_shim/mpvtk_browser/downloads.py:185
-#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1105
+#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1038
 msgid "Playlist"
 msgstr ""
 
@@ -1335,30 +1359,30 @@ msgstr ""
 msgid "Movies & Videos"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/home_sections.py:103
+#: jellyfin_mpv_shim/mpvtk_browser/home_sections.py:104
 msgid "My Media"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/home_sections.py:104
-#: jellyfin_mpv_shim/mpvtk_browser/repository.py:352
+#: jellyfin_mpv_shim/mpvtk_browser/home_sections.py:105
+#: jellyfin_mpv_shim/mpvtk_browser/repository.py:350
 msgid "Continue Watching"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/home_sections.py:105
-#: jellyfin_mpv_shim/mpvtk_browser/repository.py:359
+#: jellyfin_mpv_shim/mpvtk_browser/home_sections.py:106
+#: jellyfin_mpv_shim/mpvtk_browser/repository.py:357
 msgid "Continue Listening"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/home_sections.py:106
-#: jellyfin_mpv_shim/mpvtk_browser/repository.py:366
+#: jellyfin_mpv_shim/mpvtk_browser/home_sections.py:107
+#: jellyfin_mpv_shim/mpvtk_browser/repository.py:364
 msgid "Next Up"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/home_sections.py:107
+#: jellyfin_mpv_shim/mpvtk_browser/home_sections.py:108
 msgid "Recently Added"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/home_sections.py:108
+#: jellyfin_mpv_shim/mpvtk_browser/home_sections.py:109
 msgid "Live TV"
 msgstr ""
 
@@ -1611,52 +1635,52 @@ msgstr ""
 "Δεν ήταν δυνατή η προσθήκη διακομιστή.\n"
 "Ελέγξτε τις πληροφορίες σύνδεσής σας."
 
-#: jellyfin_mpv_shim/mpvtk_browser/repository.py:390
+#: jellyfin_mpv_shim/mpvtk_browser/repository.py:386
 msgid "On Now"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/repository.py:411
+#: jellyfin_mpv_shim/mpvtk_browser/repository.py:407
 msgid "Latest %s"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1119
+#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1052
 msgid "Downloaded"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1138
+#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1071
 msgid "Movies"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1143
+#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1076
 msgid "Videos"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1147
+#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1080
 msgid "TV Shows"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1151
+#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1084
 msgid "Playlists"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1168
-#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1441
+#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1101
+#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1374
 msgid "Series"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1212
+#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1145
 msgid "Downloaded Movies"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1216
+#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1149
 msgid "Downloaded Videos"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1220
+#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1153
 msgid "Downloaded Shows"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1353
+#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1286
 msgid "Season %d"
 msgstr ""
 

--- a/jellyfin_mpv_shim/messages/en@pirate/LC_MESSAGES/base.po
+++ b/jellyfin_mpv_shim/messages/en@pirate/LC_MESSAGES/base.po
@@ -5,7 +5,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2026-07-25 17:21-0400\n"
+"POT-Creation-Date: 2026-07-26 12:03-0400\n"
 "PO-Revision-Date: 2025-11-18 08:19+0000\n"
 "Last-Translator: Rufis72 <milo.games.silverstein@gmail.com>\n"
 "Language-Team: English (Pirate) <https://translate.jellyfin.org/projects/"
@@ -242,7 +242,7 @@ msgid "Select Subtitle Track"
 msgstr ""
 
 #: jellyfin_mpv_shim/menu.py:341
-#: jellyfin_mpv_shim/mpvtk_browser/home_sections.py:102
+#: jellyfin_mpv_shim/mpvtk_browser/home_sections.py:103
 #: jellyfin_mpv_shim/osc_bridge.py:81 jellyfin_mpv_shim/osc_bridge.py:82
 #: jellyfin_mpv_shim/osc_bridge.py:104 jellyfin_mpv_shim/osc_bridge.py:140
 msgid "None"
@@ -393,7 +393,7 @@ msgstr ""
 msgid "Enable thumbnail previews"
 msgstr ""
 
-#: jellyfin_mpv_shim/menu.py:609 jellyfin_mpv_shim/mpvtk_browser/config.py:186
+#: jellyfin_mpv_shim/menu.py:609 jellyfin_mpv_shim/mpvtk_browser/config.py:195
 #: jellyfin_mpv_shim/mpvtk_browser/hud.py:375
 msgid "Night Mode (Auto Volume Adj)"
 msgstr ""
@@ -658,298 +658,322 @@ msgstr ""
 msgid "Or switch to another user"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/cast.py:317
+#: jellyfin_mpv_shim/mpvtk_browser/cast.py:314
 msgid "Ready to cast"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/cast.py:318
+#: jellyfin_mpv_shim/mpvtk_browser/cast.py:315
 msgid "Select your media in Jellyfin and play it here."
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:74
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:83
 msgid "Interface"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:83
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:92
 msgid "Playback"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:88
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:97
 msgid "Audio"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:92
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:101
 msgid "Subtitles & Languages"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:97
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:106
 msgid "Transcoding"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:102
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:111
 msgid "Video Enhancement"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:104
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:113
 msgid "Skip Intro / Credits"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:107
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:116
 msgid "Library Browser"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:109
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:118
 msgid "Downloads"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:128
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:137
 msgid "Jellyfin UI"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:129
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:138
 msgid "MPV UI with thumbnails"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:130
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:139
 msgid "MPV built-in default"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:133
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:142
 msgid "Follow display"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:134
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:143
 msgid "100% (no scaling)"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:135
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:144
 msgid "125%"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:136
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:145
 msgid "150%"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:137
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:146
 msgid "200%"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:140
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:149
 msgid "Automatic (recommended)"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:141
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:150
 msgid "Vulkan"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:142
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:151
 msgid "Direct3D 11 (Windows only)"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:143
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:152
 msgid "OpenGL (compatibility)"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:146
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:155
 msgid "Default (auto)"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:147
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:156
 msgid "Force Stereo"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:148
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:157
 msgid "Optical Surround"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:149
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:158
 msgid "HDMI Passthrough"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:152
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:161
 msgid "Unset"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:153
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:162
 msgid "Dubbed (shows only)"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:154
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:163
 msgid "Subbed (shows only)"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:155
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:164
 msgid "Dubbed (all)"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:156
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:165
 msgid "Subbed (all)"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:157
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:166
 msgid "Custom (set in config)"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:162
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:171
 msgid "Download Folder"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:163
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:172
 msgid "Prefer Downloaded Copy"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:164
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:173
 msgid "Automatically Download Upcoming Episodes"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:165
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:174
 msgid "Include Next Up"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:166
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:175
 msgid "Next Up Entries to Consider"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:167
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:176
 msgid "Episodes to Keep Ahead (0 = off)"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:168
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:177
 msgid "Storage Limit for Automatic Downloads (GB)"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:169
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:178
 msgid "Delete Automatic Downloads Once Watched"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:170
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:179
 msgid "Delete Unwatched After (days, 0 = never)"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:171
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:180
 msgid "Check Every (minutes)"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:172
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:181
 msgid "Close to Tray (keep running)"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:173
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:182
 msgid "Keep Running in Background"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:174
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:183
 msgid "Remember Window Size"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:175
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:184
 msgid "Player Controls Style"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:176
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:185
 msgid "Show What You're Watching in Discord"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:177
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:186
 msgid "Interface Scale"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:178
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:187
 msgid "Cast-target mode (no library browsing)"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:179
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:188
 msgid "Casting Opens the Library Browser"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:180
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:189
 msgid "Fullscreen Library Browser"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:181
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:190
 msgid "Always Bind Arrow Keys to Player Controls"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:182
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:191
 msgid "Player Controls Activation Key"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:183
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:192
 msgid "Audio Output Mode"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:184
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:193
 msgid "Audio Output Device"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:185
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:194
 msgid "Take the Device Exclusively"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:187
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:196
 msgid "Enable Video Playback Profiles"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:188
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:197
 msgid "Profile Group"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:189
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:198
 msgid "Remember Last Used Profile"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:190
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:199
 msgid "Graphics API for Shaders"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:191
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:200
 msgid "Pass Through AC3"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:192
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:201
 msgid "Pass Through DTS"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:193
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:202
 msgid "Pass Through E-AC3"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:194
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:203
 msgid "Pass Through DTS-HD"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:195
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:204
 msgid "Pass Through TrueHD"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:196
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:205
 msgid "Re-encode Others to AC3"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:202
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:213
 msgid ""
-"MPV keybinds are used by default. Press ENTER to drive the player controls "
-"by keyboard."
+"With \"Start Minimized\" and \"Fullscreen\" this is the classic cast-target "
+"setup: the app waits out of the way, plays fullscreen when something casts "
+"to it, and goes back to waiting when the video ends or you press Q."
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:204
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:227
+msgid ""
+"Off means command-line mode: no window, no system tray and no settings "
+"screen, so the only way back is editing conf.json by hand. It is not how you "
+"get MPV's own on-screen controls — \"Player Controls Style\" under Interface "
+"does that."
+msgstr ""
+
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:234
+msgid ""
+"Show only what is cast to this machine — the library, including this "
+"settings screen, can't be reached from here. Without a system tray icon the "
+"only way back is editing conf.json. For the classic cast-target setup you "
+"want the Interface settings instead; this is for a shared TV nobody should "
+"be able to browse from."
+msgstr ""
+
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:240
+msgid ""
+"Requires restart to change. MPV keybinds are used by default. Press ENTER to "
+"drive the player controls by keyboard."
+msgstr ""
+
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:242
 msgid ""
 "Pixels one wheel notch scrolls. The scrollbar glides while the content snaps "
 "to the nearest row, so a trackpad or trackball no longer overshoots. Raise "
 "it to scroll faster, lower it for finer control."
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:209
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:247
 msgid ""
 "Make each wheel notch jump exactly one row (or one home-screen section) "
 "instead of gliding. Turn this on if you prefer the older stepped scrolling."
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:217
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:255
 msgid "Discord Rich Presence. Takes effect after a restart."
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:219
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:257
 msgid ""
 "Leave this to Default unless setting up passthrough. Note some audio servers "
 "like Pipewire don't like passthrough and will need to be disabled for a card "
@@ -957,57 +981,57 @@ msgid ""
 "silence otherwise, but results may vary."
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:225
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:263
 msgid ""
 "Stop anything else using the device while playing. Needed for passthrough on "
 "some systems, and it means other applications will be silent."
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:228
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:266
 msgid ""
 "Page the library and music tile grids instead of scrolling: each page is one "
 "screenful with First / Previous / Next / Last controls and a page number you "
 "can type into. Easier than precise scrolling on a trackpad."
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:232
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:270
 msgid ""
 "Takes effect after a restart. \"Follow display\" uses the scale your desktop "
 "reports, which is 100% on X11."
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:234
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:272
 msgid ""
 "\"Default\" changes nothing and lets MPV (and your own mpv.conf) decide. "
 "Pick a mode only if you are sending audio to a receiver."
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:237
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:275
 msgid ""
 "Audio your receiver can't be sent directly is encoded to AC3, which is the "
 "only way surround fits down an optical cable. Turn this off if the encoder "
 "causes audio delay — those tracks become stereo instead."
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:242
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:280
 msgid ""
 "\"hq\" offers heavier profiles. Pick it if you have a fast graphics card."
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:244
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:282
 msgid ""
 "Leave on Automatic unless video breaks when a profile is loaded. This only "
 "applies while a profile is active, and OpenGL can cost you HDR output."
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:248
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:286
 msgid ""
 "Evens out loud effects and quiet dialogue. This turns passthrough off while "
 "it is enabled, because the volume has to be adjusted before your receiver "
 "gets the audio."
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:330
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:368
 msgid "Advanced"
 msgstr ""
 
@@ -1185,7 +1209,7 @@ msgid "Automatic"
 msgstr ""
 
 #: jellyfin_mpv_shim/mpvtk_browser/downloads.py:51
-#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1355
+#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1288
 msgid "Episodes"
 msgstr ""
 
@@ -1194,7 +1218,7 @@ msgid "Season %s"
 msgstr ""
 
 #: jellyfin_mpv_shim/mpvtk_browser/downloads.py:52
-#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1351
+#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1284
 msgid "Specials"
 msgstr ""
 
@@ -1215,7 +1239,7 @@ msgid "Failed"
 msgstr ""
 
 #: jellyfin_mpv_shim/mpvtk_browser/downloads.py:185
-#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1105
+#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1038
 msgid "Playlist"
 msgstr ""
 
@@ -1227,30 +1251,30 @@ msgstr ""
 msgid "Movies & Videos"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/home_sections.py:103
+#: jellyfin_mpv_shim/mpvtk_browser/home_sections.py:104
 msgid "My Media"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/home_sections.py:104
-#: jellyfin_mpv_shim/mpvtk_browser/repository.py:352
+#: jellyfin_mpv_shim/mpvtk_browser/home_sections.py:105
+#: jellyfin_mpv_shim/mpvtk_browser/repository.py:350
 msgid "Continue Watching"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/home_sections.py:105
-#: jellyfin_mpv_shim/mpvtk_browser/repository.py:359
+#: jellyfin_mpv_shim/mpvtk_browser/home_sections.py:106
+#: jellyfin_mpv_shim/mpvtk_browser/repository.py:357
 msgid "Continue Listening"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/home_sections.py:106
-#: jellyfin_mpv_shim/mpvtk_browser/repository.py:366
+#: jellyfin_mpv_shim/mpvtk_browser/home_sections.py:107
+#: jellyfin_mpv_shim/mpvtk_browser/repository.py:364
 msgid "Next Up"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/home_sections.py:107
+#: jellyfin_mpv_shim/mpvtk_browser/home_sections.py:108
 msgid "Recently Added"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/home_sections.py:108
+#: jellyfin_mpv_shim/mpvtk_browser/home_sections.py:109
 msgid "Live TV"
 msgstr ""
 
@@ -1455,52 +1479,52 @@ msgstr ""
 msgid "Could not load this page."
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/repository.py:390
+#: jellyfin_mpv_shim/mpvtk_browser/repository.py:386
 msgid "On Now"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/repository.py:411
+#: jellyfin_mpv_shim/mpvtk_browser/repository.py:407
 msgid "Latest %s"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1119
+#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1052
 msgid "Downloaded"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1138
+#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1071
 msgid "Movies"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1143
+#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1076
 msgid "Videos"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1147
+#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1080
 msgid "TV Shows"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1151
+#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1084
 msgid "Playlists"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1168
-#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1441
+#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1101
+#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1374
 msgid "Series"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1212
+#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1145
 msgid "Downloaded Movies"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1216
+#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1149
 msgid "Downloaded Videos"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1220
+#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1153
 msgid "Downloaded Shows"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1353
+#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1286
 msgid "Season %d"
 msgstr ""
 

--- a/jellyfin_mpv_shim/messages/en_GB/LC_MESSAGES/base.po
+++ b/jellyfin_mpv_shim/messages/en_GB/LC_MESSAGES/base.po
@@ -5,7 +5,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2026-07-25 17:21-0400\n"
+"POT-Creation-Date: 2026-07-26 12:03-0400\n"
 "PO-Revision-Date: 2024-06-15 22:41+0000\n"
 "Last-Translator: Joseph Price <git@joe.pricey.uk>\n"
 "Language-Team: English (United Kingdom) <https://translate.jellyfin.org/"
@@ -252,7 +252,7 @@ msgid "Select Subtitle Track"
 msgstr "Select Subtitle Track"
 
 #: jellyfin_mpv_shim/menu.py:341
-#: jellyfin_mpv_shim/mpvtk_browser/home_sections.py:102
+#: jellyfin_mpv_shim/mpvtk_browser/home_sections.py:103
 #: jellyfin_mpv_shim/osc_bridge.py:81 jellyfin_mpv_shim/osc_bridge.py:82
 #: jellyfin_mpv_shim/osc_bridge.py:104 jellyfin_mpv_shim/osc_bridge.py:140
 msgid "None"
@@ -403,7 +403,7 @@ msgstr "Ask to Skip Credits"
 msgid "Enable thumbnail previews"
 msgstr "Enable thumbnail previews"
 
-#: jellyfin_mpv_shim/menu.py:609 jellyfin_mpv_shim/mpvtk_browser/config.py:186
+#: jellyfin_mpv_shim/menu.py:609 jellyfin_mpv_shim/mpvtk_browser/config.py:195
 #: jellyfin_mpv_shim/mpvtk_browser/hud.py:375
 msgid "Night Mode (Auto Volume Adj)"
 msgstr ""
@@ -702,310 +702,334 @@ msgstr ""
 msgid "Or switch to another user"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/cast.py:317
+#: jellyfin_mpv_shim/mpvtk_browser/cast.py:314
 msgid "Ready to cast"
 msgstr "Ready to cast"
 
-#: jellyfin_mpv_shim/mpvtk_browser/cast.py:318
+#: jellyfin_mpv_shim/mpvtk_browser/cast.py:315
 #, fuzzy
 #| msgid "Select your media in Jellyfin and play it here"
 msgid "Select your media in Jellyfin and play it here."
 msgstr "Select your media in Jellyfin and play it here"
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:74
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:83
 msgid "Interface"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:83
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:92
 msgid "Playback"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:88
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:97
 msgid "Audio"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:92
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:101
 msgid "Subtitles & Languages"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:97
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:106
 #, fuzzy
 #| msgid " (Transcode)"
 msgid "Transcoding"
 msgstr " (Transcode)"
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:102
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:111
 msgid "Video Enhancement"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:104
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:113
 #, fuzzy
 #| msgid "Seek to Skip Credits"
 msgid "Skip Intro / Credits"
 msgstr "Seek to Skip Credits"
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:107
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:116
 msgid "Library Browser"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:109
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:118
 msgid "Downloads"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:128
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:137
 msgid "Jellyfin UI"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:129
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:138
 msgid "MPV UI with thumbnails"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:130
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:139
 msgid "MPV built-in default"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:133
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:142
 msgid "Follow display"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:134
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:143
 msgid "100% (no scaling)"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:135
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:144
 msgid "125%"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:136
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:145
 msgid "150%"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:137
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:146
 msgid "200%"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:140
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:149
 msgid "Automatic (recommended)"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:141
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:150
 msgid "Vulkan"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:142
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:151
 msgid "Direct3D 11 (Windows only)"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:143
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:152
 msgid "OpenGL (compatibility)"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:146
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:155
 msgid "Default (auto)"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:147
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:156
 msgid "Force Stereo"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:148
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:157
 msgid "Optical Surround"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:149
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:158
 msgid "HDMI Passthrough"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:152
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:161
 msgid "Unset"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:153
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:162
 msgid "Dubbed (shows only)"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:154
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:163
 msgid "Subbed (shows only)"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:155
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:164
 msgid "Dubbed (all)"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:156
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:165
 msgid "Subbed (all)"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:157
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:166
 msgid "Custom (set in config)"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:162
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:171
 msgid "Download Folder"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:163
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:172
 msgid "Prefer Downloaded Copy"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:164
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:173
 msgid "Automatically Download Upcoming Episodes"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:165
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:174
 msgid "Include Next Up"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:166
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:175
 msgid "Next Up Entries to Consider"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:167
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:176
 msgid "Episodes to Keep Ahead (0 = off)"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:168
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:177
 msgid "Storage Limit for Automatic Downloads (GB)"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:169
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:178
 #, fuzzy
 #| msgid "Remove Server"
 msgid "Delete Automatic Downloads Once Watched"
 msgstr "Remove Server"
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:170
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:179
 msgid "Delete Unwatched After (days, 0 = never)"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:171
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:180
 msgid "Check Every (minutes)"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:172
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:181
 msgid "Close to Tray (keep running)"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:173
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:182
 msgid "Keep Running in Background"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:174
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:183
 msgid "Remember Window Size"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:175
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:184
 msgid "Player Controls Style"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:176
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:185
 msgid "Show What You're Watching in Discord"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:177
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:186
 msgid "Interface Scale"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:178
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:187
 msgid "Cast-target mode (no library browsing)"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:179
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:188
 msgid "Casting Opens the Library Browser"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:180
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:189
 msgid "Fullscreen Library Browser"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:181
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:190
 msgid "Always Bind Arrow Keys to Player Controls"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:182
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:191
 msgid "Player Controls Activation Key"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:183
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:192
 msgid "Audio Output Mode"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:184
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:193
 msgid "Audio Output Device"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:185
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:194
 msgid "Take the Device Exclusively"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:187
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:196
 #, fuzzy
 #| msgid "Video Playback Profiles"
 msgid "Enable Video Playback Profiles"
 msgstr "Video Playback Profiles"
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:188
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:197
 #, fuzzy
 #| msgid "New Group"
 msgid "Profile Group"
 msgstr "New Group"
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:189
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:198
 msgid "Remember Last Used Profile"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:190
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:199
 msgid "Graphics API for Shaders"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:191
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:200
 msgid "Pass Through AC3"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:192
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:201
 msgid "Pass Through DTS"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:193
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:202
 msgid "Pass Through E-AC3"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:194
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:203
 msgid "Pass Through DTS-HD"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:195
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:204
 msgid "Pass Through TrueHD"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:196
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:205
 msgid "Re-encode Others to AC3"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:202
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:213
 msgid ""
-"MPV keybinds are used by default. Press ENTER to drive the player controls "
-"by keyboard."
+"With \"Start Minimized\" and \"Fullscreen\" this is the classic cast-target "
+"setup: the app waits out of the way, plays fullscreen when something casts "
+"to it, and goes back to waiting when the video ends or you press Q."
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:204
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:227
+msgid ""
+"Off means command-line mode: no window, no system tray and no settings "
+"screen, so the only way back is editing conf.json by hand. It is not how you "
+"get MPV's own on-screen controls — \"Player Controls Style\" under Interface "
+"does that."
+msgstr ""
+
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:234
+msgid ""
+"Show only what is cast to this machine — the library, including this "
+"settings screen, can't be reached from here. Without a system tray icon the "
+"only way back is editing conf.json. For the classic cast-target setup you "
+"want the Interface settings instead; this is for a shared TV nobody should "
+"be able to browse from."
+msgstr ""
+
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:240
+msgid ""
+"Requires restart to change. MPV keybinds are used by default. Press ENTER to "
+"drive the player controls by keyboard."
+msgstr ""
+
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:242
 msgid ""
 "Pixels one wheel notch scrolls. The scrollbar glides while the content snaps "
 "to the nearest row, so a trackpad or trackball no longer overshoots. Raise "
 "it to scroll faster, lower it for finer control."
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:209
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:247
 msgid ""
 "Make each wheel notch jump exactly one row (or one home-screen section) "
 "instead of gliding. Turn this on if you prefer the older stepped scrolling."
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:217
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:255
 msgid "Discord Rich Presence. Takes effect after a restart."
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:219
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:257
 msgid ""
 "Leave this to Default unless setting up passthrough. Note some audio servers "
 "like Pipewire don't like passthrough and will need to be disabled for a card "
@@ -1013,57 +1037,57 @@ msgid ""
 "silence otherwise, but results may vary."
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:225
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:263
 msgid ""
 "Stop anything else using the device while playing. Needed for passthrough on "
 "some systems, and it means other applications will be silent."
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:228
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:266
 msgid ""
 "Page the library and music tile grids instead of scrolling: each page is one "
 "screenful with First / Previous / Next / Last controls and a page number you "
 "can type into. Easier than precise scrolling on a trackpad."
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:232
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:270
 msgid ""
 "Takes effect after a restart. \"Follow display\" uses the scale your desktop "
 "reports, which is 100% on X11."
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:234
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:272
 msgid ""
 "\"Default\" changes nothing and lets MPV (and your own mpv.conf) decide. "
 "Pick a mode only if you are sending audio to a receiver."
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:237
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:275
 msgid ""
 "Audio your receiver can't be sent directly is encoded to AC3, which is the "
 "only way surround fits down an optical cable. Turn this off if the encoder "
 "causes audio delay — those tracks become stereo instead."
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:242
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:280
 msgid ""
 "\"hq\" offers heavier profiles. Pick it if you have a fast graphics card."
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:244
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:282
 msgid ""
 "Leave on Automatic unless video breaks when a profile is loaded. This only "
 "applies while a profile is active, and OpenGL can cost you HDR output."
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:248
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:286
 msgid ""
 "Evens out loud effects and quiet dialogue. This turns passthrough off while "
 "it is enabled, because the volume has to be adjusted before your receiver "
 "gets the audio."
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:330
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:368
 msgid "Advanced"
 msgstr ""
 
@@ -1289,7 +1313,7 @@ msgid "Automatic"
 msgstr "Automatic"
 
 #: jellyfin_mpv_shim/mpvtk_browser/downloads.py:51
-#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1355
+#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1288
 msgid "Episodes"
 msgstr ""
 
@@ -1298,7 +1322,7 @@ msgid "Season %s"
 msgstr ""
 
 #: jellyfin_mpv_shim/mpvtk_browser/downloads.py:52
-#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1351
+#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1284
 msgid "Specials"
 msgstr ""
 
@@ -1323,7 +1347,7 @@ msgid "Failed"
 msgstr "Fail"
 
 #: jellyfin_mpv_shim/mpvtk_browser/downloads.py:185
-#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1105
+#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1038
 msgid "Playlist"
 msgstr ""
 
@@ -1335,30 +1359,30 @@ msgstr ""
 msgid "Movies & Videos"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/home_sections.py:103
+#: jellyfin_mpv_shim/mpvtk_browser/home_sections.py:104
 msgid "My Media"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/home_sections.py:104
-#: jellyfin_mpv_shim/mpvtk_browser/repository.py:352
+#: jellyfin_mpv_shim/mpvtk_browser/home_sections.py:105
+#: jellyfin_mpv_shim/mpvtk_browser/repository.py:350
 msgid "Continue Watching"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/home_sections.py:105
-#: jellyfin_mpv_shim/mpvtk_browser/repository.py:359
+#: jellyfin_mpv_shim/mpvtk_browser/home_sections.py:106
+#: jellyfin_mpv_shim/mpvtk_browser/repository.py:357
 msgid "Continue Listening"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/home_sections.py:106
-#: jellyfin_mpv_shim/mpvtk_browser/repository.py:366
+#: jellyfin_mpv_shim/mpvtk_browser/home_sections.py:107
+#: jellyfin_mpv_shim/mpvtk_browser/repository.py:364
 msgid "Next Up"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/home_sections.py:107
+#: jellyfin_mpv_shim/mpvtk_browser/home_sections.py:108
 msgid "Recently Added"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/home_sections.py:108
+#: jellyfin_mpv_shim/mpvtk_browser/home_sections.py:109
 msgid "Live TV"
 msgstr ""
 
@@ -1611,52 +1635,52 @@ msgstr ""
 "Could not add server.\n"
 "Please check your connection information."
 
-#: jellyfin_mpv_shim/mpvtk_browser/repository.py:390
+#: jellyfin_mpv_shim/mpvtk_browser/repository.py:386
 msgid "On Now"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/repository.py:411
+#: jellyfin_mpv_shim/mpvtk_browser/repository.py:407
 msgid "Latest %s"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1119
+#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1052
 msgid "Downloaded"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1138
+#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1071
 msgid "Movies"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1143
+#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1076
 msgid "Videos"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1147
+#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1080
 msgid "TV Shows"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1151
+#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1084
 msgid "Playlists"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1168
-#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1441
+#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1101
+#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1374
 msgid "Series"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1212
+#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1145
 msgid "Downloaded Movies"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1216
+#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1149
 msgid "Downloaded Videos"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1220
+#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1153
 msgid "Downloaded Shows"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1353
+#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1286
 msgid "Season %d"
 msgstr ""
 

--- a/jellyfin_mpv_shim/messages/eo/LC_MESSAGES/base.po
+++ b/jellyfin_mpv_shim/messages/eo/LC_MESSAGES/base.po
@@ -5,7 +5,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2026-07-25 17:21-0400\n"
+"POT-Creation-Date: 2026-07-26 12:03-0400\n"
 "PO-Revision-Date: 2025-03-17 10:01+0000\n"
 "Last-Translator: Joesph boukolos <joseph+weblate@boukolos.com>\n"
 "Language-Team: Esperanto <https://translate.jellyfin.org/projects/jellyfin/"
@@ -252,7 +252,7 @@ msgid "Select Subtitle Track"
 msgstr "Elekti Subtekstan Trakon"
 
 #: jellyfin_mpv_shim/menu.py:341
-#: jellyfin_mpv_shim/mpvtk_browser/home_sections.py:102
+#: jellyfin_mpv_shim/mpvtk_browser/home_sections.py:103
 #: jellyfin_mpv_shim/osc_bridge.py:81 jellyfin_mpv_shim/osc_bridge.py:82
 #: jellyfin_mpv_shim/osc_bridge.py:104 jellyfin_mpv_shim/osc_bridge.py:140
 msgid "None"
@@ -403,7 +403,7 @@ msgstr ""
 msgid "Enable thumbnail previews"
 msgstr ""
 
-#: jellyfin_mpv_shim/menu.py:609 jellyfin_mpv_shim/mpvtk_browser/config.py:186
+#: jellyfin_mpv_shim/menu.py:609 jellyfin_mpv_shim/mpvtk_browser/config.py:195
 #: jellyfin_mpv_shim/mpvtk_browser/hud.py:375
 msgid "Night Mode (Auto Volume Adj)"
 msgstr ""
@@ -702,308 +702,332 @@ msgstr ""
 msgid "Or switch to another user"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/cast.py:317
+#: jellyfin_mpv_shim/mpvtk_browser/cast.py:314
 msgid "Ready to cast"
 msgstr "Preta por elsendi"
 
-#: jellyfin_mpv_shim/mpvtk_browser/cast.py:318
+#: jellyfin_mpv_shim/mpvtk_browser/cast.py:315
 #, fuzzy
 #| msgid "Select your media in Jellyfin and play it here"
 msgid "Select your media in Jellyfin and play it here."
 msgstr "Elekti vian plurmedion en Jellyfin kaj ludi ĝin ĉi tie"
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:74
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:83
 msgid "Interface"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:83
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:92
 msgid "Playback"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:88
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:97
 msgid "Audio"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:92
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:101
 msgid "Subtitles & Languages"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:97
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:106
 #, fuzzy
 #| msgid " (Transcode)"
 msgid "Transcoding"
 msgstr " (Transkodado)"
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:102
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:111
 msgid "Video Enhancement"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:104
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:113
 msgid "Skip Intro / Credits"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:107
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:116
 msgid "Library Browser"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:109
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:118
 msgid "Downloads"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:128
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:137
 msgid "Jellyfin UI"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:129
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:138
 msgid "MPV UI with thumbnails"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:130
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:139
 msgid "MPV built-in default"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:133
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:142
 msgid "Follow display"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:134
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:143
 msgid "100% (no scaling)"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:135
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:144
 msgid "125%"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:136
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:145
 msgid "150%"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:137
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:146
 msgid "200%"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:140
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:149
 msgid "Automatic (recommended)"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:141
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:150
 msgid "Vulkan"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:142
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:151
 msgid "Direct3D 11 (Windows only)"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:143
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:152
 msgid "OpenGL (compatibility)"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:146
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:155
 msgid "Default (auto)"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:147
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:156
 msgid "Force Stereo"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:148
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:157
 msgid "Optical Surround"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:149
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:158
 msgid "HDMI Passthrough"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:152
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:161
 msgid "Unset"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:153
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:162
 msgid "Dubbed (shows only)"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:154
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:163
 msgid "Subbed (shows only)"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:155
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:164
 msgid "Dubbed (all)"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:156
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:165
 msgid "Subbed (all)"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:157
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:166
 msgid "Custom (set in config)"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:162
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:171
 msgid "Download Folder"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:163
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:172
 msgid "Prefer Downloaded Copy"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:164
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:173
 msgid "Automatically Download Upcoming Episodes"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:165
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:174
 msgid "Include Next Up"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:166
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:175
 msgid "Next Up Entries to Consider"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:167
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:176
 msgid "Episodes to Keep Ahead (0 = off)"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:168
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:177
 msgid "Storage Limit for Automatic Downloads (GB)"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:169
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:178
 #, fuzzy
 #| msgid "Remove Server"
 msgid "Delete Automatic Downloads Once Watched"
 msgstr "Forigi Servilon"
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:170
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:179
 msgid "Delete Unwatched After (days, 0 = never)"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:171
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:180
 msgid "Check Every (minutes)"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:172
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:181
 msgid "Close to Tray (keep running)"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:173
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:182
 msgid "Keep Running in Background"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:174
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:183
 msgid "Remember Window Size"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:175
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:184
 msgid "Player Controls Style"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:176
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:185
 msgid "Show What You're Watching in Discord"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:177
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:186
 msgid "Interface Scale"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:178
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:187
 msgid "Cast-target mode (no library browsing)"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:179
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:188
 msgid "Casting Opens the Library Browser"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:180
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:189
 msgid "Fullscreen Library Browser"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:181
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:190
 msgid "Always Bind Arrow Keys to Player Controls"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:182
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:191
 msgid "Player Controls Activation Key"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:183
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:192
 msgid "Audio Output Mode"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:184
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:193
 msgid "Audio Output Device"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:185
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:194
 msgid "Take the Device Exclusively"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:187
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:196
 #, fuzzy
 #| msgid "Video Playback Profiles"
 msgid "Enable Video Playback Profiles"
 msgstr "Profiloj pri ludado de videoj"
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:188
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:197
 #, fuzzy
 #| msgid "New Group"
 msgid "Profile Group"
 msgstr "Nova Grupo"
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:189
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:198
 msgid "Remember Last Used Profile"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:190
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:199
 msgid "Graphics API for Shaders"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:191
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:200
 msgid "Pass Through AC3"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:192
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:201
 msgid "Pass Through DTS"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:193
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:202
 msgid "Pass Through E-AC3"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:194
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:203
 msgid "Pass Through DTS-HD"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:195
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:204
 msgid "Pass Through TrueHD"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:196
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:205
 msgid "Re-encode Others to AC3"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:202
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:213
 msgid ""
-"MPV keybinds are used by default. Press ENTER to drive the player controls "
-"by keyboard."
+"With \"Start Minimized\" and \"Fullscreen\" this is the classic cast-target "
+"setup: the app waits out of the way, plays fullscreen when something casts "
+"to it, and goes back to waiting when the video ends or you press Q."
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:204
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:227
+msgid ""
+"Off means command-line mode: no window, no system tray and no settings "
+"screen, so the only way back is editing conf.json by hand. It is not how you "
+"get MPV's own on-screen controls — \"Player Controls Style\" under Interface "
+"does that."
+msgstr ""
+
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:234
+msgid ""
+"Show only what is cast to this machine — the library, including this "
+"settings screen, can't be reached from here. Without a system tray icon the "
+"only way back is editing conf.json. For the classic cast-target setup you "
+"want the Interface settings instead; this is for a shared TV nobody should "
+"be able to browse from."
+msgstr ""
+
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:240
+msgid ""
+"Requires restart to change. MPV keybinds are used by default. Press ENTER to "
+"drive the player controls by keyboard."
+msgstr ""
+
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:242
 msgid ""
 "Pixels one wheel notch scrolls. The scrollbar glides while the content snaps "
 "to the nearest row, so a trackpad or trackball no longer overshoots. Raise "
 "it to scroll faster, lower it for finer control."
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:209
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:247
 msgid ""
 "Make each wheel notch jump exactly one row (or one home-screen section) "
 "instead of gliding. Turn this on if you prefer the older stepped scrolling."
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:217
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:255
 msgid "Discord Rich Presence. Takes effect after a restart."
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:219
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:257
 msgid ""
 "Leave this to Default unless setting up passthrough. Note some audio servers "
 "like Pipewire don't like passthrough and will need to be disabled for a card "
@@ -1011,57 +1035,57 @@ msgid ""
 "silence otherwise, but results may vary."
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:225
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:263
 msgid ""
 "Stop anything else using the device while playing. Needed for passthrough on "
 "some systems, and it means other applications will be silent."
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:228
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:266
 msgid ""
 "Page the library and music tile grids instead of scrolling: each page is one "
 "screenful with First / Previous / Next / Last controls and a page number you "
 "can type into. Easier than precise scrolling on a trackpad."
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:232
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:270
 msgid ""
 "Takes effect after a restart. \"Follow display\" uses the scale your desktop "
 "reports, which is 100% on X11."
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:234
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:272
 msgid ""
 "\"Default\" changes nothing and lets MPV (and your own mpv.conf) decide. "
 "Pick a mode only if you are sending audio to a receiver."
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:237
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:275
 msgid ""
 "Audio your receiver can't be sent directly is encoded to AC3, which is the "
 "only way surround fits down an optical cable. Turn this off if the encoder "
 "causes audio delay — those tracks become stereo instead."
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:242
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:280
 msgid ""
 "\"hq\" offers heavier profiles. Pick it if you have a fast graphics card."
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:244
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:282
 msgid ""
 "Leave on Automatic unless video breaks when a profile is loaded. This only "
 "applies while a profile is active, and OpenGL can cost you HDR output."
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:248
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:286
 msgid ""
 "Evens out loud effects and quiet dialogue. This turns passthrough off while "
 "it is enabled, because the volume has to be adjusted before your receiver "
 "gets the audio."
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:330
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:368
 msgid "Advanced"
 msgstr ""
 
@@ -1287,7 +1311,7 @@ msgid "Automatic"
 msgstr "Aŭtomata"
 
 #: jellyfin_mpv_shim/mpvtk_browser/downloads.py:51
-#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1355
+#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1288
 msgid "Episodes"
 msgstr ""
 
@@ -1296,7 +1320,7 @@ msgid "Season %s"
 msgstr ""
 
 #: jellyfin_mpv_shim/mpvtk_browser/downloads.py:52
-#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1351
+#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1284
 msgid "Specials"
 msgstr ""
 
@@ -1321,7 +1345,7 @@ msgid "Failed"
 msgstr "Malsukcese"
 
 #: jellyfin_mpv_shim/mpvtk_browser/downloads.py:185
-#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1105
+#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1038
 msgid "Playlist"
 msgstr ""
 
@@ -1333,30 +1357,30 @@ msgstr ""
 msgid "Movies & Videos"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/home_sections.py:103
+#: jellyfin_mpv_shim/mpvtk_browser/home_sections.py:104
 msgid "My Media"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/home_sections.py:104
-#: jellyfin_mpv_shim/mpvtk_browser/repository.py:352
+#: jellyfin_mpv_shim/mpvtk_browser/home_sections.py:105
+#: jellyfin_mpv_shim/mpvtk_browser/repository.py:350
 msgid "Continue Watching"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/home_sections.py:105
-#: jellyfin_mpv_shim/mpvtk_browser/repository.py:359
+#: jellyfin_mpv_shim/mpvtk_browser/home_sections.py:106
+#: jellyfin_mpv_shim/mpvtk_browser/repository.py:357
 msgid "Continue Listening"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/home_sections.py:106
-#: jellyfin_mpv_shim/mpvtk_browser/repository.py:366
+#: jellyfin_mpv_shim/mpvtk_browser/home_sections.py:107
+#: jellyfin_mpv_shim/mpvtk_browser/repository.py:364
 msgid "Next Up"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/home_sections.py:107
+#: jellyfin_mpv_shim/mpvtk_browser/home_sections.py:108
 msgid "Recently Added"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/home_sections.py:108
+#: jellyfin_mpv_shim/mpvtk_browser/home_sections.py:109
 msgid "Live TV"
 msgstr ""
 
@@ -1609,52 +1633,52 @@ msgstr ""
 "Ne povis aldoni servilon.\n"
 "Kontrolu viajn konektajn informojn."
 
-#: jellyfin_mpv_shim/mpvtk_browser/repository.py:390
+#: jellyfin_mpv_shim/mpvtk_browser/repository.py:386
 msgid "On Now"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/repository.py:411
+#: jellyfin_mpv_shim/mpvtk_browser/repository.py:407
 msgid "Latest %s"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1119
+#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1052
 msgid "Downloaded"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1138
+#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1071
 msgid "Movies"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1143
+#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1076
 msgid "Videos"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1147
+#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1080
 msgid "TV Shows"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1151
+#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1084
 msgid "Playlists"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1168
-#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1441
+#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1101
+#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1374
 msgid "Series"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1212
+#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1145
 msgid "Downloaded Movies"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1216
+#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1149
 msgid "Downloaded Videos"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1220
+#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1153
 msgid "Downloaded Shows"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1353
+#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1286
 msgid "Season %d"
 msgstr ""
 

--- a/jellyfin_mpv_shim/messages/es/LC_MESSAGES/base.po
+++ b/jellyfin_mpv_shim/messages/es/LC_MESSAGES/base.po
@@ -5,7 +5,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2026-07-25 17:21-0400\n"
+"POT-Creation-Date: 2026-07-26 12:03-0400\n"
 "PO-Revision-Date: 2026-07-13 05:32+0000\n"
 "Last-Translator: Simon Barth <sb@b1t.at>\n"
 "Language-Team: Spanish <https://translate.jellyfin.org/projects/jellyfin/"
@@ -252,7 +252,7 @@ msgid "Select Subtitle Track"
 msgstr "Seleccionar Pista de Subtítulos"
 
 #: jellyfin_mpv_shim/menu.py:341
-#: jellyfin_mpv_shim/mpvtk_browser/home_sections.py:102
+#: jellyfin_mpv_shim/mpvtk_browser/home_sections.py:103
 #: jellyfin_mpv_shim/osc_bridge.py:81 jellyfin_mpv_shim/osc_bridge.py:82
 #: jellyfin_mpv_shim/osc_bridge.py:104 jellyfin_mpv_shim/osc_bridge.py:140
 msgid "None"
@@ -403,7 +403,7 @@ msgstr "Solicitar omitir créditos"
 msgid "Enable thumbnail previews"
 msgstr "Activar vistas previas en miniatura"
 
-#: jellyfin_mpv_shim/menu.py:609 jellyfin_mpv_shim/mpvtk_browser/config.py:186
+#: jellyfin_mpv_shim/menu.py:609 jellyfin_mpv_shim/mpvtk_browser/config.py:195
 #: jellyfin_mpv_shim/mpvtk_browser/hud.py:375
 msgid "Night Mode (Auto Volume Adj)"
 msgstr ""
@@ -702,310 +702,334 @@ msgstr ""
 msgid "Or switch to another user"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/cast.py:317
+#: jellyfin_mpv_shim/mpvtk_browser/cast.py:314
 msgid "Ready to cast"
 msgstr "Listo para cast"
 
-#: jellyfin_mpv_shim/mpvtk_browser/cast.py:318
+#: jellyfin_mpv_shim/mpvtk_browser/cast.py:315
 #, fuzzy
 #| msgid "Select your media in Jellyfin and play it here"
 msgid "Select your media in Jellyfin and play it here."
 msgstr "Seleccione su contenido multimedia en Jellyfin y reprodúzcalo aquí"
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:74
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:83
 msgid "Interface"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:83
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:92
 msgid "Playback"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:88
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:97
 msgid "Audio"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:92
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:101
 msgid "Subtitles & Languages"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:97
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:106
 #, fuzzy
 #| msgid " (Transcode)"
 msgid "Transcoding"
 msgstr " (Transcodificar)"
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:102
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:111
 msgid "Video Enhancement"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:104
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:113
 #, fuzzy
 #| msgid "Seek to Skip Credits"
 msgid "Skip Intro / Credits"
 msgstr "Solicitar omitir créditos"
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:107
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:116
 msgid "Library Browser"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:109
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:118
 msgid "Downloads"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:128
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:137
 msgid "Jellyfin UI"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:129
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:138
 msgid "MPV UI with thumbnails"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:130
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:139
 msgid "MPV built-in default"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:133
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:142
 msgid "Follow display"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:134
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:143
 msgid "100% (no scaling)"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:135
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:144
 msgid "125%"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:136
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:145
 msgid "150%"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:137
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:146
 msgid "200%"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:140
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:149
 msgid "Automatic (recommended)"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:141
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:150
 msgid "Vulkan"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:142
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:151
 msgid "Direct3D 11 (Windows only)"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:143
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:152
 msgid "OpenGL (compatibility)"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:146
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:155
 msgid "Default (auto)"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:147
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:156
 msgid "Force Stereo"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:148
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:157
 msgid "Optical Surround"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:149
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:158
 msgid "HDMI Passthrough"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:152
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:161
 msgid "Unset"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:153
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:162
 msgid "Dubbed (shows only)"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:154
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:163
 msgid "Subbed (shows only)"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:155
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:164
 msgid "Dubbed (all)"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:156
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:165
 msgid "Subbed (all)"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:157
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:166
 msgid "Custom (set in config)"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:162
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:171
 msgid "Download Folder"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:163
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:172
 msgid "Prefer Downloaded Copy"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:164
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:173
 msgid "Automatically Download Upcoming Episodes"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:165
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:174
 msgid "Include Next Up"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:166
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:175
 msgid "Next Up Entries to Consider"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:167
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:176
 msgid "Episodes to Keep Ahead (0 = off)"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:168
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:177
 msgid "Storage Limit for Automatic Downloads (GB)"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:169
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:178
 #, fuzzy
 #| msgid "Remove Server"
 msgid "Delete Automatic Downloads Once Watched"
 msgstr "Eliminar servidor"
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:170
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:179
 msgid "Delete Unwatched After (days, 0 = never)"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:171
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:180
 msgid "Check Every (minutes)"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:172
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:181
 msgid "Close to Tray (keep running)"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:173
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:182
 msgid "Keep Running in Background"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:174
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:183
 msgid "Remember Window Size"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:175
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:184
 msgid "Player Controls Style"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:176
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:185
 msgid "Show What You're Watching in Discord"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:177
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:186
 msgid "Interface Scale"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:178
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:187
 msgid "Cast-target mode (no library browsing)"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:179
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:188
 msgid "Casting Opens the Library Browser"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:180
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:189
 msgid "Fullscreen Library Browser"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:181
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:190
 msgid "Always Bind Arrow Keys to Player Controls"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:182
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:191
 msgid "Player Controls Activation Key"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:183
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:192
 msgid "Audio Output Mode"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:184
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:193
 msgid "Audio Output Device"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:185
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:194
 msgid "Take the Device Exclusively"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:187
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:196
 #, fuzzy
 #| msgid "Video Playback Profiles"
 msgid "Enable Video Playback Profiles"
 msgstr "Perfiles de Reproducción de Video"
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:188
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:197
 #, fuzzy
 #| msgid "New Group"
 msgid "Profile Group"
 msgstr "Nuevo Grupo"
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:189
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:198
 msgid "Remember Last Used Profile"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:190
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:199
 msgid "Graphics API for Shaders"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:191
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:200
 msgid "Pass Through AC3"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:192
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:201
 msgid "Pass Through DTS"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:193
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:202
 msgid "Pass Through E-AC3"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:194
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:203
 msgid "Pass Through DTS-HD"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:195
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:204
 msgid "Pass Through TrueHD"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:196
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:205
 msgid "Re-encode Others to AC3"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:202
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:213
 msgid ""
-"MPV keybinds are used by default. Press ENTER to drive the player controls "
-"by keyboard."
+"With \"Start Minimized\" and \"Fullscreen\" this is the classic cast-target "
+"setup: the app waits out of the way, plays fullscreen when something casts "
+"to it, and goes back to waiting when the video ends or you press Q."
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:204
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:227
+msgid ""
+"Off means command-line mode: no window, no system tray and no settings "
+"screen, so the only way back is editing conf.json by hand. It is not how you "
+"get MPV's own on-screen controls — \"Player Controls Style\" under Interface "
+"does that."
+msgstr ""
+
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:234
+msgid ""
+"Show only what is cast to this machine — the library, including this "
+"settings screen, can't be reached from here. Without a system tray icon the "
+"only way back is editing conf.json. For the classic cast-target setup you "
+"want the Interface settings instead; this is for a shared TV nobody should "
+"be able to browse from."
+msgstr ""
+
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:240
+msgid ""
+"Requires restart to change. MPV keybinds are used by default. Press ENTER to "
+"drive the player controls by keyboard."
+msgstr ""
+
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:242
 msgid ""
 "Pixels one wheel notch scrolls. The scrollbar glides while the content snaps "
 "to the nearest row, so a trackpad or trackball no longer overshoots. Raise "
 "it to scroll faster, lower it for finer control."
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:209
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:247
 msgid ""
 "Make each wheel notch jump exactly one row (or one home-screen section) "
 "instead of gliding. Turn this on if you prefer the older stepped scrolling."
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:217
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:255
 msgid "Discord Rich Presence. Takes effect after a restart."
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:219
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:257
 msgid ""
 "Leave this to Default unless setting up passthrough. Note some audio servers "
 "like Pipewire don't like passthrough and will need to be disabled for a card "
@@ -1013,57 +1037,57 @@ msgid ""
 "silence otherwise, but results may vary."
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:225
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:263
 msgid ""
 "Stop anything else using the device while playing. Needed for passthrough on "
 "some systems, and it means other applications will be silent."
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:228
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:266
 msgid ""
 "Page the library and music tile grids instead of scrolling: each page is one "
 "screenful with First / Previous / Next / Last controls and a page number you "
 "can type into. Easier than precise scrolling on a trackpad."
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:232
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:270
 msgid ""
 "Takes effect after a restart. \"Follow display\" uses the scale your desktop "
 "reports, which is 100% on X11."
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:234
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:272
 msgid ""
 "\"Default\" changes nothing and lets MPV (and your own mpv.conf) decide. "
 "Pick a mode only if you are sending audio to a receiver."
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:237
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:275
 msgid ""
 "Audio your receiver can't be sent directly is encoded to AC3, which is the "
 "only way surround fits down an optical cable. Turn this off if the encoder "
 "causes audio delay — those tracks become stereo instead."
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:242
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:280
 msgid ""
 "\"hq\" offers heavier profiles. Pick it if you have a fast graphics card."
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:244
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:282
 msgid ""
 "Leave on Automatic unless video breaks when a profile is loaded. This only "
 "applies while a profile is active, and OpenGL can cost you HDR output."
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:248
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:286
 msgid ""
 "Evens out loud effects and quiet dialogue. This turns passthrough off while "
 "it is enabled, because the volume has to be adjusted before your receiver "
 "gets the audio."
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:330
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:368
 msgid "Advanced"
 msgstr ""
 
@@ -1289,7 +1313,7 @@ msgid "Automatic"
 msgstr "Automático"
 
 #: jellyfin_mpv_shim/mpvtk_browser/downloads.py:51
-#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1355
+#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1288
 msgid "Episodes"
 msgstr ""
 
@@ -1298,7 +1322,7 @@ msgid "Season %s"
 msgstr ""
 
 #: jellyfin_mpv_shim/mpvtk_browser/downloads.py:52
-#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1351
+#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1284
 msgid "Specials"
 msgstr ""
 
@@ -1323,7 +1347,7 @@ msgid "Failed"
 msgstr "Falla"
 
 #: jellyfin_mpv_shim/mpvtk_browser/downloads.py:185
-#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1105
+#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1038
 msgid "Playlist"
 msgstr ""
 
@@ -1335,30 +1359,30 @@ msgstr ""
 msgid "Movies & Videos"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/home_sections.py:103
+#: jellyfin_mpv_shim/mpvtk_browser/home_sections.py:104
 msgid "My Media"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/home_sections.py:104
-#: jellyfin_mpv_shim/mpvtk_browser/repository.py:352
+#: jellyfin_mpv_shim/mpvtk_browser/home_sections.py:105
+#: jellyfin_mpv_shim/mpvtk_browser/repository.py:350
 msgid "Continue Watching"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/home_sections.py:105
-#: jellyfin_mpv_shim/mpvtk_browser/repository.py:359
+#: jellyfin_mpv_shim/mpvtk_browser/home_sections.py:106
+#: jellyfin_mpv_shim/mpvtk_browser/repository.py:357
 msgid "Continue Listening"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/home_sections.py:106
-#: jellyfin_mpv_shim/mpvtk_browser/repository.py:366
+#: jellyfin_mpv_shim/mpvtk_browser/home_sections.py:107
+#: jellyfin_mpv_shim/mpvtk_browser/repository.py:364
 msgid "Next Up"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/home_sections.py:107
+#: jellyfin_mpv_shim/mpvtk_browser/home_sections.py:108
 msgid "Recently Added"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/home_sections.py:108
+#: jellyfin_mpv_shim/mpvtk_browser/home_sections.py:109
 msgid "Live TV"
 msgstr ""
 
@@ -1611,52 +1635,52 @@ msgstr ""
 "No se pudo agregar el servidor.\n"
 "Compruebe la información de su conexión."
 
-#: jellyfin_mpv_shim/mpvtk_browser/repository.py:390
+#: jellyfin_mpv_shim/mpvtk_browser/repository.py:386
 msgid "On Now"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/repository.py:411
+#: jellyfin_mpv_shim/mpvtk_browser/repository.py:407
 msgid "Latest %s"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1119
+#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1052
 msgid "Downloaded"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1138
+#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1071
 msgid "Movies"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1143
+#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1076
 msgid "Videos"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1147
+#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1080
 msgid "TV Shows"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1151
+#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1084
 msgid "Playlists"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1168
-#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1441
+#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1101
+#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1374
 msgid "Series"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1212
+#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1145
 msgid "Downloaded Movies"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1216
+#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1149
 msgid "Downloaded Videos"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1220
+#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1153
 msgid "Downloaded Shows"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1353
+#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1286
 msgid "Season %d"
 msgstr ""
 

--- a/jellyfin_mpv_shim/messages/es_419/LC_MESSAGES/base.po
+++ b/jellyfin_mpv_shim/messages/es_419/LC_MESSAGES/base.po
@@ -5,7 +5,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2026-07-25 17:21-0400\n"
+"POT-Creation-Date: 2026-07-26 12:03-0400\n"
 "PO-Revision-Date: 2026-02-15 03:07+0000\n"
 "Last-Translator: Ramiro Farias <ramirofarias.dev@gmail.com>\n"
 "Language-Team: Spanish (Latin America) <https://translate.jellyfin.org/"
@@ -252,7 +252,7 @@ msgid "Select Subtitle Track"
 msgstr "Seleccionar Pista de Subtítulo"
 
 #: jellyfin_mpv_shim/menu.py:341
-#: jellyfin_mpv_shim/mpvtk_browser/home_sections.py:102
+#: jellyfin_mpv_shim/mpvtk_browser/home_sections.py:103
 #: jellyfin_mpv_shim/osc_bridge.py:81 jellyfin_mpv_shim/osc_bridge.py:82
 #: jellyfin_mpv_shim/osc_bridge.py:104 jellyfin_mpv_shim/osc_bridge.py:140
 msgid "None"
@@ -403,7 +403,7 @@ msgstr "Preguntar para saltar créditos"
 msgid "Enable thumbnail previews"
 msgstr "Activar vista previa de miniaturas"
 
-#: jellyfin_mpv_shim/menu.py:609 jellyfin_mpv_shim/mpvtk_browser/config.py:186
+#: jellyfin_mpv_shim/menu.py:609 jellyfin_mpv_shim/mpvtk_browser/config.py:195
 #: jellyfin_mpv_shim/mpvtk_browser/hud.py:375
 msgid "Night Mode (Auto Volume Adj)"
 msgstr ""
@@ -702,310 +702,334 @@ msgstr ""
 msgid "Or switch to another user"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/cast.py:317
+#: jellyfin_mpv_shim/mpvtk_browser/cast.py:314
 msgid "Ready to cast"
 msgstr "Listo para emitir"
 
-#: jellyfin_mpv_shim/mpvtk_browser/cast.py:318
+#: jellyfin_mpv_shim/mpvtk_browser/cast.py:315
 #, fuzzy
 #| msgid "Select your media in Jellyfin and play it here"
 msgid "Select your media in Jellyfin and play it here."
 msgstr "Selecciona tu contenido multimedia en Jellyfin y reprodúcelo aquí"
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:74
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:83
 msgid "Interface"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:83
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:92
 msgid "Playback"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:88
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:97
 msgid "Audio"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:92
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:101
 msgid "Subtitles & Languages"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:97
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:106
 #, fuzzy
 #| msgid " (Transcode)"
 msgid "Transcoding"
 msgstr " (Transcodificar)"
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:102
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:111
 msgid "Video Enhancement"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:104
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:113
 #, fuzzy
 #| msgid "Seek to Skip Credits"
 msgid "Skip Intro / Credits"
 msgstr "Intentar omitir créditos"
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:107
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:116
 msgid "Library Browser"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:109
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:118
 msgid "Downloads"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:128
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:137
 msgid "Jellyfin UI"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:129
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:138
 msgid "MPV UI with thumbnails"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:130
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:139
 msgid "MPV built-in default"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:133
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:142
 msgid "Follow display"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:134
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:143
 msgid "100% (no scaling)"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:135
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:144
 msgid "125%"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:136
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:145
 msgid "150%"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:137
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:146
 msgid "200%"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:140
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:149
 msgid "Automatic (recommended)"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:141
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:150
 msgid "Vulkan"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:142
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:151
 msgid "Direct3D 11 (Windows only)"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:143
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:152
 msgid "OpenGL (compatibility)"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:146
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:155
 msgid "Default (auto)"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:147
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:156
 msgid "Force Stereo"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:148
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:157
 msgid "Optical Surround"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:149
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:158
 msgid "HDMI Passthrough"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:152
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:161
 msgid "Unset"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:153
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:162
 msgid "Dubbed (shows only)"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:154
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:163
 msgid "Subbed (shows only)"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:155
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:164
 msgid "Dubbed (all)"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:156
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:165
 msgid "Subbed (all)"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:157
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:166
 msgid "Custom (set in config)"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:162
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:171
 msgid "Download Folder"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:163
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:172
 msgid "Prefer Downloaded Copy"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:164
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:173
 msgid "Automatically Download Upcoming Episodes"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:165
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:174
 msgid "Include Next Up"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:166
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:175
 msgid "Next Up Entries to Consider"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:167
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:176
 msgid "Episodes to Keep Ahead (0 = off)"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:168
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:177
 msgid "Storage Limit for Automatic Downloads (GB)"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:169
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:178
 #, fuzzy
 #| msgid "Remove Server"
 msgid "Delete Automatic Downloads Once Watched"
 msgstr "Eliminar servidor"
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:170
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:179
 msgid "Delete Unwatched After (days, 0 = never)"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:171
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:180
 msgid "Check Every (minutes)"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:172
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:181
 msgid "Close to Tray (keep running)"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:173
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:182
 msgid "Keep Running in Background"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:174
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:183
 msgid "Remember Window Size"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:175
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:184
 msgid "Player Controls Style"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:176
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:185
 msgid "Show What You're Watching in Discord"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:177
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:186
 msgid "Interface Scale"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:178
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:187
 msgid "Cast-target mode (no library browsing)"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:179
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:188
 msgid "Casting Opens the Library Browser"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:180
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:189
 msgid "Fullscreen Library Browser"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:181
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:190
 msgid "Always Bind Arrow Keys to Player Controls"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:182
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:191
 msgid "Player Controls Activation Key"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:183
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:192
 msgid "Audio Output Mode"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:184
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:193
 msgid "Audio Output Device"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:185
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:194
 msgid "Take the Device Exclusively"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:187
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:196
 #, fuzzy
 #| msgid "Video Playback Profiles"
 msgid "Enable Video Playback Profiles"
 msgstr "Perfiles de Reproducción de Video"
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:188
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:197
 #, fuzzy
 #| msgid "New Group"
 msgid "Profile Group"
 msgstr "Nuevo Grupo"
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:189
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:198
 msgid "Remember Last Used Profile"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:190
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:199
 msgid "Graphics API for Shaders"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:191
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:200
 msgid "Pass Through AC3"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:192
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:201
 msgid "Pass Through DTS"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:193
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:202
 msgid "Pass Through E-AC3"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:194
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:203
 msgid "Pass Through DTS-HD"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:195
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:204
 msgid "Pass Through TrueHD"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:196
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:205
 msgid "Re-encode Others to AC3"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:202
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:213
 msgid ""
-"MPV keybinds are used by default. Press ENTER to drive the player controls "
-"by keyboard."
+"With \"Start Minimized\" and \"Fullscreen\" this is the classic cast-target "
+"setup: the app waits out of the way, plays fullscreen when something casts "
+"to it, and goes back to waiting when the video ends or you press Q."
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:204
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:227
+msgid ""
+"Off means command-line mode: no window, no system tray and no settings "
+"screen, so the only way back is editing conf.json by hand. It is not how you "
+"get MPV's own on-screen controls — \"Player Controls Style\" under Interface "
+"does that."
+msgstr ""
+
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:234
+msgid ""
+"Show only what is cast to this machine — the library, including this "
+"settings screen, can't be reached from here. Without a system tray icon the "
+"only way back is editing conf.json. For the classic cast-target setup you "
+"want the Interface settings instead; this is for a shared TV nobody should "
+"be able to browse from."
+msgstr ""
+
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:240
+msgid ""
+"Requires restart to change. MPV keybinds are used by default. Press ENTER to "
+"drive the player controls by keyboard."
+msgstr ""
+
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:242
 msgid ""
 "Pixels one wheel notch scrolls. The scrollbar glides while the content snaps "
 "to the nearest row, so a trackpad or trackball no longer overshoots. Raise "
 "it to scroll faster, lower it for finer control."
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:209
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:247
 msgid ""
 "Make each wheel notch jump exactly one row (or one home-screen section) "
 "instead of gliding. Turn this on if you prefer the older stepped scrolling."
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:217
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:255
 msgid "Discord Rich Presence. Takes effect after a restart."
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:219
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:257
 msgid ""
 "Leave this to Default unless setting up passthrough. Note some audio servers "
 "like Pipewire don't like passthrough and will need to be disabled for a card "
@@ -1013,57 +1037,57 @@ msgid ""
 "silence otherwise, but results may vary."
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:225
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:263
 msgid ""
 "Stop anything else using the device while playing. Needed for passthrough on "
 "some systems, and it means other applications will be silent."
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:228
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:266
 msgid ""
 "Page the library and music tile grids instead of scrolling: each page is one "
 "screenful with First / Previous / Next / Last controls and a page number you "
 "can type into. Easier than precise scrolling on a trackpad."
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:232
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:270
 msgid ""
 "Takes effect after a restart. \"Follow display\" uses the scale your desktop "
 "reports, which is 100% on X11."
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:234
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:272
 msgid ""
 "\"Default\" changes nothing and lets MPV (and your own mpv.conf) decide. "
 "Pick a mode only if you are sending audio to a receiver."
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:237
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:275
 msgid ""
 "Audio your receiver can't be sent directly is encoded to AC3, which is the "
 "only way surround fits down an optical cable. Turn this off if the encoder "
 "causes audio delay — those tracks become stereo instead."
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:242
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:280
 msgid ""
 "\"hq\" offers heavier profiles. Pick it if you have a fast graphics card."
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:244
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:282
 msgid ""
 "Leave on Automatic unless video breaks when a profile is loaded. This only "
 "applies while a profile is active, and OpenGL can cost you HDR output."
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:248
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:286
 msgid ""
 "Evens out loud effects and quiet dialogue. This turns passthrough off while "
 "it is enabled, because the volume has to be adjusted before your receiver "
 "gets the audio."
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:330
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:368
 msgid "Advanced"
 msgstr ""
 
@@ -1289,7 +1313,7 @@ msgid "Automatic"
 msgstr "Automático"
 
 #: jellyfin_mpv_shim/mpvtk_browser/downloads.py:51
-#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1355
+#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1288
 msgid "Episodes"
 msgstr ""
 
@@ -1298,7 +1322,7 @@ msgid "Season %s"
 msgstr ""
 
 #: jellyfin_mpv_shim/mpvtk_browser/downloads.py:52
-#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1351
+#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1284
 msgid "Specials"
 msgstr ""
 
@@ -1323,7 +1347,7 @@ msgid "Failed"
 msgstr "Error"
 
 #: jellyfin_mpv_shim/mpvtk_browser/downloads.py:185
-#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1105
+#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1038
 msgid "Playlist"
 msgstr ""
 
@@ -1335,30 +1359,30 @@ msgstr ""
 msgid "Movies & Videos"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/home_sections.py:103
+#: jellyfin_mpv_shim/mpvtk_browser/home_sections.py:104
 msgid "My Media"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/home_sections.py:104
-#: jellyfin_mpv_shim/mpvtk_browser/repository.py:352
+#: jellyfin_mpv_shim/mpvtk_browser/home_sections.py:105
+#: jellyfin_mpv_shim/mpvtk_browser/repository.py:350
 msgid "Continue Watching"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/home_sections.py:105
-#: jellyfin_mpv_shim/mpvtk_browser/repository.py:359
+#: jellyfin_mpv_shim/mpvtk_browser/home_sections.py:106
+#: jellyfin_mpv_shim/mpvtk_browser/repository.py:357
 msgid "Continue Listening"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/home_sections.py:106
-#: jellyfin_mpv_shim/mpvtk_browser/repository.py:366
+#: jellyfin_mpv_shim/mpvtk_browser/home_sections.py:107
+#: jellyfin_mpv_shim/mpvtk_browser/repository.py:364
 msgid "Next Up"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/home_sections.py:107
+#: jellyfin_mpv_shim/mpvtk_browser/home_sections.py:108
 msgid "Recently Added"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/home_sections.py:108
+#: jellyfin_mpv_shim/mpvtk_browser/home_sections.py:109
 msgid "Live TV"
 msgstr ""
 
@@ -1611,52 +1635,52 @@ msgstr ""
 "No se pudo agregar el servidor.\n"
 "Por favor, revisa la información de tu conexión."
 
-#: jellyfin_mpv_shim/mpvtk_browser/repository.py:390
+#: jellyfin_mpv_shim/mpvtk_browser/repository.py:386
 msgid "On Now"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/repository.py:411
+#: jellyfin_mpv_shim/mpvtk_browser/repository.py:407
 msgid "Latest %s"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1119
+#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1052
 msgid "Downloaded"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1138
+#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1071
 msgid "Movies"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1143
+#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1076
 msgid "Videos"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1147
+#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1080
 msgid "TV Shows"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1151
+#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1084
 msgid "Playlists"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1168
-#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1441
+#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1101
+#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1374
 msgid "Series"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1212
+#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1145
 msgid "Downloaded Movies"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1216
+#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1149
 msgid "Downloaded Videos"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1220
+#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1153
 msgid "Downloaded Shows"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1353
+#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1286
 msgid "Season %d"
 msgstr ""
 

--- a/jellyfin_mpv_shim/messages/es_AR/LC_MESSAGES/base.po
+++ b/jellyfin_mpv_shim/messages/es_AR/LC_MESSAGES/base.po
@@ -5,7 +5,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2026-07-25 17:21-0400\n"
+"POT-Creation-Date: 2026-07-26 12:03-0400\n"
 "PO-Revision-Date: 2026-02-01 17:36+0000\n"
 "Last-Translator: Augusto <tasken@gmail.com>\n"
 "Language-Team: Spanish (Argentina) <https://translate.jellyfin.org/projects/"
@@ -252,7 +252,7 @@ msgid "Select Subtitle Track"
 msgstr "Seleccionar pista de subtítulos"
 
 #: jellyfin_mpv_shim/menu.py:341
-#: jellyfin_mpv_shim/mpvtk_browser/home_sections.py:102
+#: jellyfin_mpv_shim/mpvtk_browser/home_sections.py:103
 #: jellyfin_mpv_shim/osc_bridge.py:81 jellyfin_mpv_shim/osc_bridge.py:82
 #: jellyfin_mpv_shim/osc_bridge.py:104 jellyfin_mpv_shim/osc_bridge.py:140
 msgid "None"
@@ -403,7 +403,7 @@ msgstr "Preguntar para saltar los créditos"
 msgid "Enable thumbnail previews"
 msgstr "Activar la vista previa de miniaturas"
 
-#: jellyfin_mpv_shim/menu.py:609 jellyfin_mpv_shim/mpvtk_browser/config.py:186
+#: jellyfin_mpv_shim/menu.py:609 jellyfin_mpv_shim/mpvtk_browser/config.py:195
 #: jellyfin_mpv_shim/mpvtk_browser/hud.py:375
 msgid "Night Mode (Auto Volume Adj)"
 msgstr ""
@@ -702,310 +702,334 @@ msgstr ""
 msgid "Or switch to another user"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/cast.py:317
+#: jellyfin_mpv_shim/mpvtk_browser/cast.py:314
 msgid "Ready to cast"
 msgstr "Listo para transmitir"
 
-#: jellyfin_mpv_shim/mpvtk_browser/cast.py:318
+#: jellyfin_mpv_shim/mpvtk_browser/cast.py:315
 #, fuzzy
 #| msgid "Select your media in Jellyfin and play it here"
 msgid "Select your media in Jellyfin and play it here."
 msgstr "Seleccioná tu contenido multimedia en Jellyfin y reproducilo acá"
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:74
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:83
 msgid "Interface"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:83
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:92
 msgid "Playback"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:88
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:97
 msgid "Audio"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:92
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:101
 msgid "Subtitles & Languages"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:97
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:106
 #, fuzzy
 #| msgid " (Transcode)"
 msgid "Transcoding"
 msgstr " (Transcodificar)"
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:102
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:111
 msgid "Video Enhancement"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:104
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:113
 #, fuzzy
 #| msgid "Seek to Skip Credits"
 msgid "Skip Intro / Credits"
 msgstr "Intentar omitir los créditos"
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:107
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:116
 msgid "Library Browser"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:109
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:118
 msgid "Downloads"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:128
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:137
 msgid "Jellyfin UI"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:129
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:138
 msgid "MPV UI with thumbnails"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:130
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:139
 msgid "MPV built-in default"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:133
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:142
 msgid "Follow display"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:134
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:143
 msgid "100% (no scaling)"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:135
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:144
 msgid "125%"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:136
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:145
 msgid "150%"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:137
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:146
 msgid "200%"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:140
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:149
 msgid "Automatic (recommended)"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:141
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:150
 msgid "Vulkan"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:142
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:151
 msgid "Direct3D 11 (Windows only)"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:143
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:152
 msgid "OpenGL (compatibility)"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:146
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:155
 msgid "Default (auto)"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:147
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:156
 msgid "Force Stereo"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:148
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:157
 msgid "Optical Surround"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:149
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:158
 msgid "HDMI Passthrough"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:152
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:161
 msgid "Unset"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:153
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:162
 msgid "Dubbed (shows only)"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:154
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:163
 msgid "Subbed (shows only)"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:155
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:164
 msgid "Dubbed (all)"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:156
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:165
 msgid "Subbed (all)"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:157
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:166
 msgid "Custom (set in config)"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:162
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:171
 msgid "Download Folder"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:163
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:172
 msgid "Prefer Downloaded Copy"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:164
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:173
 msgid "Automatically Download Upcoming Episodes"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:165
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:174
 msgid "Include Next Up"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:166
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:175
 msgid "Next Up Entries to Consider"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:167
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:176
 msgid "Episodes to Keep Ahead (0 = off)"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:168
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:177
 msgid "Storage Limit for Automatic Downloads (GB)"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:169
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:178
 #, fuzzy
 #| msgid "Remove Server"
 msgid "Delete Automatic Downloads Once Watched"
 msgstr "Eliminar servidor"
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:170
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:179
 msgid "Delete Unwatched After (days, 0 = never)"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:171
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:180
 msgid "Check Every (minutes)"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:172
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:181
 msgid "Close to Tray (keep running)"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:173
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:182
 msgid "Keep Running in Background"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:174
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:183
 msgid "Remember Window Size"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:175
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:184
 msgid "Player Controls Style"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:176
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:185
 msgid "Show What You're Watching in Discord"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:177
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:186
 msgid "Interface Scale"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:178
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:187
 msgid "Cast-target mode (no library browsing)"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:179
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:188
 msgid "Casting Opens the Library Browser"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:180
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:189
 msgid "Fullscreen Library Browser"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:181
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:190
 msgid "Always Bind Arrow Keys to Player Controls"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:182
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:191
 msgid "Player Controls Activation Key"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:183
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:192
 msgid "Audio Output Mode"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:184
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:193
 msgid "Audio Output Device"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:185
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:194
 msgid "Take the Device Exclusively"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:187
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:196
 #, fuzzy
 #| msgid "Video Playback Profiles"
 msgid "Enable Video Playback Profiles"
 msgstr "Perfiles de reproducción de video"
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:188
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:197
 #, fuzzy
 #| msgid "New Group"
 msgid "Profile Group"
 msgstr "Nuevo grupo"
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:189
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:198
 msgid "Remember Last Used Profile"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:190
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:199
 msgid "Graphics API for Shaders"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:191
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:200
 msgid "Pass Through AC3"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:192
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:201
 msgid "Pass Through DTS"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:193
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:202
 msgid "Pass Through E-AC3"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:194
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:203
 msgid "Pass Through DTS-HD"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:195
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:204
 msgid "Pass Through TrueHD"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:196
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:205
 msgid "Re-encode Others to AC3"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:202
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:213
 msgid ""
-"MPV keybinds are used by default. Press ENTER to drive the player controls "
-"by keyboard."
+"With \"Start Minimized\" and \"Fullscreen\" this is the classic cast-target "
+"setup: the app waits out of the way, plays fullscreen when something casts "
+"to it, and goes back to waiting when the video ends or you press Q."
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:204
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:227
+msgid ""
+"Off means command-line mode: no window, no system tray and no settings "
+"screen, so the only way back is editing conf.json by hand. It is not how you "
+"get MPV's own on-screen controls — \"Player Controls Style\" under Interface "
+"does that."
+msgstr ""
+
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:234
+msgid ""
+"Show only what is cast to this machine — the library, including this "
+"settings screen, can't be reached from here. Without a system tray icon the "
+"only way back is editing conf.json. For the classic cast-target setup you "
+"want the Interface settings instead; this is for a shared TV nobody should "
+"be able to browse from."
+msgstr ""
+
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:240
+msgid ""
+"Requires restart to change. MPV keybinds are used by default. Press ENTER to "
+"drive the player controls by keyboard."
+msgstr ""
+
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:242
 msgid ""
 "Pixels one wheel notch scrolls. The scrollbar glides while the content snaps "
 "to the nearest row, so a trackpad or trackball no longer overshoots. Raise "
 "it to scroll faster, lower it for finer control."
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:209
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:247
 msgid ""
 "Make each wheel notch jump exactly one row (or one home-screen section) "
 "instead of gliding. Turn this on if you prefer the older stepped scrolling."
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:217
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:255
 msgid "Discord Rich Presence. Takes effect after a restart."
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:219
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:257
 msgid ""
 "Leave this to Default unless setting up passthrough. Note some audio servers "
 "like Pipewire don't like passthrough and will need to be disabled for a card "
@@ -1013,57 +1037,57 @@ msgid ""
 "silence otherwise, but results may vary."
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:225
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:263
 msgid ""
 "Stop anything else using the device while playing. Needed for passthrough on "
 "some systems, and it means other applications will be silent."
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:228
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:266
 msgid ""
 "Page the library and music tile grids instead of scrolling: each page is one "
 "screenful with First / Previous / Next / Last controls and a page number you "
 "can type into. Easier than precise scrolling on a trackpad."
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:232
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:270
 msgid ""
 "Takes effect after a restart. \"Follow display\" uses the scale your desktop "
 "reports, which is 100% on X11."
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:234
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:272
 msgid ""
 "\"Default\" changes nothing and lets MPV (and your own mpv.conf) decide. "
 "Pick a mode only if you are sending audio to a receiver."
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:237
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:275
 msgid ""
 "Audio your receiver can't be sent directly is encoded to AC3, which is the "
 "only way surround fits down an optical cable. Turn this off if the encoder "
 "causes audio delay — those tracks become stereo instead."
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:242
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:280
 msgid ""
 "\"hq\" offers heavier profiles. Pick it if you have a fast graphics card."
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:244
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:282
 msgid ""
 "Leave on Automatic unless video breaks when a profile is loaded. This only "
 "applies while a profile is active, and OpenGL can cost you HDR output."
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:248
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:286
 msgid ""
 "Evens out loud effects and quiet dialogue. This turns passthrough off while "
 "it is enabled, because the volume has to be adjusted before your receiver "
 "gets the audio."
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:330
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:368
 msgid "Advanced"
 msgstr ""
 
@@ -1289,7 +1313,7 @@ msgid "Automatic"
 msgstr "Automático"
 
 #: jellyfin_mpv_shim/mpvtk_browser/downloads.py:51
-#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1355
+#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1288
 msgid "Episodes"
 msgstr ""
 
@@ -1298,7 +1322,7 @@ msgid "Season %s"
 msgstr ""
 
 #: jellyfin_mpv_shim/mpvtk_browser/downloads.py:52
-#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1351
+#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1284
 msgid "Specials"
 msgstr ""
 
@@ -1323,7 +1347,7 @@ msgid "Failed"
 msgstr "Falló"
 
 #: jellyfin_mpv_shim/mpvtk_browser/downloads.py:185
-#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1105
+#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1038
 msgid "Playlist"
 msgstr ""
 
@@ -1335,30 +1359,30 @@ msgstr ""
 msgid "Movies & Videos"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/home_sections.py:103
+#: jellyfin_mpv_shim/mpvtk_browser/home_sections.py:104
 msgid "My Media"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/home_sections.py:104
-#: jellyfin_mpv_shim/mpvtk_browser/repository.py:352
+#: jellyfin_mpv_shim/mpvtk_browser/home_sections.py:105
+#: jellyfin_mpv_shim/mpvtk_browser/repository.py:350
 msgid "Continue Watching"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/home_sections.py:105
-#: jellyfin_mpv_shim/mpvtk_browser/repository.py:359
+#: jellyfin_mpv_shim/mpvtk_browser/home_sections.py:106
+#: jellyfin_mpv_shim/mpvtk_browser/repository.py:357
 msgid "Continue Listening"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/home_sections.py:106
-#: jellyfin_mpv_shim/mpvtk_browser/repository.py:366
+#: jellyfin_mpv_shim/mpvtk_browser/home_sections.py:107
+#: jellyfin_mpv_shim/mpvtk_browser/repository.py:364
 msgid "Next Up"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/home_sections.py:107
+#: jellyfin_mpv_shim/mpvtk_browser/home_sections.py:108
 msgid "Recently Added"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/home_sections.py:108
+#: jellyfin_mpv_shim/mpvtk_browser/home_sections.py:109
 msgid "Live TV"
 msgstr ""
 
@@ -1611,52 +1635,52 @@ msgstr ""
 "No se pudo agregar el servidor.\n"
 "Verificá la información de conexión."
 
-#: jellyfin_mpv_shim/mpvtk_browser/repository.py:390
+#: jellyfin_mpv_shim/mpvtk_browser/repository.py:386
 msgid "On Now"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/repository.py:411
+#: jellyfin_mpv_shim/mpvtk_browser/repository.py:407
 msgid "Latest %s"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1119
+#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1052
 msgid "Downloaded"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1138
+#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1071
 msgid "Movies"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1143
+#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1076
 msgid "Videos"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1147
+#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1080
 msgid "TV Shows"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1151
+#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1084
 msgid "Playlists"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1168
-#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1441
+#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1101
+#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1374
 msgid "Series"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1212
+#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1145
 msgid "Downloaded Movies"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1216
+#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1149
 msgid "Downloaded Videos"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1220
+#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1153
 msgid "Downloaded Shows"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1353
+#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1286
 msgid "Season %d"
 msgstr ""
 

--- a/jellyfin_mpv_shim/messages/es_MX/LC_MESSAGES/base.po
+++ b/jellyfin_mpv_shim/messages/es_MX/LC_MESSAGES/base.po
@@ -5,9 +5,9 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2026-07-25 17:21-0400\n"
-"PO-Revision-Date: 2026-07-26 06:33+0000\n"
-"Last-Translator: Roberto Abarca <rabarkar@gmail.com>\n"
+"POT-Creation-Date: 2026-07-26 12:03-0400\n"
+"PO-Revision-Date: 2025-12-20 05:23+0000\n"
+"Last-Translator: Warper <warper@ymail.com>\n"
 "Language-Team: Spanish (Mexico) <https://translate.jellyfin.org/projects/"
 "jellyfin/jellyfin-mpv-shim/es_MX/>\n"
 "Language: es_MX\n"
@@ -15,7 +15,7 @@ msgstr ""
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=n != 1;\n"
-"X-Generator: Weblate 5.15.1\n"
+"X-Generator: Weblate 5.14\n"
 "Generated-By: pygettext.py 1.5\n"
 
 #: jellyfin_mpv_shim/bulk_subtitle.py:29
@@ -99,11 +99,17 @@ msgstr ""
 
 #: jellyfin_mpv_shim/clients.py:330
 msgid "Add another server?"
-msgstr "¿Agregar otro servidor?"
+msgstr "Agregar otro servidor?"
 
 #: jellyfin_mpv_shim/clients.py:617
+#, fuzzy
+#| msgid ""
+#| "Could not add server.\n"
+#| "Please check your connection information."
 msgid "Could not connect to the server."
-msgstr "No se pudo conectar con el servidor."
+msgstr ""
+"No se pudo agregar el servidor.\n"
+"Porfsvor revise su información de conexión."
 
 #: jellyfin_mpv_shim/clients.py:622
 msgid "Quick Connect is not enabled on this server."
@@ -246,7 +252,7 @@ msgid "Select Subtitle Track"
 msgstr ""
 
 #: jellyfin_mpv_shim/menu.py:341
-#: jellyfin_mpv_shim/mpvtk_browser/home_sections.py:102
+#: jellyfin_mpv_shim/mpvtk_browser/home_sections.py:103
 #: jellyfin_mpv_shim/osc_bridge.py:81 jellyfin_mpv_shim/osc_bridge.py:82
 #: jellyfin_mpv_shim/osc_bridge.py:104 jellyfin_mpv_shim/osc_bridge.py:140
 msgid "None"
@@ -397,7 +403,7 @@ msgstr ""
 msgid "Enable thumbnail previews"
 msgstr ""
 
-#: jellyfin_mpv_shim/menu.py:609 jellyfin_mpv_shim/mpvtk_browser/config.py:186
+#: jellyfin_mpv_shim/menu.py:609 jellyfin_mpv_shim/mpvtk_browser/config.py:195
 #: jellyfin_mpv_shim/mpvtk_browser/hud.py:375
 msgid "Night Mode (Auto Volume Adj)"
 msgstr ""
@@ -688,298 +694,322 @@ msgstr ""
 msgid "Or switch to another user"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/cast.py:317
+#: jellyfin_mpv_shim/mpvtk_browser/cast.py:314
 msgid "Ready to cast"
 msgstr "Listo para transmitir"
 
-#: jellyfin_mpv_shim/mpvtk_browser/cast.py:318
+#: jellyfin_mpv_shim/mpvtk_browser/cast.py:315
 msgid "Select your media in Jellyfin and play it here."
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:74
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:83
 msgid "Interface"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:83
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:92
 msgid "Playback"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:88
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:97
 msgid "Audio"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:92
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:101
 msgid "Subtitles & Languages"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:97
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:106
 msgid "Transcoding"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:102
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:111
 msgid "Video Enhancement"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:104
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:113
 msgid "Skip Intro / Credits"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:107
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:116
 msgid "Library Browser"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:109
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:118
 msgid "Downloads"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:128
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:137
 msgid "Jellyfin UI"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:129
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:138
 msgid "MPV UI with thumbnails"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:130
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:139
 msgid "MPV built-in default"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:133
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:142
 msgid "Follow display"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:134
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:143
 msgid "100% (no scaling)"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:135
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:144
 msgid "125%"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:136
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:145
 msgid "150%"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:137
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:146
 msgid "200%"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:140
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:149
 msgid "Automatic (recommended)"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:141
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:150
 msgid "Vulkan"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:142
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:151
 msgid "Direct3D 11 (Windows only)"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:143
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:152
 msgid "OpenGL (compatibility)"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:146
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:155
 msgid "Default (auto)"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:147
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:156
 msgid "Force Stereo"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:148
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:157
 msgid "Optical Surround"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:149
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:158
 msgid "HDMI Passthrough"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:152
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:161
 msgid "Unset"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:153
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:162
 msgid "Dubbed (shows only)"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:154
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:163
 msgid "Subbed (shows only)"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:155
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:164
 msgid "Dubbed (all)"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:156
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:165
 msgid "Subbed (all)"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:157
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:166
 msgid "Custom (set in config)"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:162
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:171
 msgid "Download Folder"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:163
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:172
 msgid "Prefer Downloaded Copy"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:164
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:173
 msgid "Automatically Download Upcoming Episodes"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:165
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:174
 msgid "Include Next Up"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:166
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:175
 msgid "Next Up Entries to Consider"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:167
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:176
 msgid "Episodes to Keep Ahead (0 = off)"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:168
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:177
 msgid "Storage Limit for Automatic Downloads (GB)"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:169
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:178
 msgid "Delete Automatic Downloads Once Watched"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:170
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:179
 msgid "Delete Unwatched After (days, 0 = never)"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:171
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:180
 msgid "Check Every (minutes)"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:172
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:181
 msgid "Close to Tray (keep running)"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:173
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:182
 msgid "Keep Running in Background"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:174
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:183
 msgid "Remember Window Size"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:175
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:184
 msgid "Player Controls Style"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:176
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:185
 msgid "Show What You're Watching in Discord"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:177
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:186
 msgid "Interface Scale"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:178
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:187
 msgid "Cast-target mode (no library browsing)"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:179
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:188
 msgid "Casting Opens the Library Browser"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:180
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:189
 msgid "Fullscreen Library Browser"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:181
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:190
 msgid "Always Bind Arrow Keys to Player Controls"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:182
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:191
 msgid "Player Controls Activation Key"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:183
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:192
 msgid "Audio Output Mode"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:184
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:193
 msgid "Audio Output Device"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:185
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:194
 msgid "Take the Device Exclusively"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:187
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:196
 msgid "Enable Video Playback Profiles"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:188
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:197
 msgid "Profile Group"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:189
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:198
 msgid "Remember Last Used Profile"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:190
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:199
 msgid "Graphics API for Shaders"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:191
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:200
 msgid "Pass Through AC3"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:192
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:201
 msgid "Pass Through DTS"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:193
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:202
 msgid "Pass Through E-AC3"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:194
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:203
 msgid "Pass Through DTS-HD"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:195
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:204
 msgid "Pass Through TrueHD"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:196
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:205
 msgid "Re-encode Others to AC3"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:202
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:213
 msgid ""
-"MPV keybinds are used by default. Press ENTER to drive the player controls "
-"by keyboard."
+"With \"Start Minimized\" and \"Fullscreen\" this is the classic cast-target "
+"setup: the app waits out of the way, plays fullscreen when something casts "
+"to it, and goes back to waiting when the video ends or you press Q."
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:204
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:227
+msgid ""
+"Off means command-line mode: no window, no system tray and no settings "
+"screen, so the only way back is editing conf.json by hand. It is not how you "
+"get MPV's own on-screen controls — \"Player Controls Style\" under Interface "
+"does that."
+msgstr ""
+
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:234
+msgid ""
+"Show only what is cast to this machine — the library, including this "
+"settings screen, can't be reached from here. Without a system tray icon the "
+"only way back is editing conf.json. For the classic cast-target setup you "
+"want the Interface settings instead; this is for a shared TV nobody should "
+"be able to browse from."
+msgstr ""
+
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:240
+msgid ""
+"Requires restart to change. MPV keybinds are used by default. Press ENTER to "
+"drive the player controls by keyboard."
+msgstr ""
+
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:242
 msgid ""
 "Pixels one wheel notch scrolls. The scrollbar glides while the content snaps "
 "to the nearest row, so a trackpad or trackball no longer overshoots. Raise "
 "it to scroll faster, lower it for finer control."
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:209
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:247
 msgid ""
 "Make each wheel notch jump exactly one row (or one home-screen section) "
 "instead of gliding. Turn this on if you prefer the older stepped scrolling."
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:217
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:255
 msgid "Discord Rich Presence. Takes effect after a restart."
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:219
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:257
 msgid ""
 "Leave this to Default unless setting up passthrough. Note some audio servers "
 "like Pipewire don't like passthrough and will need to be disabled for a card "
@@ -987,57 +1017,57 @@ msgid ""
 "silence otherwise, but results may vary."
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:225
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:263
 msgid ""
 "Stop anything else using the device while playing. Needed for passthrough on "
 "some systems, and it means other applications will be silent."
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:228
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:266
 msgid ""
 "Page the library and music tile grids instead of scrolling: each page is one "
 "screenful with First / Previous / Next / Last controls and a page number you "
 "can type into. Easier than precise scrolling on a trackpad."
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:232
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:270
 msgid ""
 "Takes effect after a restart. \"Follow display\" uses the scale your desktop "
 "reports, which is 100% on X11."
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:234
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:272
 msgid ""
 "\"Default\" changes nothing and lets MPV (and your own mpv.conf) decide. "
 "Pick a mode only if you are sending audio to a receiver."
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:237
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:275
 msgid ""
 "Audio your receiver can't be sent directly is encoded to AC3, which is the "
 "only way surround fits down an optical cable. Turn this off if the encoder "
 "causes audio delay — those tracks become stereo instead."
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:242
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:280
 msgid ""
 "\"hq\" offers heavier profiles. Pick it if you have a fast graphics card."
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:244
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:282
 msgid ""
 "Leave on Automatic unless video breaks when a profile is loaded. This only "
 "applies while a profile is active, and OpenGL can cost you HDR output."
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:248
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:286
 msgid ""
 "Evens out loud effects and quiet dialogue. This turns passthrough off while "
 "it is enabled, because the volume has to be adjusted before your receiver "
 "gets the audio."
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:330
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:368
 msgid "Advanced"
 msgstr ""
 
@@ -1239,7 +1269,7 @@ msgid "Automatic"
 msgstr ""
 
 #: jellyfin_mpv_shim/mpvtk_browser/downloads.py:51
-#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1355
+#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1288
 msgid "Episodes"
 msgstr ""
 
@@ -1248,7 +1278,7 @@ msgid "Season %s"
 msgstr ""
 
 #: jellyfin_mpv_shim/mpvtk_browser/downloads.py:52
-#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1351
+#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1284
 msgid "Specials"
 msgstr ""
 
@@ -1271,7 +1301,7 @@ msgid "Failed"
 msgstr "Fallo"
 
 #: jellyfin_mpv_shim/mpvtk_browser/downloads.py:185
-#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1105
+#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1038
 msgid "Playlist"
 msgstr ""
 
@@ -1283,30 +1313,30 @@ msgstr ""
 msgid "Movies & Videos"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/home_sections.py:103
+#: jellyfin_mpv_shim/mpvtk_browser/home_sections.py:104
 msgid "My Media"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/home_sections.py:104
-#: jellyfin_mpv_shim/mpvtk_browser/repository.py:352
+#: jellyfin_mpv_shim/mpvtk_browser/home_sections.py:105
+#: jellyfin_mpv_shim/mpvtk_browser/repository.py:350
 msgid "Continue Watching"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/home_sections.py:105
-#: jellyfin_mpv_shim/mpvtk_browser/repository.py:359
+#: jellyfin_mpv_shim/mpvtk_browser/home_sections.py:106
+#: jellyfin_mpv_shim/mpvtk_browser/repository.py:357
 msgid "Continue Listening"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/home_sections.py:106
-#: jellyfin_mpv_shim/mpvtk_browser/repository.py:366
+#: jellyfin_mpv_shim/mpvtk_browser/home_sections.py:107
+#: jellyfin_mpv_shim/mpvtk_browser/repository.py:364
 msgid "Next Up"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/home_sections.py:107
+#: jellyfin_mpv_shim/mpvtk_browser/home_sections.py:108
 msgid "Recently Added"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/home_sections.py:108
+#: jellyfin_mpv_shim/mpvtk_browser/home_sections.py:109
 msgid "Live TV"
 msgstr ""
 
@@ -1539,52 +1569,52 @@ msgstr ""
 "No se pudo agregar el servidor.\n"
 "Porfsvor revise su información de conexión."
 
-#: jellyfin_mpv_shim/mpvtk_browser/repository.py:390
+#: jellyfin_mpv_shim/mpvtk_browser/repository.py:386
 msgid "On Now"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/repository.py:411
+#: jellyfin_mpv_shim/mpvtk_browser/repository.py:407
 msgid "Latest %s"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1119
+#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1052
 msgid "Downloaded"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1138
+#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1071
 msgid "Movies"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1143
+#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1076
 msgid "Videos"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1147
+#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1080
 msgid "TV Shows"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1151
+#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1084
 msgid "Playlists"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1168
-#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1441
+#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1101
+#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1374
 msgid "Series"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1212
+#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1145
 msgid "Downloaded Movies"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1216
+#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1149
 msgid "Downloaded Videos"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1220
+#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1153
 msgid "Downloaded Shows"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1353
+#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1286
 msgid "Season %d"
 msgstr ""
 

--- a/jellyfin_mpv_shim/messages/et/LC_MESSAGES/base.po
+++ b/jellyfin_mpv_shim/messages/et/LC_MESSAGES/base.po
@@ -5,7 +5,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2026-07-25 17:21-0400\n"
+"POT-Creation-Date: 2026-07-26 12:03-0400\n"
 "PO-Revision-Date: 2026-06-14 06:33+0000\n"
 "Last-Translator: rimasx <riks_12@hot.ee>\n"
 "Language-Team: Estonian <https://translate.jellyfin.org/projects/jellyfin/"
@@ -252,7 +252,7 @@ msgid "Select Subtitle Track"
 msgstr "Vali subtiitririba"
 
 #: jellyfin_mpv_shim/menu.py:341
-#: jellyfin_mpv_shim/mpvtk_browser/home_sections.py:102
+#: jellyfin_mpv_shim/mpvtk_browser/home_sections.py:103
 #: jellyfin_mpv_shim/osc_bridge.py:81 jellyfin_mpv_shim/osc_bridge.py:82
 #: jellyfin_mpv_shim/osc_bridge.py:104 jellyfin_mpv_shim/osc_bridge.py:140
 msgid "None"
@@ -403,7 +403,7 @@ msgstr "Küsi alati alguse- ja lõputiitrite vahelejätmise kohta"
 msgid "Enable thumbnail previews"
 msgstr "Luba pisipiltide eelvaade"
 
-#: jellyfin_mpv_shim/menu.py:609 jellyfin_mpv_shim/mpvtk_browser/config.py:186
+#: jellyfin_mpv_shim/menu.py:609 jellyfin_mpv_shim/mpvtk_browser/config.py:195
 #: jellyfin_mpv_shim/mpvtk_browser/hud.py:375
 msgid "Night Mode (Auto Volume Adj)"
 msgstr ""
@@ -702,310 +702,334 @@ msgstr ""
 msgid "Or switch to another user"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/cast.py:317
+#: jellyfin_mpv_shim/mpvtk_browser/cast.py:314
 msgid "Ready to cast"
 msgstr "Ülekandeks valmis"
 
-#: jellyfin_mpv_shim/mpvtk_browser/cast.py:318
+#: jellyfin_mpv_shim/mpvtk_browser/cast.py:315
 #, fuzzy
 #| msgid "Select your media in Jellyfin and play it here"
 msgid "Select your media in Jellyfin and play it here."
 msgstr "Vali oma meedia Jellyfinis ja esita seda siin"
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:74
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:83
 msgid "Interface"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:83
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:92
 msgid "Playback"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:88
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:97
 msgid "Audio"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:92
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:101
 msgid "Subtitles & Languages"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:97
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:106
 #, fuzzy
 #| msgid " (Transcode)"
 msgid "Transcoding"
 msgstr " (Teisendamine)"
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:102
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:111
 msgid "Video Enhancement"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:104
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:113
 #, fuzzy
 #| msgid "Seek to Skip Credits"
 msgid "Skip Intro / Credits"
 msgstr "Otsi tiitrite vahelejätmist"
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:107
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:116
 msgid "Library Browser"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:109
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:118
 msgid "Downloads"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:128
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:137
 msgid "Jellyfin UI"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:129
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:138
 msgid "MPV UI with thumbnails"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:130
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:139
 msgid "MPV built-in default"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:133
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:142
 msgid "Follow display"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:134
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:143
 msgid "100% (no scaling)"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:135
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:144
 msgid "125%"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:136
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:145
 msgid "150%"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:137
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:146
 msgid "200%"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:140
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:149
 msgid "Automatic (recommended)"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:141
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:150
 msgid "Vulkan"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:142
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:151
 msgid "Direct3D 11 (Windows only)"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:143
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:152
 msgid "OpenGL (compatibility)"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:146
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:155
 msgid "Default (auto)"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:147
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:156
 msgid "Force Stereo"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:148
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:157
 msgid "Optical Surround"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:149
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:158
 msgid "HDMI Passthrough"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:152
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:161
 msgid "Unset"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:153
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:162
 msgid "Dubbed (shows only)"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:154
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:163
 msgid "Subbed (shows only)"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:155
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:164
 msgid "Dubbed (all)"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:156
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:165
 msgid "Subbed (all)"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:157
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:166
 msgid "Custom (set in config)"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:162
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:171
 msgid "Download Folder"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:163
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:172
 msgid "Prefer Downloaded Copy"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:164
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:173
 msgid "Automatically Download Upcoming Episodes"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:165
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:174
 msgid "Include Next Up"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:166
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:175
 msgid "Next Up Entries to Consider"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:167
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:176
 msgid "Episodes to Keep Ahead (0 = off)"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:168
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:177
 msgid "Storage Limit for Automatic Downloads (GB)"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:169
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:178
 #, fuzzy
 #| msgid "Remove Server"
 msgid "Delete Automatic Downloads Once Watched"
 msgstr "Eemalda server"
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:170
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:179
 msgid "Delete Unwatched After (days, 0 = never)"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:171
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:180
 msgid "Check Every (minutes)"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:172
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:181
 msgid "Close to Tray (keep running)"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:173
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:182
 msgid "Keep Running in Background"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:174
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:183
 msgid "Remember Window Size"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:175
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:184
 msgid "Player Controls Style"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:176
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:185
 msgid "Show What You're Watching in Discord"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:177
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:186
 msgid "Interface Scale"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:178
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:187
 msgid "Cast-target mode (no library browsing)"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:179
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:188
 msgid "Casting Opens the Library Browser"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:180
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:189
 msgid "Fullscreen Library Browser"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:181
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:190
 msgid "Always Bind Arrow Keys to Player Controls"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:182
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:191
 msgid "Player Controls Activation Key"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:183
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:192
 msgid "Audio Output Mode"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:184
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:193
 msgid "Audio Output Device"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:185
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:194
 msgid "Take the Device Exclusively"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:187
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:196
 #, fuzzy
 #| msgid "Video Playback Profiles"
 msgid "Enable Video Playback Profiles"
 msgstr "Video taasesituse profiilid"
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:188
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:197
 #, fuzzy
 #| msgid "New Group"
 msgid "Profile Group"
 msgstr "Uus rühm"
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:189
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:198
 msgid "Remember Last Used Profile"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:190
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:199
 msgid "Graphics API for Shaders"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:191
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:200
 msgid "Pass Through AC3"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:192
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:201
 msgid "Pass Through DTS"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:193
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:202
 msgid "Pass Through E-AC3"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:194
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:203
 msgid "Pass Through DTS-HD"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:195
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:204
 msgid "Pass Through TrueHD"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:196
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:205
 msgid "Re-encode Others to AC3"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:202
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:213
 msgid ""
-"MPV keybinds are used by default. Press ENTER to drive the player controls "
-"by keyboard."
+"With \"Start Minimized\" and \"Fullscreen\" this is the classic cast-target "
+"setup: the app waits out of the way, plays fullscreen when something casts "
+"to it, and goes back to waiting when the video ends or you press Q."
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:204
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:227
+msgid ""
+"Off means command-line mode: no window, no system tray and no settings "
+"screen, so the only way back is editing conf.json by hand. It is not how you "
+"get MPV's own on-screen controls — \"Player Controls Style\" under Interface "
+"does that."
+msgstr ""
+
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:234
+msgid ""
+"Show only what is cast to this machine — the library, including this "
+"settings screen, can't be reached from here. Without a system tray icon the "
+"only way back is editing conf.json. For the classic cast-target setup you "
+"want the Interface settings instead; this is for a shared TV nobody should "
+"be able to browse from."
+msgstr ""
+
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:240
+msgid ""
+"Requires restart to change. MPV keybinds are used by default. Press ENTER to "
+"drive the player controls by keyboard."
+msgstr ""
+
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:242
 msgid ""
 "Pixels one wheel notch scrolls. The scrollbar glides while the content snaps "
 "to the nearest row, so a trackpad or trackball no longer overshoots. Raise "
 "it to scroll faster, lower it for finer control."
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:209
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:247
 msgid ""
 "Make each wheel notch jump exactly one row (or one home-screen section) "
 "instead of gliding. Turn this on if you prefer the older stepped scrolling."
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:217
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:255
 msgid "Discord Rich Presence. Takes effect after a restart."
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:219
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:257
 msgid ""
 "Leave this to Default unless setting up passthrough. Note some audio servers "
 "like Pipewire don't like passthrough and will need to be disabled for a card "
@@ -1013,57 +1037,57 @@ msgid ""
 "silence otherwise, but results may vary."
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:225
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:263
 msgid ""
 "Stop anything else using the device while playing. Needed for passthrough on "
 "some systems, and it means other applications will be silent."
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:228
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:266
 msgid ""
 "Page the library and music tile grids instead of scrolling: each page is one "
 "screenful with First / Previous / Next / Last controls and a page number you "
 "can type into. Easier than precise scrolling on a trackpad."
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:232
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:270
 msgid ""
 "Takes effect after a restart. \"Follow display\" uses the scale your desktop "
 "reports, which is 100% on X11."
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:234
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:272
 msgid ""
 "\"Default\" changes nothing and lets MPV (and your own mpv.conf) decide. "
 "Pick a mode only if you are sending audio to a receiver."
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:237
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:275
 msgid ""
 "Audio your receiver can't be sent directly is encoded to AC3, which is the "
 "only way surround fits down an optical cable. Turn this off if the encoder "
 "causes audio delay — those tracks become stereo instead."
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:242
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:280
 msgid ""
 "\"hq\" offers heavier profiles. Pick it if you have a fast graphics card."
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:244
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:282
 msgid ""
 "Leave on Automatic unless video breaks when a profile is loaded. This only "
 "applies while a profile is active, and OpenGL can cost you HDR output."
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:248
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:286
 msgid ""
 "Evens out loud effects and quiet dialogue. This turns passthrough off while "
 "it is enabled, because the volume has to be adjusted before your receiver "
 "gets the audio."
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:330
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:368
 msgid "Advanced"
 msgstr ""
 
@@ -1289,7 +1313,7 @@ msgid "Automatic"
 msgstr "Automaatne"
 
 #: jellyfin_mpv_shim/mpvtk_browser/downloads.py:51
-#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1355
+#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1288
 msgid "Episodes"
 msgstr ""
 
@@ -1298,7 +1322,7 @@ msgid "Season %s"
 msgstr ""
 
 #: jellyfin_mpv_shim/mpvtk_browser/downloads.py:52
-#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1351
+#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1284
 msgid "Specials"
 msgstr ""
 
@@ -1323,7 +1347,7 @@ msgid "Failed"
 msgstr "Nurjumine"
 
 #: jellyfin_mpv_shim/mpvtk_browser/downloads.py:185
-#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1105
+#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1038
 msgid "Playlist"
 msgstr ""
 
@@ -1335,30 +1359,30 @@ msgstr ""
 msgid "Movies & Videos"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/home_sections.py:103
+#: jellyfin_mpv_shim/mpvtk_browser/home_sections.py:104
 msgid "My Media"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/home_sections.py:104
-#: jellyfin_mpv_shim/mpvtk_browser/repository.py:352
+#: jellyfin_mpv_shim/mpvtk_browser/home_sections.py:105
+#: jellyfin_mpv_shim/mpvtk_browser/repository.py:350
 msgid "Continue Watching"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/home_sections.py:105
-#: jellyfin_mpv_shim/mpvtk_browser/repository.py:359
+#: jellyfin_mpv_shim/mpvtk_browser/home_sections.py:106
+#: jellyfin_mpv_shim/mpvtk_browser/repository.py:357
 msgid "Continue Listening"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/home_sections.py:106
-#: jellyfin_mpv_shim/mpvtk_browser/repository.py:366
+#: jellyfin_mpv_shim/mpvtk_browser/home_sections.py:107
+#: jellyfin_mpv_shim/mpvtk_browser/repository.py:364
 msgid "Next Up"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/home_sections.py:107
+#: jellyfin_mpv_shim/mpvtk_browser/home_sections.py:108
 msgid "Recently Added"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/home_sections.py:108
+#: jellyfin_mpv_shim/mpvtk_browser/home_sections.py:109
 msgid "Live TV"
 msgstr ""
 
@@ -1611,52 +1635,52 @@ msgstr ""
 "Serveri lisamine nurjus.\n"
 "Kontrolli ühenduse andmeid."
 
-#: jellyfin_mpv_shim/mpvtk_browser/repository.py:390
+#: jellyfin_mpv_shim/mpvtk_browser/repository.py:386
 msgid "On Now"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/repository.py:411
+#: jellyfin_mpv_shim/mpvtk_browser/repository.py:407
 msgid "Latest %s"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1119
+#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1052
 msgid "Downloaded"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1138
+#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1071
 msgid "Movies"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1143
+#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1076
 msgid "Videos"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1147
+#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1080
 msgid "TV Shows"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1151
+#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1084
 msgid "Playlists"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1168
-#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1441
+#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1101
+#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1374
 msgid "Series"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1212
+#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1145
 msgid "Downloaded Movies"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1216
+#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1149
 msgid "Downloaded Videos"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1220
+#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1153
 msgid "Downloaded Shows"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1353
+#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1286
 msgid "Season %d"
 msgstr ""
 

--- a/jellyfin_mpv_shim/messages/eu/LC_MESSAGES/base.po
+++ b/jellyfin_mpv_shim/messages/eu/LC_MESSAGES/base.po
@@ -5,7 +5,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2026-07-25 17:21-0400\n"
+"POT-Creation-Date: 2026-07-26 12:03-0400\n"
 "PO-Revision-Date: 2026-05-15 14:08+0000\n"
 "Last-Translator: \"Thadah D. Denyse\" <thadahdenyse@protonmail.com>\n"
 "Language-Team: Basque <https://translate.jellyfin.org/projects/jellyfin/"
@@ -252,7 +252,7 @@ msgid "Select Subtitle Track"
 msgstr "Azpititulu-Pista Aukeratu"
 
 #: jellyfin_mpv_shim/menu.py:341
-#: jellyfin_mpv_shim/mpvtk_browser/home_sections.py:102
+#: jellyfin_mpv_shim/mpvtk_browser/home_sections.py:103
 #: jellyfin_mpv_shim/osc_bridge.py:81 jellyfin_mpv_shim/osc_bridge.py:82
 #: jellyfin_mpv_shim/osc_bridge.py:104 jellyfin_mpv_shim/osc_bridge.py:140
 msgid "None"
@@ -403,7 +403,7 @@ msgstr "Kredituak Saltatzeko Galdetu"
 msgid "Enable thumbnail previews"
 msgstr "Aurreikusi-Miniaturak Aktibatu"
 
-#: jellyfin_mpv_shim/menu.py:609 jellyfin_mpv_shim/mpvtk_browser/config.py:186
+#: jellyfin_mpv_shim/menu.py:609 jellyfin_mpv_shim/mpvtk_browser/config.py:195
 #: jellyfin_mpv_shim/mpvtk_browser/hud.py:375
 msgid "Night Mode (Auto Volume Adj)"
 msgstr ""
@@ -702,310 +702,334 @@ msgstr ""
 msgid "Or switch to another user"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/cast.py:317
+#: jellyfin_mpv_shim/mpvtk_browser/cast.py:314
 msgid "Ready to cast"
 msgstr "Igortzeko prest"
 
-#: jellyfin_mpv_shim/mpvtk_browser/cast.py:318
+#: jellyfin_mpv_shim/mpvtk_browser/cast.py:315
 #, fuzzy
 #| msgid "Select your media in Jellyfin and play it here"
 msgid "Select your media in Jellyfin and play it here."
 msgstr "Aukeratu zure multimedia edukiak Jellyfinen eta hemen erreproduzitu"
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:74
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:83
 msgid "Interface"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:83
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:92
 msgid "Playback"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:88
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:97
 msgid "Audio"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:92
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:101
 msgid "Subtitles & Languages"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:97
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:106
 #, fuzzy
 #| msgid " (Transcode)"
 msgid "Transcoding"
 msgstr " (Transkodifikatu)"
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:102
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:111
 msgid "Video Enhancement"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:104
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:113
 #, fuzzy
 #| msgid "Seek to Skip Credits"
 msgid "Skip Intro / Credits"
 msgstr "Kredituak Saltatzen Saiatu"
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:107
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:116
 msgid "Library Browser"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:109
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:118
 msgid "Downloads"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:128
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:137
 msgid "Jellyfin UI"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:129
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:138
 msgid "MPV UI with thumbnails"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:130
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:139
 msgid "MPV built-in default"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:133
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:142
 msgid "Follow display"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:134
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:143
 msgid "100% (no scaling)"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:135
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:144
 msgid "125%"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:136
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:145
 msgid "150%"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:137
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:146
 msgid "200%"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:140
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:149
 msgid "Automatic (recommended)"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:141
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:150
 msgid "Vulkan"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:142
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:151
 msgid "Direct3D 11 (Windows only)"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:143
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:152
 msgid "OpenGL (compatibility)"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:146
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:155
 msgid "Default (auto)"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:147
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:156
 msgid "Force Stereo"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:148
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:157
 msgid "Optical Surround"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:149
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:158
 msgid "HDMI Passthrough"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:152
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:161
 msgid "Unset"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:153
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:162
 msgid "Dubbed (shows only)"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:154
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:163
 msgid "Subbed (shows only)"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:155
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:164
 msgid "Dubbed (all)"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:156
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:165
 msgid "Subbed (all)"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:157
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:166
 msgid "Custom (set in config)"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:162
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:171
 msgid "Download Folder"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:163
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:172
 msgid "Prefer Downloaded Copy"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:164
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:173
 msgid "Automatically Download Upcoming Episodes"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:165
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:174
 msgid "Include Next Up"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:166
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:175
 msgid "Next Up Entries to Consider"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:167
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:176
 msgid "Episodes to Keep Ahead (0 = off)"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:168
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:177
 msgid "Storage Limit for Automatic Downloads (GB)"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:169
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:178
 #, fuzzy
 #| msgid "Remove Server"
 msgid "Delete Automatic Downloads Once Watched"
 msgstr "Zerbitzaria ezabatu"
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:170
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:179
 msgid "Delete Unwatched After (days, 0 = never)"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:171
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:180
 msgid "Check Every (minutes)"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:172
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:181
 msgid "Close to Tray (keep running)"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:173
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:182
 msgid "Keep Running in Background"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:174
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:183
 msgid "Remember Window Size"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:175
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:184
 msgid "Player Controls Style"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:176
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:185
 msgid "Show What You're Watching in Discord"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:177
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:186
 msgid "Interface Scale"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:178
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:187
 msgid "Cast-target mode (no library browsing)"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:179
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:188
 msgid "Casting Opens the Library Browser"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:180
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:189
 msgid "Fullscreen Library Browser"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:181
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:190
 msgid "Always Bind Arrow Keys to Player Controls"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:182
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:191
 msgid "Player Controls Activation Key"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:183
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:192
 msgid "Audio Output Mode"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:184
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:193
 msgid "Audio Output Device"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:185
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:194
 msgid "Take the Device Exclusively"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:187
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:196
 #, fuzzy
 #| msgid "Video Playback Profiles"
 msgid "Enable Video Playback Profiles"
 msgstr "Bideo Erreprodukzio Profilak"
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:188
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:197
 #, fuzzy
 #| msgid "New Group"
 msgid "Profile Group"
 msgstr "Talde Berria"
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:189
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:198
 msgid "Remember Last Used Profile"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:190
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:199
 msgid "Graphics API for Shaders"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:191
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:200
 msgid "Pass Through AC3"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:192
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:201
 msgid "Pass Through DTS"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:193
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:202
 msgid "Pass Through E-AC3"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:194
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:203
 msgid "Pass Through DTS-HD"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:195
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:204
 msgid "Pass Through TrueHD"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:196
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:205
 msgid "Re-encode Others to AC3"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:202
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:213
 msgid ""
-"MPV keybinds are used by default. Press ENTER to drive the player controls "
-"by keyboard."
+"With \"Start Minimized\" and \"Fullscreen\" this is the classic cast-target "
+"setup: the app waits out of the way, plays fullscreen when something casts "
+"to it, and goes back to waiting when the video ends or you press Q."
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:204
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:227
+msgid ""
+"Off means command-line mode: no window, no system tray and no settings "
+"screen, so the only way back is editing conf.json by hand. It is not how you "
+"get MPV's own on-screen controls — \"Player Controls Style\" under Interface "
+"does that."
+msgstr ""
+
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:234
+msgid ""
+"Show only what is cast to this machine — the library, including this "
+"settings screen, can't be reached from here. Without a system tray icon the "
+"only way back is editing conf.json. For the classic cast-target setup you "
+"want the Interface settings instead; this is for a shared TV nobody should "
+"be able to browse from."
+msgstr ""
+
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:240
+msgid ""
+"Requires restart to change. MPV keybinds are used by default. Press ENTER to "
+"drive the player controls by keyboard."
+msgstr ""
+
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:242
 msgid ""
 "Pixels one wheel notch scrolls. The scrollbar glides while the content snaps "
 "to the nearest row, so a trackpad or trackball no longer overshoots. Raise "
 "it to scroll faster, lower it for finer control."
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:209
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:247
 msgid ""
 "Make each wheel notch jump exactly one row (or one home-screen section) "
 "instead of gliding. Turn this on if you prefer the older stepped scrolling."
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:217
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:255
 msgid "Discord Rich Presence. Takes effect after a restart."
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:219
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:257
 msgid ""
 "Leave this to Default unless setting up passthrough. Note some audio servers "
 "like Pipewire don't like passthrough and will need to be disabled for a card "
@@ -1013,57 +1037,57 @@ msgid ""
 "silence otherwise, but results may vary."
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:225
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:263
 msgid ""
 "Stop anything else using the device while playing. Needed for passthrough on "
 "some systems, and it means other applications will be silent."
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:228
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:266
 msgid ""
 "Page the library and music tile grids instead of scrolling: each page is one "
 "screenful with First / Previous / Next / Last controls and a page number you "
 "can type into. Easier than precise scrolling on a trackpad."
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:232
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:270
 msgid ""
 "Takes effect after a restart. \"Follow display\" uses the scale your desktop "
 "reports, which is 100% on X11."
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:234
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:272
 msgid ""
 "\"Default\" changes nothing and lets MPV (and your own mpv.conf) decide. "
 "Pick a mode only if you are sending audio to a receiver."
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:237
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:275
 msgid ""
 "Audio your receiver can't be sent directly is encoded to AC3, which is the "
 "only way surround fits down an optical cable. Turn this off if the encoder "
 "causes audio delay — those tracks become stereo instead."
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:242
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:280
 msgid ""
 "\"hq\" offers heavier profiles. Pick it if you have a fast graphics card."
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:244
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:282
 msgid ""
 "Leave on Automatic unless video breaks when a profile is loaded. This only "
 "applies while a profile is active, and OpenGL can cost you HDR output."
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:248
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:286
 msgid ""
 "Evens out loud effects and quiet dialogue. This turns passthrough off while "
 "it is enabled, because the volume has to be adjusted before your receiver "
 "gets the audio."
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:330
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:368
 msgid "Advanced"
 msgstr ""
 
@@ -1289,7 +1313,7 @@ msgid "Automatic"
 msgstr "Automatikoa"
 
 #: jellyfin_mpv_shim/mpvtk_browser/downloads.py:51
-#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1355
+#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1288
 msgid "Episodes"
 msgstr ""
 
@@ -1298,7 +1322,7 @@ msgid "Season %s"
 msgstr ""
 
 #: jellyfin_mpv_shim/mpvtk_browser/downloads.py:52
-#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1351
+#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1284
 msgid "Specials"
 msgstr ""
 
@@ -1323,7 +1347,7 @@ msgid "Failed"
 msgstr "Errorea"
 
 #: jellyfin_mpv_shim/mpvtk_browser/downloads.py:185
-#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1105
+#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1038
 msgid "Playlist"
 msgstr ""
 
@@ -1335,30 +1359,30 @@ msgstr ""
 msgid "Movies & Videos"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/home_sections.py:103
+#: jellyfin_mpv_shim/mpvtk_browser/home_sections.py:104
 msgid "My Media"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/home_sections.py:104
-#: jellyfin_mpv_shim/mpvtk_browser/repository.py:352
+#: jellyfin_mpv_shim/mpvtk_browser/home_sections.py:105
+#: jellyfin_mpv_shim/mpvtk_browser/repository.py:350
 msgid "Continue Watching"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/home_sections.py:105
-#: jellyfin_mpv_shim/mpvtk_browser/repository.py:359
+#: jellyfin_mpv_shim/mpvtk_browser/home_sections.py:106
+#: jellyfin_mpv_shim/mpvtk_browser/repository.py:357
 msgid "Continue Listening"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/home_sections.py:106
-#: jellyfin_mpv_shim/mpvtk_browser/repository.py:366
+#: jellyfin_mpv_shim/mpvtk_browser/home_sections.py:107
+#: jellyfin_mpv_shim/mpvtk_browser/repository.py:364
 msgid "Next Up"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/home_sections.py:107
+#: jellyfin_mpv_shim/mpvtk_browser/home_sections.py:108
 msgid "Recently Added"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/home_sections.py:108
+#: jellyfin_mpv_shim/mpvtk_browser/home_sections.py:109
 msgid "Live TV"
 msgstr ""
 
@@ -1611,52 +1635,52 @@ msgstr ""
 "Ezin izan da zerbitzaria gehitu.\n"
 "Egiaztatu zure konexioaren informazioa."
 
-#: jellyfin_mpv_shim/mpvtk_browser/repository.py:390
+#: jellyfin_mpv_shim/mpvtk_browser/repository.py:386
 msgid "On Now"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/repository.py:411
+#: jellyfin_mpv_shim/mpvtk_browser/repository.py:407
 msgid "Latest %s"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1119
+#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1052
 msgid "Downloaded"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1138
+#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1071
 msgid "Movies"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1143
+#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1076
 msgid "Videos"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1147
+#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1080
 msgid "TV Shows"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1151
+#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1084
 msgid "Playlists"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1168
-#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1441
+#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1101
+#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1374
 msgid "Series"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1212
+#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1145
 msgid "Downloaded Movies"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1216
+#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1149
 msgid "Downloaded Videos"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1220
+#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1153
 msgid "Downloaded Shows"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1353
+#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1286
 msgid "Season %d"
 msgstr ""
 

--- a/jellyfin_mpv_shim/messages/fa/LC_MESSAGES/base.po
+++ b/jellyfin_mpv_shim/messages/fa/LC_MESSAGES/base.po
@@ -5,7 +5,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2026-07-25 17:21-0400\n"
+"POT-Creation-Date: 2026-07-26 12:03-0400\n"
 "PO-Revision-Date: 2025-08-23 13:20+0000\n"
 "Last-Translator: RadvinM <tworadvin@gmail.com>\n"
 "Language-Team: Persian <https://translate.jellyfin.org/projects/jellyfin/"
@@ -252,7 +252,7 @@ msgid "Select Subtitle Track"
 msgstr "زیرنویس را انتخاب کنید"
 
 #: jellyfin_mpv_shim/menu.py:341
-#: jellyfin_mpv_shim/mpvtk_browser/home_sections.py:102
+#: jellyfin_mpv_shim/mpvtk_browser/home_sections.py:103
 #: jellyfin_mpv_shim/osc_bridge.py:81 jellyfin_mpv_shim/osc_bridge.py:82
 #: jellyfin_mpv_shim/osc_bridge.py:104 jellyfin_mpv_shim/osc_bridge.py:140
 msgid "None"
@@ -403,7 +403,7 @@ msgstr "برای رد کردن تیتراژ پایانی سوال بپرس"
 msgid "Enable thumbnail previews"
 msgstr "فعال کردن پیش نمایش تصاویر"
 
-#: jellyfin_mpv_shim/menu.py:609 jellyfin_mpv_shim/mpvtk_browser/config.py:186
+#: jellyfin_mpv_shim/menu.py:609 jellyfin_mpv_shim/mpvtk_browser/config.py:195
 #: jellyfin_mpv_shim/mpvtk_browser/hud.py:375
 msgid "Night Mode (Auto Volume Adj)"
 msgstr ""
@@ -702,310 +702,334 @@ msgstr ""
 msgid "Or switch to another user"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/cast.py:317
+#: jellyfin_mpv_shim/mpvtk_browser/cast.py:314
 msgid "Ready to cast"
 msgstr "آماده انتقال تصویر"
 
-#: jellyfin_mpv_shim/mpvtk_browser/cast.py:318
+#: jellyfin_mpv_shim/mpvtk_browser/cast.py:315
 #, fuzzy
 #| msgid "Select your media in Jellyfin and play it here"
 msgid "Select your media in Jellyfin and play it here."
 msgstr "رسانه خود را در Jellyfin انتخاب کنید و آن را در اینجا پخش کنید"
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:74
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:83
 msgid "Interface"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:83
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:92
 msgid "Playback"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:88
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:97
 msgid "Audio"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:92
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:101
 msgid "Subtitles & Languages"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:97
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:106
 #, fuzzy
 #| msgid " (Transcode)"
 msgid "Transcoding"
 msgstr " (کد رمز)"
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:102
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:111
 msgid "Video Enhancement"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:104
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:113
 #, fuzzy
 #| msgid "Seek to Skip Credits"
 msgid "Skip Intro / Credits"
 msgstr "پرش برای رد کردن تیتراژ پایانی"
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:107
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:116
 msgid "Library Browser"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:109
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:118
 msgid "Downloads"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:128
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:137
 msgid "Jellyfin UI"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:129
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:138
 msgid "MPV UI with thumbnails"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:130
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:139
 msgid "MPV built-in default"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:133
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:142
 msgid "Follow display"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:134
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:143
 msgid "100% (no scaling)"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:135
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:144
 msgid "125%"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:136
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:145
 msgid "150%"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:137
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:146
 msgid "200%"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:140
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:149
 msgid "Automatic (recommended)"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:141
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:150
 msgid "Vulkan"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:142
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:151
 msgid "Direct3D 11 (Windows only)"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:143
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:152
 msgid "OpenGL (compatibility)"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:146
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:155
 msgid "Default (auto)"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:147
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:156
 msgid "Force Stereo"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:148
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:157
 msgid "Optical Surround"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:149
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:158
 msgid "HDMI Passthrough"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:152
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:161
 msgid "Unset"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:153
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:162
 msgid "Dubbed (shows only)"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:154
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:163
 msgid "Subbed (shows only)"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:155
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:164
 msgid "Dubbed (all)"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:156
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:165
 msgid "Subbed (all)"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:157
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:166
 msgid "Custom (set in config)"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:162
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:171
 msgid "Download Folder"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:163
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:172
 msgid "Prefer Downloaded Copy"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:164
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:173
 msgid "Automatically Download Upcoming Episodes"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:165
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:174
 msgid "Include Next Up"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:166
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:175
 msgid "Next Up Entries to Consider"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:167
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:176
 msgid "Episodes to Keep Ahead (0 = off)"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:168
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:177
 msgid "Storage Limit for Automatic Downloads (GB)"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:169
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:178
 #, fuzzy
 #| msgid "Remove Server"
 msgid "Delete Automatic Downloads Once Watched"
 msgstr "حذف سرور"
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:170
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:179
 msgid "Delete Unwatched After (days, 0 = never)"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:171
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:180
 msgid "Check Every (minutes)"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:172
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:181
 msgid "Close to Tray (keep running)"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:173
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:182
 msgid "Keep Running in Background"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:174
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:183
 msgid "Remember Window Size"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:175
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:184
 msgid "Player Controls Style"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:176
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:185
 msgid "Show What You're Watching in Discord"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:177
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:186
 msgid "Interface Scale"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:178
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:187
 msgid "Cast-target mode (no library browsing)"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:179
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:188
 msgid "Casting Opens the Library Browser"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:180
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:189
 msgid "Fullscreen Library Browser"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:181
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:190
 msgid "Always Bind Arrow Keys to Player Controls"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:182
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:191
 msgid "Player Controls Activation Key"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:183
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:192
 msgid "Audio Output Mode"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:184
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:193
 msgid "Audio Output Device"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:185
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:194
 msgid "Take the Device Exclusively"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:187
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:196
 #, fuzzy
 #| msgid "Video Playback Profiles"
 msgid "Enable Video Playback Profiles"
 msgstr "پروفایل های پخش ویدئو"
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:188
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:197
 #, fuzzy
 #| msgid "New Group"
 msgid "Profile Group"
 msgstr "گروه جدید"
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:189
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:198
 msgid "Remember Last Used Profile"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:190
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:199
 msgid "Graphics API for Shaders"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:191
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:200
 msgid "Pass Through AC3"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:192
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:201
 msgid "Pass Through DTS"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:193
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:202
 msgid "Pass Through E-AC3"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:194
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:203
 msgid "Pass Through DTS-HD"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:195
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:204
 msgid "Pass Through TrueHD"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:196
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:205
 msgid "Re-encode Others to AC3"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:202
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:213
 msgid ""
-"MPV keybinds are used by default. Press ENTER to drive the player controls "
-"by keyboard."
+"With \"Start Minimized\" and \"Fullscreen\" this is the classic cast-target "
+"setup: the app waits out of the way, plays fullscreen when something casts "
+"to it, and goes back to waiting when the video ends or you press Q."
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:204
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:227
+msgid ""
+"Off means command-line mode: no window, no system tray and no settings "
+"screen, so the only way back is editing conf.json by hand. It is not how you "
+"get MPV's own on-screen controls — \"Player Controls Style\" under Interface "
+"does that."
+msgstr ""
+
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:234
+msgid ""
+"Show only what is cast to this machine — the library, including this "
+"settings screen, can't be reached from here. Without a system tray icon the "
+"only way back is editing conf.json. For the classic cast-target setup you "
+"want the Interface settings instead; this is for a shared TV nobody should "
+"be able to browse from."
+msgstr ""
+
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:240
+msgid ""
+"Requires restart to change. MPV keybinds are used by default. Press ENTER to "
+"drive the player controls by keyboard."
+msgstr ""
+
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:242
 msgid ""
 "Pixels one wheel notch scrolls. The scrollbar glides while the content snaps "
 "to the nearest row, so a trackpad or trackball no longer overshoots. Raise "
 "it to scroll faster, lower it for finer control."
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:209
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:247
 msgid ""
 "Make each wheel notch jump exactly one row (or one home-screen section) "
 "instead of gliding. Turn this on if you prefer the older stepped scrolling."
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:217
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:255
 msgid "Discord Rich Presence. Takes effect after a restart."
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:219
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:257
 msgid ""
 "Leave this to Default unless setting up passthrough. Note some audio servers "
 "like Pipewire don't like passthrough and will need to be disabled for a card "
@@ -1013,57 +1037,57 @@ msgid ""
 "silence otherwise, but results may vary."
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:225
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:263
 msgid ""
 "Stop anything else using the device while playing. Needed for passthrough on "
 "some systems, and it means other applications will be silent."
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:228
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:266
 msgid ""
 "Page the library and music tile grids instead of scrolling: each page is one "
 "screenful with First / Previous / Next / Last controls and a page number you "
 "can type into. Easier than precise scrolling on a trackpad."
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:232
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:270
 msgid ""
 "Takes effect after a restart. \"Follow display\" uses the scale your desktop "
 "reports, which is 100% on X11."
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:234
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:272
 msgid ""
 "\"Default\" changes nothing and lets MPV (and your own mpv.conf) decide. "
 "Pick a mode only if you are sending audio to a receiver."
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:237
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:275
 msgid ""
 "Audio your receiver can't be sent directly is encoded to AC3, which is the "
 "only way surround fits down an optical cable. Turn this off if the encoder "
 "causes audio delay — those tracks become stereo instead."
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:242
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:280
 msgid ""
 "\"hq\" offers heavier profiles. Pick it if you have a fast graphics card."
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:244
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:282
 msgid ""
 "Leave on Automatic unless video breaks when a profile is loaded. This only "
 "applies while a profile is active, and OpenGL can cost you HDR output."
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:248
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:286
 msgid ""
 "Evens out loud effects and quiet dialogue. This turns passthrough off while "
 "it is enabled, because the volume has to be adjusted before your receiver "
 "gets the audio."
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:330
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:368
 msgid "Advanced"
 msgstr ""
 
@@ -1289,7 +1313,7 @@ msgid "Automatic"
 msgstr "خودکار"
 
 #: jellyfin_mpv_shim/mpvtk_browser/downloads.py:51
-#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1355
+#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1288
 msgid "Episodes"
 msgstr ""
 
@@ -1298,7 +1322,7 @@ msgid "Season %s"
 msgstr ""
 
 #: jellyfin_mpv_shim/mpvtk_browser/downloads.py:52
-#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1351
+#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1284
 msgid "Specials"
 msgstr ""
 
@@ -1323,7 +1347,7 @@ msgid "Failed"
 msgstr "شکست"
 
 #: jellyfin_mpv_shim/mpvtk_browser/downloads.py:185
-#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1105
+#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1038
 msgid "Playlist"
 msgstr ""
 
@@ -1335,30 +1359,30 @@ msgstr ""
 msgid "Movies & Videos"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/home_sections.py:103
+#: jellyfin_mpv_shim/mpvtk_browser/home_sections.py:104
 msgid "My Media"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/home_sections.py:104
-#: jellyfin_mpv_shim/mpvtk_browser/repository.py:352
+#: jellyfin_mpv_shim/mpvtk_browser/home_sections.py:105
+#: jellyfin_mpv_shim/mpvtk_browser/repository.py:350
 msgid "Continue Watching"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/home_sections.py:105
-#: jellyfin_mpv_shim/mpvtk_browser/repository.py:359
+#: jellyfin_mpv_shim/mpvtk_browser/home_sections.py:106
+#: jellyfin_mpv_shim/mpvtk_browser/repository.py:357
 msgid "Continue Listening"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/home_sections.py:106
-#: jellyfin_mpv_shim/mpvtk_browser/repository.py:366
+#: jellyfin_mpv_shim/mpvtk_browser/home_sections.py:107
+#: jellyfin_mpv_shim/mpvtk_browser/repository.py:364
 msgid "Next Up"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/home_sections.py:107
+#: jellyfin_mpv_shim/mpvtk_browser/home_sections.py:108
 msgid "Recently Added"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/home_sections.py:108
+#: jellyfin_mpv_shim/mpvtk_browser/home_sections.py:109
 msgid "Live TV"
 msgstr ""
 
@@ -1611,52 +1635,52 @@ msgstr ""
 "سرور اضافه نشد\n"
 "لطفاً اطلاعات اتصال خود را بررسی کنید."
 
-#: jellyfin_mpv_shim/mpvtk_browser/repository.py:390
+#: jellyfin_mpv_shim/mpvtk_browser/repository.py:386
 msgid "On Now"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/repository.py:411
+#: jellyfin_mpv_shim/mpvtk_browser/repository.py:407
 msgid "Latest %s"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1119
+#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1052
 msgid "Downloaded"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1138
+#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1071
 msgid "Movies"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1143
+#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1076
 msgid "Videos"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1147
+#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1080
 msgid "TV Shows"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1151
+#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1084
 msgid "Playlists"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1168
-#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1441
+#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1101
+#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1374
 msgid "Series"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1212
+#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1145
 msgid "Downloaded Movies"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1216
+#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1149
 msgid "Downloaded Videos"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1220
+#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1153
 msgid "Downloaded Shows"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1353
+#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1286
 msgid "Season %d"
 msgstr ""
 

--- a/jellyfin_mpv_shim/messages/fi/LC_MESSAGES/base.po
+++ b/jellyfin_mpv_shim/messages/fi/LC_MESSAGES/base.po
@@ -5,7 +5,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2026-07-25 17:21-0400\n"
+"POT-Creation-Date: 2026-07-26 12:03-0400\n"
 "PO-Revision-Date: 2024-12-14 12:01+0000\n"
 "Last-Translator: John Doe <diefor-93@hotmail.com>\n"
 "Language-Team: Finnish <https://translate.jellyfin.org/projects/jellyfin/"
@@ -252,7 +252,7 @@ msgid "Select Subtitle Track"
 msgstr "Valitse tekstitysraita"
 
 #: jellyfin_mpv_shim/menu.py:341
-#: jellyfin_mpv_shim/mpvtk_browser/home_sections.py:102
+#: jellyfin_mpv_shim/mpvtk_browser/home_sections.py:103
 #: jellyfin_mpv_shim/osc_bridge.py:81 jellyfin_mpv_shim/osc_bridge.py:82
 #: jellyfin_mpv_shim/osc_bridge.py:104 jellyfin_mpv_shim/osc_bridge.py:140
 msgid "None"
@@ -403,7 +403,7 @@ msgstr "Ehdota lopputekstien ohitusta"
 msgid "Enable thumbnail previews"
 msgstr "Käytä esikatselukuvia"
 
-#: jellyfin_mpv_shim/menu.py:609 jellyfin_mpv_shim/mpvtk_browser/config.py:186
+#: jellyfin_mpv_shim/menu.py:609 jellyfin_mpv_shim/mpvtk_browser/config.py:195
 #: jellyfin_mpv_shim/mpvtk_browser/hud.py:375
 msgid "Night Mode (Auto Volume Adj)"
 msgstr ""
@@ -702,310 +702,334 @@ msgstr ""
 msgid "Or switch to another user"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/cast.py:317
+#: jellyfin_mpv_shim/mpvtk_browser/cast.py:314
 msgid "Ready to cast"
 msgstr "Valmis suoratoistoon"
 
-#: jellyfin_mpv_shim/mpvtk_browser/cast.py:318
+#: jellyfin_mpv_shim/mpvtk_browser/cast.py:315
 #, fuzzy
 #| msgid "Select your media in Jellyfin and play it here"
 msgid "Select your media in Jellyfin and play it here."
 msgstr "Valitse mediasi Jellyfinissä ja toista se tässä"
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:74
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:83
 msgid "Interface"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:83
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:92
 msgid "Playback"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:88
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:97
 msgid "Audio"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:92
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:101
 msgid "Subtitles & Languages"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:97
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:106
 #, fuzzy
 #| msgid " (Transcode)"
 msgid "Transcoding"
 msgstr " (transkoodaus)"
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:102
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:111
 msgid "Video Enhancement"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:104
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:113
 #, fuzzy
 #| msgid "Seek to Skip Credits"
 msgid "Skip Intro / Credits"
 msgstr "Vaihda toistokohtaa lopputekstien ohittamiseksi"
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:107
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:116
 msgid "Library Browser"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:109
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:118
 msgid "Downloads"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:128
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:137
 msgid "Jellyfin UI"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:129
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:138
 msgid "MPV UI with thumbnails"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:130
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:139
 msgid "MPV built-in default"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:133
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:142
 msgid "Follow display"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:134
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:143
 msgid "100% (no scaling)"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:135
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:144
 msgid "125%"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:136
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:145
 msgid "150%"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:137
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:146
 msgid "200%"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:140
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:149
 msgid "Automatic (recommended)"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:141
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:150
 msgid "Vulkan"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:142
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:151
 msgid "Direct3D 11 (Windows only)"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:143
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:152
 msgid "OpenGL (compatibility)"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:146
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:155
 msgid "Default (auto)"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:147
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:156
 msgid "Force Stereo"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:148
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:157
 msgid "Optical Surround"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:149
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:158
 msgid "HDMI Passthrough"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:152
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:161
 msgid "Unset"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:153
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:162
 msgid "Dubbed (shows only)"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:154
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:163
 msgid "Subbed (shows only)"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:155
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:164
 msgid "Dubbed (all)"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:156
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:165
 msgid "Subbed (all)"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:157
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:166
 msgid "Custom (set in config)"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:162
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:171
 msgid "Download Folder"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:163
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:172
 msgid "Prefer Downloaded Copy"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:164
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:173
 msgid "Automatically Download Upcoming Episodes"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:165
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:174
 msgid "Include Next Up"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:166
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:175
 msgid "Next Up Entries to Consider"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:167
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:176
 msgid "Episodes to Keep Ahead (0 = off)"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:168
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:177
 msgid "Storage Limit for Automatic Downloads (GB)"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:169
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:178
 #, fuzzy
 #| msgid "Remove Server"
 msgid "Delete Automatic Downloads Once Watched"
 msgstr "Poista palvelin"
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:170
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:179
 msgid "Delete Unwatched After (days, 0 = never)"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:171
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:180
 msgid "Check Every (minutes)"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:172
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:181
 msgid "Close to Tray (keep running)"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:173
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:182
 msgid "Keep Running in Background"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:174
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:183
 msgid "Remember Window Size"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:175
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:184
 msgid "Player Controls Style"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:176
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:185
 msgid "Show What You're Watching in Discord"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:177
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:186
 msgid "Interface Scale"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:178
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:187
 msgid "Cast-target mode (no library browsing)"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:179
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:188
 msgid "Casting Opens the Library Browser"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:180
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:189
 msgid "Fullscreen Library Browser"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:181
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:190
 msgid "Always Bind Arrow Keys to Player Controls"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:182
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:191
 msgid "Player Controls Activation Key"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:183
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:192
 msgid "Audio Output Mode"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:184
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:193
 msgid "Audio Output Device"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:185
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:194
 msgid "Take the Device Exclusively"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:187
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:196
 #, fuzzy
 #| msgid "Video Playback Profiles"
 msgid "Enable Video Playback Profiles"
 msgstr "Video toistoprofiilit"
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:188
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:197
 #, fuzzy
 #| msgid "New Group"
 msgid "Profile Group"
 msgstr "Uusi ryhmä"
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:189
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:198
 msgid "Remember Last Used Profile"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:190
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:199
 msgid "Graphics API for Shaders"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:191
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:200
 msgid "Pass Through AC3"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:192
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:201
 msgid "Pass Through DTS"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:193
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:202
 msgid "Pass Through E-AC3"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:194
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:203
 msgid "Pass Through DTS-HD"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:195
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:204
 msgid "Pass Through TrueHD"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:196
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:205
 msgid "Re-encode Others to AC3"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:202
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:213
 msgid ""
-"MPV keybinds are used by default. Press ENTER to drive the player controls "
-"by keyboard."
+"With \"Start Minimized\" and \"Fullscreen\" this is the classic cast-target "
+"setup: the app waits out of the way, plays fullscreen when something casts "
+"to it, and goes back to waiting when the video ends or you press Q."
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:204
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:227
+msgid ""
+"Off means command-line mode: no window, no system tray and no settings "
+"screen, so the only way back is editing conf.json by hand. It is not how you "
+"get MPV's own on-screen controls — \"Player Controls Style\" under Interface "
+"does that."
+msgstr ""
+
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:234
+msgid ""
+"Show only what is cast to this machine — the library, including this "
+"settings screen, can't be reached from here. Without a system tray icon the "
+"only way back is editing conf.json. For the classic cast-target setup you "
+"want the Interface settings instead; this is for a shared TV nobody should "
+"be able to browse from."
+msgstr ""
+
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:240
+msgid ""
+"Requires restart to change. MPV keybinds are used by default. Press ENTER to "
+"drive the player controls by keyboard."
+msgstr ""
+
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:242
 msgid ""
 "Pixels one wheel notch scrolls. The scrollbar glides while the content snaps "
 "to the nearest row, so a trackpad or trackball no longer overshoots. Raise "
 "it to scroll faster, lower it for finer control."
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:209
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:247
 msgid ""
 "Make each wheel notch jump exactly one row (or one home-screen section) "
 "instead of gliding. Turn this on if you prefer the older stepped scrolling."
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:217
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:255
 msgid "Discord Rich Presence. Takes effect after a restart."
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:219
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:257
 msgid ""
 "Leave this to Default unless setting up passthrough. Note some audio servers "
 "like Pipewire don't like passthrough and will need to be disabled for a card "
@@ -1013,57 +1037,57 @@ msgid ""
 "silence otherwise, but results may vary."
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:225
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:263
 msgid ""
 "Stop anything else using the device while playing. Needed for passthrough on "
 "some systems, and it means other applications will be silent."
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:228
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:266
 msgid ""
 "Page the library and music tile grids instead of scrolling: each page is one "
 "screenful with First / Previous / Next / Last controls and a page number you "
 "can type into. Easier than precise scrolling on a trackpad."
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:232
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:270
 msgid ""
 "Takes effect after a restart. \"Follow display\" uses the scale your desktop "
 "reports, which is 100% on X11."
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:234
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:272
 msgid ""
 "\"Default\" changes nothing and lets MPV (and your own mpv.conf) decide. "
 "Pick a mode only if you are sending audio to a receiver."
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:237
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:275
 msgid ""
 "Audio your receiver can't be sent directly is encoded to AC3, which is the "
 "only way surround fits down an optical cable. Turn this off if the encoder "
 "causes audio delay — those tracks become stereo instead."
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:242
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:280
 msgid ""
 "\"hq\" offers heavier profiles. Pick it if you have a fast graphics card."
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:244
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:282
 msgid ""
 "Leave on Automatic unless video breaks when a profile is loaded. This only "
 "applies while a profile is active, and OpenGL can cost you HDR output."
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:248
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:286
 msgid ""
 "Evens out loud effects and quiet dialogue. This turns passthrough off while "
 "it is enabled, because the volume has to be adjusted before your receiver "
 "gets the audio."
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:330
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:368
 msgid "Advanced"
 msgstr ""
 
@@ -1289,7 +1313,7 @@ msgid "Automatic"
 msgstr "Automaattinen"
 
 #: jellyfin_mpv_shim/mpvtk_browser/downloads.py:51
-#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1355
+#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1288
 msgid "Episodes"
 msgstr ""
 
@@ -1298,7 +1322,7 @@ msgid "Season %s"
 msgstr ""
 
 #: jellyfin_mpv_shim/mpvtk_browser/downloads.py:52
-#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1351
+#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1284
 msgid "Specials"
 msgstr ""
 
@@ -1323,7 +1347,7 @@ msgid "Failed"
 msgstr "Epäonnistui"
 
 #: jellyfin_mpv_shim/mpvtk_browser/downloads.py:185
-#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1105
+#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1038
 msgid "Playlist"
 msgstr ""
 
@@ -1335,30 +1359,30 @@ msgstr ""
 msgid "Movies & Videos"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/home_sections.py:103
+#: jellyfin_mpv_shim/mpvtk_browser/home_sections.py:104
 msgid "My Media"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/home_sections.py:104
-#: jellyfin_mpv_shim/mpvtk_browser/repository.py:352
+#: jellyfin_mpv_shim/mpvtk_browser/home_sections.py:105
+#: jellyfin_mpv_shim/mpvtk_browser/repository.py:350
 msgid "Continue Watching"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/home_sections.py:105
-#: jellyfin_mpv_shim/mpvtk_browser/repository.py:359
+#: jellyfin_mpv_shim/mpvtk_browser/home_sections.py:106
+#: jellyfin_mpv_shim/mpvtk_browser/repository.py:357
 msgid "Continue Listening"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/home_sections.py:106
-#: jellyfin_mpv_shim/mpvtk_browser/repository.py:366
+#: jellyfin_mpv_shim/mpvtk_browser/home_sections.py:107
+#: jellyfin_mpv_shim/mpvtk_browser/repository.py:364
 msgid "Next Up"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/home_sections.py:107
+#: jellyfin_mpv_shim/mpvtk_browser/home_sections.py:108
 msgid "Recently Added"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/home_sections.py:108
+#: jellyfin_mpv_shim/mpvtk_browser/home_sections.py:109
 msgid "Live TV"
 msgstr ""
 
@@ -1611,52 +1635,52 @@ msgstr ""
 "Ei voitu lisätä palvelinta.\n"
 "Tarkista yhteyden tiedot."
 
-#: jellyfin_mpv_shim/mpvtk_browser/repository.py:390
+#: jellyfin_mpv_shim/mpvtk_browser/repository.py:386
 msgid "On Now"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/repository.py:411
+#: jellyfin_mpv_shim/mpvtk_browser/repository.py:407
 msgid "Latest %s"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1119
+#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1052
 msgid "Downloaded"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1138
+#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1071
 msgid "Movies"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1143
+#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1076
 msgid "Videos"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1147
+#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1080
 msgid "TV Shows"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1151
+#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1084
 msgid "Playlists"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1168
-#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1441
+#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1101
+#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1374
 msgid "Series"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1212
+#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1145
 msgid "Downloaded Movies"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1216
+#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1149
 msgid "Downloaded Videos"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1220
+#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1153
 msgid "Downloaded Shows"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1353
+#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1286
 msgid "Season %d"
 msgstr ""
 

--- a/jellyfin_mpv_shim/messages/fil/LC_MESSAGES/base.po
+++ b/jellyfin_mpv_shim/messages/fil/LC_MESSAGES/base.po
@@ -5,7 +5,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2026-07-25 17:21-0400\n"
+"POT-Creation-Date: 2026-07-26 12:03-0400\n"
 "PO-Revision-Date: 2024-02-10 16:30+0000\n"
 "Last-Translator: hatsiko panado <dedioskimoy96@gmail.com>\n"
 "Language-Team: Filipino <https://translate.jellyfin.org/projects/jellyfin/"
@@ -253,7 +253,7 @@ msgid "Select Subtitle Track"
 msgstr "Piliin ang Subtitle na Track"
 
 #: jellyfin_mpv_shim/menu.py:341
-#: jellyfin_mpv_shim/mpvtk_browser/home_sections.py:102
+#: jellyfin_mpv_shim/mpvtk_browser/home_sections.py:103
 #: jellyfin_mpv_shim/osc_bridge.py:81 jellyfin_mpv_shim/osc_bridge.py:82
 #: jellyfin_mpv_shim/osc_bridge.py:104 jellyfin_mpv_shim/osc_bridge.py:140
 msgid "None"
@@ -408,7 +408,7 @@ msgstr "Magtanong muna bago magskip ng intro"
 msgid "Enable thumbnail previews"
 msgstr "Magpakita ng thumbnail"
 
-#: jellyfin_mpv_shim/menu.py:609 jellyfin_mpv_shim/mpvtk_browser/config.py:186
+#: jellyfin_mpv_shim/menu.py:609 jellyfin_mpv_shim/mpvtk_browser/config.py:195
 #: jellyfin_mpv_shim/mpvtk_browser/hud.py:375
 msgid "Night Mode (Auto Volume Adj)"
 msgstr ""
@@ -707,310 +707,334 @@ msgstr ""
 msgid "Or switch to another user"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/cast.py:317
+#: jellyfin_mpv_shim/mpvtk_browser/cast.py:314
 msgid "Ready to cast"
 msgstr "Handa nang mag-cast"
 
-#: jellyfin_mpv_shim/mpvtk_browser/cast.py:318
+#: jellyfin_mpv_shim/mpvtk_browser/cast.py:315
 #, fuzzy
 #| msgid "Select your media in Jellyfin and play it here"
 msgid "Select your media in Jellyfin and play it here."
 msgstr "Piliin ang iyong media sa Jellyfin at i-play ito dito"
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:74
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:83
 msgid "Interface"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:83
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:92
 msgid "Playback"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:88
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:97
 msgid "Audio"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:92
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:101
 msgid "Subtitles & Languages"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:97
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:106
 #, fuzzy
 #| msgid " (Transcode)"
 msgid "Transcoding"
 msgstr " (Transcode)"
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:102
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:111
 msgid "Video Enhancement"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:104
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:113
 #, fuzzy
 #| msgid "Seek to Skip Intro"
 msgid "Skip Intro / Credits"
 msgstr "Iskip ang intro"
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:107
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:116
 msgid "Library Browser"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:109
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:118
 msgid "Downloads"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:128
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:137
 msgid "Jellyfin UI"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:129
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:138
 msgid "MPV UI with thumbnails"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:130
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:139
 msgid "MPV built-in default"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:133
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:142
 msgid "Follow display"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:134
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:143
 msgid "100% (no scaling)"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:135
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:144
 msgid "125%"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:136
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:145
 msgid "150%"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:137
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:146
 msgid "200%"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:140
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:149
 msgid "Automatic (recommended)"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:141
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:150
 msgid "Vulkan"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:142
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:151
 msgid "Direct3D 11 (Windows only)"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:143
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:152
 msgid "OpenGL (compatibility)"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:146
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:155
 msgid "Default (auto)"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:147
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:156
 msgid "Force Stereo"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:148
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:157
 msgid "Optical Surround"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:149
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:158
 msgid "HDMI Passthrough"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:152
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:161
 msgid "Unset"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:153
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:162
 msgid "Dubbed (shows only)"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:154
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:163
 msgid "Subbed (shows only)"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:155
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:164
 msgid "Dubbed (all)"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:156
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:165
 msgid "Subbed (all)"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:157
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:166
 msgid "Custom (set in config)"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:162
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:171
 msgid "Download Folder"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:163
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:172
 msgid "Prefer Downloaded Copy"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:164
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:173
 msgid "Automatically Download Upcoming Episodes"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:165
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:174
 msgid "Include Next Up"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:166
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:175
 msgid "Next Up Entries to Consider"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:167
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:176
 msgid "Episodes to Keep Ahead (0 = off)"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:168
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:177
 msgid "Storage Limit for Automatic Downloads (GB)"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:169
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:178
 #, fuzzy
 #| msgid "Remove Server"
 msgid "Delete Automatic Downloads Once Watched"
 msgstr "Alisin ang Server"
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:170
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:179
 msgid "Delete Unwatched After (days, 0 = never)"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:171
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:180
 msgid "Check Every (minutes)"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:172
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:181
 msgid "Close to Tray (keep running)"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:173
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:182
 msgid "Keep Running in Background"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:174
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:183
 msgid "Remember Window Size"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:175
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:184
 msgid "Player Controls Style"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:176
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:185
 msgid "Show What You're Watching in Discord"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:177
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:186
 msgid "Interface Scale"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:178
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:187
 msgid "Cast-target mode (no library browsing)"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:179
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:188
 msgid "Casting Opens the Library Browser"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:180
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:189
 msgid "Fullscreen Library Browser"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:181
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:190
 msgid "Always Bind Arrow Keys to Player Controls"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:182
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:191
 msgid "Player Controls Activation Key"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:183
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:192
 msgid "Audio Output Mode"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:184
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:193
 msgid "Audio Output Device"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:185
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:194
 msgid "Take the Device Exclusively"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:187
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:196
 #, fuzzy
 #| msgid "Video Playback Profiles"
 msgid "Enable Video Playback Profiles"
 msgstr "Mga Profile sa Pag-playback ng Video"
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:188
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:197
 #, fuzzy
 #| msgid "New Group"
 msgid "Profile Group"
 msgstr "Bagong grupo"
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:189
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:198
 msgid "Remember Last Used Profile"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:190
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:199
 msgid "Graphics API for Shaders"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:191
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:200
 msgid "Pass Through AC3"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:192
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:201
 msgid "Pass Through DTS"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:193
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:202
 msgid "Pass Through E-AC3"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:194
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:203
 msgid "Pass Through DTS-HD"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:195
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:204
 msgid "Pass Through TrueHD"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:196
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:205
 msgid "Re-encode Others to AC3"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:202
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:213
 msgid ""
-"MPV keybinds are used by default. Press ENTER to drive the player controls "
-"by keyboard."
+"With \"Start Minimized\" and \"Fullscreen\" this is the classic cast-target "
+"setup: the app waits out of the way, plays fullscreen when something casts "
+"to it, and goes back to waiting when the video ends or you press Q."
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:204
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:227
+msgid ""
+"Off means command-line mode: no window, no system tray and no settings "
+"screen, so the only way back is editing conf.json by hand. It is not how you "
+"get MPV's own on-screen controls — \"Player Controls Style\" under Interface "
+"does that."
+msgstr ""
+
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:234
+msgid ""
+"Show only what is cast to this machine — the library, including this "
+"settings screen, can't be reached from here. Without a system tray icon the "
+"only way back is editing conf.json. For the classic cast-target setup you "
+"want the Interface settings instead; this is for a shared TV nobody should "
+"be able to browse from."
+msgstr ""
+
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:240
+msgid ""
+"Requires restart to change. MPV keybinds are used by default. Press ENTER to "
+"drive the player controls by keyboard."
+msgstr ""
+
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:242
 msgid ""
 "Pixels one wheel notch scrolls. The scrollbar glides while the content snaps "
 "to the nearest row, so a trackpad or trackball no longer overshoots. Raise "
 "it to scroll faster, lower it for finer control."
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:209
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:247
 msgid ""
 "Make each wheel notch jump exactly one row (or one home-screen section) "
 "instead of gliding. Turn this on if you prefer the older stepped scrolling."
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:217
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:255
 msgid "Discord Rich Presence. Takes effect after a restart."
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:219
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:257
 msgid ""
 "Leave this to Default unless setting up passthrough. Note some audio servers "
 "like Pipewire don't like passthrough and will need to be disabled for a card "
@@ -1018,57 +1042,57 @@ msgid ""
 "silence otherwise, but results may vary."
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:225
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:263
 msgid ""
 "Stop anything else using the device while playing. Needed for passthrough on "
 "some systems, and it means other applications will be silent."
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:228
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:266
 msgid ""
 "Page the library and music tile grids instead of scrolling: each page is one "
 "screenful with First / Previous / Next / Last controls and a page number you "
 "can type into. Easier than precise scrolling on a trackpad."
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:232
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:270
 msgid ""
 "Takes effect after a restart. \"Follow display\" uses the scale your desktop "
 "reports, which is 100% on X11."
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:234
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:272
 msgid ""
 "\"Default\" changes nothing and lets MPV (and your own mpv.conf) decide. "
 "Pick a mode only if you are sending audio to a receiver."
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:237
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:275
 msgid ""
 "Audio your receiver can't be sent directly is encoded to AC3, which is the "
 "only way surround fits down an optical cable. Turn this off if the encoder "
 "causes audio delay — those tracks become stereo instead."
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:242
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:280
 msgid ""
 "\"hq\" offers heavier profiles. Pick it if you have a fast graphics card."
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:244
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:282
 msgid ""
 "Leave on Automatic unless video breaks when a profile is loaded. This only "
 "applies while a profile is active, and OpenGL can cost you HDR output."
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:248
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:286
 msgid ""
 "Evens out loud effects and quiet dialogue. This turns passthrough off while "
 "it is enabled, because the volume has to be adjusted before your receiver "
 "gets the audio."
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:330
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:368
 msgid "Advanced"
 msgstr ""
 
@@ -1294,7 +1318,7 @@ msgid "Automatic"
 msgstr "Awtomatiko"
 
 #: jellyfin_mpv_shim/mpvtk_browser/downloads.py:51
-#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1355
+#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1288
 msgid "Episodes"
 msgstr ""
 
@@ -1303,7 +1327,7 @@ msgid "Season %s"
 msgstr ""
 
 #: jellyfin_mpv_shim/mpvtk_browser/downloads.py:52
-#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1351
+#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1284
 msgid "Specials"
 msgstr ""
 
@@ -1328,7 +1352,7 @@ msgid "Failed"
 msgstr "Nag-fail"
 
 #: jellyfin_mpv_shim/mpvtk_browser/downloads.py:185
-#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1105
+#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1038
 msgid "Playlist"
 msgstr ""
 
@@ -1340,30 +1364,30 @@ msgstr ""
 msgid "Movies & Videos"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/home_sections.py:103
+#: jellyfin_mpv_shim/mpvtk_browser/home_sections.py:104
 msgid "My Media"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/home_sections.py:104
-#: jellyfin_mpv_shim/mpvtk_browser/repository.py:352
+#: jellyfin_mpv_shim/mpvtk_browser/home_sections.py:105
+#: jellyfin_mpv_shim/mpvtk_browser/repository.py:350
 msgid "Continue Watching"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/home_sections.py:105
-#: jellyfin_mpv_shim/mpvtk_browser/repository.py:359
+#: jellyfin_mpv_shim/mpvtk_browser/home_sections.py:106
+#: jellyfin_mpv_shim/mpvtk_browser/repository.py:357
 msgid "Continue Listening"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/home_sections.py:106
-#: jellyfin_mpv_shim/mpvtk_browser/repository.py:366
+#: jellyfin_mpv_shim/mpvtk_browser/home_sections.py:107
+#: jellyfin_mpv_shim/mpvtk_browser/repository.py:364
 msgid "Next Up"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/home_sections.py:107
+#: jellyfin_mpv_shim/mpvtk_browser/home_sections.py:108
 msgid "Recently Added"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/home_sections.py:108
+#: jellyfin_mpv_shim/mpvtk_browser/home_sections.py:109
 msgid "Live TV"
 msgstr ""
 
@@ -1616,52 +1640,52 @@ msgstr ""
 "Hindi maidagdag ang server.\n"
 "Pakisuri ang iyong impormasyon sa koneksyon."
 
-#: jellyfin_mpv_shim/mpvtk_browser/repository.py:390
+#: jellyfin_mpv_shim/mpvtk_browser/repository.py:386
 msgid "On Now"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/repository.py:411
+#: jellyfin_mpv_shim/mpvtk_browser/repository.py:407
 msgid "Latest %s"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1119
+#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1052
 msgid "Downloaded"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1138
+#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1071
 msgid "Movies"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1143
+#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1076
 msgid "Videos"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1147
+#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1080
 msgid "TV Shows"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1151
+#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1084
 msgid "Playlists"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1168
-#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1441
+#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1101
+#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1374
 msgid "Series"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1212
+#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1145
 msgid "Downloaded Movies"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1216
+#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1149
 msgid "Downloaded Videos"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1220
+#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1153
 msgid "Downloaded Shows"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1353
+#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1286
 msgid "Season %d"
 msgstr ""
 

--- a/jellyfin_mpv_shim/messages/fr/LC_MESSAGES/base.po
+++ b/jellyfin_mpv_shim/messages/fr/LC_MESSAGES/base.po
@@ -5,7 +5,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2026-07-25 17:21-0400\n"
+"POT-Creation-Date: 2026-07-26 12:03-0400\n"
 "PO-Revision-Date: 2026-06-28 13:23+0000\n"
 "Last-Translator: Romain Sickenberg <haux49@gmail.com>\n"
 "Language-Team: French <https://translate.jellyfin.org/projects/jellyfin/"
@@ -246,7 +246,7 @@ msgid "Select Subtitle Track"
 msgstr "Choisir une piste de sous-titres"
 
 #: jellyfin_mpv_shim/menu.py:341
-#: jellyfin_mpv_shim/mpvtk_browser/home_sections.py:102
+#: jellyfin_mpv_shim/mpvtk_browser/home_sections.py:103
 #: jellyfin_mpv_shim/osc_bridge.py:81 jellyfin_mpv_shim/osc_bridge.py:82
 #: jellyfin_mpv_shim/osc_bridge.py:104 jellyfin_mpv_shim/osc_bridge.py:140
 msgid "None"
@@ -397,7 +397,7 @@ msgstr "Demander pour passer les crédits"
 msgid "Enable thumbnail previews"
 msgstr "Activer la prévisualisation des miniatures"
 
-#: jellyfin_mpv_shim/menu.py:609 jellyfin_mpv_shim/mpvtk_browser/config.py:186
+#: jellyfin_mpv_shim/menu.py:609 jellyfin_mpv_shim/mpvtk_browser/config.py:195
 #: jellyfin_mpv_shim/mpvtk_browser/hud.py:375
 msgid "Night Mode (Auto Volume Adj)"
 msgstr ""
@@ -682,310 +682,334 @@ msgstr ""
 msgid "Or switch to another user"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/cast.py:317
+#: jellyfin_mpv_shim/mpvtk_browser/cast.py:314
 msgid "Ready to cast"
 msgstr "Prêt à diffuser"
 
-#: jellyfin_mpv_shim/mpvtk_browser/cast.py:318
+#: jellyfin_mpv_shim/mpvtk_browser/cast.py:315
 #, fuzzy
 #| msgid "Select your media in Jellyfin and play it here"
 msgid "Select your media in Jellyfin and play it here."
 msgstr "Choisissez votre média dans Jellyfin et jouez-le ici"
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:74
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:83
 msgid "Interface"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:83
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:92
 msgid "Playback"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:88
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:97
 msgid "Audio"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:92
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:101
 msgid "Subtitles & Languages"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:97
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:106
 #, fuzzy
 #| msgid " (Transcode)"
 msgid "Transcoding"
 msgstr " (Transcoder)"
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:102
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:111
 msgid "Video Enhancement"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:104
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:113
 #, fuzzy
 #| msgid "Seek to Skip Credits"
 msgid "Skip Intro / Credits"
 msgstr "Avancer pour passer les crédits"
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:107
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:116
 msgid "Library Browser"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:109
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:118
 msgid "Downloads"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:128
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:137
 msgid "Jellyfin UI"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:129
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:138
 msgid "MPV UI with thumbnails"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:130
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:139
 msgid "MPV built-in default"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:133
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:142
 msgid "Follow display"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:134
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:143
 msgid "100% (no scaling)"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:135
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:144
 msgid "125%"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:136
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:145
 msgid "150%"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:137
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:146
 msgid "200%"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:140
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:149
 msgid "Automatic (recommended)"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:141
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:150
 msgid "Vulkan"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:142
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:151
 msgid "Direct3D 11 (Windows only)"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:143
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:152
 msgid "OpenGL (compatibility)"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:146
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:155
 msgid "Default (auto)"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:147
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:156
 msgid "Force Stereo"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:148
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:157
 msgid "Optical Surround"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:149
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:158
 msgid "HDMI Passthrough"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:152
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:161
 msgid "Unset"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:153
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:162
 msgid "Dubbed (shows only)"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:154
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:163
 msgid "Subbed (shows only)"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:155
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:164
 msgid "Dubbed (all)"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:156
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:165
 msgid "Subbed (all)"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:157
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:166
 msgid "Custom (set in config)"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:162
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:171
 msgid "Download Folder"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:163
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:172
 msgid "Prefer Downloaded Copy"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:164
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:173
 msgid "Automatically Download Upcoming Episodes"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:165
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:174
 msgid "Include Next Up"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:166
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:175
 msgid "Next Up Entries to Consider"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:167
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:176
 msgid "Episodes to Keep Ahead (0 = off)"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:168
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:177
 msgid "Storage Limit for Automatic Downloads (GB)"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:169
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:178
 #, fuzzy
 #| msgid "Remove Server"
 msgid "Delete Automatic Downloads Once Watched"
 msgstr "Supprimer le serveur"
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:170
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:179
 msgid "Delete Unwatched After (days, 0 = never)"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:171
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:180
 msgid "Check Every (minutes)"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:172
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:181
 msgid "Close to Tray (keep running)"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:173
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:182
 msgid "Keep Running in Background"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:174
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:183
 msgid "Remember Window Size"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:175
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:184
 msgid "Player Controls Style"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:176
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:185
 msgid "Show What You're Watching in Discord"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:177
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:186
 msgid "Interface Scale"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:178
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:187
 msgid "Cast-target mode (no library browsing)"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:179
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:188
 msgid "Casting Opens the Library Browser"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:180
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:189
 msgid "Fullscreen Library Browser"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:181
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:190
 msgid "Always Bind Arrow Keys to Player Controls"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:182
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:191
 msgid "Player Controls Activation Key"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:183
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:192
 msgid "Audio Output Mode"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:184
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:193
 msgid "Audio Output Device"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:185
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:194
 msgid "Take the Device Exclusively"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:187
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:196
 #, fuzzy
 #| msgid "Video Playback Profiles"
 msgid "Enable Video Playback Profiles"
 msgstr "Profils de lecture vidéo"
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:188
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:197
 #, fuzzy
 #| msgid "New Group"
 msgid "Profile Group"
 msgstr "Nouveau groupe"
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:189
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:198
 msgid "Remember Last Used Profile"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:190
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:199
 msgid "Graphics API for Shaders"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:191
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:200
 msgid "Pass Through AC3"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:192
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:201
 msgid "Pass Through DTS"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:193
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:202
 msgid "Pass Through E-AC3"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:194
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:203
 msgid "Pass Through DTS-HD"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:195
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:204
 msgid "Pass Through TrueHD"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:196
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:205
 msgid "Re-encode Others to AC3"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:202
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:213
 msgid ""
-"MPV keybinds are used by default. Press ENTER to drive the player controls "
-"by keyboard."
+"With \"Start Minimized\" and \"Fullscreen\" this is the classic cast-target "
+"setup: the app waits out of the way, plays fullscreen when something casts "
+"to it, and goes back to waiting when the video ends or you press Q."
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:204
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:227
+msgid ""
+"Off means command-line mode: no window, no system tray and no settings "
+"screen, so the only way back is editing conf.json by hand. It is not how you "
+"get MPV's own on-screen controls — \"Player Controls Style\" under Interface "
+"does that."
+msgstr ""
+
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:234
+msgid ""
+"Show only what is cast to this machine — the library, including this "
+"settings screen, can't be reached from here. Without a system tray icon the "
+"only way back is editing conf.json. For the classic cast-target setup you "
+"want the Interface settings instead; this is for a shared TV nobody should "
+"be able to browse from."
+msgstr ""
+
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:240
+msgid ""
+"Requires restart to change. MPV keybinds are used by default. Press ENTER to "
+"drive the player controls by keyboard."
+msgstr ""
+
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:242
 msgid ""
 "Pixels one wheel notch scrolls. The scrollbar glides while the content snaps "
 "to the nearest row, so a trackpad or trackball no longer overshoots. Raise "
 "it to scroll faster, lower it for finer control."
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:209
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:247
 msgid ""
 "Make each wheel notch jump exactly one row (or one home-screen section) "
 "instead of gliding. Turn this on if you prefer the older stepped scrolling."
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:217
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:255
 msgid "Discord Rich Presence. Takes effect after a restart."
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:219
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:257
 msgid ""
 "Leave this to Default unless setting up passthrough. Note some audio servers "
 "like Pipewire don't like passthrough and will need to be disabled for a card "
@@ -993,57 +1017,57 @@ msgid ""
 "silence otherwise, but results may vary."
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:225
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:263
 msgid ""
 "Stop anything else using the device while playing. Needed for passthrough on "
 "some systems, and it means other applications will be silent."
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:228
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:266
 msgid ""
 "Page the library and music tile grids instead of scrolling: each page is one "
 "screenful with First / Previous / Next / Last controls and a page number you "
 "can type into. Easier than precise scrolling on a trackpad."
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:232
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:270
 msgid ""
 "Takes effect after a restart. \"Follow display\" uses the scale your desktop "
 "reports, which is 100% on X11."
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:234
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:272
 msgid ""
 "\"Default\" changes nothing and lets MPV (and your own mpv.conf) decide. "
 "Pick a mode only if you are sending audio to a receiver."
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:237
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:275
 msgid ""
 "Audio your receiver can't be sent directly is encoded to AC3, which is the "
 "only way surround fits down an optical cable. Turn this off if the encoder "
 "causes audio delay — those tracks become stereo instead."
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:242
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:280
 msgid ""
 "\"hq\" offers heavier profiles. Pick it if you have a fast graphics card."
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:244
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:282
 msgid ""
 "Leave on Automatic unless video breaks when a profile is loaded. This only "
 "applies while a profile is active, and OpenGL can cost you HDR output."
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:248
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:286
 msgid ""
 "Evens out loud effects and quiet dialogue. This turns passthrough off while "
 "it is enabled, because the volume has to be adjusted before your receiver "
 "gets the audio."
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:330
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:368
 msgid "Advanced"
 msgstr ""
 
@@ -1243,7 +1267,7 @@ msgid "Automatic"
 msgstr "Automatique"
 
 #: jellyfin_mpv_shim/mpvtk_browser/downloads.py:51
-#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1355
+#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1288
 msgid "Episodes"
 msgstr ""
 
@@ -1252,7 +1276,7 @@ msgid "Season %s"
 msgstr ""
 
 #: jellyfin_mpv_shim/mpvtk_browser/downloads.py:52
-#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1351
+#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1284
 msgid "Specials"
 msgstr ""
 
@@ -1277,7 +1301,7 @@ msgid "Failed"
 msgstr "Échec"
 
 #: jellyfin_mpv_shim/mpvtk_browser/downloads.py:185
-#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1105
+#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1038
 msgid "Playlist"
 msgstr ""
 
@@ -1289,30 +1313,30 @@ msgstr ""
 msgid "Movies & Videos"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/home_sections.py:103
+#: jellyfin_mpv_shim/mpvtk_browser/home_sections.py:104
 msgid "My Media"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/home_sections.py:104
-#: jellyfin_mpv_shim/mpvtk_browser/repository.py:352
+#: jellyfin_mpv_shim/mpvtk_browser/home_sections.py:105
+#: jellyfin_mpv_shim/mpvtk_browser/repository.py:350
 msgid "Continue Watching"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/home_sections.py:105
-#: jellyfin_mpv_shim/mpvtk_browser/repository.py:359
+#: jellyfin_mpv_shim/mpvtk_browser/home_sections.py:106
+#: jellyfin_mpv_shim/mpvtk_browser/repository.py:357
 msgid "Continue Listening"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/home_sections.py:106
-#: jellyfin_mpv_shim/mpvtk_browser/repository.py:366
+#: jellyfin_mpv_shim/mpvtk_browser/home_sections.py:107
+#: jellyfin_mpv_shim/mpvtk_browser/repository.py:364
 msgid "Next Up"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/home_sections.py:107
+#: jellyfin_mpv_shim/mpvtk_browser/home_sections.py:108
 msgid "Recently Added"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/home_sections.py:108
+#: jellyfin_mpv_shim/mpvtk_browser/home_sections.py:109
 msgid "Live TV"
 msgstr ""
 
@@ -1547,52 +1571,52 @@ msgstr ""
 msgid "Could not load this page."
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/repository.py:390
+#: jellyfin_mpv_shim/mpvtk_browser/repository.py:386
 msgid "On Now"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/repository.py:411
+#: jellyfin_mpv_shim/mpvtk_browser/repository.py:407
 msgid "Latest %s"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1119
+#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1052
 msgid "Downloaded"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1138
+#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1071
 msgid "Movies"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1143
+#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1076
 msgid "Videos"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1147
+#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1080
 msgid "TV Shows"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1151
+#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1084
 msgid "Playlists"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1168
-#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1441
+#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1101
+#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1374
 msgid "Series"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1212
+#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1145
 msgid "Downloaded Movies"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1216
+#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1149
 msgid "Downloaded Videos"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1220
+#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1153
 msgid "Downloaded Shows"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1353
+#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1286
 msgid "Season %d"
 msgstr ""
 

--- a/jellyfin_mpv_shim/messages/ga/LC_MESSAGES/base.po
+++ b/jellyfin_mpv_shim/messages/ga/LC_MESSAGES/base.po
@@ -5,7 +5,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2026-07-25 17:21-0400\n"
+"POT-Creation-Date: 2026-07-26 12:03-0400\n"
 "PO-Revision-Date: 2026-05-04 14:15+0000\n"
 "Last-Translator: Aindriú Mac Giolla Eoin <aindriu80@gmail.com>\n"
 "Language-Team: Irish <https://translate.jellyfin.org/projects/jellyfin/"
@@ -253,7 +253,7 @@ msgid "Select Subtitle Track"
 msgstr "Roghnaigh Amhrán Fotheideal"
 
 #: jellyfin_mpv_shim/menu.py:341
-#: jellyfin_mpv_shim/mpvtk_browser/home_sections.py:102
+#: jellyfin_mpv_shim/mpvtk_browser/home_sections.py:103
 #: jellyfin_mpv_shim/osc_bridge.py:81 jellyfin_mpv_shim/osc_bridge.py:82
 #: jellyfin_mpv_shim/osc_bridge.py:104 jellyfin_mpv_shim/osc_bridge.py:140
 msgid "None"
@@ -404,7 +404,7 @@ msgstr "Iarr creidmheasanna a scipeáil"
 msgid "Enable thumbnail previews"
 msgstr "Cumasaigh réamhamhairc mhionsamhlacha"
 
-#: jellyfin_mpv_shim/menu.py:609 jellyfin_mpv_shim/mpvtk_browser/config.py:186
+#: jellyfin_mpv_shim/menu.py:609 jellyfin_mpv_shim/mpvtk_browser/config.py:195
 #: jellyfin_mpv_shim/mpvtk_browser/hud.py:375
 msgid "Night Mode (Auto Volume Adj)"
 msgstr ""
@@ -703,310 +703,334 @@ msgstr ""
 msgid "Or switch to another user"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/cast.py:317
+#: jellyfin_mpv_shim/mpvtk_browser/cast.py:314
 msgid "Ready to cast"
 msgstr "Réidh le caitheamh"
 
-#: jellyfin_mpv_shim/mpvtk_browser/cast.py:318
+#: jellyfin_mpv_shim/mpvtk_browser/cast.py:315
 #, fuzzy
 #| msgid "Select your media in Jellyfin and play it here"
 msgid "Select your media in Jellyfin and play it here."
 msgstr "Roghnaigh do na meáin i Jellyfin agus é a imirt anseo"
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:74
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:83
 msgid "Interface"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:83
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:92
 msgid "Playback"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:88
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:97
 msgid "Audio"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:92
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:101
 msgid "Subtitles & Languages"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:97
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:106
 #, fuzzy
 #| msgid " (Transcode)"
 msgid "Transcoding"
 msgstr " (Traschódú)"
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:102
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:111
 msgid "Video Enhancement"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:104
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:113
 #, fuzzy
 #| msgid "Seek to Skip Credits"
 msgid "Skip Intro / Credits"
 msgstr "Déan iarracht creidmheasanna a scipeáil"
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:107
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:116
 msgid "Library Browser"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:109
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:118
 msgid "Downloads"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:128
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:137
 msgid "Jellyfin UI"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:129
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:138
 msgid "MPV UI with thumbnails"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:130
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:139
 msgid "MPV built-in default"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:133
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:142
 msgid "Follow display"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:134
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:143
 msgid "100% (no scaling)"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:135
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:144
 msgid "125%"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:136
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:145
 msgid "150%"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:137
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:146
 msgid "200%"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:140
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:149
 msgid "Automatic (recommended)"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:141
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:150
 msgid "Vulkan"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:142
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:151
 msgid "Direct3D 11 (Windows only)"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:143
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:152
 msgid "OpenGL (compatibility)"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:146
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:155
 msgid "Default (auto)"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:147
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:156
 msgid "Force Stereo"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:148
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:157
 msgid "Optical Surround"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:149
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:158
 msgid "HDMI Passthrough"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:152
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:161
 msgid "Unset"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:153
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:162
 msgid "Dubbed (shows only)"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:154
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:163
 msgid "Subbed (shows only)"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:155
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:164
 msgid "Dubbed (all)"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:156
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:165
 msgid "Subbed (all)"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:157
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:166
 msgid "Custom (set in config)"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:162
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:171
 msgid "Download Folder"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:163
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:172
 msgid "Prefer Downloaded Copy"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:164
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:173
 msgid "Automatically Download Upcoming Episodes"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:165
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:174
 msgid "Include Next Up"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:166
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:175
 msgid "Next Up Entries to Consider"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:167
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:176
 msgid "Episodes to Keep Ahead (0 = off)"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:168
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:177
 msgid "Storage Limit for Automatic Downloads (GB)"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:169
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:178
 #, fuzzy
 #| msgid "Remove Server"
 msgid "Delete Automatic Downloads Once Watched"
 msgstr "Bain Freastalaí"
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:170
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:179
 msgid "Delete Unwatched After (days, 0 = never)"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:171
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:180
 msgid "Check Every (minutes)"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:172
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:181
 msgid "Close to Tray (keep running)"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:173
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:182
 msgid "Keep Running in Background"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:174
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:183
 msgid "Remember Window Size"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:175
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:184
 msgid "Player Controls Style"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:176
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:185
 msgid "Show What You're Watching in Discord"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:177
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:186
 msgid "Interface Scale"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:178
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:187
 msgid "Cast-target mode (no library browsing)"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:179
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:188
 msgid "Casting Opens the Library Browser"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:180
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:189
 msgid "Fullscreen Library Browser"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:181
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:190
 msgid "Always Bind Arrow Keys to Player Controls"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:182
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:191
 msgid "Player Controls Activation Key"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:183
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:192
 msgid "Audio Output Mode"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:184
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:193
 msgid "Audio Output Device"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:185
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:194
 msgid "Take the Device Exclusively"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:187
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:196
 #, fuzzy
 #| msgid "Video Playback Profiles"
 msgid "Enable Video Playback Profiles"
 msgstr "Próifílí Athsheinm Físe"
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:188
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:197
 #, fuzzy
 #| msgid "New Group"
 msgid "Profile Group"
 msgstr "Grúpa Nua"
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:189
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:198
 msgid "Remember Last Used Profile"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:190
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:199
 msgid "Graphics API for Shaders"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:191
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:200
 msgid "Pass Through AC3"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:192
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:201
 msgid "Pass Through DTS"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:193
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:202
 msgid "Pass Through E-AC3"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:194
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:203
 msgid "Pass Through DTS-HD"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:195
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:204
 msgid "Pass Through TrueHD"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:196
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:205
 msgid "Re-encode Others to AC3"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:202
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:213
 msgid ""
-"MPV keybinds are used by default. Press ENTER to drive the player controls "
-"by keyboard."
+"With \"Start Minimized\" and \"Fullscreen\" this is the classic cast-target "
+"setup: the app waits out of the way, plays fullscreen when something casts "
+"to it, and goes back to waiting when the video ends or you press Q."
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:204
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:227
+msgid ""
+"Off means command-line mode: no window, no system tray and no settings "
+"screen, so the only way back is editing conf.json by hand. It is not how you "
+"get MPV's own on-screen controls — \"Player Controls Style\" under Interface "
+"does that."
+msgstr ""
+
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:234
+msgid ""
+"Show only what is cast to this machine — the library, including this "
+"settings screen, can't be reached from here. Without a system tray icon the "
+"only way back is editing conf.json. For the classic cast-target setup you "
+"want the Interface settings instead; this is for a shared TV nobody should "
+"be able to browse from."
+msgstr ""
+
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:240
+msgid ""
+"Requires restart to change. MPV keybinds are used by default. Press ENTER to "
+"drive the player controls by keyboard."
+msgstr ""
+
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:242
 msgid ""
 "Pixels one wheel notch scrolls. The scrollbar glides while the content snaps "
 "to the nearest row, so a trackpad or trackball no longer overshoots. Raise "
 "it to scroll faster, lower it for finer control."
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:209
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:247
 msgid ""
 "Make each wheel notch jump exactly one row (or one home-screen section) "
 "instead of gliding. Turn this on if you prefer the older stepped scrolling."
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:217
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:255
 msgid "Discord Rich Presence. Takes effect after a restart."
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:219
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:257
 msgid ""
 "Leave this to Default unless setting up passthrough. Note some audio servers "
 "like Pipewire don't like passthrough and will need to be disabled for a card "
@@ -1014,57 +1038,57 @@ msgid ""
 "silence otherwise, but results may vary."
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:225
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:263
 msgid ""
 "Stop anything else using the device while playing. Needed for passthrough on "
 "some systems, and it means other applications will be silent."
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:228
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:266
 msgid ""
 "Page the library and music tile grids instead of scrolling: each page is one "
 "screenful with First / Previous / Next / Last controls and a page number you "
 "can type into. Easier than precise scrolling on a trackpad."
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:232
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:270
 msgid ""
 "Takes effect after a restart. \"Follow display\" uses the scale your desktop "
 "reports, which is 100% on X11."
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:234
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:272
 msgid ""
 "\"Default\" changes nothing and lets MPV (and your own mpv.conf) decide. "
 "Pick a mode only if you are sending audio to a receiver."
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:237
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:275
 msgid ""
 "Audio your receiver can't be sent directly is encoded to AC3, which is the "
 "only way surround fits down an optical cable. Turn this off if the encoder "
 "causes audio delay — those tracks become stereo instead."
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:242
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:280
 msgid ""
 "\"hq\" offers heavier profiles. Pick it if you have a fast graphics card."
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:244
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:282
 msgid ""
 "Leave on Automatic unless video breaks when a profile is loaded. This only "
 "applies while a profile is active, and OpenGL can cost you HDR output."
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:248
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:286
 msgid ""
 "Evens out loud effects and quiet dialogue. This turns passthrough off while "
 "it is enabled, because the volume has to be adjusted before your receiver "
 "gets the audio."
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:330
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:368
 msgid "Advanced"
 msgstr ""
 
@@ -1290,7 +1314,7 @@ msgid "Automatic"
 msgstr "Uathoibríoch"
 
 #: jellyfin_mpv_shim/mpvtk_browser/downloads.py:51
-#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1355
+#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1288
 msgid "Episodes"
 msgstr ""
 
@@ -1299,7 +1323,7 @@ msgid "Season %s"
 msgstr ""
 
 #: jellyfin_mpv_shim/mpvtk_browser/downloads.py:52
-#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1351
+#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1284
 msgid "Specials"
 msgstr ""
 
@@ -1324,7 +1348,7 @@ msgid "Failed"
 msgstr "Teip"
 
 #: jellyfin_mpv_shim/mpvtk_browser/downloads.py:185
-#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1105
+#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1038
 msgid "Playlist"
 msgstr ""
 
@@ -1336,30 +1360,30 @@ msgstr ""
 msgid "Movies & Videos"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/home_sections.py:103
+#: jellyfin_mpv_shim/mpvtk_browser/home_sections.py:104
 msgid "My Media"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/home_sections.py:104
-#: jellyfin_mpv_shim/mpvtk_browser/repository.py:352
+#: jellyfin_mpv_shim/mpvtk_browser/home_sections.py:105
+#: jellyfin_mpv_shim/mpvtk_browser/repository.py:350
 msgid "Continue Watching"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/home_sections.py:105
-#: jellyfin_mpv_shim/mpvtk_browser/repository.py:359
+#: jellyfin_mpv_shim/mpvtk_browser/home_sections.py:106
+#: jellyfin_mpv_shim/mpvtk_browser/repository.py:357
 msgid "Continue Listening"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/home_sections.py:106
-#: jellyfin_mpv_shim/mpvtk_browser/repository.py:366
+#: jellyfin_mpv_shim/mpvtk_browser/home_sections.py:107
+#: jellyfin_mpv_shim/mpvtk_browser/repository.py:364
 msgid "Next Up"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/home_sections.py:107
+#: jellyfin_mpv_shim/mpvtk_browser/home_sections.py:108
 msgid "Recently Added"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/home_sections.py:108
+#: jellyfin_mpv_shim/mpvtk_browser/home_sections.py:109
 msgid "Live TV"
 msgstr ""
 
@@ -1612,52 +1636,52 @@ msgstr ""
 "Níorbh fhéidir freastalaí a chur leis.\n"
 "Seiceáil faisnéis do naisc le do thoil."
 
-#: jellyfin_mpv_shim/mpvtk_browser/repository.py:390
+#: jellyfin_mpv_shim/mpvtk_browser/repository.py:386
 msgid "On Now"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/repository.py:411
+#: jellyfin_mpv_shim/mpvtk_browser/repository.py:407
 msgid "Latest %s"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1119
+#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1052
 msgid "Downloaded"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1138
+#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1071
 msgid "Movies"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1143
+#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1076
 msgid "Videos"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1147
+#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1080
 msgid "TV Shows"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1151
+#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1084
 msgid "Playlists"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1168
-#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1441
+#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1101
+#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1374
 msgid "Series"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1212
+#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1145
 msgid "Downloaded Movies"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1216
+#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1149
 msgid "Downloaded Videos"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1220
+#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1153
 msgid "Downloaded Shows"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1353
+#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1286
 msgid "Season %d"
 msgstr ""
 

--- a/jellyfin_mpv_shim/messages/gl/LC_MESSAGES/base.po
+++ b/jellyfin_mpv_shim/messages/gl/LC_MESSAGES/base.po
@@ -5,7 +5,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2026-07-25 17:21-0400\n"
+"POT-Creation-Date: 2026-07-26 12:03-0400\n"
 "PO-Revision-Date: 2026-03-05 22:02+0000\n"
 "Last-Translator: Daniel Vázquez <danielmvazquez.audio@gmail.com>\n"
 "Language-Team: Galician <https://translate.jellyfin.org/projects/jellyfin/"
@@ -252,7 +252,7 @@ msgid "Select Subtitle Track"
 msgstr "Selecionar Faixa de Subtítulos"
 
 #: jellyfin_mpv_shim/menu.py:341
-#: jellyfin_mpv_shim/mpvtk_browser/home_sections.py:102
+#: jellyfin_mpv_shim/mpvtk_browser/home_sections.py:103
 #: jellyfin_mpv_shim/osc_bridge.py:81 jellyfin_mpv_shim/osc_bridge.py:82
 #: jellyfin_mpv_shim/osc_bridge.py:104 jellyfin_mpv_shim/osc_bridge.py:140
 msgid "None"
@@ -406,7 +406,7 @@ msgstr "Solicitar saltar os créditos"
 msgid "Enable thumbnail previews"
 msgstr "Activar vistas previas na miniatura"
 
-#: jellyfin_mpv_shim/menu.py:609 jellyfin_mpv_shim/mpvtk_browser/config.py:186
+#: jellyfin_mpv_shim/menu.py:609 jellyfin_mpv_shim/mpvtk_browser/config.py:195
 #: jellyfin_mpv_shim/mpvtk_browser/hud.py:375
 msgid "Night Mode (Auto Volume Adj)"
 msgstr ""
@@ -705,311 +705,335 @@ msgstr ""
 msgid "Or switch to another user"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/cast.py:317
+#: jellyfin_mpv_shim/mpvtk_browser/cast.py:314
 #, fuzzy
 msgid "Ready to cast"
 msgstr "Listo para transmitir"
 
-#: jellyfin_mpv_shim/mpvtk_browser/cast.py:318
+#: jellyfin_mpv_shim/mpvtk_browser/cast.py:315
 #, fuzzy
 #| msgid "Select your media in Jellyfin and play it here"
 msgid "Select your media in Jellyfin and play it here."
 msgstr "Seleccione a súa multimedia en Jellyfin e reprodúzaa aquí"
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:74
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:83
 msgid "Interface"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:83
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:92
 msgid "Playback"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:88
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:97
 msgid "Audio"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:92
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:101
 msgid "Subtitles & Languages"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:97
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:106
 #, fuzzy
 #| msgid " (Transcode)"
 msgid "Transcoding"
 msgstr " (Transcodificar)"
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:102
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:111
 msgid "Video Enhancement"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:104
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:113
 #, fuzzy
 #| msgid "Seek to Skip Intro"
 msgid "Skip Intro / Credits"
 msgstr "Intentar saltar a introdución"
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:107
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:116
 msgid "Library Browser"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:109
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:118
 msgid "Downloads"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:128
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:137
 msgid "Jellyfin UI"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:129
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:138
 msgid "MPV UI with thumbnails"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:130
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:139
 msgid "MPV built-in default"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:133
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:142
 msgid "Follow display"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:134
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:143
 msgid "100% (no scaling)"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:135
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:144
 msgid "125%"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:136
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:145
 msgid "150%"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:137
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:146
 msgid "200%"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:140
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:149
 msgid "Automatic (recommended)"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:141
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:150
 msgid "Vulkan"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:142
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:151
 msgid "Direct3D 11 (Windows only)"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:143
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:152
 msgid "OpenGL (compatibility)"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:146
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:155
 msgid "Default (auto)"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:147
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:156
 msgid "Force Stereo"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:148
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:157
 msgid "Optical Surround"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:149
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:158
 msgid "HDMI Passthrough"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:152
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:161
 msgid "Unset"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:153
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:162
 msgid "Dubbed (shows only)"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:154
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:163
 msgid "Subbed (shows only)"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:155
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:164
 msgid "Dubbed (all)"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:156
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:165
 msgid "Subbed (all)"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:157
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:166
 msgid "Custom (set in config)"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:162
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:171
 msgid "Download Folder"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:163
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:172
 msgid "Prefer Downloaded Copy"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:164
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:173
 msgid "Automatically Download Upcoming Episodes"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:165
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:174
 msgid "Include Next Up"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:166
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:175
 msgid "Next Up Entries to Consider"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:167
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:176
 msgid "Episodes to Keep Ahead (0 = off)"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:168
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:177
 msgid "Storage Limit for Automatic Downloads (GB)"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:169
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:178
 #, fuzzy
 #| msgid "Remove Server"
 msgid "Delete Automatic Downloads Once Watched"
 msgstr "Eliminar Servidor"
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:170
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:179
 msgid "Delete Unwatched After (days, 0 = never)"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:171
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:180
 msgid "Check Every (minutes)"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:172
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:181
 msgid "Close to Tray (keep running)"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:173
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:182
 msgid "Keep Running in Background"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:174
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:183
 msgid "Remember Window Size"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:175
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:184
 msgid "Player Controls Style"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:176
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:185
 msgid "Show What You're Watching in Discord"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:177
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:186
 msgid "Interface Scale"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:178
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:187
 msgid "Cast-target mode (no library browsing)"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:179
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:188
 msgid "Casting Opens the Library Browser"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:180
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:189
 msgid "Fullscreen Library Browser"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:181
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:190
 msgid "Always Bind Arrow Keys to Player Controls"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:182
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:191
 msgid "Player Controls Activation Key"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:183
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:192
 msgid "Audio Output Mode"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:184
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:193
 msgid "Audio Output Device"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:185
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:194
 msgid "Take the Device Exclusively"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:187
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:196
 #, fuzzy
 #| msgid "Video Playback Profiles"
 msgid "Enable Video Playback Profiles"
 msgstr "Perfís de Reprodución de Vídeo"
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:188
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:197
 #, fuzzy
 #| msgid "New Group"
 msgid "Profile Group"
 msgstr "Novo Grupo"
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:189
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:198
 msgid "Remember Last Used Profile"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:190
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:199
 msgid "Graphics API for Shaders"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:191
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:200
 msgid "Pass Through AC3"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:192
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:201
 msgid "Pass Through DTS"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:193
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:202
 msgid "Pass Through E-AC3"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:194
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:203
 msgid "Pass Through DTS-HD"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:195
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:204
 msgid "Pass Through TrueHD"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:196
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:205
 msgid "Re-encode Others to AC3"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:202
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:213
 msgid ""
-"MPV keybinds are used by default. Press ENTER to drive the player controls "
-"by keyboard."
+"With \"Start Minimized\" and \"Fullscreen\" this is the classic cast-target "
+"setup: the app waits out of the way, plays fullscreen when something casts "
+"to it, and goes back to waiting when the video ends or you press Q."
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:204
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:227
+msgid ""
+"Off means command-line mode: no window, no system tray and no settings "
+"screen, so the only way back is editing conf.json by hand. It is not how you "
+"get MPV's own on-screen controls — \"Player Controls Style\" under Interface "
+"does that."
+msgstr ""
+
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:234
+msgid ""
+"Show only what is cast to this machine — the library, including this "
+"settings screen, can't be reached from here. Without a system tray icon the "
+"only way back is editing conf.json. For the classic cast-target setup you "
+"want the Interface settings instead; this is for a shared TV nobody should "
+"be able to browse from."
+msgstr ""
+
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:240
+msgid ""
+"Requires restart to change. MPV keybinds are used by default. Press ENTER to "
+"drive the player controls by keyboard."
+msgstr ""
+
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:242
 msgid ""
 "Pixels one wheel notch scrolls. The scrollbar glides while the content snaps "
 "to the nearest row, so a trackpad or trackball no longer overshoots. Raise "
 "it to scroll faster, lower it for finer control."
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:209
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:247
 msgid ""
 "Make each wheel notch jump exactly one row (or one home-screen section) "
 "instead of gliding. Turn this on if you prefer the older stepped scrolling."
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:217
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:255
 msgid "Discord Rich Presence. Takes effect after a restart."
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:219
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:257
 msgid ""
 "Leave this to Default unless setting up passthrough. Note some audio servers "
 "like Pipewire don't like passthrough and will need to be disabled for a card "
@@ -1017,57 +1041,57 @@ msgid ""
 "silence otherwise, but results may vary."
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:225
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:263
 msgid ""
 "Stop anything else using the device while playing. Needed for passthrough on "
 "some systems, and it means other applications will be silent."
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:228
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:266
 msgid ""
 "Page the library and music tile grids instead of scrolling: each page is one "
 "screenful with First / Previous / Next / Last controls and a page number you "
 "can type into. Easier than precise scrolling on a trackpad."
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:232
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:270
 msgid ""
 "Takes effect after a restart. \"Follow display\" uses the scale your desktop "
 "reports, which is 100% on X11."
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:234
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:272
 msgid ""
 "\"Default\" changes nothing and lets MPV (and your own mpv.conf) decide. "
 "Pick a mode only if you are sending audio to a receiver."
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:237
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:275
 msgid ""
 "Audio your receiver can't be sent directly is encoded to AC3, which is the "
 "only way surround fits down an optical cable. Turn this off if the encoder "
 "causes audio delay — those tracks become stereo instead."
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:242
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:280
 msgid ""
 "\"hq\" offers heavier profiles. Pick it if you have a fast graphics card."
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:244
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:282
 msgid ""
 "Leave on Automatic unless video breaks when a profile is loaded. This only "
 "applies while a profile is active, and OpenGL can cost you HDR output."
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:248
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:286
 msgid ""
 "Evens out loud effects and quiet dialogue. This turns passthrough off while "
 "it is enabled, because the volume has to be adjusted before your receiver "
 "gets the audio."
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:330
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:368
 msgid "Advanced"
 msgstr ""
 
@@ -1293,7 +1317,7 @@ msgid "Automatic"
 msgstr "Automático"
 
 #: jellyfin_mpv_shim/mpvtk_browser/downloads.py:51
-#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1355
+#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1288
 msgid "Episodes"
 msgstr ""
 
@@ -1302,7 +1326,7 @@ msgid "Season %s"
 msgstr ""
 
 #: jellyfin_mpv_shim/mpvtk_browser/downloads.py:52
-#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1351
+#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1284
 msgid "Specials"
 msgstr ""
 
@@ -1327,7 +1351,7 @@ msgid "Failed"
 msgstr "Fallo"
 
 #: jellyfin_mpv_shim/mpvtk_browser/downloads.py:185
-#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1105
+#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1038
 msgid "Playlist"
 msgstr ""
 
@@ -1339,30 +1363,30 @@ msgstr ""
 msgid "Movies & Videos"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/home_sections.py:103
+#: jellyfin_mpv_shim/mpvtk_browser/home_sections.py:104
 msgid "My Media"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/home_sections.py:104
-#: jellyfin_mpv_shim/mpvtk_browser/repository.py:352
+#: jellyfin_mpv_shim/mpvtk_browser/home_sections.py:105
+#: jellyfin_mpv_shim/mpvtk_browser/repository.py:350
 msgid "Continue Watching"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/home_sections.py:105
-#: jellyfin_mpv_shim/mpvtk_browser/repository.py:359
+#: jellyfin_mpv_shim/mpvtk_browser/home_sections.py:106
+#: jellyfin_mpv_shim/mpvtk_browser/repository.py:357
 msgid "Continue Listening"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/home_sections.py:106
-#: jellyfin_mpv_shim/mpvtk_browser/repository.py:366
+#: jellyfin_mpv_shim/mpvtk_browser/home_sections.py:107
+#: jellyfin_mpv_shim/mpvtk_browser/repository.py:364
 msgid "Next Up"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/home_sections.py:107
+#: jellyfin_mpv_shim/mpvtk_browser/home_sections.py:108
 msgid "Recently Added"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/home_sections.py:108
+#: jellyfin_mpv_shim/mpvtk_browser/home_sections.py:109
 msgid "Live TV"
 msgstr ""
 
@@ -1615,52 +1639,52 @@ msgstr ""
 "Non foi posíbel engadir o servidor.\n"
 "Por favor, revise os parámetros de conexión."
 
-#: jellyfin_mpv_shim/mpvtk_browser/repository.py:390
+#: jellyfin_mpv_shim/mpvtk_browser/repository.py:386
 msgid "On Now"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/repository.py:411
+#: jellyfin_mpv_shim/mpvtk_browser/repository.py:407
 msgid "Latest %s"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1119
+#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1052
 msgid "Downloaded"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1138
+#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1071
 msgid "Movies"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1143
+#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1076
 msgid "Videos"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1147
+#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1080
 msgid "TV Shows"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1151
+#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1084
 msgid "Playlists"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1168
-#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1441
+#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1101
+#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1374
 msgid "Series"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1212
+#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1145
 msgid "Downloaded Movies"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1216
+#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1149
 msgid "Downloaded Videos"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1220
+#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1153
 msgid "Downloaded Shows"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1353
+#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1286
 msgid "Season %d"
 msgstr ""
 

--- a/jellyfin_mpv_shim/messages/gsw/LC_MESSAGES/base.po
+++ b/jellyfin_mpv_shim/messages/gsw/LC_MESSAGES/base.po
@@ -5,7 +5,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2026-07-25 17:21-0400\n"
+"POT-Creation-Date: 2026-07-26 12:03-0400\n"
 "PO-Revision-Date: 2025-12-29 17:50+0000\n"
 "Last-Translator: wrecker454 <jellyfin.wrecker454@passmail.net>\n"
 "Language-Team: Alemannic <https://translate.jellyfin.org/projects/jellyfin/"
@@ -252,7 +252,7 @@ msgid "Select Subtitle Track"
 msgstr ""
 
 #: jellyfin_mpv_shim/menu.py:341
-#: jellyfin_mpv_shim/mpvtk_browser/home_sections.py:102
+#: jellyfin_mpv_shim/mpvtk_browser/home_sections.py:103
 #: jellyfin_mpv_shim/osc_bridge.py:81 jellyfin_mpv_shim/osc_bridge.py:82
 #: jellyfin_mpv_shim/osc_bridge.py:104 jellyfin_mpv_shim/osc_bridge.py:140
 msgid "None"
@@ -403,7 +403,7 @@ msgstr ""
 msgid "Enable thumbnail previews"
 msgstr ""
 
-#: jellyfin_mpv_shim/menu.py:609 jellyfin_mpv_shim/mpvtk_browser/config.py:186
+#: jellyfin_mpv_shim/menu.py:609 jellyfin_mpv_shim/mpvtk_browser/config.py:195
 #: jellyfin_mpv_shim/mpvtk_browser/hud.py:375
 msgid "Night Mode (Auto Volume Adj)"
 msgstr ""
@@ -700,302 +700,326 @@ msgstr ""
 msgid "Or switch to another user"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/cast.py:317
+#: jellyfin_mpv_shim/mpvtk_browser/cast.py:314
 msgid "Ready to cast"
 msgstr "Parat zum Überträge"
 
-#: jellyfin_mpv_shim/mpvtk_browser/cast.py:318
+#: jellyfin_mpv_shim/mpvtk_browser/cast.py:315
 #, fuzzy
 #| msgid "Select your media in Jellyfin and play it here"
 msgid "Select your media in Jellyfin and play it here."
 msgstr "Wähl dini Medie in Jellyfin und spiel sie da ab"
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:74
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:83
 msgid "Interface"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:83
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:92
 msgid "Playback"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:88
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:97
 msgid "Audio"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:92
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:101
 msgid "Subtitles & Languages"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:97
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:106
 msgid "Transcoding"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:102
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:111
 msgid "Video Enhancement"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:104
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:113
 msgid "Skip Intro / Credits"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:107
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:116
 msgid "Library Browser"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:109
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:118
 msgid "Downloads"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:128
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:137
 msgid "Jellyfin UI"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:129
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:138
 msgid "MPV UI with thumbnails"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:130
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:139
 msgid "MPV built-in default"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:133
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:142
 msgid "Follow display"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:134
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:143
 msgid "100% (no scaling)"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:135
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:144
 msgid "125%"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:136
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:145
 msgid "150%"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:137
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:146
 msgid "200%"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:140
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:149
 msgid "Automatic (recommended)"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:141
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:150
 msgid "Vulkan"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:142
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:151
 msgid "Direct3D 11 (Windows only)"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:143
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:152
 msgid "OpenGL (compatibility)"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:146
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:155
 msgid "Default (auto)"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:147
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:156
 msgid "Force Stereo"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:148
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:157
 msgid "Optical Surround"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:149
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:158
 msgid "HDMI Passthrough"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:152
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:161
 msgid "Unset"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:153
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:162
 msgid "Dubbed (shows only)"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:154
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:163
 msgid "Subbed (shows only)"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:155
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:164
 msgid "Dubbed (all)"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:156
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:165
 msgid "Subbed (all)"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:157
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:166
 msgid "Custom (set in config)"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:162
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:171
 msgid "Download Folder"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:163
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:172
 msgid "Prefer Downloaded Copy"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:164
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:173
 msgid "Automatically Download Upcoming Episodes"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:165
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:174
 msgid "Include Next Up"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:166
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:175
 msgid "Next Up Entries to Consider"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:167
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:176
 msgid "Episodes to Keep Ahead (0 = off)"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:168
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:177
 msgid "Storage Limit for Automatic Downloads (GB)"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:169
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:178
 #, fuzzy
 #| msgid "Remove Server"
 msgid "Delete Automatic Downloads Once Watched"
 msgstr "Server entfärne"
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:170
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:179
 msgid "Delete Unwatched After (days, 0 = never)"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:171
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:180
 msgid "Check Every (minutes)"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:172
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:181
 msgid "Close to Tray (keep running)"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:173
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:182
 msgid "Keep Running in Background"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:174
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:183
 msgid "Remember Window Size"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:175
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:184
 msgid "Player Controls Style"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:176
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:185
 msgid "Show What You're Watching in Discord"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:177
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:186
 msgid "Interface Scale"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:178
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:187
 msgid "Cast-target mode (no library browsing)"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:179
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:188
 msgid "Casting Opens the Library Browser"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:180
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:189
 msgid "Fullscreen Library Browser"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:181
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:190
 msgid "Always Bind Arrow Keys to Player Controls"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:182
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:191
 msgid "Player Controls Activation Key"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:183
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:192
 msgid "Audio Output Mode"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:184
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:193
 msgid "Audio Output Device"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:185
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:194
 msgid "Take the Device Exclusively"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:187
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:196
 msgid "Enable Video Playback Profiles"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:188
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:197
 msgid "Profile Group"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:189
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:198
 msgid "Remember Last Used Profile"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:190
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:199
 msgid "Graphics API for Shaders"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:191
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:200
 msgid "Pass Through AC3"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:192
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:201
 msgid "Pass Through DTS"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:193
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:202
 msgid "Pass Through E-AC3"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:194
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:203
 msgid "Pass Through DTS-HD"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:195
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:204
 msgid "Pass Through TrueHD"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:196
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:205
 msgid "Re-encode Others to AC3"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:202
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:213
 msgid ""
-"MPV keybinds are used by default. Press ENTER to drive the player controls "
-"by keyboard."
+"With \"Start Minimized\" and \"Fullscreen\" this is the classic cast-target "
+"setup: the app waits out of the way, plays fullscreen when something casts "
+"to it, and goes back to waiting when the video ends or you press Q."
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:204
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:227
+msgid ""
+"Off means command-line mode: no window, no system tray and no settings "
+"screen, so the only way back is editing conf.json by hand. It is not how you "
+"get MPV's own on-screen controls — \"Player Controls Style\" under Interface "
+"does that."
+msgstr ""
+
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:234
+msgid ""
+"Show only what is cast to this machine — the library, including this "
+"settings screen, can't be reached from here. Without a system tray icon the "
+"only way back is editing conf.json. For the classic cast-target setup you "
+"want the Interface settings instead; this is for a shared TV nobody should "
+"be able to browse from."
+msgstr ""
+
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:240
+msgid ""
+"Requires restart to change. MPV keybinds are used by default. Press ENTER to "
+"drive the player controls by keyboard."
+msgstr ""
+
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:242
 msgid ""
 "Pixels one wheel notch scrolls. The scrollbar glides while the content snaps "
 "to the nearest row, so a trackpad or trackball no longer overshoots. Raise "
 "it to scroll faster, lower it for finer control."
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:209
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:247
 msgid ""
 "Make each wheel notch jump exactly one row (or one home-screen section) "
 "instead of gliding. Turn this on if you prefer the older stepped scrolling."
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:217
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:255
 msgid "Discord Rich Presence. Takes effect after a restart."
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:219
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:257
 msgid ""
 "Leave this to Default unless setting up passthrough. Note some audio servers "
 "like Pipewire don't like passthrough and will need to be disabled for a card "
@@ -1003,57 +1027,57 @@ msgid ""
 "silence otherwise, but results may vary."
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:225
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:263
 msgid ""
 "Stop anything else using the device while playing. Needed for passthrough on "
 "some systems, and it means other applications will be silent."
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:228
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:266
 msgid ""
 "Page the library and music tile grids instead of scrolling: each page is one "
 "screenful with First / Previous / Next / Last controls and a page number you "
 "can type into. Easier than precise scrolling on a trackpad."
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:232
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:270
 msgid ""
 "Takes effect after a restart. \"Follow display\" uses the scale your desktop "
 "reports, which is 100% on X11."
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:234
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:272
 msgid ""
 "\"Default\" changes nothing and lets MPV (and your own mpv.conf) decide. "
 "Pick a mode only if you are sending audio to a receiver."
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:237
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:275
 msgid ""
 "Audio your receiver can't be sent directly is encoded to AC3, which is the "
 "only way surround fits down an optical cable. Turn this off if the encoder "
 "causes audio delay — those tracks become stereo instead."
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:242
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:280
 msgid ""
 "\"hq\" offers heavier profiles. Pick it if you have a fast graphics card."
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:244
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:282
 msgid ""
 "Leave on Automatic unless video breaks when a profile is loaded. This only "
 "applies while a profile is active, and OpenGL can cost you HDR output."
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:248
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:286
 msgid ""
 "Evens out loud effects and quiet dialogue. This turns passthrough off while "
 "it is enabled, because the volume has to be adjusted before your receiver "
 "gets the audio."
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:330
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:368
 msgid "Advanced"
 msgstr ""
 
@@ -1267,7 +1291,7 @@ msgid "Automatic"
 msgstr ""
 
 #: jellyfin_mpv_shim/mpvtk_browser/downloads.py:51
-#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1355
+#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1288
 msgid "Episodes"
 msgstr ""
 
@@ -1276,7 +1300,7 @@ msgid "Season %s"
 msgstr ""
 
 #: jellyfin_mpv_shim/mpvtk_browser/downloads.py:52
-#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1351
+#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1284
 msgid "Specials"
 msgstr ""
 
@@ -1301,7 +1325,7 @@ msgid "Failed"
 msgstr "Fähler"
 
 #: jellyfin_mpv_shim/mpvtk_browser/downloads.py:185
-#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1105
+#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1038
 msgid "Playlist"
 msgstr ""
 
@@ -1313,30 +1337,30 @@ msgstr ""
 msgid "Movies & Videos"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/home_sections.py:103
+#: jellyfin_mpv_shim/mpvtk_browser/home_sections.py:104
 msgid "My Media"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/home_sections.py:104
-#: jellyfin_mpv_shim/mpvtk_browser/repository.py:352
+#: jellyfin_mpv_shim/mpvtk_browser/home_sections.py:105
+#: jellyfin_mpv_shim/mpvtk_browser/repository.py:350
 msgid "Continue Watching"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/home_sections.py:105
-#: jellyfin_mpv_shim/mpvtk_browser/repository.py:359
+#: jellyfin_mpv_shim/mpvtk_browser/home_sections.py:106
+#: jellyfin_mpv_shim/mpvtk_browser/repository.py:357
 msgid "Continue Listening"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/home_sections.py:106
-#: jellyfin_mpv_shim/mpvtk_browser/repository.py:366
+#: jellyfin_mpv_shim/mpvtk_browser/home_sections.py:107
+#: jellyfin_mpv_shim/mpvtk_browser/repository.py:364
 msgid "Next Up"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/home_sections.py:107
+#: jellyfin_mpv_shim/mpvtk_browser/home_sections.py:108
 msgid "Recently Added"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/home_sections.py:108
+#: jellyfin_mpv_shim/mpvtk_browser/home_sections.py:109
 msgid "Live TV"
 msgstr ""
 
@@ -1575,52 +1599,52 @@ msgstr ""
 "Server hät ned chönne hinzuegfüegt werde.\n"
 "Bitte überprüef dini Verbindigsinformatione."
 
-#: jellyfin_mpv_shim/mpvtk_browser/repository.py:390
+#: jellyfin_mpv_shim/mpvtk_browser/repository.py:386
 msgid "On Now"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/repository.py:411
+#: jellyfin_mpv_shim/mpvtk_browser/repository.py:407
 msgid "Latest %s"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1119
+#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1052
 msgid "Downloaded"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1138
+#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1071
 msgid "Movies"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1143
+#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1076
 msgid "Videos"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1147
+#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1080
 msgid "TV Shows"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1151
+#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1084
 msgid "Playlists"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1168
-#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1441
+#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1101
+#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1374
 msgid "Series"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1212
+#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1145
 msgid "Downloaded Movies"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1216
+#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1149
 msgid "Downloaded Videos"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1220
+#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1153
 msgid "Downloaded Shows"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1353
+#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1286
 msgid "Season %d"
 msgstr ""
 

--- a/jellyfin_mpv_shim/messages/he/LC_MESSAGES/base.po
+++ b/jellyfin_mpv_shim/messages/he/LC_MESSAGES/base.po
@@ -5,7 +5,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2026-07-25 17:21-0400\n"
+"POT-Creation-Date: 2026-07-26 12:03-0400\n"
 "PO-Revision-Date: 2025-07-04 11:41+0000\n"
 "Last-Translator: Tal Sarid <sarid.tal@gmail.com>\n"
 "Language-Team: Hebrew <https://translate.jellyfin.org/projects/jellyfin/"
@@ -253,7 +253,7 @@ msgid "Select Subtitle Track"
 msgstr "בחר כתוביות"
 
 #: jellyfin_mpv_shim/menu.py:341
-#: jellyfin_mpv_shim/mpvtk_browser/home_sections.py:102
+#: jellyfin_mpv_shim/mpvtk_browser/home_sections.py:103
 #: jellyfin_mpv_shim/osc_bridge.py:81 jellyfin_mpv_shim/osc_bridge.py:82
 #: jellyfin_mpv_shim/osc_bridge.py:104 jellyfin_mpv_shim/osc_bridge.py:140
 msgid "None"
@@ -404,7 +404,7 @@ msgstr "שאל אם לדלג על קרדיטים"
 msgid "Enable thumbnail previews"
 msgstr "הפעל תצוגה מקדימה של תמונות קטנות"
 
-#: jellyfin_mpv_shim/menu.py:609 jellyfin_mpv_shim/mpvtk_browser/config.py:186
+#: jellyfin_mpv_shim/menu.py:609 jellyfin_mpv_shim/mpvtk_browser/config.py:195
 #: jellyfin_mpv_shim/mpvtk_browser/hud.py:375
 msgid "Night Mode (Auto Volume Adj)"
 msgstr ""
@@ -703,310 +703,334 @@ msgstr ""
 msgid "Or switch to another user"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/cast.py:317
+#: jellyfin_mpv_shim/mpvtk_browser/cast.py:314
 msgid "Ready to cast"
 msgstr "מוכן לשדר"
 
-#: jellyfin_mpv_shim/mpvtk_browser/cast.py:318
+#: jellyfin_mpv_shim/mpvtk_browser/cast.py:315
 #, fuzzy
 #| msgid "Select your media in Jellyfin and play it here"
 msgid "Select your media in Jellyfin and play it here."
 msgstr "בחר את המדיה הרצויה ב-Jellyfin ונגן אותה פה"
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:74
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:83
 msgid "Interface"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:83
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:92
 msgid "Playback"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:88
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:97
 msgid "Audio"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:92
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:101
 msgid "Subtitles & Languages"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:97
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:106
 #, fuzzy
 #| msgid " (Transcode)"
 msgid "Transcoding"
 msgstr " (המרת קידוד)"
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:102
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:111
 msgid "Video Enhancement"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:104
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:113
 #, fuzzy
 #| msgid "Seek to Skip Credits"
 msgid "Skip Intro / Credits"
 msgstr "העברה לדילוג על הקרדיטים"
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:107
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:116
 msgid "Library Browser"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:109
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:118
 msgid "Downloads"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:128
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:137
 msgid "Jellyfin UI"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:129
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:138
 msgid "MPV UI with thumbnails"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:130
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:139
 msgid "MPV built-in default"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:133
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:142
 msgid "Follow display"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:134
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:143
 msgid "100% (no scaling)"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:135
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:144
 msgid "125%"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:136
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:145
 msgid "150%"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:137
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:146
 msgid "200%"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:140
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:149
 msgid "Automatic (recommended)"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:141
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:150
 msgid "Vulkan"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:142
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:151
 msgid "Direct3D 11 (Windows only)"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:143
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:152
 msgid "OpenGL (compatibility)"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:146
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:155
 msgid "Default (auto)"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:147
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:156
 msgid "Force Stereo"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:148
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:157
 msgid "Optical Surround"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:149
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:158
 msgid "HDMI Passthrough"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:152
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:161
 msgid "Unset"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:153
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:162
 msgid "Dubbed (shows only)"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:154
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:163
 msgid "Subbed (shows only)"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:155
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:164
 msgid "Dubbed (all)"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:156
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:165
 msgid "Subbed (all)"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:157
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:166
 msgid "Custom (set in config)"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:162
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:171
 msgid "Download Folder"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:163
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:172
 msgid "Prefer Downloaded Copy"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:164
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:173
 msgid "Automatically Download Upcoming Episodes"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:165
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:174
 msgid "Include Next Up"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:166
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:175
 msgid "Next Up Entries to Consider"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:167
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:176
 msgid "Episodes to Keep Ahead (0 = off)"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:168
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:177
 msgid "Storage Limit for Automatic Downloads (GB)"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:169
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:178
 #, fuzzy
 #| msgid "Remove Server"
 msgid "Delete Automatic Downloads Once Watched"
 msgstr "הסר שרת"
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:170
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:179
 msgid "Delete Unwatched After (days, 0 = never)"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:171
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:180
 msgid "Check Every (minutes)"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:172
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:181
 msgid "Close to Tray (keep running)"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:173
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:182
 msgid "Keep Running in Background"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:174
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:183
 msgid "Remember Window Size"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:175
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:184
 msgid "Player Controls Style"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:176
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:185
 msgid "Show What You're Watching in Discord"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:177
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:186
 msgid "Interface Scale"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:178
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:187
 msgid "Cast-target mode (no library browsing)"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:179
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:188
 msgid "Casting Opens the Library Browser"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:180
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:189
 msgid "Fullscreen Library Browser"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:181
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:190
 msgid "Always Bind Arrow Keys to Player Controls"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:182
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:191
 msgid "Player Controls Activation Key"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:183
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:192
 msgid "Audio Output Mode"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:184
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:193
 msgid "Audio Output Device"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:185
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:194
 msgid "Take the Device Exclusively"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:187
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:196
 #, fuzzy
 #| msgid "Video Playback Profiles"
 msgid "Enable Video Playback Profiles"
 msgstr "פרופילים לניגון וידאו"
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:188
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:197
 #, fuzzy
 #| msgid "New Group"
 msgid "Profile Group"
 msgstr "קבוצה חדשה"
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:189
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:198
 msgid "Remember Last Used Profile"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:190
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:199
 msgid "Graphics API for Shaders"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:191
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:200
 msgid "Pass Through AC3"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:192
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:201
 msgid "Pass Through DTS"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:193
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:202
 msgid "Pass Through E-AC3"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:194
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:203
 msgid "Pass Through DTS-HD"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:195
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:204
 msgid "Pass Through TrueHD"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:196
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:205
 msgid "Re-encode Others to AC3"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:202
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:213
 msgid ""
-"MPV keybinds are used by default. Press ENTER to drive the player controls "
-"by keyboard."
+"With \"Start Minimized\" and \"Fullscreen\" this is the classic cast-target "
+"setup: the app waits out of the way, plays fullscreen when something casts "
+"to it, and goes back to waiting when the video ends or you press Q."
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:204
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:227
+msgid ""
+"Off means command-line mode: no window, no system tray and no settings "
+"screen, so the only way back is editing conf.json by hand. It is not how you "
+"get MPV's own on-screen controls — \"Player Controls Style\" under Interface "
+"does that."
+msgstr ""
+
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:234
+msgid ""
+"Show only what is cast to this machine — the library, including this "
+"settings screen, can't be reached from here. Without a system tray icon the "
+"only way back is editing conf.json. For the classic cast-target setup you "
+"want the Interface settings instead; this is for a shared TV nobody should "
+"be able to browse from."
+msgstr ""
+
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:240
+msgid ""
+"Requires restart to change. MPV keybinds are used by default. Press ENTER to "
+"drive the player controls by keyboard."
+msgstr ""
+
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:242
 msgid ""
 "Pixels one wheel notch scrolls. The scrollbar glides while the content snaps "
 "to the nearest row, so a trackpad or trackball no longer overshoots. Raise "
 "it to scroll faster, lower it for finer control."
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:209
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:247
 msgid ""
 "Make each wheel notch jump exactly one row (or one home-screen section) "
 "instead of gliding. Turn this on if you prefer the older stepped scrolling."
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:217
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:255
 msgid "Discord Rich Presence. Takes effect after a restart."
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:219
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:257
 msgid ""
 "Leave this to Default unless setting up passthrough. Note some audio servers "
 "like Pipewire don't like passthrough and will need to be disabled for a card "
@@ -1014,57 +1038,57 @@ msgid ""
 "silence otherwise, but results may vary."
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:225
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:263
 msgid ""
 "Stop anything else using the device while playing. Needed for passthrough on "
 "some systems, and it means other applications will be silent."
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:228
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:266
 msgid ""
 "Page the library and music tile grids instead of scrolling: each page is one "
 "screenful with First / Previous / Next / Last controls and a page number you "
 "can type into. Easier than precise scrolling on a trackpad."
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:232
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:270
 msgid ""
 "Takes effect after a restart. \"Follow display\" uses the scale your desktop "
 "reports, which is 100% on X11."
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:234
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:272
 msgid ""
 "\"Default\" changes nothing and lets MPV (and your own mpv.conf) decide. "
 "Pick a mode only if you are sending audio to a receiver."
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:237
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:275
 msgid ""
 "Audio your receiver can't be sent directly is encoded to AC3, which is the "
 "only way surround fits down an optical cable. Turn this off if the encoder "
 "causes audio delay — those tracks become stereo instead."
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:242
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:280
 msgid ""
 "\"hq\" offers heavier profiles. Pick it if you have a fast graphics card."
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:244
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:282
 msgid ""
 "Leave on Automatic unless video breaks when a profile is loaded. This only "
 "applies while a profile is active, and OpenGL can cost you HDR output."
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:248
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:286
 msgid ""
 "Evens out loud effects and quiet dialogue. This turns passthrough off while "
 "it is enabled, because the volume has to be adjusted before your receiver "
 "gets the audio."
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:330
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:368
 msgid "Advanced"
 msgstr ""
 
@@ -1290,7 +1314,7 @@ msgid "Automatic"
 msgstr "אוטומטי"
 
 #: jellyfin_mpv_shim/mpvtk_browser/downloads.py:51
-#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1355
+#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1288
 msgid "Episodes"
 msgstr ""
 
@@ -1299,7 +1323,7 @@ msgid "Season %s"
 msgstr ""
 
 #: jellyfin_mpv_shim/mpvtk_browser/downloads.py:52
-#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1351
+#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1284
 msgid "Specials"
 msgstr ""
 
@@ -1324,7 +1348,7 @@ msgid "Failed"
 msgstr "נכשל"
 
 #: jellyfin_mpv_shim/mpvtk_browser/downloads.py:185
-#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1105
+#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1038
 msgid "Playlist"
 msgstr ""
 
@@ -1336,30 +1360,30 @@ msgstr ""
 msgid "Movies & Videos"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/home_sections.py:103
+#: jellyfin_mpv_shim/mpvtk_browser/home_sections.py:104
 msgid "My Media"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/home_sections.py:104
-#: jellyfin_mpv_shim/mpvtk_browser/repository.py:352
+#: jellyfin_mpv_shim/mpvtk_browser/home_sections.py:105
+#: jellyfin_mpv_shim/mpvtk_browser/repository.py:350
 msgid "Continue Watching"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/home_sections.py:105
-#: jellyfin_mpv_shim/mpvtk_browser/repository.py:359
+#: jellyfin_mpv_shim/mpvtk_browser/home_sections.py:106
+#: jellyfin_mpv_shim/mpvtk_browser/repository.py:357
 msgid "Continue Listening"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/home_sections.py:106
-#: jellyfin_mpv_shim/mpvtk_browser/repository.py:366
+#: jellyfin_mpv_shim/mpvtk_browser/home_sections.py:107
+#: jellyfin_mpv_shim/mpvtk_browser/repository.py:364
 msgid "Next Up"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/home_sections.py:107
+#: jellyfin_mpv_shim/mpvtk_browser/home_sections.py:108
 msgid "Recently Added"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/home_sections.py:108
+#: jellyfin_mpv_shim/mpvtk_browser/home_sections.py:109
 msgid "Live TV"
 msgstr ""
 
@@ -1612,52 +1636,52 @@ msgstr ""
 "השרת לא נוסף.\n"
 "אנא בדוק את החיבור."
 
-#: jellyfin_mpv_shim/mpvtk_browser/repository.py:390
+#: jellyfin_mpv_shim/mpvtk_browser/repository.py:386
 msgid "On Now"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/repository.py:411
+#: jellyfin_mpv_shim/mpvtk_browser/repository.py:407
 msgid "Latest %s"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1119
+#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1052
 msgid "Downloaded"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1138
+#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1071
 msgid "Movies"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1143
+#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1076
 msgid "Videos"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1147
+#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1080
 msgid "TV Shows"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1151
+#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1084
 msgid "Playlists"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1168
-#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1441
+#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1101
+#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1374
 msgid "Series"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1212
+#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1145
 msgid "Downloaded Movies"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1216
+#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1149
 msgid "Downloaded Videos"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1220
+#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1153
 msgid "Downloaded Shows"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1353
+#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1286
 msgid "Season %d"
 msgstr ""
 

--- a/jellyfin_mpv_shim/messages/hi/LC_MESSAGES/base.po
+++ b/jellyfin_mpv_shim/messages/hi/LC_MESSAGES/base.po
@@ -5,7 +5,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2026-07-25 17:21-0400\n"
+"POT-Creation-Date: 2026-07-26 12:03-0400\n"
 "PO-Revision-Date: 2026-05-21 07:45+0000\n"
 "Last-Translator: Dart og <onice757@gmail.com>\n"
 "Language-Team: Hindi <https://translate.jellyfin.org/projects/jellyfin/"
@@ -252,7 +252,7 @@ msgid "Select Subtitle Track"
 msgstr ""
 
 #: jellyfin_mpv_shim/menu.py:341
-#: jellyfin_mpv_shim/mpvtk_browser/home_sections.py:102
+#: jellyfin_mpv_shim/mpvtk_browser/home_sections.py:103
 #: jellyfin_mpv_shim/osc_bridge.py:81 jellyfin_mpv_shim/osc_bridge.py:82
 #: jellyfin_mpv_shim/osc_bridge.py:104 jellyfin_mpv_shim/osc_bridge.py:140
 msgid "None"
@@ -403,7 +403,7 @@ msgstr ""
 msgid "Enable thumbnail previews"
 msgstr ""
 
-#: jellyfin_mpv_shim/menu.py:609 jellyfin_mpv_shim/mpvtk_browser/config.py:186
+#: jellyfin_mpv_shim/menu.py:609 jellyfin_mpv_shim/mpvtk_browser/config.py:195
 #: jellyfin_mpv_shim/mpvtk_browser/hud.py:375
 msgid "Night Mode (Auto Volume Adj)"
 msgstr ""
@@ -700,306 +700,330 @@ msgstr ""
 msgid "Or switch to another user"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/cast.py:317
+#: jellyfin_mpv_shim/mpvtk_browser/cast.py:314
 msgid "Ready to cast"
 msgstr "डालने के लिए तैयार है"
 
-#: jellyfin_mpv_shim/mpvtk_browser/cast.py:318
+#: jellyfin_mpv_shim/mpvtk_browser/cast.py:315
 #, fuzzy
 #| msgid "Select your media in Jellyfin and play it here"
 msgid "Select your media in Jellyfin and play it here."
 msgstr "अपने मीडिया फाइल को जेलीफिन में चयन करें और यहां चलाए"
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:74
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:83
 msgid "Interface"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:83
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:92
 msgid "Playback"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:88
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:97
 msgid "Audio"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:92
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:101
 msgid "Subtitles & Languages"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:97
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:106
 #, fuzzy
 #| msgid " (Transcode)"
 msgid "Transcoding"
 msgstr " (ट्रांसकोड)"
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:102
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:111
 msgid "Video Enhancement"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:104
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:113
 msgid "Skip Intro / Credits"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:107
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:116
 msgid "Library Browser"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:109
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:118
 msgid "Downloads"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:128
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:137
 msgid "Jellyfin UI"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:129
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:138
 msgid "MPV UI with thumbnails"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:130
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:139
 msgid "MPV built-in default"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:133
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:142
 msgid "Follow display"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:134
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:143
 msgid "100% (no scaling)"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:135
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:144
 msgid "125%"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:136
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:145
 msgid "150%"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:137
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:146
 msgid "200%"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:140
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:149
 msgid "Automatic (recommended)"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:141
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:150
 msgid "Vulkan"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:142
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:151
 msgid "Direct3D 11 (Windows only)"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:143
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:152
 msgid "OpenGL (compatibility)"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:146
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:155
 msgid "Default (auto)"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:147
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:156
 msgid "Force Stereo"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:148
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:157
 msgid "Optical Surround"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:149
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:158
 msgid "HDMI Passthrough"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:152
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:161
 msgid "Unset"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:153
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:162
 msgid "Dubbed (shows only)"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:154
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:163
 msgid "Subbed (shows only)"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:155
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:164
 msgid "Dubbed (all)"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:156
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:165
 msgid "Subbed (all)"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:157
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:166
 msgid "Custom (set in config)"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:162
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:171
 msgid "Download Folder"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:163
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:172
 msgid "Prefer Downloaded Copy"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:164
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:173
 msgid "Automatically Download Upcoming Episodes"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:165
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:174
 msgid "Include Next Up"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:166
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:175
 msgid "Next Up Entries to Consider"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:167
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:176
 msgid "Episodes to Keep Ahead (0 = off)"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:168
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:177
 msgid "Storage Limit for Automatic Downloads (GB)"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:169
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:178
 #, fuzzy
 #| msgid "Remove Server"
 msgid "Delete Automatic Downloads Once Watched"
 msgstr "सर्वर हटाएं"
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:170
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:179
 msgid "Delete Unwatched After (days, 0 = never)"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:171
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:180
 msgid "Check Every (minutes)"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:172
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:181
 msgid "Close to Tray (keep running)"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:173
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:182
 msgid "Keep Running in Background"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:174
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:183
 msgid "Remember Window Size"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:175
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:184
 msgid "Player Controls Style"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:176
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:185
 msgid "Show What You're Watching in Discord"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:177
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:186
 msgid "Interface Scale"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:178
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:187
 msgid "Cast-target mode (no library browsing)"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:179
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:188
 msgid "Casting Opens the Library Browser"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:180
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:189
 msgid "Fullscreen Library Browser"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:181
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:190
 msgid "Always Bind Arrow Keys to Player Controls"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:182
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:191
 msgid "Player Controls Activation Key"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:183
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:192
 msgid "Audio Output Mode"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:184
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:193
 msgid "Audio Output Device"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:185
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:194
 msgid "Take the Device Exclusively"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:187
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:196
 #, fuzzy
 #| msgid "Change Video Playback Profile"
 msgid "Enable Video Playback Profiles"
 msgstr "वीडियो प्लेबैक प्रोफाइल बदलें"
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:188
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:197
 msgid "Profile Group"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:189
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:198
 msgid "Remember Last Used Profile"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:190
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:199
 msgid "Graphics API for Shaders"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:191
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:200
 msgid "Pass Through AC3"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:192
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:201
 msgid "Pass Through DTS"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:193
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:202
 msgid "Pass Through E-AC3"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:194
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:203
 msgid "Pass Through DTS-HD"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:195
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:204
 msgid "Pass Through TrueHD"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:196
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:205
 msgid "Re-encode Others to AC3"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:202
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:213
 msgid ""
-"MPV keybinds are used by default. Press ENTER to drive the player controls "
-"by keyboard."
+"With \"Start Minimized\" and \"Fullscreen\" this is the classic cast-target "
+"setup: the app waits out of the way, plays fullscreen when something casts "
+"to it, and goes back to waiting when the video ends or you press Q."
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:204
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:227
+msgid ""
+"Off means command-line mode: no window, no system tray and no settings "
+"screen, so the only way back is editing conf.json by hand. It is not how you "
+"get MPV's own on-screen controls — \"Player Controls Style\" under Interface "
+"does that."
+msgstr ""
+
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:234
+msgid ""
+"Show only what is cast to this machine — the library, including this "
+"settings screen, can't be reached from here. Without a system tray icon the "
+"only way back is editing conf.json. For the classic cast-target setup you "
+"want the Interface settings instead; this is for a shared TV nobody should "
+"be able to browse from."
+msgstr ""
+
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:240
+msgid ""
+"Requires restart to change. MPV keybinds are used by default. Press ENTER to "
+"drive the player controls by keyboard."
+msgstr ""
+
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:242
 msgid ""
 "Pixels one wheel notch scrolls. The scrollbar glides while the content snaps "
 "to the nearest row, so a trackpad or trackball no longer overshoots. Raise "
 "it to scroll faster, lower it for finer control."
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:209
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:247
 msgid ""
 "Make each wheel notch jump exactly one row (or one home-screen section) "
 "instead of gliding. Turn this on if you prefer the older stepped scrolling."
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:217
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:255
 msgid "Discord Rich Presence. Takes effect after a restart."
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:219
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:257
 msgid ""
 "Leave this to Default unless setting up passthrough. Note some audio servers "
 "like Pipewire don't like passthrough and will need to be disabled for a card "
@@ -1007,57 +1031,57 @@ msgid ""
 "silence otherwise, but results may vary."
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:225
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:263
 msgid ""
 "Stop anything else using the device while playing. Needed for passthrough on "
 "some systems, and it means other applications will be silent."
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:228
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:266
 msgid ""
 "Page the library and music tile grids instead of scrolling: each page is one "
 "screenful with First / Previous / Next / Last controls and a page number you "
 "can type into. Easier than precise scrolling on a trackpad."
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:232
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:270
 msgid ""
 "Takes effect after a restart. \"Follow display\" uses the scale your desktop "
 "reports, which is 100% on X11."
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:234
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:272
 msgid ""
 "\"Default\" changes nothing and lets MPV (and your own mpv.conf) decide. "
 "Pick a mode only if you are sending audio to a receiver."
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:237
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:275
 msgid ""
 "Audio your receiver can't be sent directly is encoded to AC3, which is the "
 "only way surround fits down an optical cable. Turn this off if the encoder "
 "causes audio delay — those tracks become stereo instead."
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:242
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:280
 msgid ""
 "\"hq\" offers heavier profiles. Pick it if you have a fast graphics card."
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:244
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:282
 msgid ""
 "Leave on Automatic unless video breaks when a profile is loaded. This only "
 "applies while a profile is active, and OpenGL can cost you HDR output."
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:248
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:286
 msgid ""
 "Evens out loud effects and quiet dialogue. This turns passthrough off while "
 "it is enabled, because the volume has to be adjusted before your receiver "
 "gets the audio."
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:330
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:368
 msgid "Advanced"
 msgstr ""
 
@@ -1271,7 +1295,7 @@ msgid "Automatic"
 msgstr ""
 
 #: jellyfin_mpv_shim/mpvtk_browser/downloads.py:51
-#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1355
+#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1288
 msgid "Episodes"
 msgstr ""
 
@@ -1280,7 +1304,7 @@ msgid "Season %s"
 msgstr ""
 
 #: jellyfin_mpv_shim/mpvtk_browser/downloads.py:52
-#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1351
+#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1284
 msgid "Specials"
 msgstr ""
 
@@ -1305,7 +1329,7 @@ msgid "Failed"
 msgstr "विफल"
 
 #: jellyfin_mpv_shim/mpvtk_browser/downloads.py:185
-#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1105
+#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1038
 msgid "Playlist"
 msgstr ""
 
@@ -1317,30 +1341,30 @@ msgstr ""
 msgid "Movies & Videos"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/home_sections.py:103
+#: jellyfin_mpv_shim/mpvtk_browser/home_sections.py:104
 msgid "My Media"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/home_sections.py:104
-#: jellyfin_mpv_shim/mpvtk_browser/repository.py:352
+#: jellyfin_mpv_shim/mpvtk_browser/home_sections.py:105
+#: jellyfin_mpv_shim/mpvtk_browser/repository.py:350
 msgid "Continue Watching"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/home_sections.py:105
-#: jellyfin_mpv_shim/mpvtk_browser/repository.py:359
+#: jellyfin_mpv_shim/mpvtk_browser/home_sections.py:106
+#: jellyfin_mpv_shim/mpvtk_browser/repository.py:357
 msgid "Continue Listening"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/home_sections.py:106
-#: jellyfin_mpv_shim/mpvtk_browser/repository.py:366
+#: jellyfin_mpv_shim/mpvtk_browser/home_sections.py:107
+#: jellyfin_mpv_shim/mpvtk_browser/repository.py:364
 msgid "Next Up"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/home_sections.py:107
+#: jellyfin_mpv_shim/mpvtk_browser/home_sections.py:108
 msgid "Recently Added"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/home_sections.py:108
+#: jellyfin_mpv_shim/mpvtk_browser/home_sections.py:109
 msgid "Live TV"
 msgstr ""
 
@@ -1585,52 +1609,52 @@ msgstr ""
 "सर्वर नहीं जोड़ सका।\n"
 "कृपया अपनी कनेक्शन जानकारी जांचें।"
 
-#: jellyfin_mpv_shim/mpvtk_browser/repository.py:390
+#: jellyfin_mpv_shim/mpvtk_browser/repository.py:386
 msgid "On Now"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/repository.py:411
+#: jellyfin_mpv_shim/mpvtk_browser/repository.py:407
 msgid "Latest %s"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1119
+#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1052
 msgid "Downloaded"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1138
+#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1071
 msgid "Movies"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1143
+#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1076
 msgid "Videos"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1147
+#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1080
 msgid "TV Shows"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1151
+#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1084
 msgid "Playlists"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1168
-#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1441
+#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1101
+#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1374
 msgid "Series"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1212
+#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1145
 msgid "Downloaded Movies"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1216
+#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1149
 msgid "Downloaded Videos"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1220
+#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1153
 msgid "Downloaded Shows"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1353
+#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1286
 msgid "Season %d"
 msgstr ""
 

--- a/jellyfin_mpv_shim/messages/hr/LC_MESSAGES/base.po
+++ b/jellyfin_mpv_shim/messages/hr/LC_MESSAGES/base.po
@@ -5,7 +5,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2026-07-25 17:21-0400\n"
+"POT-Creation-Date: 2026-07-26 12:03-0400\n"
 "PO-Revision-Date: 2026-04-15 13:45+0000\n"
 "Last-Translator: Milo Ivir <mail@milotype.de>\n"
 "Language-Team: Croatian <https://translate.jellyfin.org/projects/jellyfin/"
@@ -253,7 +253,7 @@ msgid "Select Subtitle Track"
 msgstr "Odaberi zapis titlova"
 
 #: jellyfin_mpv_shim/menu.py:341
-#: jellyfin_mpv_shim/mpvtk_browser/home_sections.py:102
+#: jellyfin_mpv_shim/mpvtk_browser/home_sections.py:103
 #: jellyfin_mpv_shim/osc_bridge.py:81 jellyfin_mpv_shim/osc_bridge.py:82
 #: jellyfin_mpv_shim/osc_bridge.py:104 jellyfin_mpv_shim/osc_bridge.py:140
 msgid "None"
@@ -404,7 +404,7 @@ msgstr "Pitaj za preskakanje špica"
 msgid "Enable thumbnail previews"
 msgstr "Omogući pregled sličica"
 
-#: jellyfin_mpv_shim/menu.py:609 jellyfin_mpv_shim/mpvtk_browser/config.py:186
+#: jellyfin_mpv_shim/menu.py:609 jellyfin_mpv_shim/mpvtk_browser/config.py:195
 #: jellyfin_mpv_shim/mpvtk_browser/hud.py:375
 msgid "Night Mode (Auto Volume Adj)"
 msgstr ""
@@ -703,11 +703,11 @@ msgstr ""
 msgid "Or switch to another user"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/cast.py:317
+#: jellyfin_mpv_shim/mpvtk_browser/cast.py:314
 msgid "Ready to cast"
 msgstr "Spreman za prijenos"
 
-#: jellyfin_mpv_shim/mpvtk_browser/cast.py:318
+#: jellyfin_mpv_shim/mpvtk_browser/cast.py:315
 #, fuzzy
 #| msgid "Select your media in Jellyfin and play it here"
 msgid "Select your media in Jellyfin and play it here."
@@ -715,300 +715,324 @@ msgstr ""
 "Odaberite svoje medijske datoteke unutar Jellyfin sučelja i reproducirajte "
 "ih ovdje"
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:74
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:83
 msgid "Interface"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:83
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:92
 msgid "Playback"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:88
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:97
 msgid "Audio"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:92
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:101
 msgid "Subtitles & Languages"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:97
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:106
 #, fuzzy
 #| msgid " (Transcode)"
 msgid "Transcoding"
 msgstr " (Transkodiraj)"
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:102
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:111
 msgid "Video Enhancement"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:104
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:113
 #, fuzzy
 #| msgid "Seek to Skip Credits"
 msgid "Skip Intro / Credits"
 msgstr "Traži za preskakanje špice"
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:107
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:116
 msgid "Library Browser"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:109
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:118
 msgid "Downloads"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:128
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:137
 msgid "Jellyfin UI"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:129
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:138
 msgid "MPV UI with thumbnails"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:130
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:139
 msgid "MPV built-in default"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:133
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:142
 msgid "Follow display"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:134
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:143
 msgid "100% (no scaling)"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:135
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:144
 msgid "125%"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:136
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:145
 msgid "150%"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:137
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:146
 msgid "200%"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:140
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:149
 msgid "Automatic (recommended)"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:141
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:150
 msgid "Vulkan"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:142
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:151
 msgid "Direct3D 11 (Windows only)"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:143
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:152
 msgid "OpenGL (compatibility)"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:146
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:155
 msgid "Default (auto)"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:147
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:156
 msgid "Force Stereo"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:148
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:157
 msgid "Optical Surround"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:149
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:158
 msgid "HDMI Passthrough"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:152
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:161
 msgid "Unset"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:153
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:162
 msgid "Dubbed (shows only)"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:154
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:163
 msgid "Subbed (shows only)"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:155
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:164
 msgid "Dubbed (all)"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:156
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:165
 msgid "Subbed (all)"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:157
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:166
 msgid "Custom (set in config)"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:162
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:171
 msgid "Download Folder"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:163
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:172
 msgid "Prefer Downloaded Copy"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:164
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:173
 msgid "Automatically Download Upcoming Episodes"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:165
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:174
 msgid "Include Next Up"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:166
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:175
 msgid "Next Up Entries to Consider"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:167
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:176
 msgid "Episodes to Keep Ahead (0 = off)"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:168
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:177
 msgid "Storage Limit for Automatic Downloads (GB)"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:169
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:178
 #, fuzzy
 #| msgid "Remove Server"
 msgid "Delete Automatic Downloads Once Watched"
 msgstr "Ukloni server"
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:170
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:179
 msgid "Delete Unwatched After (days, 0 = never)"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:171
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:180
 msgid "Check Every (minutes)"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:172
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:181
 msgid "Close to Tray (keep running)"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:173
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:182
 msgid "Keep Running in Background"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:174
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:183
 msgid "Remember Window Size"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:175
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:184
 msgid "Player Controls Style"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:176
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:185
 msgid "Show What You're Watching in Discord"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:177
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:186
 msgid "Interface Scale"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:178
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:187
 msgid "Cast-target mode (no library browsing)"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:179
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:188
 msgid "Casting Opens the Library Browser"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:180
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:189
 msgid "Fullscreen Library Browser"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:181
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:190
 msgid "Always Bind Arrow Keys to Player Controls"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:182
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:191
 msgid "Player Controls Activation Key"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:183
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:192
 msgid "Audio Output Mode"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:184
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:193
 msgid "Audio Output Device"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:185
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:194
 msgid "Take the Device Exclusively"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:187
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:196
 #, fuzzy
 #| msgid "Video Playback Profiles"
 msgid "Enable Video Playback Profiles"
 msgstr "Profili reprodukcije video zapisa"
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:188
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:197
 #, fuzzy
 #| msgid "New Group"
 msgid "Profile Group"
 msgstr "Nova grupa"
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:189
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:198
 msgid "Remember Last Used Profile"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:190
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:199
 msgid "Graphics API for Shaders"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:191
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:200
 msgid "Pass Through AC3"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:192
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:201
 msgid "Pass Through DTS"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:193
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:202
 msgid "Pass Through E-AC3"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:194
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:203
 msgid "Pass Through DTS-HD"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:195
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:204
 msgid "Pass Through TrueHD"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:196
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:205
 msgid "Re-encode Others to AC3"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:202
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:213
 msgid ""
-"MPV keybinds are used by default. Press ENTER to drive the player controls "
-"by keyboard."
+"With \"Start Minimized\" and \"Fullscreen\" this is the classic cast-target "
+"setup: the app waits out of the way, plays fullscreen when something casts "
+"to it, and goes back to waiting when the video ends or you press Q."
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:204
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:227
+msgid ""
+"Off means command-line mode: no window, no system tray and no settings "
+"screen, so the only way back is editing conf.json by hand. It is not how you "
+"get MPV's own on-screen controls — \"Player Controls Style\" under Interface "
+"does that."
+msgstr ""
+
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:234
+msgid ""
+"Show only what is cast to this machine — the library, including this "
+"settings screen, can't be reached from here. Without a system tray icon the "
+"only way back is editing conf.json. For the classic cast-target setup you "
+"want the Interface settings instead; this is for a shared TV nobody should "
+"be able to browse from."
+msgstr ""
+
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:240
+msgid ""
+"Requires restart to change. MPV keybinds are used by default. Press ENTER to "
+"drive the player controls by keyboard."
+msgstr ""
+
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:242
 msgid ""
 "Pixels one wheel notch scrolls. The scrollbar glides while the content snaps "
 "to the nearest row, so a trackpad or trackball no longer overshoots. Raise "
 "it to scroll faster, lower it for finer control."
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:209
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:247
 msgid ""
 "Make each wheel notch jump exactly one row (or one home-screen section) "
 "instead of gliding. Turn this on if you prefer the older stepped scrolling."
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:217
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:255
 msgid "Discord Rich Presence. Takes effect after a restart."
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:219
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:257
 msgid ""
 "Leave this to Default unless setting up passthrough. Note some audio servers "
 "like Pipewire don't like passthrough and will need to be disabled for a card "
@@ -1016,57 +1040,57 @@ msgid ""
 "silence otherwise, but results may vary."
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:225
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:263
 msgid ""
 "Stop anything else using the device while playing. Needed for passthrough on "
 "some systems, and it means other applications will be silent."
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:228
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:266
 msgid ""
 "Page the library and music tile grids instead of scrolling: each page is one "
 "screenful with First / Previous / Next / Last controls and a page number you "
 "can type into. Easier than precise scrolling on a trackpad."
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:232
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:270
 msgid ""
 "Takes effect after a restart. \"Follow display\" uses the scale your desktop "
 "reports, which is 100% on X11."
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:234
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:272
 msgid ""
 "\"Default\" changes nothing and lets MPV (and your own mpv.conf) decide. "
 "Pick a mode only if you are sending audio to a receiver."
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:237
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:275
 msgid ""
 "Audio your receiver can't be sent directly is encoded to AC3, which is the "
 "only way surround fits down an optical cable. Turn this off if the encoder "
 "causes audio delay — those tracks become stereo instead."
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:242
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:280
 msgid ""
 "\"hq\" offers heavier profiles. Pick it if you have a fast graphics card."
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:244
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:282
 msgid ""
 "Leave on Automatic unless video breaks when a profile is loaded. This only "
 "applies while a profile is active, and OpenGL can cost you HDR output."
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:248
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:286
 msgid ""
 "Evens out loud effects and quiet dialogue. This turns passthrough off while "
 "it is enabled, because the volume has to be adjusted before your receiver "
 "gets the audio."
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:330
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:368
 msgid "Advanced"
 msgstr ""
 
@@ -1292,7 +1316,7 @@ msgid "Automatic"
 msgstr "Automatski"
 
 #: jellyfin_mpv_shim/mpvtk_browser/downloads.py:51
-#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1355
+#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1288
 msgid "Episodes"
 msgstr ""
 
@@ -1301,7 +1325,7 @@ msgid "Season %s"
 msgstr ""
 
 #: jellyfin_mpv_shim/mpvtk_browser/downloads.py:52
-#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1351
+#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1284
 msgid "Specials"
 msgstr ""
 
@@ -1326,7 +1350,7 @@ msgid "Failed"
 msgstr "Greška"
 
 #: jellyfin_mpv_shim/mpvtk_browser/downloads.py:185
-#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1105
+#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1038
 msgid "Playlist"
 msgstr ""
 
@@ -1338,30 +1362,30 @@ msgstr ""
 msgid "Movies & Videos"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/home_sections.py:103
+#: jellyfin_mpv_shim/mpvtk_browser/home_sections.py:104
 msgid "My Media"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/home_sections.py:104
-#: jellyfin_mpv_shim/mpvtk_browser/repository.py:352
+#: jellyfin_mpv_shim/mpvtk_browser/home_sections.py:105
+#: jellyfin_mpv_shim/mpvtk_browser/repository.py:350
 msgid "Continue Watching"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/home_sections.py:105
-#: jellyfin_mpv_shim/mpvtk_browser/repository.py:359
+#: jellyfin_mpv_shim/mpvtk_browser/home_sections.py:106
+#: jellyfin_mpv_shim/mpvtk_browser/repository.py:357
 msgid "Continue Listening"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/home_sections.py:106
-#: jellyfin_mpv_shim/mpvtk_browser/repository.py:366
+#: jellyfin_mpv_shim/mpvtk_browser/home_sections.py:107
+#: jellyfin_mpv_shim/mpvtk_browser/repository.py:364
 msgid "Next Up"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/home_sections.py:107
+#: jellyfin_mpv_shim/mpvtk_browser/home_sections.py:108
 msgid "Recently Added"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/home_sections.py:108
+#: jellyfin_mpv_shim/mpvtk_browser/home_sections.py:109
 msgid "Live TV"
 msgstr ""
 
@@ -1614,52 +1638,52 @@ msgstr ""
 "Nije moguće dodati server.\n"
 "Molimo provjerite postavke veze."
 
-#: jellyfin_mpv_shim/mpvtk_browser/repository.py:390
+#: jellyfin_mpv_shim/mpvtk_browser/repository.py:386
 msgid "On Now"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/repository.py:411
+#: jellyfin_mpv_shim/mpvtk_browser/repository.py:407
 msgid "Latest %s"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1119
+#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1052
 msgid "Downloaded"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1138
+#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1071
 msgid "Movies"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1143
+#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1076
 msgid "Videos"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1147
+#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1080
 msgid "TV Shows"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1151
+#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1084
 msgid "Playlists"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1168
-#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1441
+#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1101
+#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1374
 msgid "Series"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1212
+#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1145
 msgid "Downloaded Movies"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1216
+#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1149
 msgid "Downloaded Videos"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1220
+#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1153
 msgid "Downloaded Shows"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1353
+#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1286
 msgid "Season %d"
 msgstr ""
 

--- a/jellyfin_mpv_shim/messages/hu/LC_MESSAGES/base.po
+++ b/jellyfin_mpv_shim/messages/hu/LC_MESSAGES/base.po
@@ -5,7 +5,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2026-07-25 17:21-0400\n"
+"POT-Creation-Date: 2026-07-26 12:03-0400\n"
 "PO-Revision-Date: 2025-06-17 02:01+0000\n"
 "Last-Translator: Daniel Szente <szentedaniel25@gmail.com>\n"
 "Language-Team: Hungarian <https://translate.jellyfin.org/projects/jellyfin/"
@@ -252,7 +252,7 @@ msgid "Select Subtitle Track"
 msgstr "Feliratsáv kiválasztása"
 
 #: jellyfin_mpv_shim/menu.py:341
-#: jellyfin_mpv_shim/mpvtk_browser/home_sections.py:102
+#: jellyfin_mpv_shim/mpvtk_browser/home_sections.py:103
 #: jellyfin_mpv_shim/osc_bridge.py:81 jellyfin_mpv_shim/osc_bridge.py:82
 #: jellyfin_mpv_shim/osc_bridge.py:104 jellyfin_mpv_shim/osc_bridge.py:140
 msgid "None"
@@ -403,7 +403,7 @@ msgstr "Rákérdezés a stáblista átugrására"
 msgid "Enable thumbnail previews"
 msgstr "Bélyegképek-előnézetek engedélyezése"
 
-#: jellyfin_mpv_shim/menu.py:609 jellyfin_mpv_shim/mpvtk_browser/config.py:186
+#: jellyfin_mpv_shim/menu.py:609 jellyfin_mpv_shim/mpvtk_browser/config.py:195
 #: jellyfin_mpv_shim/mpvtk_browser/hud.py:375
 msgid "Night Mode (Auto Volume Adj)"
 msgstr ""
@@ -702,310 +702,334 @@ msgstr ""
 msgid "Or switch to another user"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/cast.py:317
+#: jellyfin_mpv_shim/mpvtk_browser/cast.py:314
 msgid "Ready to cast"
 msgstr "Közvetítésre készen"
 
-#: jellyfin_mpv_shim/mpvtk_browser/cast.py:318
+#: jellyfin_mpv_shim/mpvtk_browser/cast.py:315
 #, fuzzy
 #| msgid "Select your media in Jellyfin and play it here"
 msgid "Select your media in Jellyfin and play it here."
 msgstr "Válassza ki a médiát a Jellyfinben, és játssza le itt"
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:74
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:83
 msgid "Interface"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:83
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:92
 msgid "Playback"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:88
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:97
 msgid "Audio"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:92
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:101
 msgid "Subtitles & Languages"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:97
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:106
 #, fuzzy
 #| msgid " (Transcode)"
 msgid "Transcoding"
 msgstr " (Átkódolás)"
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:102
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:111
 msgid "Video Enhancement"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:104
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:113
 #, fuzzy
 #| msgid "Seek to Skip Credits"
 msgid "Skip Intro / Credits"
 msgstr "Tekerés a stáblista átugrásához"
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:107
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:116
 msgid "Library Browser"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:109
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:118
 msgid "Downloads"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:128
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:137
 msgid "Jellyfin UI"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:129
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:138
 msgid "MPV UI with thumbnails"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:130
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:139
 msgid "MPV built-in default"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:133
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:142
 msgid "Follow display"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:134
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:143
 msgid "100% (no scaling)"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:135
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:144
 msgid "125%"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:136
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:145
 msgid "150%"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:137
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:146
 msgid "200%"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:140
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:149
 msgid "Automatic (recommended)"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:141
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:150
 msgid "Vulkan"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:142
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:151
 msgid "Direct3D 11 (Windows only)"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:143
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:152
 msgid "OpenGL (compatibility)"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:146
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:155
 msgid "Default (auto)"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:147
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:156
 msgid "Force Stereo"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:148
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:157
 msgid "Optical Surround"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:149
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:158
 msgid "HDMI Passthrough"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:152
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:161
 msgid "Unset"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:153
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:162
 msgid "Dubbed (shows only)"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:154
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:163
 msgid "Subbed (shows only)"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:155
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:164
 msgid "Dubbed (all)"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:156
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:165
 msgid "Subbed (all)"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:157
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:166
 msgid "Custom (set in config)"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:162
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:171
 msgid "Download Folder"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:163
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:172
 msgid "Prefer Downloaded Copy"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:164
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:173
 msgid "Automatically Download Upcoming Episodes"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:165
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:174
 msgid "Include Next Up"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:166
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:175
 msgid "Next Up Entries to Consider"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:167
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:176
 msgid "Episodes to Keep Ahead (0 = off)"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:168
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:177
 msgid "Storage Limit for Automatic Downloads (GB)"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:169
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:178
 #, fuzzy
 #| msgid "Remove Server"
 msgid "Delete Automatic Downloads Once Watched"
 msgstr "Kiszolgáló eltávolítása"
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:170
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:179
 msgid "Delete Unwatched After (days, 0 = never)"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:171
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:180
 msgid "Check Every (minutes)"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:172
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:181
 msgid "Close to Tray (keep running)"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:173
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:182
 msgid "Keep Running in Background"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:174
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:183
 msgid "Remember Window Size"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:175
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:184
 msgid "Player Controls Style"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:176
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:185
 msgid "Show What You're Watching in Discord"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:177
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:186
 msgid "Interface Scale"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:178
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:187
 msgid "Cast-target mode (no library browsing)"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:179
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:188
 msgid "Casting Opens the Library Browser"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:180
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:189
 msgid "Fullscreen Library Browser"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:181
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:190
 msgid "Always Bind Arrow Keys to Player Controls"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:182
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:191
 msgid "Player Controls Activation Key"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:183
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:192
 msgid "Audio Output Mode"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:184
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:193
 msgid "Audio Output Device"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:185
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:194
 msgid "Take the Device Exclusively"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:187
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:196
 #, fuzzy
 #| msgid "Video Playback Profiles"
 msgid "Enable Video Playback Profiles"
 msgstr "Videólejátszási profilok"
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:188
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:197
 #, fuzzy
 #| msgid "New Group"
 msgid "Profile Group"
 msgstr "Új csoport"
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:189
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:198
 msgid "Remember Last Used Profile"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:190
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:199
 msgid "Graphics API for Shaders"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:191
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:200
 msgid "Pass Through AC3"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:192
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:201
 msgid "Pass Through DTS"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:193
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:202
 msgid "Pass Through E-AC3"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:194
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:203
 msgid "Pass Through DTS-HD"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:195
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:204
 msgid "Pass Through TrueHD"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:196
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:205
 msgid "Re-encode Others to AC3"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:202
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:213
 msgid ""
-"MPV keybinds are used by default. Press ENTER to drive the player controls "
-"by keyboard."
+"With \"Start Minimized\" and \"Fullscreen\" this is the classic cast-target "
+"setup: the app waits out of the way, plays fullscreen when something casts "
+"to it, and goes back to waiting when the video ends or you press Q."
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:204
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:227
+msgid ""
+"Off means command-line mode: no window, no system tray and no settings "
+"screen, so the only way back is editing conf.json by hand. It is not how you "
+"get MPV's own on-screen controls — \"Player Controls Style\" under Interface "
+"does that."
+msgstr ""
+
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:234
+msgid ""
+"Show only what is cast to this machine — the library, including this "
+"settings screen, can't be reached from here. Without a system tray icon the "
+"only way back is editing conf.json. For the classic cast-target setup you "
+"want the Interface settings instead; this is for a shared TV nobody should "
+"be able to browse from."
+msgstr ""
+
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:240
+msgid ""
+"Requires restart to change. MPV keybinds are used by default. Press ENTER to "
+"drive the player controls by keyboard."
+msgstr ""
+
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:242
 msgid ""
 "Pixels one wheel notch scrolls. The scrollbar glides while the content snaps "
 "to the nearest row, so a trackpad or trackball no longer overshoots. Raise "
 "it to scroll faster, lower it for finer control."
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:209
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:247
 msgid ""
 "Make each wheel notch jump exactly one row (or one home-screen section) "
 "instead of gliding. Turn this on if you prefer the older stepped scrolling."
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:217
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:255
 msgid "Discord Rich Presence. Takes effect after a restart."
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:219
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:257
 msgid ""
 "Leave this to Default unless setting up passthrough. Note some audio servers "
 "like Pipewire don't like passthrough and will need to be disabled for a card "
@@ -1013,57 +1037,57 @@ msgid ""
 "silence otherwise, but results may vary."
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:225
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:263
 msgid ""
 "Stop anything else using the device while playing. Needed for passthrough on "
 "some systems, and it means other applications will be silent."
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:228
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:266
 msgid ""
 "Page the library and music tile grids instead of scrolling: each page is one "
 "screenful with First / Previous / Next / Last controls and a page number you "
 "can type into. Easier than precise scrolling on a trackpad."
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:232
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:270
 msgid ""
 "Takes effect after a restart. \"Follow display\" uses the scale your desktop "
 "reports, which is 100% on X11."
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:234
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:272
 msgid ""
 "\"Default\" changes nothing and lets MPV (and your own mpv.conf) decide. "
 "Pick a mode only if you are sending audio to a receiver."
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:237
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:275
 msgid ""
 "Audio your receiver can't be sent directly is encoded to AC3, which is the "
 "only way surround fits down an optical cable. Turn this off if the encoder "
 "causes audio delay — those tracks become stereo instead."
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:242
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:280
 msgid ""
 "\"hq\" offers heavier profiles. Pick it if you have a fast graphics card."
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:244
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:282
 msgid ""
 "Leave on Automatic unless video breaks when a profile is loaded. This only "
 "applies while a profile is active, and OpenGL can cost you HDR output."
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:248
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:286
 msgid ""
 "Evens out loud effects and quiet dialogue. This turns passthrough off while "
 "it is enabled, because the volume has to be adjusted before your receiver "
 "gets the audio."
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:330
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:368
 msgid "Advanced"
 msgstr ""
 
@@ -1289,7 +1313,7 @@ msgid "Automatic"
 msgstr "Automatikus"
 
 #: jellyfin_mpv_shim/mpvtk_browser/downloads.py:51
-#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1355
+#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1288
 msgid "Episodes"
 msgstr ""
 
@@ -1298,7 +1322,7 @@ msgid "Season %s"
 msgstr ""
 
 #: jellyfin_mpv_shim/mpvtk_browser/downloads.py:52
-#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1351
+#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1284
 msgid "Specials"
 msgstr ""
 
@@ -1323,7 +1347,7 @@ msgid "Failed"
 msgstr "Hiba"
 
 #: jellyfin_mpv_shim/mpvtk_browser/downloads.py:185
-#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1105
+#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1038
 msgid "Playlist"
 msgstr ""
 
@@ -1335,30 +1359,30 @@ msgstr ""
 msgid "Movies & Videos"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/home_sections.py:103
+#: jellyfin_mpv_shim/mpvtk_browser/home_sections.py:104
 msgid "My Media"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/home_sections.py:104
-#: jellyfin_mpv_shim/mpvtk_browser/repository.py:352
+#: jellyfin_mpv_shim/mpvtk_browser/home_sections.py:105
+#: jellyfin_mpv_shim/mpvtk_browser/repository.py:350
 msgid "Continue Watching"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/home_sections.py:105
-#: jellyfin_mpv_shim/mpvtk_browser/repository.py:359
+#: jellyfin_mpv_shim/mpvtk_browser/home_sections.py:106
+#: jellyfin_mpv_shim/mpvtk_browser/repository.py:357
 msgid "Continue Listening"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/home_sections.py:106
-#: jellyfin_mpv_shim/mpvtk_browser/repository.py:366
+#: jellyfin_mpv_shim/mpvtk_browser/home_sections.py:107
+#: jellyfin_mpv_shim/mpvtk_browser/repository.py:364
 msgid "Next Up"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/home_sections.py:107
+#: jellyfin_mpv_shim/mpvtk_browser/home_sections.py:108
 msgid "Recently Added"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/home_sections.py:108
+#: jellyfin_mpv_shim/mpvtk_browser/home_sections.py:109
 msgid "Live TV"
 msgstr ""
 
@@ -1611,52 +1635,52 @@ msgstr ""
 "Nem sikerült a kiszolgáló hozzáadása.\n"
 "Ellenőrizze a kapcsolódási információkat."
 
-#: jellyfin_mpv_shim/mpvtk_browser/repository.py:390
+#: jellyfin_mpv_shim/mpvtk_browser/repository.py:386
 msgid "On Now"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/repository.py:411
+#: jellyfin_mpv_shim/mpvtk_browser/repository.py:407
 msgid "Latest %s"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1119
+#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1052
 msgid "Downloaded"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1138
+#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1071
 msgid "Movies"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1143
+#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1076
 msgid "Videos"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1147
+#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1080
 msgid "TV Shows"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1151
+#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1084
 msgid "Playlists"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1168
-#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1441
+#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1101
+#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1374
 msgid "Series"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1212
+#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1145
 msgid "Downloaded Movies"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1216
+#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1149
 msgid "Downloaded Videos"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1220
+#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1153
 msgid "Downloaded Shows"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1353
+#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1286
 msgid "Season %d"
 msgstr ""
 

--- a/jellyfin_mpv_shim/messages/id/LC_MESSAGES/base.po
+++ b/jellyfin_mpv_shim/messages/id/LC_MESSAGES/base.po
@@ -5,7 +5,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2026-07-25 17:21-0400\n"
+"POT-Creation-Date: 2026-07-26 12:03-0400\n"
 "PO-Revision-Date: 2025-07-24 16:30+0000\n"
 "Last-Translator: Khoirul Umam <khoirul_229@yahoo.com>\n"
 "Language-Team: Indonesian <https://translate.jellyfin.org/projects/jellyfin/"
@@ -252,7 +252,7 @@ msgid "Select Subtitle Track"
 msgstr "Pilih Trek Subtitle"
 
 #: jellyfin_mpv_shim/menu.py:341
-#: jellyfin_mpv_shim/mpvtk_browser/home_sections.py:102
+#: jellyfin_mpv_shim/mpvtk_browser/home_sections.py:103
 #: jellyfin_mpv_shim/osc_bridge.py:81 jellyfin_mpv_shim/osc_bridge.py:82
 #: jellyfin_mpv_shim/osc_bridge.py:104 jellyfin_mpv_shim/osc_bridge.py:140
 msgid "None"
@@ -403,7 +403,7 @@ msgstr "Minta untuk Melewati Kredit"
 msgid "Enable thumbnail previews"
 msgstr "Aktifkan tampilan gambar mini"
 
-#: jellyfin_mpv_shim/menu.py:609 jellyfin_mpv_shim/mpvtk_browser/config.py:186
+#: jellyfin_mpv_shim/menu.py:609 jellyfin_mpv_shim/mpvtk_browser/config.py:195
 #: jellyfin_mpv_shim/mpvtk_browser/hud.py:375
 msgid "Night Mode (Auto Volume Adj)"
 msgstr ""
@@ -702,310 +702,334 @@ msgstr ""
 msgid "Or switch to another user"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/cast.py:317
+#: jellyfin_mpv_shim/mpvtk_browser/cast.py:314
 msgid "Ready to cast"
 msgstr "Siap untuk pencerminan layar"
 
-#: jellyfin_mpv_shim/mpvtk_browser/cast.py:318
+#: jellyfin_mpv_shim/mpvtk_browser/cast.py:315
 #, fuzzy
 #| msgid "Select your media in Jellyfin and play it here"
 msgid "Select your media in Jellyfin and play it here."
 msgstr "Pilih media di Jellyfin dan putar di sini"
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:74
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:83
 msgid "Interface"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:83
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:92
 msgid "Playback"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:88
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:97
 msgid "Audio"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:92
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:101
 msgid "Subtitles & Languages"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:97
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:106
 #, fuzzy
 #| msgid " (Transcode)"
 msgid "Transcoding"
 msgstr " (Transkode)"
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:102
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:111
 msgid "Video Enhancement"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:104
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:113
 #, fuzzy
 #| msgid "Seek to Skip Credits"
 msgid "Skip Intro / Credits"
 msgstr "Berusaha untuk Melewati Kredit"
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:107
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:116
 msgid "Library Browser"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:109
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:118
 msgid "Downloads"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:128
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:137
 msgid "Jellyfin UI"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:129
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:138
 msgid "MPV UI with thumbnails"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:130
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:139
 msgid "MPV built-in default"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:133
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:142
 msgid "Follow display"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:134
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:143
 msgid "100% (no scaling)"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:135
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:144
 msgid "125%"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:136
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:145
 msgid "150%"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:137
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:146
 msgid "200%"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:140
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:149
 msgid "Automatic (recommended)"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:141
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:150
 msgid "Vulkan"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:142
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:151
 msgid "Direct3D 11 (Windows only)"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:143
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:152
 msgid "OpenGL (compatibility)"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:146
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:155
 msgid "Default (auto)"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:147
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:156
 msgid "Force Stereo"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:148
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:157
 msgid "Optical Surround"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:149
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:158
 msgid "HDMI Passthrough"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:152
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:161
 msgid "Unset"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:153
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:162
 msgid "Dubbed (shows only)"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:154
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:163
 msgid "Subbed (shows only)"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:155
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:164
 msgid "Dubbed (all)"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:156
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:165
 msgid "Subbed (all)"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:157
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:166
 msgid "Custom (set in config)"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:162
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:171
 msgid "Download Folder"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:163
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:172
 msgid "Prefer Downloaded Copy"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:164
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:173
 msgid "Automatically Download Upcoming Episodes"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:165
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:174
 msgid "Include Next Up"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:166
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:175
 msgid "Next Up Entries to Consider"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:167
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:176
 msgid "Episodes to Keep Ahead (0 = off)"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:168
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:177
 msgid "Storage Limit for Automatic Downloads (GB)"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:169
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:178
 #, fuzzy
 #| msgid "Remove Server"
 msgid "Delete Automatic Downloads Once Watched"
 msgstr "Hapus Server"
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:170
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:179
 msgid "Delete Unwatched After (days, 0 = never)"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:171
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:180
 msgid "Check Every (minutes)"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:172
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:181
 msgid "Close to Tray (keep running)"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:173
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:182
 msgid "Keep Running in Background"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:174
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:183
 msgid "Remember Window Size"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:175
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:184
 msgid "Player Controls Style"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:176
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:185
 msgid "Show What You're Watching in Discord"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:177
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:186
 msgid "Interface Scale"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:178
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:187
 msgid "Cast-target mode (no library browsing)"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:179
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:188
 msgid "Casting Opens the Library Browser"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:180
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:189
 msgid "Fullscreen Library Browser"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:181
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:190
 msgid "Always Bind Arrow Keys to Player Controls"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:182
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:191
 msgid "Player Controls Activation Key"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:183
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:192
 msgid "Audio Output Mode"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:184
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:193
 msgid "Audio Output Device"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:185
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:194
 msgid "Take the Device Exclusively"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:187
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:196
 #, fuzzy
 #| msgid "Video Playback Profiles"
 msgid "Enable Video Playback Profiles"
 msgstr "Profil Pemutaran Video"
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:188
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:197
 #, fuzzy
 #| msgid "New Group"
 msgid "Profile Group"
 msgstr "Grup Baru"
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:189
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:198
 msgid "Remember Last Used Profile"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:190
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:199
 msgid "Graphics API for Shaders"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:191
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:200
 msgid "Pass Through AC3"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:192
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:201
 msgid "Pass Through DTS"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:193
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:202
 msgid "Pass Through E-AC3"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:194
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:203
 msgid "Pass Through DTS-HD"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:195
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:204
 msgid "Pass Through TrueHD"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:196
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:205
 msgid "Re-encode Others to AC3"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:202
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:213
 msgid ""
-"MPV keybinds are used by default. Press ENTER to drive the player controls "
-"by keyboard."
+"With \"Start Minimized\" and \"Fullscreen\" this is the classic cast-target "
+"setup: the app waits out of the way, plays fullscreen when something casts "
+"to it, and goes back to waiting when the video ends or you press Q."
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:204
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:227
+msgid ""
+"Off means command-line mode: no window, no system tray and no settings "
+"screen, so the only way back is editing conf.json by hand. It is not how you "
+"get MPV's own on-screen controls — \"Player Controls Style\" under Interface "
+"does that."
+msgstr ""
+
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:234
+msgid ""
+"Show only what is cast to this machine — the library, including this "
+"settings screen, can't be reached from here. Without a system tray icon the "
+"only way back is editing conf.json. For the classic cast-target setup you "
+"want the Interface settings instead; this is for a shared TV nobody should "
+"be able to browse from."
+msgstr ""
+
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:240
+msgid ""
+"Requires restart to change. MPV keybinds are used by default. Press ENTER to "
+"drive the player controls by keyboard."
+msgstr ""
+
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:242
 msgid ""
 "Pixels one wheel notch scrolls. The scrollbar glides while the content snaps "
 "to the nearest row, so a trackpad or trackball no longer overshoots. Raise "
 "it to scroll faster, lower it for finer control."
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:209
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:247
 msgid ""
 "Make each wheel notch jump exactly one row (or one home-screen section) "
 "instead of gliding. Turn this on if you prefer the older stepped scrolling."
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:217
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:255
 msgid "Discord Rich Presence. Takes effect after a restart."
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:219
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:257
 msgid ""
 "Leave this to Default unless setting up passthrough. Note some audio servers "
 "like Pipewire don't like passthrough and will need to be disabled for a card "
@@ -1013,57 +1037,57 @@ msgid ""
 "silence otherwise, but results may vary."
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:225
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:263
 msgid ""
 "Stop anything else using the device while playing. Needed for passthrough on "
 "some systems, and it means other applications will be silent."
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:228
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:266
 msgid ""
 "Page the library and music tile grids instead of scrolling: each page is one "
 "screenful with First / Previous / Next / Last controls and a page number you "
 "can type into. Easier than precise scrolling on a trackpad."
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:232
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:270
 msgid ""
 "Takes effect after a restart. \"Follow display\" uses the scale your desktop "
 "reports, which is 100% on X11."
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:234
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:272
 msgid ""
 "\"Default\" changes nothing and lets MPV (and your own mpv.conf) decide. "
 "Pick a mode only if you are sending audio to a receiver."
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:237
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:275
 msgid ""
 "Audio your receiver can't be sent directly is encoded to AC3, which is the "
 "only way surround fits down an optical cable. Turn this off if the encoder "
 "causes audio delay — those tracks become stereo instead."
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:242
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:280
 msgid ""
 "\"hq\" offers heavier profiles. Pick it if you have a fast graphics card."
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:244
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:282
 msgid ""
 "Leave on Automatic unless video breaks when a profile is loaded. This only "
 "applies while a profile is active, and OpenGL can cost you HDR output."
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:248
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:286
 msgid ""
 "Evens out loud effects and quiet dialogue. This turns passthrough off while "
 "it is enabled, because the volume has to be adjusted before your receiver "
 "gets the audio."
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:330
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:368
 msgid "Advanced"
 msgstr ""
 
@@ -1289,7 +1313,7 @@ msgid "Automatic"
 msgstr "Otomatis"
 
 #: jellyfin_mpv_shim/mpvtk_browser/downloads.py:51
-#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1355
+#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1288
 msgid "Episodes"
 msgstr ""
 
@@ -1298,7 +1322,7 @@ msgid "Season %s"
 msgstr ""
 
 #: jellyfin_mpv_shim/mpvtk_browser/downloads.py:52
-#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1351
+#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1284
 msgid "Specials"
 msgstr ""
 
@@ -1323,7 +1347,7 @@ msgid "Failed"
 msgstr "Gagal"
 
 #: jellyfin_mpv_shim/mpvtk_browser/downloads.py:185
-#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1105
+#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1038
 msgid "Playlist"
 msgstr ""
 
@@ -1335,30 +1359,30 @@ msgstr ""
 msgid "Movies & Videos"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/home_sections.py:103
+#: jellyfin_mpv_shim/mpvtk_browser/home_sections.py:104
 msgid "My Media"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/home_sections.py:104
-#: jellyfin_mpv_shim/mpvtk_browser/repository.py:352
+#: jellyfin_mpv_shim/mpvtk_browser/home_sections.py:105
+#: jellyfin_mpv_shim/mpvtk_browser/repository.py:350
 msgid "Continue Watching"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/home_sections.py:105
-#: jellyfin_mpv_shim/mpvtk_browser/repository.py:359
+#: jellyfin_mpv_shim/mpvtk_browser/home_sections.py:106
+#: jellyfin_mpv_shim/mpvtk_browser/repository.py:357
 msgid "Continue Listening"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/home_sections.py:106
-#: jellyfin_mpv_shim/mpvtk_browser/repository.py:366
+#: jellyfin_mpv_shim/mpvtk_browser/home_sections.py:107
+#: jellyfin_mpv_shim/mpvtk_browser/repository.py:364
 msgid "Next Up"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/home_sections.py:107
+#: jellyfin_mpv_shim/mpvtk_browser/home_sections.py:108
 msgid "Recently Added"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/home_sections.py:108
+#: jellyfin_mpv_shim/mpvtk_browser/home_sections.py:109
 msgid "Live TV"
 msgstr ""
 
@@ -1611,52 +1635,52 @@ msgstr ""
 "Tidak dapat menambahkan server.\n"
 "Harap cek kembali koneksi Anda."
 
-#: jellyfin_mpv_shim/mpvtk_browser/repository.py:390
+#: jellyfin_mpv_shim/mpvtk_browser/repository.py:386
 msgid "On Now"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/repository.py:411
+#: jellyfin_mpv_shim/mpvtk_browser/repository.py:407
 msgid "Latest %s"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1119
+#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1052
 msgid "Downloaded"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1138
+#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1071
 msgid "Movies"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1143
+#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1076
 msgid "Videos"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1147
+#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1080
 msgid "TV Shows"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1151
+#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1084
 msgid "Playlists"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1168
-#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1441
+#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1101
+#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1374
 msgid "Series"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1212
+#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1145
 msgid "Downloaded Movies"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1216
+#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1149
 msgid "Downloaded Videos"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1220
+#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1153
 msgid "Downloaded Shows"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1353
+#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1286
 msgid "Season %d"
 msgstr ""
 

--- a/jellyfin_mpv_shim/messages/it/LC_MESSAGES/base.po
+++ b/jellyfin_mpv_shim/messages/it/LC_MESSAGES/base.po
@@ -5,7 +5,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2026-07-25 17:21-0400\n"
+"POT-Creation-Date: 2026-07-26 12:03-0400\n"
 "PO-Revision-Date: 2026-04-23 17:58+0000\n"
 "Last-Translator: cricca <cry.calva@hotmail.it>\n"
 "Language-Team: Italian <https://translate.jellyfin.org/projects/jellyfin/"
@@ -252,7 +252,7 @@ msgid "Select Subtitle Track"
 msgstr "Seleziona traccia sottotitoli"
 
 #: jellyfin_mpv_shim/menu.py:341
-#: jellyfin_mpv_shim/mpvtk_browser/home_sections.py:102
+#: jellyfin_mpv_shim/mpvtk_browser/home_sections.py:103
 #: jellyfin_mpv_shim/osc_bridge.py:81 jellyfin_mpv_shim/osc_bridge.py:82
 #: jellyfin_mpv_shim/osc_bridge.py:104 jellyfin_mpv_shim/osc_bridge.py:140
 msgid "None"
@@ -403,7 +403,7 @@ msgstr "Chiedi di saltare i riconoscimenti"
 msgid "Enable thumbnail previews"
 msgstr "Abilita le anteprime in miniatura"
 
-#: jellyfin_mpv_shim/menu.py:609 jellyfin_mpv_shim/mpvtk_browser/config.py:186
+#: jellyfin_mpv_shim/menu.py:609 jellyfin_mpv_shim/mpvtk_browser/config.py:195
 #: jellyfin_mpv_shim/mpvtk_browser/hud.py:375
 msgid "Night Mode (Auto Volume Adj)"
 msgstr ""
@@ -702,310 +702,334 @@ msgstr ""
 msgid "Or switch to another user"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/cast.py:317
+#: jellyfin_mpv_shim/mpvtk_browser/cast.py:314
 msgid "Ready to cast"
 msgstr "Pronto a trasmettere"
 
-#: jellyfin_mpv_shim/mpvtk_browser/cast.py:318
+#: jellyfin_mpv_shim/mpvtk_browser/cast.py:315
 #, fuzzy
 #| msgid "Select your media in Jellyfin and play it here"
 msgid "Select your media in Jellyfin and play it here."
 msgstr "Seleziona il tuo media in Jellyfin e riproducilo qui"
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:74
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:83
 msgid "Interface"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:83
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:92
 msgid "Playback"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:88
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:97
 msgid "Audio"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:92
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:101
 msgid "Subtitles & Languages"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:97
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:106
 #, fuzzy
 #| msgid " (Transcode)"
 msgid "Transcoding"
 msgstr " (Transcodifica)"
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:102
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:111
 msgid "Video Enhancement"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:104
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:113
 #, fuzzy
 #| msgid "Seek to Skip Credits"
 msgid "Skip Intro / Credits"
 msgstr "Avanza per saltare i riconoscimenti"
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:107
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:116
 msgid "Library Browser"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:109
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:118
 msgid "Downloads"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:128
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:137
 msgid "Jellyfin UI"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:129
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:138
 msgid "MPV UI with thumbnails"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:130
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:139
 msgid "MPV built-in default"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:133
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:142
 msgid "Follow display"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:134
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:143
 msgid "100% (no scaling)"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:135
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:144
 msgid "125%"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:136
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:145
 msgid "150%"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:137
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:146
 msgid "200%"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:140
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:149
 msgid "Automatic (recommended)"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:141
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:150
 msgid "Vulkan"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:142
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:151
 msgid "Direct3D 11 (Windows only)"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:143
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:152
 msgid "OpenGL (compatibility)"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:146
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:155
 msgid "Default (auto)"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:147
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:156
 msgid "Force Stereo"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:148
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:157
 msgid "Optical Surround"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:149
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:158
 msgid "HDMI Passthrough"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:152
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:161
 msgid "Unset"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:153
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:162
 msgid "Dubbed (shows only)"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:154
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:163
 msgid "Subbed (shows only)"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:155
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:164
 msgid "Dubbed (all)"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:156
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:165
 msgid "Subbed (all)"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:157
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:166
 msgid "Custom (set in config)"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:162
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:171
 msgid "Download Folder"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:163
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:172
 msgid "Prefer Downloaded Copy"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:164
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:173
 msgid "Automatically Download Upcoming Episodes"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:165
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:174
 msgid "Include Next Up"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:166
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:175
 msgid "Next Up Entries to Consider"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:167
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:176
 msgid "Episodes to Keep Ahead (0 = off)"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:168
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:177
 msgid "Storage Limit for Automatic Downloads (GB)"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:169
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:178
 #, fuzzy
 #| msgid "Remove Server"
 msgid "Delete Automatic Downloads Once Watched"
 msgstr "Rimuovi server"
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:170
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:179
 msgid "Delete Unwatched After (days, 0 = never)"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:171
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:180
 msgid "Check Every (minutes)"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:172
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:181
 msgid "Close to Tray (keep running)"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:173
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:182
 msgid "Keep Running in Background"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:174
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:183
 msgid "Remember Window Size"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:175
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:184
 msgid "Player Controls Style"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:176
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:185
 msgid "Show What You're Watching in Discord"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:177
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:186
 msgid "Interface Scale"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:178
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:187
 msgid "Cast-target mode (no library browsing)"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:179
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:188
 msgid "Casting Opens the Library Browser"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:180
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:189
 msgid "Fullscreen Library Browser"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:181
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:190
 msgid "Always Bind Arrow Keys to Player Controls"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:182
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:191
 msgid "Player Controls Activation Key"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:183
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:192
 msgid "Audio Output Mode"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:184
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:193
 msgid "Audio Output Device"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:185
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:194
 msgid "Take the Device Exclusively"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:187
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:196
 #, fuzzy
 #| msgid "Video Playback Profiles"
 msgid "Enable Video Playback Profiles"
 msgstr "Profili riproduzione video"
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:188
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:197
 #, fuzzy
 #| msgid "New Group"
 msgid "Profile Group"
 msgstr "Nuovo gruppo"
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:189
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:198
 msgid "Remember Last Used Profile"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:190
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:199
 msgid "Graphics API for Shaders"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:191
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:200
 msgid "Pass Through AC3"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:192
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:201
 msgid "Pass Through DTS"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:193
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:202
 msgid "Pass Through E-AC3"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:194
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:203
 msgid "Pass Through DTS-HD"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:195
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:204
 msgid "Pass Through TrueHD"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:196
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:205
 msgid "Re-encode Others to AC3"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:202
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:213
 msgid ""
-"MPV keybinds are used by default. Press ENTER to drive the player controls "
-"by keyboard."
+"With \"Start Minimized\" and \"Fullscreen\" this is the classic cast-target "
+"setup: the app waits out of the way, plays fullscreen when something casts "
+"to it, and goes back to waiting when the video ends or you press Q."
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:204
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:227
+msgid ""
+"Off means command-line mode: no window, no system tray and no settings "
+"screen, so the only way back is editing conf.json by hand. It is not how you "
+"get MPV's own on-screen controls — \"Player Controls Style\" under Interface "
+"does that."
+msgstr ""
+
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:234
+msgid ""
+"Show only what is cast to this machine — the library, including this "
+"settings screen, can't be reached from here. Without a system tray icon the "
+"only way back is editing conf.json. For the classic cast-target setup you "
+"want the Interface settings instead; this is for a shared TV nobody should "
+"be able to browse from."
+msgstr ""
+
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:240
+msgid ""
+"Requires restart to change. MPV keybinds are used by default. Press ENTER to "
+"drive the player controls by keyboard."
+msgstr ""
+
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:242
 msgid ""
 "Pixels one wheel notch scrolls. The scrollbar glides while the content snaps "
 "to the nearest row, so a trackpad or trackball no longer overshoots. Raise "
 "it to scroll faster, lower it for finer control."
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:209
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:247
 msgid ""
 "Make each wheel notch jump exactly one row (or one home-screen section) "
 "instead of gliding. Turn this on if you prefer the older stepped scrolling."
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:217
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:255
 msgid "Discord Rich Presence. Takes effect after a restart."
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:219
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:257
 msgid ""
 "Leave this to Default unless setting up passthrough. Note some audio servers "
 "like Pipewire don't like passthrough and will need to be disabled for a card "
@@ -1013,57 +1037,57 @@ msgid ""
 "silence otherwise, but results may vary."
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:225
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:263
 msgid ""
 "Stop anything else using the device while playing. Needed for passthrough on "
 "some systems, and it means other applications will be silent."
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:228
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:266
 msgid ""
 "Page the library and music tile grids instead of scrolling: each page is one "
 "screenful with First / Previous / Next / Last controls and a page number you "
 "can type into. Easier than precise scrolling on a trackpad."
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:232
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:270
 msgid ""
 "Takes effect after a restart. \"Follow display\" uses the scale your desktop "
 "reports, which is 100% on X11."
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:234
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:272
 msgid ""
 "\"Default\" changes nothing and lets MPV (and your own mpv.conf) decide. "
 "Pick a mode only if you are sending audio to a receiver."
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:237
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:275
 msgid ""
 "Audio your receiver can't be sent directly is encoded to AC3, which is the "
 "only way surround fits down an optical cable. Turn this off if the encoder "
 "causes audio delay — those tracks become stereo instead."
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:242
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:280
 msgid ""
 "\"hq\" offers heavier profiles. Pick it if you have a fast graphics card."
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:244
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:282
 msgid ""
 "Leave on Automatic unless video breaks when a profile is loaded. This only "
 "applies while a profile is active, and OpenGL can cost you HDR output."
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:248
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:286
 msgid ""
 "Evens out loud effects and quiet dialogue. This turns passthrough off while "
 "it is enabled, because the volume has to be adjusted before your receiver "
 "gets the audio."
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:330
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:368
 msgid "Advanced"
 msgstr ""
 
@@ -1289,7 +1313,7 @@ msgid "Automatic"
 msgstr "Automatico"
 
 #: jellyfin_mpv_shim/mpvtk_browser/downloads.py:51
-#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1355
+#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1288
 msgid "Episodes"
 msgstr ""
 
@@ -1298,7 +1322,7 @@ msgid "Season %s"
 msgstr ""
 
 #: jellyfin_mpv_shim/mpvtk_browser/downloads.py:52
-#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1351
+#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1284
 msgid "Specials"
 msgstr ""
 
@@ -1323,7 +1347,7 @@ msgid "Failed"
 msgstr "Fallito"
 
 #: jellyfin_mpv_shim/mpvtk_browser/downloads.py:185
-#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1105
+#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1038
 msgid "Playlist"
 msgstr ""
 
@@ -1335,30 +1359,30 @@ msgstr ""
 msgid "Movies & Videos"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/home_sections.py:103
+#: jellyfin_mpv_shim/mpvtk_browser/home_sections.py:104
 msgid "My Media"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/home_sections.py:104
-#: jellyfin_mpv_shim/mpvtk_browser/repository.py:352
+#: jellyfin_mpv_shim/mpvtk_browser/home_sections.py:105
+#: jellyfin_mpv_shim/mpvtk_browser/repository.py:350
 msgid "Continue Watching"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/home_sections.py:105
-#: jellyfin_mpv_shim/mpvtk_browser/repository.py:359
+#: jellyfin_mpv_shim/mpvtk_browser/home_sections.py:106
+#: jellyfin_mpv_shim/mpvtk_browser/repository.py:357
 msgid "Continue Listening"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/home_sections.py:106
-#: jellyfin_mpv_shim/mpvtk_browser/repository.py:366
+#: jellyfin_mpv_shim/mpvtk_browser/home_sections.py:107
+#: jellyfin_mpv_shim/mpvtk_browser/repository.py:364
 msgid "Next Up"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/home_sections.py:107
+#: jellyfin_mpv_shim/mpvtk_browser/home_sections.py:108
 msgid "Recently Added"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/home_sections.py:108
+#: jellyfin_mpv_shim/mpvtk_browser/home_sections.py:109
 msgid "Live TV"
 msgstr ""
 
@@ -1611,52 +1635,52 @@ msgstr ""
 "Impossibile aggiungere server.\n"
 "Controlla le informazioni di connessione."
 
-#: jellyfin_mpv_shim/mpvtk_browser/repository.py:390
+#: jellyfin_mpv_shim/mpvtk_browser/repository.py:386
 msgid "On Now"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/repository.py:411
+#: jellyfin_mpv_shim/mpvtk_browser/repository.py:407
 msgid "Latest %s"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1119
+#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1052
 msgid "Downloaded"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1138
+#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1071
 msgid "Movies"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1143
+#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1076
 msgid "Videos"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1147
+#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1080
 msgid "TV Shows"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1151
+#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1084
 msgid "Playlists"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1168
-#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1441
+#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1101
+#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1374
 msgid "Series"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1212
+#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1145
 msgid "Downloaded Movies"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1216
+#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1149
 msgid "Downloaded Videos"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1220
+#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1153
 msgid "Downloaded Shows"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1353
+#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1286
 msgid "Season %d"
 msgstr ""
 

--- a/jellyfin_mpv_shim/messages/ja/LC_MESSAGES/base.po
+++ b/jellyfin_mpv_shim/messages/ja/LC_MESSAGES/base.po
@@ -5,7 +5,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2026-07-25 17:21-0400\n"
+"POT-Creation-Date: 2026-07-26 12:03-0400\n"
 "PO-Revision-Date: 2026-01-09 10:54+0000\n"
 "Last-Translator: mf_Mii <myomyonn.exfat32@gmail.com>\n"
 "Language-Team: Japanese <https://translate.jellyfin.org/projects/jellyfin/"
@@ -252,7 +252,7 @@ msgid "Select Subtitle Track"
 msgstr "字幕の選択"
 
 #: jellyfin_mpv_shim/menu.py:341
-#: jellyfin_mpv_shim/mpvtk_browser/home_sections.py:102
+#: jellyfin_mpv_shim/mpvtk_browser/home_sections.py:103
 #: jellyfin_mpv_shim/osc_bridge.py:81 jellyfin_mpv_shim/osc_bridge.py:82
 #: jellyfin_mpv_shim/osc_bridge.py:104 jellyfin_mpv_shim/osc_bridge.py:140
 msgid "None"
@@ -403,7 +403,7 @@ msgstr "クレジットタイトルのスッキプを選択"
 msgid "Enable thumbnail previews"
 msgstr "サムネイルのプレビューの有効化"
 
-#: jellyfin_mpv_shim/menu.py:609 jellyfin_mpv_shim/mpvtk_browser/config.py:186
+#: jellyfin_mpv_shim/menu.py:609 jellyfin_mpv_shim/mpvtk_browser/config.py:195
 #: jellyfin_mpv_shim/mpvtk_browser/hud.py:375
 msgid "Night Mode (Auto Volume Adj)"
 msgstr ""
@@ -702,310 +702,334 @@ msgstr ""
 msgid "Or switch to another user"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/cast.py:317
+#: jellyfin_mpv_shim/mpvtk_browser/cast.py:314
 msgid "Ready to cast"
 msgstr "キャストができるようになりました"
 
-#: jellyfin_mpv_shim/mpvtk_browser/cast.py:318
+#: jellyfin_mpv_shim/mpvtk_browser/cast.py:315
 #, fuzzy
 #| msgid "Select your media in Jellyfin and play it here"
 msgid "Select your media in Jellyfin and play it here."
 msgstr "Jellyfinでメディアを選択してこちらで再生します"
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:74
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:83
 msgid "Interface"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:83
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:92
 msgid "Playback"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:88
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:97
 msgid "Audio"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:92
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:101
 msgid "Subtitles & Languages"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:97
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:106
 #, fuzzy
 #| msgid " (Transcode)"
 msgid "Transcoding"
 msgstr " (トランスコード)"
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:102
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:111
 msgid "Video Enhancement"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:104
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:113
 #, fuzzy
 #| msgid "Seek to Skip Credits"
 msgid "Skip Intro / Credits"
 msgstr "クレジットをスキップする"
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:107
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:116
 msgid "Library Browser"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:109
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:118
 msgid "Downloads"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:128
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:137
 msgid "Jellyfin UI"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:129
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:138
 msgid "MPV UI with thumbnails"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:130
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:139
 msgid "MPV built-in default"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:133
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:142
 msgid "Follow display"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:134
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:143
 msgid "100% (no scaling)"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:135
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:144
 msgid "125%"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:136
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:145
 msgid "150%"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:137
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:146
 msgid "200%"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:140
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:149
 msgid "Automatic (recommended)"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:141
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:150
 msgid "Vulkan"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:142
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:151
 msgid "Direct3D 11 (Windows only)"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:143
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:152
 msgid "OpenGL (compatibility)"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:146
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:155
 msgid "Default (auto)"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:147
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:156
 msgid "Force Stereo"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:148
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:157
 msgid "Optical Surround"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:149
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:158
 msgid "HDMI Passthrough"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:152
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:161
 msgid "Unset"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:153
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:162
 msgid "Dubbed (shows only)"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:154
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:163
 msgid "Subbed (shows only)"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:155
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:164
 msgid "Dubbed (all)"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:156
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:165
 msgid "Subbed (all)"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:157
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:166
 msgid "Custom (set in config)"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:162
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:171
 msgid "Download Folder"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:163
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:172
 msgid "Prefer Downloaded Copy"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:164
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:173
 msgid "Automatically Download Upcoming Episodes"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:165
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:174
 msgid "Include Next Up"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:166
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:175
 msgid "Next Up Entries to Consider"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:167
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:176
 msgid "Episodes to Keep Ahead (0 = off)"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:168
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:177
 msgid "Storage Limit for Automatic Downloads (GB)"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:169
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:178
 #, fuzzy
 #| msgid "Remove Server"
 msgid "Delete Automatic Downloads Once Watched"
 msgstr "サーバーを削除"
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:170
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:179
 msgid "Delete Unwatched After (days, 0 = never)"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:171
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:180
 msgid "Check Every (minutes)"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:172
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:181
 msgid "Close to Tray (keep running)"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:173
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:182
 msgid "Keep Running in Background"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:174
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:183
 msgid "Remember Window Size"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:175
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:184
 msgid "Player Controls Style"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:176
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:185
 msgid "Show What You're Watching in Discord"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:177
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:186
 msgid "Interface Scale"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:178
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:187
 msgid "Cast-target mode (no library browsing)"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:179
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:188
 msgid "Casting Opens the Library Browser"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:180
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:189
 msgid "Fullscreen Library Browser"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:181
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:190
 msgid "Always Bind Arrow Keys to Player Controls"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:182
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:191
 msgid "Player Controls Activation Key"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:183
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:192
 msgid "Audio Output Mode"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:184
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:193
 msgid "Audio Output Device"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:185
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:194
 msgid "Take the Device Exclusively"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:187
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:196
 #, fuzzy
 #| msgid "Video Playback Profiles"
 msgid "Enable Video Playback Profiles"
 msgstr "動画再生プロファイル"
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:188
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:197
 #, fuzzy
 #| msgid "New Group"
 msgid "Profile Group"
 msgstr "新しいグループ"
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:189
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:198
 msgid "Remember Last Used Profile"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:190
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:199
 msgid "Graphics API for Shaders"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:191
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:200
 msgid "Pass Through AC3"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:192
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:201
 msgid "Pass Through DTS"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:193
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:202
 msgid "Pass Through E-AC3"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:194
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:203
 msgid "Pass Through DTS-HD"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:195
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:204
 msgid "Pass Through TrueHD"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:196
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:205
 msgid "Re-encode Others to AC3"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:202
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:213
 msgid ""
-"MPV keybinds are used by default. Press ENTER to drive the player controls "
-"by keyboard."
+"With \"Start Minimized\" and \"Fullscreen\" this is the classic cast-target "
+"setup: the app waits out of the way, plays fullscreen when something casts "
+"to it, and goes back to waiting when the video ends or you press Q."
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:204
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:227
+msgid ""
+"Off means command-line mode: no window, no system tray and no settings "
+"screen, so the only way back is editing conf.json by hand. It is not how you "
+"get MPV's own on-screen controls — \"Player Controls Style\" under Interface "
+"does that."
+msgstr ""
+
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:234
+msgid ""
+"Show only what is cast to this machine — the library, including this "
+"settings screen, can't be reached from here. Without a system tray icon the "
+"only way back is editing conf.json. For the classic cast-target setup you "
+"want the Interface settings instead; this is for a shared TV nobody should "
+"be able to browse from."
+msgstr ""
+
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:240
+msgid ""
+"Requires restart to change. MPV keybinds are used by default. Press ENTER to "
+"drive the player controls by keyboard."
+msgstr ""
+
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:242
 msgid ""
 "Pixels one wheel notch scrolls. The scrollbar glides while the content snaps "
 "to the nearest row, so a trackpad or trackball no longer overshoots. Raise "
 "it to scroll faster, lower it for finer control."
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:209
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:247
 msgid ""
 "Make each wheel notch jump exactly one row (or one home-screen section) "
 "instead of gliding. Turn this on if you prefer the older stepped scrolling."
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:217
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:255
 msgid "Discord Rich Presence. Takes effect after a restart."
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:219
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:257
 msgid ""
 "Leave this to Default unless setting up passthrough. Note some audio servers "
 "like Pipewire don't like passthrough and will need to be disabled for a card "
@@ -1013,57 +1037,57 @@ msgid ""
 "silence otherwise, but results may vary."
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:225
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:263
 msgid ""
 "Stop anything else using the device while playing. Needed for passthrough on "
 "some systems, and it means other applications will be silent."
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:228
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:266
 msgid ""
 "Page the library and music tile grids instead of scrolling: each page is one "
 "screenful with First / Previous / Next / Last controls and a page number you "
 "can type into. Easier than precise scrolling on a trackpad."
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:232
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:270
 msgid ""
 "Takes effect after a restart. \"Follow display\" uses the scale your desktop "
 "reports, which is 100% on X11."
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:234
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:272
 msgid ""
 "\"Default\" changes nothing and lets MPV (and your own mpv.conf) decide. "
 "Pick a mode only if you are sending audio to a receiver."
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:237
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:275
 msgid ""
 "Audio your receiver can't be sent directly is encoded to AC3, which is the "
 "only way surround fits down an optical cable. Turn this off if the encoder "
 "causes audio delay — those tracks become stereo instead."
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:242
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:280
 msgid ""
 "\"hq\" offers heavier profiles. Pick it if you have a fast graphics card."
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:244
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:282
 msgid ""
 "Leave on Automatic unless video breaks when a profile is loaded. This only "
 "applies while a profile is active, and OpenGL can cost you HDR output."
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:248
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:286
 msgid ""
 "Evens out loud effects and quiet dialogue. This turns passthrough off while "
 "it is enabled, because the volume has to be adjusted before your receiver "
 "gets the audio."
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:330
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:368
 msgid "Advanced"
 msgstr ""
 
@@ -1289,7 +1313,7 @@ msgid "Automatic"
 msgstr "自動"
 
 #: jellyfin_mpv_shim/mpvtk_browser/downloads.py:51
-#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1355
+#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1288
 msgid "Episodes"
 msgstr ""
 
@@ -1298,7 +1322,7 @@ msgid "Season %s"
 msgstr ""
 
 #: jellyfin_mpv_shim/mpvtk_browser/downloads.py:52
-#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1351
+#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1284
 msgid "Specials"
 msgstr ""
 
@@ -1323,7 +1347,7 @@ msgid "Failed"
 msgstr "失敗"
 
 #: jellyfin_mpv_shim/mpvtk_browser/downloads.py:185
-#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1105
+#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1038
 msgid "Playlist"
 msgstr ""
 
@@ -1335,30 +1359,30 @@ msgstr ""
 msgid "Movies & Videos"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/home_sections.py:103
+#: jellyfin_mpv_shim/mpvtk_browser/home_sections.py:104
 msgid "My Media"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/home_sections.py:104
-#: jellyfin_mpv_shim/mpvtk_browser/repository.py:352
+#: jellyfin_mpv_shim/mpvtk_browser/home_sections.py:105
+#: jellyfin_mpv_shim/mpvtk_browser/repository.py:350
 msgid "Continue Watching"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/home_sections.py:105
-#: jellyfin_mpv_shim/mpvtk_browser/repository.py:359
+#: jellyfin_mpv_shim/mpvtk_browser/home_sections.py:106
+#: jellyfin_mpv_shim/mpvtk_browser/repository.py:357
 msgid "Continue Listening"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/home_sections.py:106
-#: jellyfin_mpv_shim/mpvtk_browser/repository.py:366
+#: jellyfin_mpv_shim/mpvtk_browser/home_sections.py:107
+#: jellyfin_mpv_shim/mpvtk_browser/repository.py:364
 msgid "Next Up"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/home_sections.py:107
+#: jellyfin_mpv_shim/mpvtk_browser/home_sections.py:108
 msgid "Recently Added"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/home_sections.py:108
+#: jellyfin_mpv_shim/mpvtk_browser/home_sections.py:109
 msgid "Live TV"
 msgstr ""
 
@@ -1611,52 +1635,52 @@ msgstr ""
 "サーバーを追加できません。\n"
 "接続設定を確認してください。"
 
-#: jellyfin_mpv_shim/mpvtk_browser/repository.py:390
+#: jellyfin_mpv_shim/mpvtk_browser/repository.py:386
 msgid "On Now"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/repository.py:411
+#: jellyfin_mpv_shim/mpvtk_browser/repository.py:407
 msgid "Latest %s"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1119
+#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1052
 msgid "Downloaded"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1138
+#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1071
 msgid "Movies"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1143
+#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1076
 msgid "Videos"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1147
+#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1080
 msgid "TV Shows"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1151
+#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1084
 msgid "Playlists"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1168
-#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1441
+#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1101
+#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1374
 msgid "Series"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1212
+#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1145
 msgid "Downloaded Movies"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1216
+#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1149
 msgid "Downloaded Videos"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1220
+#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1153
 msgid "Downloaded Shows"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1353
+#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1286
 msgid "Season %d"
 msgstr ""
 

--- a/jellyfin_mpv_shim/messages/jbo/LC_MESSAGES/base.po
+++ b/jellyfin_mpv_shim/messages/jbo/LC_MESSAGES/base.po
@@ -5,7 +5,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2026-07-25 17:21-0400\n"
+"POT-Creation-Date: 2026-07-26 12:03-0400\n"
 "PO-Revision-Date: 2022-10-19 21:50+0000\n"
 "Last-Translator: Polaris <axvantia@protonmail.com>\n"
 "Language-Team: Lojban <https://translate.jellyfin.org/projects/jellyfin/"
@@ -247,7 +247,7 @@ msgid "Select Subtitle Track"
 msgstr ""
 
 #: jellyfin_mpv_shim/menu.py:341
-#: jellyfin_mpv_shim/mpvtk_browser/home_sections.py:102
+#: jellyfin_mpv_shim/mpvtk_browser/home_sections.py:103
 #: jellyfin_mpv_shim/osc_bridge.py:81 jellyfin_mpv_shim/osc_bridge.py:82
 #: jellyfin_mpv_shim/osc_bridge.py:104 jellyfin_mpv_shim/osc_bridge.py:140
 msgid "None"
@@ -398,7 +398,7 @@ msgstr ""
 msgid "Enable thumbnail previews"
 msgstr ""
 
-#: jellyfin_mpv_shim/menu.py:609 jellyfin_mpv_shim/mpvtk_browser/config.py:186
+#: jellyfin_mpv_shim/menu.py:609 jellyfin_mpv_shim/mpvtk_browser/config.py:195
 #: jellyfin_mpv_shim/mpvtk_browser/hud.py:375
 msgid "Night Mode (Auto Volume Adj)"
 msgstr ""
@@ -674,298 +674,322 @@ msgstr ""
 msgid "Or switch to another user"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/cast.py:317
+#: jellyfin_mpv_shim/mpvtk_browser/cast.py:314
 msgid "Ready to cast"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/cast.py:318
+#: jellyfin_mpv_shim/mpvtk_browser/cast.py:315
 msgid "Select your media in Jellyfin and play it here."
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:74
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:83
 msgid "Interface"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:83
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:92
 msgid "Playback"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:88
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:97
 msgid "Audio"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:92
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:101
 msgid "Subtitles & Languages"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:97
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:106
 msgid "Transcoding"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:102
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:111
 msgid "Video Enhancement"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:104
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:113
 msgid "Skip Intro / Credits"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:107
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:116
 msgid "Library Browser"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:109
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:118
 msgid "Downloads"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:128
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:137
 msgid "Jellyfin UI"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:129
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:138
 msgid "MPV UI with thumbnails"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:130
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:139
 msgid "MPV built-in default"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:133
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:142
 msgid "Follow display"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:134
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:143
 msgid "100% (no scaling)"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:135
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:144
 msgid "125%"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:136
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:145
 msgid "150%"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:137
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:146
 msgid "200%"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:140
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:149
 msgid "Automatic (recommended)"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:141
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:150
 msgid "Vulkan"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:142
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:151
 msgid "Direct3D 11 (Windows only)"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:143
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:152
 msgid "OpenGL (compatibility)"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:146
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:155
 msgid "Default (auto)"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:147
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:156
 msgid "Force Stereo"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:148
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:157
 msgid "Optical Surround"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:149
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:158
 msgid "HDMI Passthrough"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:152
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:161
 msgid "Unset"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:153
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:162
 msgid "Dubbed (shows only)"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:154
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:163
 msgid "Subbed (shows only)"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:155
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:164
 msgid "Dubbed (all)"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:156
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:165
 msgid "Subbed (all)"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:157
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:166
 msgid "Custom (set in config)"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:162
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:171
 msgid "Download Folder"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:163
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:172
 msgid "Prefer Downloaded Copy"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:164
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:173
 msgid "Automatically Download Upcoming Episodes"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:165
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:174
 msgid "Include Next Up"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:166
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:175
 msgid "Next Up Entries to Consider"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:167
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:176
 msgid "Episodes to Keep Ahead (0 = off)"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:168
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:177
 msgid "Storage Limit for Automatic Downloads (GB)"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:169
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:178
 msgid "Delete Automatic Downloads Once Watched"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:170
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:179
 msgid "Delete Unwatched After (days, 0 = never)"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:171
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:180
 msgid "Check Every (minutes)"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:172
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:181
 msgid "Close to Tray (keep running)"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:173
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:182
 msgid "Keep Running in Background"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:174
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:183
 msgid "Remember Window Size"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:175
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:184
 msgid "Player Controls Style"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:176
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:185
 msgid "Show What You're Watching in Discord"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:177
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:186
 msgid "Interface Scale"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:178
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:187
 msgid "Cast-target mode (no library browsing)"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:179
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:188
 msgid "Casting Opens the Library Browser"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:180
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:189
 msgid "Fullscreen Library Browser"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:181
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:190
 msgid "Always Bind Arrow Keys to Player Controls"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:182
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:191
 msgid "Player Controls Activation Key"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:183
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:192
 msgid "Audio Output Mode"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:184
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:193
 msgid "Audio Output Device"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:185
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:194
 msgid "Take the Device Exclusively"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:187
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:196
 msgid "Enable Video Playback Profiles"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:188
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:197
 msgid "Profile Group"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:189
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:198
 msgid "Remember Last Used Profile"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:190
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:199
 msgid "Graphics API for Shaders"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:191
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:200
 msgid "Pass Through AC3"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:192
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:201
 msgid "Pass Through DTS"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:193
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:202
 msgid "Pass Through E-AC3"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:194
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:203
 msgid "Pass Through DTS-HD"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:195
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:204
 msgid "Pass Through TrueHD"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:196
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:205
 msgid "Re-encode Others to AC3"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:202
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:213
 msgid ""
-"MPV keybinds are used by default. Press ENTER to drive the player controls "
-"by keyboard."
+"With \"Start Minimized\" and \"Fullscreen\" this is the classic cast-target "
+"setup: the app waits out of the way, plays fullscreen when something casts "
+"to it, and goes back to waiting when the video ends or you press Q."
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:204
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:227
+msgid ""
+"Off means command-line mode: no window, no system tray and no settings "
+"screen, so the only way back is editing conf.json by hand. It is not how you "
+"get MPV's own on-screen controls — \"Player Controls Style\" under Interface "
+"does that."
+msgstr ""
+
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:234
+msgid ""
+"Show only what is cast to this machine — the library, including this "
+"settings screen, can't be reached from here. Without a system tray icon the "
+"only way back is editing conf.json. For the classic cast-target setup you "
+"want the Interface settings instead; this is for a shared TV nobody should "
+"be able to browse from."
+msgstr ""
+
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:240
+msgid ""
+"Requires restart to change. MPV keybinds are used by default. Press ENTER to "
+"drive the player controls by keyboard."
+msgstr ""
+
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:242
 msgid ""
 "Pixels one wheel notch scrolls. The scrollbar glides while the content snaps "
 "to the nearest row, so a trackpad or trackball no longer overshoots. Raise "
 "it to scroll faster, lower it for finer control."
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:209
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:247
 msgid ""
 "Make each wheel notch jump exactly one row (or one home-screen section) "
 "instead of gliding. Turn this on if you prefer the older stepped scrolling."
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:217
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:255
 msgid "Discord Rich Presence. Takes effect after a restart."
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:219
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:257
 msgid ""
 "Leave this to Default unless setting up passthrough. Note some audio servers "
 "like Pipewire don't like passthrough and will need to be disabled for a card "
@@ -973,57 +997,57 @@ msgid ""
 "silence otherwise, but results may vary."
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:225
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:263
 msgid ""
 "Stop anything else using the device while playing. Needed for passthrough on "
 "some systems, and it means other applications will be silent."
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:228
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:266
 msgid ""
 "Page the library and music tile grids instead of scrolling: each page is one "
 "screenful with First / Previous / Next / Last controls and a page number you "
 "can type into. Easier than precise scrolling on a trackpad."
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:232
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:270
 msgid ""
 "Takes effect after a restart. \"Follow display\" uses the scale your desktop "
 "reports, which is 100% on X11."
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:234
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:272
 msgid ""
 "\"Default\" changes nothing and lets MPV (and your own mpv.conf) decide. "
 "Pick a mode only if you are sending audio to a receiver."
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:237
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:275
 msgid ""
 "Audio your receiver can't be sent directly is encoded to AC3, which is the "
 "only way surround fits down an optical cable. Turn this off if the encoder "
 "causes audio delay — those tracks become stereo instead."
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:242
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:280
 msgid ""
 "\"hq\" offers heavier profiles. Pick it if you have a fast graphics card."
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:244
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:282
 msgid ""
 "Leave on Automatic unless video breaks when a profile is loaded. This only "
 "applies while a profile is active, and OpenGL can cost you HDR output."
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:248
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:286
 msgid ""
 "Evens out loud effects and quiet dialogue. This turns passthrough off while "
 "it is enabled, because the volume has to be adjusted before your receiver "
 "gets the audio."
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:330
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:368
 msgid "Advanced"
 msgstr ""
 
@@ -1205,7 +1229,7 @@ msgid "Automatic"
 msgstr "zmiku"
 
 #: jellyfin_mpv_shim/mpvtk_browser/downloads.py:51
-#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1355
+#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1288
 msgid "Episodes"
 msgstr ""
 
@@ -1214,7 +1238,7 @@ msgid "Season %s"
 msgstr ""
 
 #: jellyfin_mpv_shim/mpvtk_browser/downloads.py:52
-#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1351
+#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1284
 msgid "Specials"
 msgstr ""
 
@@ -1237,7 +1261,7 @@ msgid "Failed"
 msgstr "fliba"
 
 #: jellyfin_mpv_shim/mpvtk_browser/downloads.py:185
-#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1105
+#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1038
 msgid "Playlist"
 msgstr ""
 
@@ -1249,30 +1273,30 @@ msgstr ""
 msgid "Movies & Videos"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/home_sections.py:103
+#: jellyfin_mpv_shim/mpvtk_browser/home_sections.py:104
 msgid "My Media"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/home_sections.py:104
-#: jellyfin_mpv_shim/mpvtk_browser/repository.py:352
+#: jellyfin_mpv_shim/mpvtk_browser/home_sections.py:105
+#: jellyfin_mpv_shim/mpvtk_browser/repository.py:350
 msgid "Continue Watching"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/home_sections.py:105
-#: jellyfin_mpv_shim/mpvtk_browser/repository.py:359
+#: jellyfin_mpv_shim/mpvtk_browser/home_sections.py:106
+#: jellyfin_mpv_shim/mpvtk_browser/repository.py:357
 msgid "Continue Listening"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/home_sections.py:106
-#: jellyfin_mpv_shim/mpvtk_browser/repository.py:366
+#: jellyfin_mpv_shim/mpvtk_browser/home_sections.py:107
+#: jellyfin_mpv_shim/mpvtk_browser/repository.py:364
 msgid "Next Up"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/home_sections.py:107
+#: jellyfin_mpv_shim/mpvtk_browser/home_sections.py:108
 msgid "Recently Added"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/home_sections.py:108
+#: jellyfin_mpv_shim/mpvtk_browser/home_sections.py:109
 msgid "Live TV"
 msgstr ""
 
@@ -1481,52 +1505,52 @@ msgstr ""
 msgid "Could not load this page."
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/repository.py:390
+#: jellyfin_mpv_shim/mpvtk_browser/repository.py:386
 msgid "On Now"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/repository.py:411
+#: jellyfin_mpv_shim/mpvtk_browser/repository.py:407
 msgid "Latest %s"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1119
+#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1052
 msgid "Downloaded"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1138
+#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1071
 msgid "Movies"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1143
+#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1076
 msgid "Videos"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1147
+#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1080
 msgid "TV Shows"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1151
+#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1084
 msgid "Playlists"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1168
-#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1441
+#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1101
+#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1374
 msgid "Series"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1212
+#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1145
 msgid "Downloaded Movies"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1216
+#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1149
 msgid "Downloaded Videos"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1220
+#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1153
 msgid "Downloaded Shows"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1353
+#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1286
 msgid "Season %d"
 msgstr ""
 

--- a/jellyfin_mpv_shim/messages/ka/LC_MESSAGES/base.po
+++ b/jellyfin_mpv_shim/messages/ka/LC_MESSAGES/base.po
@@ -5,7 +5,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2026-07-25 17:21-0400\n"
+"POT-Creation-Date: 2026-07-26 12:03-0400\n"
 "PO-Revision-Date: 2026-05-24 14:38+0000\n"
 "Last-Translator: Ekaterine Papava <papava.e@gtu.ge>\n"
 "Language-Team: Georgian <https://translate.jellyfin.org/projects/jellyfin/"
@@ -252,7 +252,7 @@ msgid "Select Subtitle Track"
 msgstr "სუბტიტრის ტრეკის არჩევა"
 
 #: jellyfin_mpv_shim/menu.py:341
-#: jellyfin_mpv_shim/mpvtk_browser/home_sections.py:102
+#: jellyfin_mpv_shim/mpvtk_browser/home_sections.py:103
 #: jellyfin_mpv_shim/osc_bridge.py:81 jellyfin_mpv_shim/osc_bridge.py:82
 #: jellyfin_mpv_shim/osc_bridge.py:104 jellyfin_mpv_shim/osc_bridge.py:140
 msgid "None"
@@ -403,7 +403,7 @@ msgstr "ტიტრების გამოტოვების დადა�
 msgid "Enable thumbnail previews"
 msgstr "მინიატურის გადახედვების ჩართვა"
 
-#: jellyfin_mpv_shim/menu.py:609 jellyfin_mpv_shim/mpvtk_browser/config.py:186
+#: jellyfin_mpv_shim/menu.py:609 jellyfin_mpv_shim/mpvtk_browser/config.py:195
 #: jellyfin_mpv_shim/mpvtk_browser/hud.py:375
 msgid "Night Mode (Auto Volume Adj)"
 msgstr ""
@@ -702,310 +702,334 @@ msgstr ""
 msgid "Or switch to another user"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/cast.py:317
+#: jellyfin_mpv_shim/mpvtk_browser/cast.py:314
 msgid "Ready to cast"
 msgstr "მზადაა ტრანსლაციისთვის"
 
-#: jellyfin_mpv_shim/mpvtk_browser/cast.py:318
+#: jellyfin_mpv_shim/mpvtk_browser/cast.py:315
 #, fuzzy
 #| msgid "Select your media in Jellyfin and play it here"
 msgid "Select your media in Jellyfin and play it here."
 msgstr "აირჩიეთ თქვენი მედია Jellyfin-ში და დაუკარით ის აქ"
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:74
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:83
 msgid "Interface"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:83
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:92
 msgid "Playback"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:88
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:97
 msgid "Audio"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:92
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:101
 msgid "Subtitles & Languages"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:97
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:106
 #, fuzzy
 #| msgid " (Transcode)"
 msgid "Transcoding"
 msgstr " (ტრანსკოდირება)"
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:102
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:111
 msgid "Video Enhancement"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:104
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:113
 #, fuzzy
 #| msgid "Seek to Skip Credits"
 msgid "Skip Intro / Credits"
 msgstr "ტიტრების გადახვევა"
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:107
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:116
 msgid "Library Browser"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:109
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:118
 msgid "Downloads"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:128
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:137
 msgid "Jellyfin UI"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:129
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:138
 msgid "MPV UI with thumbnails"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:130
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:139
 msgid "MPV built-in default"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:133
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:142
 msgid "Follow display"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:134
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:143
 msgid "100% (no scaling)"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:135
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:144
 msgid "125%"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:136
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:145
 msgid "150%"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:137
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:146
 msgid "200%"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:140
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:149
 msgid "Automatic (recommended)"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:141
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:150
 msgid "Vulkan"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:142
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:151
 msgid "Direct3D 11 (Windows only)"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:143
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:152
 msgid "OpenGL (compatibility)"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:146
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:155
 msgid "Default (auto)"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:147
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:156
 msgid "Force Stereo"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:148
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:157
 msgid "Optical Surround"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:149
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:158
 msgid "HDMI Passthrough"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:152
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:161
 msgid "Unset"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:153
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:162
 msgid "Dubbed (shows only)"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:154
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:163
 msgid "Subbed (shows only)"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:155
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:164
 msgid "Dubbed (all)"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:156
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:165
 msgid "Subbed (all)"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:157
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:166
 msgid "Custom (set in config)"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:162
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:171
 msgid "Download Folder"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:163
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:172
 msgid "Prefer Downloaded Copy"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:164
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:173
 msgid "Automatically Download Upcoming Episodes"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:165
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:174
 msgid "Include Next Up"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:166
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:175
 msgid "Next Up Entries to Consider"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:167
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:176
 msgid "Episodes to Keep Ahead (0 = off)"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:168
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:177
 msgid "Storage Limit for Automatic Downloads (GB)"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:169
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:178
 #, fuzzy
 #| msgid "Remove Server"
 msgid "Delete Automatic Downloads Once Watched"
 msgstr "სერვერის წაშლა"
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:170
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:179
 msgid "Delete Unwatched After (days, 0 = never)"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:171
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:180
 msgid "Check Every (minutes)"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:172
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:181
 msgid "Close to Tray (keep running)"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:173
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:182
 msgid "Keep Running in Background"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:174
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:183
 msgid "Remember Window Size"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:175
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:184
 msgid "Player Controls Style"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:176
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:185
 msgid "Show What You're Watching in Discord"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:177
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:186
 msgid "Interface Scale"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:178
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:187
 msgid "Cast-target mode (no library browsing)"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:179
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:188
 msgid "Casting Opens the Library Browser"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:180
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:189
 msgid "Fullscreen Library Browser"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:181
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:190
 msgid "Always Bind Arrow Keys to Player Controls"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:182
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:191
 msgid "Player Controls Activation Key"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:183
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:192
 msgid "Audio Output Mode"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:184
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:193
 msgid "Audio Output Device"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:185
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:194
 msgid "Take the Device Exclusively"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:187
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:196
 #, fuzzy
 #| msgid "Video Playback Profiles"
 msgid "Enable Video Playback Profiles"
 msgstr "ვიდეოს დაკვრის პროფილები"
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:188
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:197
 #, fuzzy
 #| msgid "New Group"
 msgid "Profile Group"
 msgstr "ახალი ჯგუფი"
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:189
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:198
 msgid "Remember Last Used Profile"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:190
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:199
 msgid "Graphics API for Shaders"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:191
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:200
 msgid "Pass Through AC3"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:192
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:201
 msgid "Pass Through DTS"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:193
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:202
 msgid "Pass Through E-AC3"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:194
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:203
 msgid "Pass Through DTS-HD"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:195
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:204
 msgid "Pass Through TrueHD"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:196
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:205
 msgid "Re-encode Others to AC3"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:202
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:213
 msgid ""
-"MPV keybinds are used by default. Press ENTER to drive the player controls "
-"by keyboard."
+"With \"Start Minimized\" and \"Fullscreen\" this is the classic cast-target "
+"setup: the app waits out of the way, plays fullscreen when something casts "
+"to it, and goes back to waiting when the video ends or you press Q."
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:204
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:227
+msgid ""
+"Off means command-line mode: no window, no system tray and no settings "
+"screen, so the only way back is editing conf.json by hand. It is not how you "
+"get MPV's own on-screen controls — \"Player Controls Style\" under Interface "
+"does that."
+msgstr ""
+
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:234
+msgid ""
+"Show only what is cast to this machine — the library, including this "
+"settings screen, can't be reached from here. Without a system tray icon the "
+"only way back is editing conf.json. For the classic cast-target setup you "
+"want the Interface settings instead; this is for a shared TV nobody should "
+"be able to browse from."
+msgstr ""
+
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:240
+msgid ""
+"Requires restart to change. MPV keybinds are used by default. Press ENTER to "
+"drive the player controls by keyboard."
+msgstr ""
+
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:242
 msgid ""
 "Pixels one wheel notch scrolls. The scrollbar glides while the content snaps "
 "to the nearest row, so a trackpad or trackball no longer overshoots. Raise "
 "it to scroll faster, lower it for finer control."
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:209
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:247
 msgid ""
 "Make each wheel notch jump exactly one row (or one home-screen section) "
 "instead of gliding. Turn this on if you prefer the older stepped scrolling."
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:217
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:255
 msgid "Discord Rich Presence. Takes effect after a restart."
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:219
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:257
 msgid ""
 "Leave this to Default unless setting up passthrough. Note some audio servers "
 "like Pipewire don't like passthrough and will need to be disabled for a card "
@@ -1013,57 +1037,57 @@ msgid ""
 "silence otherwise, but results may vary."
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:225
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:263
 msgid ""
 "Stop anything else using the device while playing. Needed for passthrough on "
 "some systems, and it means other applications will be silent."
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:228
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:266
 msgid ""
 "Page the library and music tile grids instead of scrolling: each page is one "
 "screenful with First / Previous / Next / Last controls and a page number you "
 "can type into. Easier than precise scrolling on a trackpad."
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:232
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:270
 msgid ""
 "Takes effect after a restart. \"Follow display\" uses the scale your desktop "
 "reports, which is 100% on X11."
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:234
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:272
 msgid ""
 "\"Default\" changes nothing and lets MPV (and your own mpv.conf) decide. "
 "Pick a mode only if you are sending audio to a receiver."
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:237
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:275
 msgid ""
 "Audio your receiver can't be sent directly is encoded to AC3, which is the "
 "only way surround fits down an optical cable. Turn this off if the encoder "
 "causes audio delay — those tracks become stereo instead."
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:242
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:280
 msgid ""
 "\"hq\" offers heavier profiles. Pick it if you have a fast graphics card."
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:244
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:282
 msgid ""
 "Leave on Automatic unless video breaks when a profile is loaded. This only "
 "applies while a profile is active, and OpenGL can cost you HDR output."
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:248
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:286
 msgid ""
 "Evens out loud effects and quiet dialogue. This turns passthrough off while "
 "it is enabled, because the volume has to be adjusted before your receiver "
 "gets the audio."
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:330
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:368
 msgid "Advanced"
 msgstr ""
 
@@ -1289,7 +1313,7 @@ msgid "Automatic"
 msgstr "ავტომატური"
 
 #: jellyfin_mpv_shim/mpvtk_browser/downloads.py:51
-#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1355
+#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1288
 msgid "Episodes"
 msgstr ""
 
@@ -1298,7 +1322,7 @@ msgid "Season %s"
 msgstr ""
 
 #: jellyfin_mpv_shim/mpvtk_browser/downloads.py:52
-#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1351
+#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1284
 msgid "Specials"
 msgstr ""
 
@@ -1323,7 +1347,7 @@ msgid "Failed"
 msgstr "ჩავარდნა"
 
 #: jellyfin_mpv_shim/mpvtk_browser/downloads.py:185
-#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1105
+#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1038
 msgid "Playlist"
 msgstr ""
 
@@ -1335,30 +1359,30 @@ msgstr ""
 msgid "Movies & Videos"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/home_sections.py:103
+#: jellyfin_mpv_shim/mpvtk_browser/home_sections.py:104
 msgid "My Media"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/home_sections.py:104
-#: jellyfin_mpv_shim/mpvtk_browser/repository.py:352
+#: jellyfin_mpv_shim/mpvtk_browser/home_sections.py:105
+#: jellyfin_mpv_shim/mpvtk_browser/repository.py:350
 msgid "Continue Watching"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/home_sections.py:105
-#: jellyfin_mpv_shim/mpvtk_browser/repository.py:359
+#: jellyfin_mpv_shim/mpvtk_browser/home_sections.py:106
+#: jellyfin_mpv_shim/mpvtk_browser/repository.py:357
 msgid "Continue Listening"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/home_sections.py:106
-#: jellyfin_mpv_shim/mpvtk_browser/repository.py:366
+#: jellyfin_mpv_shim/mpvtk_browser/home_sections.py:107
+#: jellyfin_mpv_shim/mpvtk_browser/repository.py:364
 msgid "Next Up"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/home_sections.py:107
+#: jellyfin_mpv_shim/mpvtk_browser/home_sections.py:108
 msgid "Recently Added"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/home_sections.py:108
+#: jellyfin_mpv_shim/mpvtk_browser/home_sections.py:109
 msgid "Live TV"
 msgstr ""
 
@@ -1611,52 +1635,52 @@ msgstr ""
 "სერვერის დამატება შეუძლებელია.\n"
 "შეამოწმეთ თქვენი კავშირის ინფორმაცია."
 
-#: jellyfin_mpv_shim/mpvtk_browser/repository.py:390
+#: jellyfin_mpv_shim/mpvtk_browser/repository.py:386
 msgid "On Now"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/repository.py:411
+#: jellyfin_mpv_shim/mpvtk_browser/repository.py:407
 msgid "Latest %s"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1119
+#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1052
 msgid "Downloaded"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1138
+#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1071
 msgid "Movies"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1143
+#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1076
 msgid "Videos"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1147
+#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1080
 msgid "TV Shows"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1151
+#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1084
 msgid "Playlists"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1168
-#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1441
+#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1101
+#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1374
 msgid "Series"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1212
+#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1145
 msgid "Downloaded Movies"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1216
+#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1149
 msgid "Downloaded Videos"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1220
+#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1153
 msgid "Downloaded Shows"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1353
+#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1286
 msgid "Season %d"
 msgstr ""
 

--- a/jellyfin_mpv_shim/messages/kk/LC_MESSAGES/base.po
+++ b/jellyfin_mpv_shim/messages/kk/LC_MESSAGES/base.po
@@ -5,7 +5,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2026-07-25 17:21-0400\n"
+"POT-Creation-Date: 2026-07-26 12:03-0400\n"
 "PO-Revision-Date: 2022-07-04 21:06+0000\n"
 "Last-Translator: WWWesten <wwwesten@gmail.com>\n"
 "Language-Team: Kazakh <https://translate.jellyfin.org/projects/jellyfin/"
@@ -252,7 +252,7 @@ msgid "Select Subtitle Track"
 msgstr "Subtitrler jolşyğyn tañdau"
 
 #: jellyfin_mpv_shim/menu.py:341
-#: jellyfin_mpv_shim/mpvtk_browser/home_sections.py:102
+#: jellyfin_mpv_shim/mpvtk_browser/home_sections.py:103
 #: jellyfin_mpv_shim/osc_bridge.py:81 jellyfin_mpv_shim/osc_bridge.py:82
 #: jellyfin_mpv_shim/osc_bridge.py:104 jellyfin_mpv_shim/osc_bridge.py:140
 msgid "None"
@@ -405,7 +405,7 @@ msgstr ""
 msgid "Enable thumbnail previews"
 msgstr ""
 
-#: jellyfin_mpv_shim/menu.py:609 jellyfin_mpv_shim/mpvtk_browser/config.py:186
+#: jellyfin_mpv_shim/menu.py:609 jellyfin_mpv_shim/mpvtk_browser/config.py:195
 #: jellyfin_mpv_shim/mpvtk_browser/hud.py:375
 msgid "Night Mode (Auto Volume Adj)"
 msgstr ""
@@ -704,308 +704,332 @@ msgstr ""
 msgid "Or switch to another user"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/cast.py:317
+#: jellyfin_mpv_shim/mpvtk_browser/cast.py:314
 msgid "Ready to cast"
 msgstr "Taratuğa daiyn"
 
-#: jellyfin_mpv_shim/mpvtk_browser/cast.py:318
+#: jellyfin_mpv_shim/mpvtk_browser/cast.py:315
 #, fuzzy
 #| msgid "Select your media in Jellyfin and play it here"
 msgid "Select your media in Jellyfin and play it here."
 msgstr "Tasyğyşderekterıñızdı Jellyfin ışınde tañdap, osy jerde oinatyñyz"
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:74
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:83
 msgid "Interface"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:83
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:92
 msgid "Playback"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:88
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:97
 msgid "Audio"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:92
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:101
 msgid "Subtitles & Languages"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:97
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:106
 #, fuzzy
 #| msgid " (Transcode)"
 msgid "Transcoding"
 msgstr " (Qaita kodtau)"
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:102
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:111
 msgid "Video Enhancement"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:104
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:113
 msgid "Skip Intro / Credits"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:107
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:116
 msgid "Library Browser"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:109
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:118
 msgid "Downloads"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:128
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:137
 msgid "Jellyfin UI"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:129
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:138
 msgid "MPV UI with thumbnails"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:130
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:139
 msgid "MPV built-in default"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:133
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:142
 msgid "Follow display"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:134
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:143
 msgid "100% (no scaling)"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:135
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:144
 msgid "125%"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:136
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:145
 msgid "150%"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:137
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:146
 msgid "200%"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:140
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:149
 msgid "Automatic (recommended)"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:141
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:150
 msgid "Vulkan"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:142
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:151
 msgid "Direct3D 11 (Windows only)"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:143
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:152
 msgid "OpenGL (compatibility)"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:146
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:155
 msgid "Default (auto)"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:147
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:156
 msgid "Force Stereo"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:148
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:157
 msgid "Optical Surround"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:149
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:158
 msgid "HDMI Passthrough"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:152
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:161
 msgid "Unset"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:153
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:162
 msgid "Dubbed (shows only)"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:154
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:163
 msgid "Subbed (shows only)"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:155
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:164
 msgid "Dubbed (all)"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:156
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:165
 msgid "Subbed (all)"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:157
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:166
 msgid "Custom (set in config)"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:162
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:171
 msgid "Download Folder"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:163
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:172
 msgid "Prefer Downloaded Copy"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:164
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:173
 msgid "Automatically Download Upcoming Episodes"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:165
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:174
 msgid "Include Next Up"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:166
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:175
 msgid "Next Up Entries to Consider"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:167
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:176
 msgid "Episodes to Keep Ahead (0 = off)"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:168
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:177
 msgid "Storage Limit for Automatic Downloads (GB)"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:169
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:178
 #, fuzzy
 #| msgid "Remove Server"
 msgid "Delete Automatic Downloads Once Watched"
 msgstr "Serverdı alastau"
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:170
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:179
 msgid "Delete Unwatched After (days, 0 = never)"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:171
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:180
 msgid "Check Every (minutes)"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:172
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:181
 msgid "Close to Tray (keep running)"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:173
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:182
 msgid "Keep Running in Background"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:174
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:183
 msgid "Remember Window Size"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:175
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:184
 msgid "Player Controls Style"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:176
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:185
 msgid "Show What You're Watching in Discord"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:177
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:186
 msgid "Interface Scale"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:178
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:187
 msgid "Cast-target mode (no library browsing)"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:179
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:188
 msgid "Casting Opens the Library Browser"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:180
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:189
 msgid "Fullscreen Library Browser"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:181
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:190
 msgid "Always Bind Arrow Keys to Player Controls"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:182
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:191
 msgid "Player Controls Activation Key"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:183
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:192
 msgid "Audio Output Mode"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:184
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:193
 msgid "Audio Output Device"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:185
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:194
 msgid "Take the Device Exclusively"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:187
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:196
 #, fuzzy
 #| msgid "Video Playback Profiles"
 msgid "Enable Video Playback Profiles"
 msgstr "Beine oinatu profaily"
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:188
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:197
 #, fuzzy
 #| msgid "New Group"
 msgid "Profile Group"
 msgstr "Jaña top"
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:189
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:198
 msgid "Remember Last Used Profile"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:190
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:199
 msgid "Graphics API for Shaders"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:191
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:200
 msgid "Pass Through AC3"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:192
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:201
 msgid "Pass Through DTS"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:193
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:202
 msgid "Pass Through E-AC3"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:194
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:203
 msgid "Pass Through DTS-HD"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:195
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:204
 msgid "Pass Through TrueHD"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:196
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:205
 msgid "Re-encode Others to AC3"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:202
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:213
 msgid ""
-"MPV keybinds are used by default. Press ENTER to drive the player controls "
-"by keyboard."
+"With \"Start Minimized\" and \"Fullscreen\" this is the classic cast-target "
+"setup: the app waits out of the way, plays fullscreen when something casts "
+"to it, and goes back to waiting when the video ends or you press Q."
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:204
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:227
+msgid ""
+"Off means command-line mode: no window, no system tray and no settings "
+"screen, so the only way back is editing conf.json by hand. It is not how you "
+"get MPV's own on-screen controls — \"Player Controls Style\" under Interface "
+"does that."
+msgstr ""
+
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:234
+msgid ""
+"Show only what is cast to this machine — the library, including this "
+"settings screen, can't be reached from here. Without a system tray icon the "
+"only way back is editing conf.json. For the classic cast-target setup you "
+"want the Interface settings instead; this is for a shared TV nobody should "
+"be able to browse from."
+msgstr ""
+
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:240
+msgid ""
+"Requires restart to change. MPV keybinds are used by default. Press ENTER to "
+"drive the player controls by keyboard."
+msgstr ""
+
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:242
 msgid ""
 "Pixels one wheel notch scrolls. The scrollbar glides while the content snaps "
 "to the nearest row, so a trackpad or trackball no longer overshoots. Raise "
 "it to scroll faster, lower it for finer control."
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:209
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:247
 msgid ""
 "Make each wheel notch jump exactly one row (or one home-screen section) "
 "instead of gliding. Turn this on if you prefer the older stepped scrolling."
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:217
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:255
 msgid "Discord Rich Presence. Takes effect after a restart."
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:219
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:257
 msgid ""
 "Leave this to Default unless setting up passthrough. Note some audio servers "
 "like Pipewire don't like passthrough and will need to be disabled for a card "
@@ -1013,57 +1037,57 @@ msgid ""
 "silence otherwise, but results may vary."
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:225
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:263
 msgid ""
 "Stop anything else using the device while playing. Needed for passthrough on "
 "some systems, and it means other applications will be silent."
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:228
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:266
 msgid ""
 "Page the library and music tile grids instead of scrolling: each page is one "
 "screenful with First / Previous / Next / Last controls and a page number you "
 "can type into. Easier than precise scrolling on a trackpad."
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:232
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:270
 msgid ""
 "Takes effect after a restart. \"Follow display\" uses the scale your desktop "
 "reports, which is 100% on X11."
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:234
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:272
 msgid ""
 "\"Default\" changes nothing and lets MPV (and your own mpv.conf) decide. "
 "Pick a mode only if you are sending audio to a receiver."
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:237
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:275
 msgid ""
 "Audio your receiver can't be sent directly is encoded to AC3, which is the "
 "only way surround fits down an optical cable. Turn this off if the encoder "
 "causes audio delay — those tracks become stereo instead."
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:242
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:280
 msgid ""
 "\"hq\" offers heavier profiles. Pick it if you have a fast graphics card."
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:244
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:282
 msgid ""
 "Leave on Automatic unless video breaks when a profile is loaded. This only "
 "applies while a profile is active, and OpenGL can cost you HDR output."
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:248
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:286
 msgid ""
 "Evens out loud effects and quiet dialogue. This turns passthrough off while "
 "it is enabled, because the volume has to be adjusted before your receiver "
 "gets the audio."
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:330
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:368
 msgid "Advanced"
 msgstr ""
 
@@ -1289,7 +1313,7 @@ msgid "Automatic"
 msgstr "Avtomatty"
 
 #: jellyfin_mpv_shim/mpvtk_browser/downloads.py:51
-#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1355
+#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1288
 msgid "Episodes"
 msgstr ""
 
@@ -1298,7 +1322,7 @@ msgid "Season %s"
 msgstr ""
 
 #: jellyfin_mpv_shim/mpvtk_browser/downloads.py:52
-#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1351
+#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1284
 msgid "Specials"
 msgstr ""
 
@@ -1323,7 +1347,7 @@ msgid "Failed"
 msgstr "Sätsız"
 
 #: jellyfin_mpv_shim/mpvtk_browser/downloads.py:185
-#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1105
+#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1038
 msgid "Playlist"
 msgstr ""
 
@@ -1335,30 +1359,30 @@ msgstr ""
 msgid "Movies & Videos"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/home_sections.py:103
+#: jellyfin_mpv_shim/mpvtk_browser/home_sections.py:104
 msgid "My Media"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/home_sections.py:104
-#: jellyfin_mpv_shim/mpvtk_browser/repository.py:352
+#: jellyfin_mpv_shim/mpvtk_browser/home_sections.py:105
+#: jellyfin_mpv_shim/mpvtk_browser/repository.py:350
 msgid "Continue Watching"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/home_sections.py:105
-#: jellyfin_mpv_shim/mpvtk_browser/repository.py:359
+#: jellyfin_mpv_shim/mpvtk_browser/home_sections.py:106
+#: jellyfin_mpv_shim/mpvtk_browser/repository.py:357
 msgid "Continue Listening"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/home_sections.py:106
-#: jellyfin_mpv_shim/mpvtk_browser/repository.py:366
+#: jellyfin_mpv_shim/mpvtk_browser/home_sections.py:107
+#: jellyfin_mpv_shim/mpvtk_browser/repository.py:364
 msgid "Next Up"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/home_sections.py:107
+#: jellyfin_mpv_shim/mpvtk_browser/home_sections.py:108
 msgid "Recently Added"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/home_sections.py:108
+#: jellyfin_mpv_shim/mpvtk_browser/home_sections.py:109
 msgid "Live TV"
 msgstr ""
 
@@ -1611,52 +1635,52 @@ msgstr ""
 "Server üstelınbedı.\n"
 "Qosylu mälımetterın tekserıñız."
 
-#: jellyfin_mpv_shim/mpvtk_browser/repository.py:390
+#: jellyfin_mpv_shim/mpvtk_browser/repository.py:386
 msgid "On Now"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/repository.py:411
+#: jellyfin_mpv_shim/mpvtk_browser/repository.py:407
 msgid "Latest %s"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1119
+#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1052
 msgid "Downloaded"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1138
+#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1071
 msgid "Movies"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1143
+#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1076
 msgid "Videos"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1147
+#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1080
 msgid "TV Shows"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1151
+#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1084
 msgid "Playlists"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1168
-#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1441
+#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1101
+#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1374
 msgid "Series"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1212
+#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1145
 msgid "Downloaded Movies"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1216
+#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1149
 msgid "Downloaded Videos"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1220
+#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1153
 msgid "Downloaded Shows"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1353
+#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1286
 msgid "Season %d"
 msgstr ""
 

--- a/jellyfin_mpv_shim/messages/km/LC_MESSAGES/base.po
+++ b/jellyfin_mpv_shim/messages/km/LC_MESSAGES/base.po
@@ -5,7 +5,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2026-07-25 17:21-0400\n"
+"POT-Creation-Date: 2026-07-26 12:03-0400\n"
 "PO-Revision-Date: 2024-08-20 19:12+0000\n"
 "Last-Translator: houching <houching.online2@gmail.com>\n"
 "Language-Team: Khmer (Central) <https://translate.jellyfin.org/projects/"
@@ -252,7 +252,7 @@ msgid "Select Subtitle Track"
 msgstr "ជ្រើសរើសសាប់ថាយថល"
 
 #: jellyfin_mpv_shim/menu.py:341
-#: jellyfin_mpv_shim/mpvtk_browser/home_sections.py:102
+#: jellyfin_mpv_shim/mpvtk_browser/home_sections.py:103
 #: jellyfin_mpv_shim/osc_bridge.py:81 jellyfin_mpv_shim/osc_bridge.py:82
 #: jellyfin_mpv_shim/osc_bridge.py:104 jellyfin_mpv_shim/osc_bridge.py:140
 msgid "None"
@@ -403,7 +403,7 @@ msgstr ""
 msgid "Enable thumbnail previews"
 msgstr ""
 
-#: jellyfin_mpv_shim/menu.py:609 jellyfin_mpv_shim/mpvtk_browser/config.py:186
+#: jellyfin_mpv_shim/menu.py:609 jellyfin_mpv_shim/mpvtk_browser/config.py:195
 #: jellyfin_mpv_shim/mpvtk_browser/hud.py:375
 msgid "Night Mode (Auto Volume Adj)"
 msgstr ""
@@ -702,306 +702,330 @@ msgstr ""
 msgid "Or switch to another user"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/cast.py:317
+#: jellyfin_mpv_shim/mpvtk_browser/cast.py:314
 msgid "Ready to cast"
 msgstr "ត្រៀម Cast"
 
-#: jellyfin_mpv_shim/mpvtk_browser/cast.py:318
+#: jellyfin_mpv_shim/mpvtk_browser/cast.py:315
 #, fuzzy
 #| msgid "Select your media in Jellyfin and play it here"
 msgid "Select your media in Jellyfin and play it here."
 msgstr "ជ្រើសរើសមេឌៀរបស់អ្នកនៅក្នុង Jellyfin ហើយចាក់វានៅទីនេះ"
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:74
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:83
 msgid "Interface"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:83
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:92
 msgid "Playback"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:88
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:97
 msgid "Audio"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:92
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:101
 msgid "Subtitles & Languages"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:97
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:106
 #, fuzzy
 #| msgid " (Transcode)"
 msgid "Transcoding"
 msgstr " (បំលែងកូដ)"
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:102
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:111
 msgid "Video Enhancement"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:104
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:113
 msgid "Skip Intro / Credits"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:107
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:116
 msgid "Library Browser"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:109
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:118
 msgid "Downloads"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:128
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:137
 msgid "Jellyfin UI"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:129
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:138
 msgid "MPV UI with thumbnails"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:130
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:139
 msgid "MPV built-in default"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:133
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:142
 msgid "Follow display"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:134
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:143
 msgid "100% (no scaling)"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:135
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:144
 msgid "125%"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:136
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:145
 msgid "150%"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:137
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:146
 msgid "200%"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:140
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:149
 msgid "Automatic (recommended)"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:141
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:150
 msgid "Vulkan"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:142
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:151
 msgid "Direct3D 11 (Windows only)"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:143
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:152
 msgid "OpenGL (compatibility)"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:146
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:155
 msgid "Default (auto)"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:147
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:156
 msgid "Force Stereo"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:148
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:157
 msgid "Optical Surround"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:149
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:158
 msgid "HDMI Passthrough"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:152
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:161
 msgid "Unset"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:153
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:162
 msgid "Dubbed (shows only)"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:154
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:163
 msgid "Subbed (shows only)"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:155
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:164
 msgid "Dubbed (all)"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:156
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:165
 msgid "Subbed (all)"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:157
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:166
 msgid "Custom (set in config)"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:162
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:171
 msgid "Download Folder"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:163
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:172
 msgid "Prefer Downloaded Copy"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:164
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:173
 msgid "Automatically Download Upcoming Episodes"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:165
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:174
 msgid "Include Next Up"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:166
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:175
 msgid "Next Up Entries to Consider"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:167
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:176
 msgid "Episodes to Keep Ahead (0 = off)"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:168
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:177
 msgid "Storage Limit for Automatic Downloads (GB)"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:169
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:178
 #, fuzzy
 #| msgid "Remove Server"
 msgid "Delete Automatic Downloads Once Watched"
 msgstr "លុបម៉ាស៊ីនមេ"
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:170
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:179
 msgid "Delete Unwatched After (days, 0 = never)"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:171
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:180
 msgid "Check Every (minutes)"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:172
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:181
 msgid "Close to Tray (keep running)"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:173
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:182
 msgid "Keep Running in Background"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:174
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:183
 msgid "Remember Window Size"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:175
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:184
 msgid "Player Controls Style"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:176
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:185
 msgid "Show What You're Watching in Discord"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:177
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:186
 msgid "Interface Scale"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:178
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:187
 msgid "Cast-target mode (no library browsing)"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:179
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:188
 msgid "Casting Opens the Library Browser"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:180
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:189
 msgid "Fullscreen Library Browser"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:181
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:190
 msgid "Always Bind Arrow Keys to Player Controls"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:182
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:191
 msgid "Player Controls Activation Key"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:183
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:192
 msgid "Audio Output Mode"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:184
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:193
 msgid "Audio Output Device"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:185
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:194
 msgid "Take the Device Exclusively"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:187
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:196
 #, fuzzy
 #| msgid "Video Playback Profiles"
 msgid "Enable Video Playback Profiles"
 msgstr "កម្រងព័ត៌មានការចាក់វីដេអូ"
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:188
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:197
 msgid "Profile Group"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:189
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:198
 msgid "Remember Last Used Profile"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:190
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:199
 msgid "Graphics API for Shaders"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:191
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:200
 msgid "Pass Through AC3"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:192
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:201
 msgid "Pass Through DTS"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:193
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:202
 msgid "Pass Through E-AC3"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:194
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:203
 msgid "Pass Through DTS-HD"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:195
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:204
 msgid "Pass Through TrueHD"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:196
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:205
 msgid "Re-encode Others to AC3"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:202
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:213
 msgid ""
-"MPV keybinds are used by default. Press ENTER to drive the player controls "
-"by keyboard."
+"With \"Start Minimized\" and \"Fullscreen\" this is the classic cast-target "
+"setup: the app waits out of the way, plays fullscreen when something casts "
+"to it, and goes back to waiting when the video ends or you press Q."
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:204
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:227
+msgid ""
+"Off means command-line mode: no window, no system tray and no settings "
+"screen, so the only way back is editing conf.json by hand. It is not how you "
+"get MPV's own on-screen controls — \"Player Controls Style\" under Interface "
+"does that."
+msgstr ""
+
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:234
+msgid ""
+"Show only what is cast to this machine — the library, including this "
+"settings screen, can't be reached from here. Without a system tray icon the "
+"only way back is editing conf.json. For the classic cast-target setup you "
+"want the Interface settings instead; this is for a shared TV nobody should "
+"be able to browse from."
+msgstr ""
+
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:240
+msgid ""
+"Requires restart to change. MPV keybinds are used by default. Press ENTER to "
+"drive the player controls by keyboard."
+msgstr ""
+
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:242
 msgid ""
 "Pixels one wheel notch scrolls. The scrollbar glides while the content snaps "
 "to the nearest row, so a trackpad or trackball no longer overshoots. Raise "
 "it to scroll faster, lower it for finer control."
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:209
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:247
 msgid ""
 "Make each wheel notch jump exactly one row (or one home-screen section) "
 "instead of gliding. Turn this on if you prefer the older stepped scrolling."
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:217
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:255
 msgid "Discord Rich Presence. Takes effect after a restart."
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:219
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:257
 msgid ""
 "Leave this to Default unless setting up passthrough. Note some audio servers "
 "like Pipewire don't like passthrough and will need to be disabled for a card "
@@ -1009,57 +1033,57 @@ msgid ""
 "silence otherwise, but results may vary."
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:225
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:263
 msgid ""
 "Stop anything else using the device while playing. Needed for passthrough on "
 "some systems, and it means other applications will be silent."
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:228
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:266
 msgid ""
 "Page the library and music tile grids instead of scrolling: each page is one "
 "screenful with First / Previous / Next / Last controls and a page number you "
 "can type into. Easier than precise scrolling on a trackpad."
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:232
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:270
 msgid ""
 "Takes effect after a restart. \"Follow display\" uses the scale your desktop "
 "reports, which is 100% on X11."
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:234
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:272
 msgid ""
 "\"Default\" changes nothing and lets MPV (and your own mpv.conf) decide. "
 "Pick a mode only if you are sending audio to a receiver."
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:237
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:275
 msgid ""
 "Audio your receiver can't be sent directly is encoded to AC3, which is the "
 "only way surround fits down an optical cable. Turn this off if the encoder "
 "causes audio delay — those tracks become stereo instead."
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:242
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:280
 msgid ""
 "\"hq\" offers heavier profiles. Pick it if you have a fast graphics card."
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:244
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:282
 msgid ""
 "Leave on Automatic unless video breaks when a profile is loaded. This only "
 "applies while a profile is active, and OpenGL can cost you HDR output."
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:248
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:286
 msgid ""
 "Evens out loud effects and quiet dialogue. This turns passthrough off while "
 "it is enabled, because the volume has to be adjusted before your receiver "
 "gets the audio."
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:330
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:368
 msgid "Advanced"
 msgstr ""
 
@@ -1275,7 +1299,7 @@ msgid "Automatic"
 msgstr ""
 
 #: jellyfin_mpv_shim/mpvtk_browser/downloads.py:51
-#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1355
+#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1288
 msgid "Episodes"
 msgstr ""
 
@@ -1284,7 +1308,7 @@ msgid "Season %s"
 msgstr ""
 
 #: jellyfin_mpv_shim/mpvtk_browser/downloads.py:52
-#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1351
+#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1284
 msgid "Specials"
 msgstr ""
 
@@ -1309,7 +1333,7 @@ msgid "Failed"
 msgstr "បរាជ័យ"
 
 #: jellyfin_mpv_shim/mpvtk_browser/downloads.py:185
-#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1105
+#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1038
 msgid "Playlist"
 msgstr ""
 
@@ -1321,30 +1345,30 @@ msgstr ""
 msgid "Movies & Videos"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/home_sections.py:103
+#: jellyfin_mpv_shim/mpvtk_browser/home_sections.py:104
 msgid "My Media"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/home_sections.py:104
-#: jellyfin_mpv_shim/mpvtk_browser/repository.py:352
+#: jellyfin_mpv_shim/mpvtk_browser/home_sections.py:105
+#: jellyfin_mpv_shim/mpvtk_browser/repository.py:350
 msgid "Continue Watching"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/home_sections.py:105
-#: jellyfin_mpv_shim/mpvtk_browser/repository.py:359
+#: jellyfin_mpv_shim/mpvtk_browser/home_sections.py:106
+#: jellyfin_mpv_shim/mpvtk_browser/repository.py:357
 msgid "Continue Listening"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/home_sections.py:106
-#: jellyfin_mpv_shim/mpvtk_browser/repository.py:366
+#: jellyfin_mpv_shim/mpvtk_browser/home_sections.py:107
+#: jellyfin_mpv_shim/mpvtk_browser/repository.py:364
 msgid "Next Up"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/home_sections.py:107
+#: jellyfin_mpv_shim/mpvtk_browser/home_sections.py:108
 msgid "Recently Added"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/home_sections.py:108
+#: jellyfin_mpv_shim/mpvtk_browser/home_sections.py:109
 msgid "Live TV"
 msgstr ""
 
@@ -1593,52 +1617,52 @@ msgstr ""
 "មិនអាចបន្ថែមម៉ាស៊ីនមេបានទេ.\n"
 "សូមពិនិត្យមើលព័ត៌មានការតភ្ជាប់របស់អ្នក."
 
-#: jellyfin_mpv_shim/mpvtk_browser/repository.py:390
+#: jellyfin_mpv_shim/mpvtk_browser/repository.py:386
 msgid "On Now"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/repository.py:411
+#: jellyfin_mpv_shim/mpvtk_browser/repository.py:407
 msgid "Latest %s"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1119
+#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1052
 msgid "Downloaded"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1138
+#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1071
 msgid "Movies"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1143
+#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1076
 msgid "Videos"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1147
+#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1080
 msgid "TV Shows"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1151
+#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1084
 msgid "Playlists"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1168
-#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1441
+#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1101
+#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1374
 msgid "Series"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1212
+#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1145
 msgid "Downloaded Movies"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1216
+#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1149
 msgid "Downloaded Videos"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1220
+#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1153
 msgid "Downloaded Shows"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1353
+#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1286
 msgid "Season %d"
 msgstr ""
 

--- a/jellyfin_mpv_shim/messages/kn/LC_MESSAGES/base.po
+++ b/jellyfin_mpv_shim/messages/kn/LC_MESSAGES/base.po
@@ -5,7 +5,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2026-07-25 17:21-0400\n"
+"POT-Creation-Date: 2026-07-26 12:03-0400\n"
 "PO-Revision-Date: 2022-08-06 12:22+0000\n"
 "Last-Translator: Daniel Papasergio <daniel.papasergio@outlook.com>\n"
 "Language-Team: Kannada <https://translate.jellyfin.org/projects/jellyfin/"
@@ -242,7 +242,7 @@ msgid "Select Subtitle Track"
 msgstr ""
 
 #: jellyfin_mpv_shim/menu.py:341
-#: jellyfin_mpv_shim/mpvtk_browser/home_sections.py:102
+#: jellyfin_mpv_shim/mpvtk_browser/home_sections.py:103
 #: jellyfin_mpv_shim/osc_bridge.py:81 jellyfin_mpv_shim/osc_bridge.py:82
 #: jellyfin_mpv_shim/osc_bridge.py:104 jellyfin_mpv_shim/osc_bridge.py:140
 msgid "None"
@@ -393,7 +393,7 @@ msgstr ""
 msgid "Enable thumbnail previews"
 msgstr ""
 
-#: jellyfin_mpv_shim/menu.py:609 jellyfin_mpv_shim/mpvtk_browser/config.py:186
+#: jellyfin_mpv_shim/menu.py:609 jellyfin_mpv_shim/mpvtk_browser/config.py:195
 #: jellyfin_mpv_shim/mpvtk_browser/hud.py:375
 msgid "Night Mode (Auto Volume Adj)"
 msgstr ""
@@ -658,298 +658,322 @@ msgstr ""
 msgid "Or switch to another user"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/cast.py:317
+#: jellyfin_mpv_shim/mpvtk_browser/cast.py:314
 msgid "Ready to cast"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/cast.py:318
+#: jellyfin_mpv_shim/mpvtk_browser/cast.py:315
 msgid "Select your media in Jellyfin and play it here."
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:74
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:83
 msgid "Interface"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:83
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:92
 msgid "Playback"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:88
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:97
 msgid "Audio"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:92
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:101
 msgid "Subtitles & Languages"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:97
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:106
 msgid "Transcoding"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:102
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:111
 msgid "Video Enhancement"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:104
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:113
 msgid "Skip Intro / Credits"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:107
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:116
 msgid "Library Browser"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:109
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:118
 msgid "Downloads"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:128
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:137
 msgid "Jellyfin UI"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:129
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:138
 msgid "MPV UI with thumbnails"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:130
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:139
 msgid "MPV built-in default"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:133
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:142
 msgid "Follow display"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:134
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:143
 msgid "100% (no scaling)"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:135
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:144
 msgid "125%"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:136
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:145
 msgid "150%"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:137
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:146
 msgid "200%"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:140
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:149
 msgid "Automatic (recommended)"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:141
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:150
 msgid "Vulkan"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:142
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:151
 msgid "Direct3D 11 (Windows only)"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:143
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:152
 msgid "OpenGL (compatibility)"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:146
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:155
 msgid "Default (auto)"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:147
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:156
 msgid "Force Stereo"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:148
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:157
 msgid "Optical Surround"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:149
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:158
 msgid "HDMI Passthrough"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:152
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:161
 msgid "Unset"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:153
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:162
 msgid "Dubbed (shows only)"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:154
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:163
 msgid "Subbed (shows only)"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:155
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:164
 msgid "Dubbed (all)"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:156
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:165
 msgid "Subbed (all)"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:157
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:166
 msgid "Custom (set in config)"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:162
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:171
 msgid "Download Folder"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:163
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:172
 msgid "Prefer Downloaded Copy"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:164
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:173
 msgid "Automatically Download Upcoming Episodes"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:165
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:174
 msgid "Include Next Up"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:166
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:175
 msgid "Next Up Entries to Consider"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:167
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:176
 msgid "Episodes to Keep Ahead (0 = off)"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:168
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:177
 msgid "Storage Limit for Automatic Downloads (GB)"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:169
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:178
 msgid "Delete Automatic Downloads Once Watched"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:170
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:179
 msgid "Delete Unwatched After (days, 0 = never)"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:171
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:180
 msgid "Check Every (minutes)"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:172
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:181
 msgid "Close to Tray (keep running)"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:173
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:182
 msgid "Keep Running in Background"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:174
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:183
 msgid "Remember Window Size"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:175
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:184
 msgid "Player Controls Style"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:176
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:185
 msgid "Show What You're Watching in Discord"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:177
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:186
 msgid "Interface Scale"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:178
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:187
 msgid "Cast-target mode (no library browsing)"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:179
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:188
 msgid "Casting Opens the Library Browser"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:180
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:189
 msgid "Fullscreen Library Browser"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:181
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:190
 msgid "Always Bind Arrow Keys to Player Controls"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:182
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:191
 msgid "Player Controls Activation Key"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:183
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:192
 msgid "Audio Output Mode"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:184
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:193
 msgid "Audio Output Device"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:185
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:194
 msgid "Take the Device Exclusively"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:187
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:196
 msgid "Enable Video Playback Profiles"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:188
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:197
 msgid "Profile Group"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:189
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:198
 msgid "Remember Last Used Profile"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:190
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:199
 msgid "Graphics API for Shaders"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:191
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:200
 msgid "Pass Through AC3"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:192
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:201
 msgid "Pass Through DTS"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:193
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:202
 msgid "Pass Through E-AC3"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:194
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:203
 msgid "Pass Through DTS-HD"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:195
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:204
 msgid "Pass Through TrueHD"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:196
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:205
 msgid "Re-encode Others to AC3"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:202
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:213
 msgid ""
-"MPV keybinds are used by default. Press ENTER to drive the player controls "
-"by keyboard."
+"With \"Start Minimized\" and \"Fullscreen\" this is the classic cast-target "
+"setup: the app waits out of the way, plays fullscreen when something casts "
+"to it, and goes back to waiting when the video ends or you press Q."
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:204
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:227
+msgid ""
+"Off means command-line mode: no window, no system tray and no settings "
+"screen, so the only way back is editing conf.json by hand. It is not how you "
+"get MPV's own on-screen controls — \"Player Controls Style\" under Interface "
+"does that."
+msgstr ""
+
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:234
+msgid ""
+"Show only what is cast to this machine — the library, including this "
+"settings screen, can't be reached from here. Without a system tray icon the "
+"only way back is editing conf.json. For the classic cast-target setup you "
+"want the Interface settings instead; this is for a shared TV nobody should "
+"be able to browse from."
+msgstr ""
+
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:240
+msgid ""
+"Requires restart to change. MPV keybinds are used by default. Press ENTER to "
+"drive the player controls by keyboard."
+msgstr ""
+
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:242
 msgid ""
 "Pixels one wheel notch scrolls. The scrollbar glides while the content snaps "
 "to the nearest row, so a trackpad or trackball no longer overshoots. Raise "
 "it to scroll faster, lower it for finer control."
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:209
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:247
 msgid ""
 "Make each wheel notch jump exactly one row (or one home-screen section) "
 "instead of gliding. Turn this on if you prefer the older stepped scrolling."
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:217
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:255
 msgid "Discord Rich Presence. Takes effect after a restart."
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:219
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:257
 msgid ""
 "Leave this to Default unless setting up passthrough. Note some audio servers "
 "like Pipewire don't like passthrough and will need to be disabled for a card "
@@ -957,57 +981,57 @@ msgid ""
 "silence otherwise, but results may vary."
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:225
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:263
 msgid ""
 "Stop anything else using the device while playing. Needed for passthrough on "
 "some systems, and it means other applications will be silent."
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:228
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:266
 msgid ""
 "Page the library and music tile grids instead of scrolling: each page is one "
 "screenful with First / Previous / Next / Last controls and a page number you "
 "can type into. Easier than precise scrolling on a trackpad."
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:232
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:270
 msgid ""
 "Takes effect after a restart. \"Follow display\" uses the scale your desktop "
 "reports, which is 100% on X11."
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:234
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:272
 msgid ""
 "\"Default\" changes nothing and lets MPV (and your own mpv.conf) decide. "
 "Pick a mode only if you are sending audio to a receiver."
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:237
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:275
 msgid ""
 "Audio your receiver can't be sent directly is encoded to AC3, which is the "
 "only way surround fits down an optical cable. Turn this off if the encoder "
 "causes audio delay — those tracks become stereo instead."
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:242
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:280
 msgid ""
 "\"hq\" offers heavier profiles. Pick it if you have a fast graphics card."
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:244
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:282
 msgid ""
 "Leave on Automatic unless video breaks when a profile is loaded. This only "
 "applies while a profile is active, and OpenGL can cost you HDR output."
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:248
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:286
 msgid ""
 "Evens out loud effects and quiet dialogue. This turns passthrough off while "
 "it is enabled, because the volume has to be adjusted before your receiver "
 "gets the audio."
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:330
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:368
 msgid "Advanced"
 msgstr ""
 
@@ -1185,7 +1209,7 @@ msgid "Automatic"
 msgstr ""
 
 #: jellyfin_mpv_shim/mpvtk_browser/downloads.py:51
-#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1355
+#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1288
 msgid "Episodes"
 msgstr ""
 
@@ -1194,7 +1218,7 @@ msgid "Season %s"
 msgstr ""
 
 #: jellyfin_mpv_shim/mpvtk_browser/downloads.py:52
-#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1351
+#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1284
 msgid "Specials"
 msgstr ""
 
@@ -1215,7 +1239,7 @@ msgid "Failed"
 msgstr ""
 
 #: jellyfin_mpv_shim/mpvtk_browser/downloads.py:185
-#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1105
+#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1038
 msgid "Playlist"
 msgstr ""
 
@@ -1227,30 +1251,30 @@ msgstr ""
 msgid "Movies & Videos"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/home_sections.py:103
+#: jellyfin_mpv_shim/mpvtk_browser/home_sections.py:104
 msgid "My Media"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/home_sections.py:104
-#: jellyfin_mpv_shim/mpvtk_browser/repository.py:352
+#: jellyfin_mpv_shim/mpvtk_browser/home_sections.py:105
+#: jellyfin_mpv_shim/mpvtk_browser/repository.py:350
 msgid "Continue Watching"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/home_sections.py:105
-#: jellyfin_mpv_shim/mpvtk_browser/repository.py:359
+#: jellyfin_mpv_shim/mpvtk_browser/home_sections.py:106
+#: jellyfin_mpv_shim/mpvtk_browser/repository.py:357
 msgid "Continue Listening"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/home_sections.py:106
-#: jellyfin_mpv_shim/mpvtk_browser/repository.py:366
+#: jellyfin_mpv_shim/mpvtk_browser/home_sections.py:107
+#: jellyfin_mpv_shim/mpvtk_browser/repository.py:364
 msgid "Next Up"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/home_sections.py:107
+#: jellyfin_mpv_shim/mpvtk_browser/home_sections.py:108
 msgid "Recently Added"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/home_sections.py:108
+#: jellyfin_mpv_shim/mpvtk_browser/home_sections.py:109
 msgid "Live TV"
 msgstr ""
 
@@ -1455,52 +1479,52 @@ msgstr ""
 msgid "Could not load this page."
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/repository.py:390
+#: jellyfin_mpv_shim/mpvtk_browser/repository.py:386
 msgid "On Now"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/repository.py:411
+#: jellyfin_mpv_shim/mpvtk_browser/repository.py:407
 msgid "Latest %s"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1119
+#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1052
 msgid "Downloaded"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1138
+#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1071
 msgid "Movies"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1143
+#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1076
 msgid "Videos"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1147
+#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1080
 msgid "TV Shows"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1151
+#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1084
 msgid "Playlists"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1168
-#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1441
+#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1101
+#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1374
 msgid "Series"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1212
+#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1145
 msgid "Downloaded Movies"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1216
+#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1149
 msgid "Downloaded Videos"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1220
+#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1153
 msgid "Downloaded Shows"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1353
+#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1286
 msgid "Season %d"
 msgstr ""
 

--- a/jellyfin_mpv_shim/messages/ko/LC_MESSAGES/base.po
+++ b/jellyfin_mpv_shim/messages/ko/LC_MESSAGES/base.po
@@ -5,7 +5,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2026-07-25 17:21-0400\n"
+"POT-Creation-Date: 2026-07-26 12:03-0400\n"
 "PO-Revision-Date: 2024-08-26 07:41+0000\n"
 "Last-Translator: aky <arksky@naver.com>\n"
 "Language-Team: Korean <https://translate.jellyfin.org/projects/jellyfin/"
@@ -252,7 +252,7 @@ msgid "Select Subtitle Track"
 msgstr "자막 트랙 선택"
 
 #: jellyfin_mpv_shim/menu.py:341
-#: jellyfin_mpv_shim/mpvtk_browser/home_sections.py:102
+#: jellyfin_mpv_shim/mpvtk_browser/home_sections.py:103
 #: jellyfin_mpv_shim/osc_bridge.py:81 jellyfin_mpv_shim/osc_bridge.py:82
 #: jellyfin_mpv_shim/osc_bridge.py:104 jellyfin_mpv_shim/osc_bridge.py:140
 msgid "None"
@@ -403,7 +403,7 @@ msgstr "크레딧 건너뛰기전에 항상 물어보기"
 msgid "Enable thumbnail previews"
 msgstr "섬네일 미리보기 활성화하기"
 
-#: jellyfin_mpv_shim/menu.py:609 jellyfin_mpv_shim/mpvtk_browser/config.py:186
+#: jellyfin_mpv_shim/menu.py:609 jellyfin_mpv_shim/mpvtk_browser/config.py:195
 #: jellyfin_mpv_shim/mpvtk_browser/hud.py:375
 msgid "Night Mode (Auto Volume Adj)"
 msgstr ""
@@ -702,310 +702,334 @@ msgstr ""
 msgid "Or switch to another user"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/cast.py:317
+#: jellyfin_mpv_shim/mpvtk_browser/cast.py:314
 msgid "Ready to cast"
 msgstr "캐스팅 준비 되었습니다"
 
-#: jellyfin_mpv_shim/mpvtk_browser/cast.py:318
+#: jellyfin_mpv_shim/mpvtk_browser/cast.py:315
 #, fuzzy
 #| msgid "Select your media in Jellyfin and play it here"
 msgid "Select your media in Jellyfin and play it here."
 msgstr "젤리핀에서 미디어를 선택하여 재생하십시오"
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:74
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:83
 msgid "Interface"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:83
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:92
 msgid "Playback"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:88
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:97
 msgid "Audio"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:92
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:101
 msgid "Subtitles & Languages"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:97
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:106
 #, fuzzy
 #| msgid " (Transcode)"
 msgid "Transcoding"
 msgstr " 코드변환"
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:102
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:111
 msgid "Video Enhancement"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:104
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:113
 #, fuzzy
 #| msgid "Seek to Skip Credits"
 msgid "Skip Intro / Credits"
 msgstr "크레딧으로 건너뛰기"
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:107
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:116
 msgid "Library Browser"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:109
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:118
 msgid "Downloads"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:128
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:137
 msgid "Jellyfin UI"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:129
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:138
 msgid "MPV UI with thumbnails"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:130
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:139
 msgid "MPV built-in default"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:133
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:142
 msgid "Follow display"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:134
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:143
 msgid "100% (no scaling)"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:135
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:144
 msgid "125%"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:136
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:145
 msgid "150%"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:137
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:146
 msgid "200%"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:140
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:149
 msgid "Automatic (recommended)"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:141
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:150
 msgid "Vulkan"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:142
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:151
 msgid "Direct3D 11 (Windows only)"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:143
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:152
 msgid "OpenGL (compatibility)"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:146
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:155
 msgid "Default (auto)"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:147
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:156
 msgid "Force Stereo"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:148
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:157
 msgid "Optical Surround"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:149
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:158
 msgid "HDMI Passthrough"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:152
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:161
 msgid "Unset"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:153
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:162
 msgid "Dubbed (shows only)"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:154
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:163
 msgid "Subbed (shows only)"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:155
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:164
 msgid "Dubbed (all)"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:156
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:165
 msgid "Subbed (all)"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:157
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:166
 msgid "Custom (set in config)"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:162
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:171
 msgid "Download Folder"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:163
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:172
 msgid "Prefer Downloaded Copy"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:164
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:173
 msgid "Automatically Download Upcoming Episodes"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:165
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:174
 msgid "Include Next Up"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:166
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:175
 msgid "Next Up Entries to Consider"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:167
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:176
 msgid "Episodes to Keep Ahead (0 = off)"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:168
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:177
 msgid "Storage Limit for Automatic Downloads (GB)"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:169
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:178
 #, fuzzy
 #| msgid "Remove Server"
 msgid "Delete Automatic Downloads Once Watched"
 msgstr "서버 제거"
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:170
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:179
 msgid "Delete Unwatched After (days, 0 = never)"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:171
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:180
 msgid "Check Every (minutes)"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:172
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:181
 msgid "Close to Tray (keep running)"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:173
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:182
 msgid "Keep Running in Background"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:174
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:183
 msgid "Remember Window Size"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:175
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:184
 msgid "Player Controls Style"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:176
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:185
 msgid "Show What You're Watching in Discord"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:177
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:186
 msgid "Interface Scale"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:178
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:187
 msgid "Cast-target mode (no library browsing)"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:179
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:188
 msgid "Casting Opens the Library Browser"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:180
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:189
 msgid "Fullscreen Library Browser"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:181
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:190
 msgid "Always Bind Arrow Keys to Player Controls"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:182
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:191
 msgid "Player Controls Activation Key"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:183
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:192
 msgid "Audio Output Mode"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:184
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:193
 msgid "Audio Output Device"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:185
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:194
 msgid "Take the Device Exclusively"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:187
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:196
 #, fuzzy
 #| msgid "Video Playback Profiles"
 msgid "Enable Video Playback Profiles"
 msgstr "비디오 재생 프로필"
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:188
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:197
 #, fuzzy
 #| msgid "New Group"
 msgid "Profile Group"
 msgstr "새 모임"
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:189
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:198
 msgid "Remember Last Used Profile"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:190
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:199
 msgid "Graphics API for Shaders"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:191
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:200
 msgid "Pass Through AC3"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:192
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:201
 msgid "Pass Through DTS"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:193
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:202
 msgid "Pass Through E-AC3"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:194
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:203
 msgid "Pass Through DTS-HD"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:195
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:204
 msgid "Pass Through TrueHD"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:196
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:205
 msgid "Re-encode Others to AC3"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:202
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:213
 msgid ""
-"MPV keybinds are used by default. Press ENTER to drive the player controls "
-"by keyboard."
+"With \"Start Minimized\" and \"Fullscreen\" this is the classic cast-target "
+"setup: the app waits out of the way, plays fullscreen when something casts "
+"to it, and goes back to waiting when the video ends or you press Q."
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:204
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:227
+msgid ""
+"Off means command-line mode: no window, no system tray and no settings "
+"screen, so the only way back is editing conf.json by hand. It is not how you "
+"get MPV's own on-screen controls — \"Player Controls Style\" under Interface "
+"does that."
+msgstr ""
+
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:234
+msgid ""
+"Show only what is cast to this machine — the library, including this "
+"settings screen, can't be reached from here. Without a system tray icon the "
+"only way back is editing conf.json. For the classic cast-target setup you "
+"want the Interface settings instead; this is for a shared TV nobody should "
+"be able to browse from."
+msgstr ""
+
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:240
+msgid ""
+"Requires restart to change. MPV keybinds are used by default. Press ENTER to "
+"drive the player controls by keyboard."
+msgstr ""
+
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:242
 msgid ""
 "Pixels one wheel notch scrolls. The scrollbar glides while the content snaps "
 "to the nearest row, so a trackpad or trackball no longer overshoots. Raise "
 "it to scroll faster, lower it for finer control."
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:209
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:247
 msgid ""
 "Make each wheel notch jump exactly one row (or one home-screen section) "
 "instead of gliding. Turn this on if you prefer the older stepped scrolling."
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:217
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:255
 msgid "Discord Rich Presence. Takes effect after a restart."
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:219
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:257
 msgid ""
 "Leave this to Default unless setting up passthrough. Note some audio servers "
 "like Pipewire don't like passthrough and will need to be disabled for a card "
@@ -1013,57 +1037,57 @@ msgid ""
 "silence otherwise, but results may vary."
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:225
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:263
 msgid ""
 "Stop anything else using the device while playing. Needed for passthrough on "
 "some systems, and it means other applications will be silent."
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:228
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:266
 msgid ""
 "Page the library and music tile grids instead of scrolling: each page is one "
 "screenful with First / Previous / Next / Last controls and a page number you "
 "can type into. Easier than precise scrolling on a trackpad."
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:232
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:270
 msgid ""
 "Takes effect after a restart. \"Follow display\" uses the scale your desktop "
 "reports, which is 100% on X11."
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:234
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:272
 msgid ""
 "\"Default\" changes nothing and lets MPV (and your own mpv.conf) decide. "
 "Pick a mode only if you are sending audio to a receiver."
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:237
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:275
 msgid ""
 "Audio your receiver can't be sent directly is encoded to AC3, which is the "
 "only way surround fits down an optical cable. Turn this off if the encoder "
 "causes audio delay — those tracks become stereo instead."
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:242
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:280
 msgid ""
 "\"hq\" offers heavier profiles. Pick it if you have a fast graphics card."
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:244
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:282
 msgid ""
 "Leave on Automatic unless video breaks when a profile is loaded. This only "
 "applies while a profile is active, and OpenGL can cost you HDR output."
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:248
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:286
 msgid ""
 "Evens out loud effects and quiet dialogue. This turns passthrough off while "
 "it is enabled, because the volume has to be adjusted before your receiver "
 "gets the audio."
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:330
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:368
 msgid "Advanced"
 msgstr ""
 
@@ -1289,7 +1313,7 @@ msgid "Automatic"
 msgstr "자동"
 
 #: jellyfin_mpv_shim/mpvtk_browser/downloads.py:51
-#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1355
+#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1288
 msgid "Episodes"
 msgstr ""
 
@@ -1298,7 +1322,7 @@ msgid "Season %s"
 msgstr ""
 
 #: jellyfin_mpv_shim/mpvtk_browser/downloads.py:52
-#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1351
+#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1284
 msgid "Specials"
 msgstr ""
 
@@ -1323,7 +1347,7 @@ msgid "Failed"
 msgstr "실패"
 
 #: jellyfin_mpv_shim/mpvtk_browser/downloads.py:185
-#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1105
+#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1038
 msgid "Playlist"
 msgstr ""
 
@@ -1335,30 +1359,30 @@ msgstr ""
 msgid "Movies & Videos"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/home_sections.py:103
+#: jellyfin_mpv_shim/mpvtk_browser/home_sections.py:104
 msgid "My Media"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/home_sections.py:104
-#: jellyfin_mpv_shim/mpvtk_browser/repository.py:352
+#: jellyfin_mpv_shim/mpvtk_browser/home_sections.py:105
+#: jellyfin_mpv_shim/mpvtk_browser/repository.py:350
 msgid "Continue Watching"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/home_sections.py:105
-#: jellyfin_mpv_shim/mpvtk_browser/repository.py:359
+#: jellyfin_mpv_shim/mpvtk_browser/home_sections.py:106
+#: jellyfin_mpv_shim/mpvtk_browser/repository.py:357
 msgid "Continue Listening"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/home_sections.py:106
-#: jellyfin_mpv_shim/mpvtk_browser/repository.py:366
+#: jellyfin_mpv_shim/mpvtk_browser/home_sections.py:107
+#: jellyfin_mpv_shim/mpvtk_browser/repository.py:364
 msgid "Next Up"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/home_sections.py:107
+#: jellyfin_mpv_shim/mpvtk_browser/home_sections.py:108
 msgid "Recently Added"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/home_sections.py:108
+#: jellyfin_mpv_shim/mpvtk_browser/home_sections.py:109
 msgid "Live TV"
 msgstr ""
 
@@ -1611,52 +1635,52 @@ msgstr ""
 "서버를 추가할 수 없습니다.\n"
 "연결 정보를 확인하십시오."
 
-#: jellyfin_mpv_shim/mpvtk_browser/repository.py:390
+#: jellyfin_mpv_shim/mpvtk_browser/repository.py:386
 msgid "On Now"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/repository.py:411
+#: jellyfin_mpv_shim/mpvtk_browser/repository.py:407
 msgid "Latest %s"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1119
+#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1052
 msgid "Downloaded"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1138
+#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1071
 msgid "Movies"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1143
+#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1076
 msgid "Videos"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1147
+#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1080
 msgid "TV Shows"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1151
+#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1084
 msgid "Playlists"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1168
-#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1441
+#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1101
+#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1374
 msgid "Series"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1212
+#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1145
 msgid "Downloaded Movies"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1216
+#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1149
 msgid "Downloaded Videos"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1220
+#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1153
 msgid "Downloaded Shows"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1353
+#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1286
 msgid "Season %d"
 msgstr ""
 

--- a/jellyfin_mpv_shim/messages/kw/LC_MESSAGES/base.po
+++ b/jellyfin_mpv_shim/messages/kw/LC_MESSAGES/base.po
@@ -5,7 +5,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2026-07-25 17:21-0400\n"
+"POT-Creation-Date: 2026-07-26 12:03-0400\n"
 "PO-Revision-Date: 2025-12-22 15:37+0000\n"
 "Last-Translator: shuimu <2246333259@qq.com>\n"
 "Language-Team: Cornish <https://translate.jellyfin.org/projects/jellyfin/"
@@ -248,7 +248,7 @@ msgid "Select Subtitle Track"
 msgstr ""
 
 #: jellyfin_mpv_shim/menu.py:341
-#: jellyfin_mpv_shim/mpvtk_browser/home_sections.py:102
+#: jellyfin_mpv_shim/mpvtk_browser/home_sections.py:103
 #: jellyfin_mpv_shim/osc_bridge.py:81 jellyfin_mpv_shim/osc_bridge.py:82
 #: jellyfin_mpv_shim/osc_bridge.py:104 jellyfin_mpv_shim/osc_bridge.py:140
 msgid "None"
@@ -399,7 +399,7 @@ msgstr ""
 msgid "Enable thumbnail previews"
 msgstr ""
 
-#: jellyfin_mpv_shim/menu.py:609 jellyfin_mpv_shim/mpvtk_browser/config.py:186
+#: jellyfin_mpv_shim/menu.py:609 jellyfin_mpv_shim/mpvtk_browser/config.py:195
 #: jellyfin_mpv_shim/mpvtk_browser/hud.py:375
 msgid "Night Mode (Auto Volume Adj)"
 msgstr ""
@@ -664,298 +664,322 @@ msgstr ""
 msgid "Or switch to another user"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/cast.py:317
+#: jellyfin_mpv_shim/mpvtk_browser/cast.py:314
 msgid "Ready to cast"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/cast.py:318
+#: jellyfin_mpv_shim/mpvtk_browser/cast.py:315
 msgid "Select your media in Jellyfin and play it here."
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:74
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:83
 msgid "Interface"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:83
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:92
 msgid "Playback"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:88
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:97
 msgid "Audio"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:92
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:101
 msgid "Subtitles & Languages"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:97
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:106
 msgid "Transcoding"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:102
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:111
 msgid "Video Enhancement"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:104
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:113
 msgid "Skip Intro / Credits"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:107
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:116
 msgid "Library Browser"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:109
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:118
 msgid "Downloads"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:128
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:137
 msgid "Jellyfin UI"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:129
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:138
 msgid "MPV UI with thumbnails"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:130
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:139
 msgid "MPV built-in default"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:133
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:142
 msgid "Follow display"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:134
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:143
 msgid "100% (no scaling)"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:135
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:144
 msgid "125%"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:136
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:145
 msgid "150%"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:137
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:146
 msgid "200%"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:140
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:149
 msgid "Automatic (recommended)"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:141
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:150
 msgid "Vulkan"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:142
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:151
 msgid "Direct3D 11 (Windows only)"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:143
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:152
 msgid "OpenGL (compatibility)"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:146
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:155
 msgid "Default (auto)"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:147
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:156
 msgid "Force Stereo"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:148
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:157
 msgid "Optical Surround"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:149
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:158
 msgid "HDMI Passthrough"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:152
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:161
 msgid "Unset"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:153
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:162
 msgid "Dubbed (shows only)"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:154
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:163
 msgid "Subbed (shows only)"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:155
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:164
 msgid "Dubbed (all)"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:156
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:165
 msgid "Subbed (all)"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:157
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:166
 msgid "Custom (set in config)"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:162
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:171
 msgid "Download Folder"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:163
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:172
 msgid "Prefer Downloaded Copy"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:164
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:173
 msgid "Automatically Download Upcoming Episodes"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:165
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:174
 msgid "Include Next Up"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:166
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:175
 msgid "Next Up Entries to Consider"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:167
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:176
 msgid "Episodes to Keep Ahead (0 = off)"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:168
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:177
 msgid "Storage Limit for Automatic Downloads (GB)"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:169
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:178
 msgid "Delete Automatic Downloads Once Watched"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:170
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:179
 msgid "Delete Unwatched After (days, 0 = never)"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:171
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:180
 msgid "Check Every (minutes)"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:172
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:181
 msgid "Close to Tray (keep running)"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:173
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:182
 msgid "Keep Running in Background"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:174
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:183
 msgid "Remember Window Size"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:175
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:184
 msgid "Player Controls Style"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:176
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:185
 msgid "Show What You're Watching in Discord"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:177
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:186
 msgid "Interface Scale"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:178
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:187
 msgid "Cast-target mode (no library browsing)"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:179
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:188
 msgid "Casting Opens the Library Browser"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:180
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:189
 msgid "Fullscreen Library Browser"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:181
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:190
 msgid "Always Bind Arrow Keys to Player Controls"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:182
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:191
 msgid "Player Controls Activation Key"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:183
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:192
 msgid "Audio Output Mode"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:184
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:193
 msgid "Audio Output Device"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:185
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:194
 msgid "Take the Device Exclusively"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:187
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:196
 msgid "Enable Video Playback Profiles"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:188
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:197
 msgid "Profile Group"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:189
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:198
 msgid "Remember Last Used Profile"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:190
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:199
 msgid "Graphics API for Shaders"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:191
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:200
 msgid "Pass Through AC3"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:192
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:201
 msgid "Pass Through DTS"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:193
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:202
 msgid "Pass Through E-AC3"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:194
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:203
 msgid "Pass Through DTS-HD"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:195
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:204
 msgid "Pass Through TrueHD"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:196
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:205
 msgid "Re-encode Others to AC3"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:202
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:213
 msgid ""
-"MPV keybinds are used by default. Press ENTER to drive the player controls "
-"by keyboard."
+"With \"Start Minimized\" and \"Fullscreen\" this is the classic cast-target "
+"setup: the app waits out of the way, plays fullscreen when something casts "
+"to it, and goes back to waiting when the video ends or you press Q."
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:204
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:227
+msgid ""
+"Off means command-line mode: no window, no system tray and no settings "
+"screen, so the only way back is editing conf.json by hand. It is not how you "
+"get MPV's own on-screen controls — \"Player Controls Style\" under Interface "
+"does that."
+msgstr ""
+
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:234
+msgid ""
+"Show only what is cast to this machine — the library, including this "
+"settings screen, can't be reached from here. Without a system tray icon the "
+"only way back is editing conf.json. For the classic cast-target setup you "
+"want the Interface settings instead; this is for a shared TV nobody should "
+"be able to browse from."
+msgstr ""
+
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:240
+msgid ""
+"Requires restart to change. MPV keybinds are used by default. Press ENTER to "
+"drive the player controls by keyboard."
+msgstr ""
+
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:242
 msgid ""
 "Pixels one wheel notch scrolls. The scrollbar glides while the content snaps "
 "to the nearest row, so a trackpad or trackball no longer overshoots. Raise "
 "it to scroll faster, lower it for finer control."
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:209
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:247
 msgid ""
 "Make each wheel notch jump exactly one row (or one home-screen section) "
 "instead of gliding. Turn this on if you prefer the older stepped scrolling."
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:217
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:255
 msgid "Discord Rich Presence. Takes effect after a restart."
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:219
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:257
 msgid ""
 "Leave this to Default unless setting up passthrough. Note some audio servers "
 "like Pipewire don't like passthrough and will need to be disabled for a card "
@@ -963,57 +987,57 @@ msgid ""
 "silence otherwise, but results may vary."
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:225
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:263
 msgid ""
 "Stop anything else using the device while playing. Needed for passthrough on "
 "some systems, and it means other applications will be silent."
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:228
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:266
 msgid ""
 "Page the library and music tile grids instead of scrolling: each page is one "
 "screenful with First / Previous / Next / Last controls and a page number you "
 "can type into. Easier than precise scrolling on a trackpad."
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:232
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:270
 msgid ""
 "Takes effect after a restart. \"Follow display\" uses the scale your desktop "
 "reports, which is 100% on X11."
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:234
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:272
 msgid ""
 "\"Default\" changes nothing and lets MPV (and your own mpv.conf) decide. "
 "Pick a mode only if you are sending audio to a receiver."
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:237
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:275
 msgid ""
 "Audio your receiver can't be sent directly is encoded to AC3, which is the "
 "only way surround fits down an optical cable. Turn this off if the encoder "
 "causes audio delay — those tracks become stereo instead."
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:242
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:280
 msgid ""
 "\"hq\" offers heavier profiles. Pick it if you have a fast graphics card."
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:244
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:282
 msgid ""
 "Leave on Automatic unless video breaks when a profile is loaded. This only "
 "applies while a profile is active, and OpenGL can cost you HDR output."
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:248
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:286
 msgid ""
 "Evens out loud effects and quiet dialogue. This turns passthrough off while "
 "it is enabled, because the volume has to be adjusted before your receiver "
 "gets the audio."
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:330
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:368
 msgid "Advanced"
 msgstr ""
 
@@ -1191,7 +1215,7 @@ msgid "Automatic"
 msgstr ""
 
 #: jellyfin_mpv_shim/mpvtk_browser/downloads.py:51
-#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1355
+#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1288
 msgid "Episodes"
 msgstr ""
 
@@ -1200,7 +1224,7 @@ msgid "Season %s"
 msgstr ""
 
 #: jellyfin_mpv_shim/mpvtk_browser/downloads.py:52
-#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1351
+#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1284
 msgid "Specials"
 msgstr ""
 
@@ -1221,7 +1245,7 @@ msgid "Failed"
 msgstr ""
 
 #: jellyfin_mpv_shim/mpvtk_browser/downloads.py:185
-#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1105
+#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1038
 msgid "Playlist"
 msgstr ""
 
@@ -1233,30 +1257,30 @@ msgstr ""
 msgid "Movies & Videos"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/home_sections.py:103
+#: jellyfin_mpv_shim/mpvtk_browser/home_sections.py:104
 msgid "My Media"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/home_sections.py:104
-#: jellyfin_mpv_shim/mpvtk_browser/repository.py:352
+#: jellyfin_mpv_shim/mpvtk_browser/home_sections.py:105
+#: jellyfin_mpv_shim/mpvtk_browser/repository.py:350
 msgid "Continue Watching"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/home_sections.py:105
-#: jellyfin_mpv_shim/mpvtk_browser/repository.py:359
+#: jellyfin_mpv_shim/mpvtk_browser/home_sections.py:106
+#: jellyfin_mpv_shim/mpvtk_browser/repository.py:357
 msgid "Continue Listening"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/home_sections.py:106
-#: jellyfin_mpv_shim/mpvtk_browser/repository.py:366
+#: jellyfin_mpv_shim/mpvtk_browser/home_sections.py:107
+#: jellyfin_mpv_shim/mpvtk_browser/repository.py:364
 msgid "Next Up"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/home_sections.py:107
+#: jellyfin_mpv_shim/mpvtk_browser/home_sections.py:108
 msgid "Recently Added"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/home_sections.py:108
+#: jellyfin_mpv_shim/mpvtk_browser/home_sections.py:109
 msgid "Live TV"
 msgstr ""
 
@@ -1461,52 +1485,52 @@ msgstr ""
 msgid "Could not load this page."
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/repository.py:390
+#: jellyfin_mpv_shim/mpvtk_browser/repository.py:386
 msgid "On Now"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/repository.py:411
+#: jellyfin_mpv_shim/mpvtk_browser/repository.py:407
 msgid "Latest %s"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1119
+#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1052
 msgid "Downloaded"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1138
+#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1071
 msgid "Movies"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1143
+#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1076
 msgid "Videos"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1147
+#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1080
 msgid "TV Shows"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1151
+#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1084
 msgid "Playlists"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1168
-#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1441
+#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1101
+#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1374
 msgid "Series"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1212
+#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1145
 msgid "Downloaded Movies"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1216
+#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1149
 msgid "Downloaded Videos"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1220
+#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1153
 msgid "Downloaded Shows"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1353
+#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1286
 msgid "Season %d"
 msgstr ""
 

--- a/jellyfin_mpv_shim/messages/lb/LC_MESSAGES/base.po
+++ b/jellyfin_mpv_shim/messages/lb/LC_MESSAGES/base.po
@@ -5,7 +5,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2026-07-25 17:21-0400\n"
+"POT-Creation-Date: 2026-07-26 12:03-0400\n"
 "PO-Revision-Date: 2026-01-06 14:42+0000\n"
 "Last-Translator: pn8z5qjdf7-tech <pn8z5qjdf7@privaterelay.appleid.com>\n"
 "Language-Team: Luxembourgish <https://translate.jellyfin.org/projects/"
@@ -243,7 +243,7 @@ msgid "Select Subtitle Track"
 msgstr ""
 
 #: jellyfin_mpv_shim/menu.py:341
-#: jellyfin_mpv_shim/mpvtk_browser/home_sections.py:102
+#: jellyfin_mpv_shim/mpvtk_browser/home_sections.py:103
 #: jellyfin_mpv_shim/osc_bridge.py:81 jellyfin_mpv_shim/osc_bridge.py:82
 #: jellyfin_mpv_shim/osc_bridge.py:104 jellyfin_mpv_shim/osc_bridge.py:140
 msgid "None"
@@ -394,7 +394,7 @@ msgstr ""
 msgid "Enable thumbnail previews"
 msgstr ""
 
-#: jellyfin_mpv_shim/menu.py:609 jellyfin_mpv_shim/mpvtk_browser/config.py:186
+#: jellyfin_mpv_shim/menu.py:609 jellyfin_mpv_shim/mpvtk_browser/config.py:195
 #: jellyfin_mpv_shim/mpvtk_browser/hud.py:375
 msgid "Night Mode (Auto Volume Adj)"
 msgstr ""
@@ -659,298 +659,322 @@ msgstr ""
 msgid "Or switch to another user"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/cast.py:317
+#: jellyfin_mpv_shim/mpvtk_browser/cast.py:314
 msgid "Ready to cast"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/cast.py:318
+#: jellyfin_mpv_shim/mpvtk_browser/cast.py:315
 msgid "Select your media in Jellyfin and play it here."
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:74
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:83
 msgid "Interface"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:83
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:92
 msgid "Playback"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:88
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:97
 msgid "Audio"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:92
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:101
 msgid "Subtitles & Languages"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:97
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:106
 msgid "Transcoding"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:102
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:111
 msgid "Video Enhancement"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:104
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:113
 msgid "Skip Intro / Credits"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:107
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:116
 msgid "Library Browser"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:109
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:118
 msgid "Downloads"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:128
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:137
 msgid "Jellyfin UI"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:129
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:138
 msgid "MPV UI with thumbnails"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:130
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:139
 msgid "MPV built-in default"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:133
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:142
 msgid "Follow display"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:134
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:143
 msgid "100% (no scaling)"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:135
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:144
 msgid "125%"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:136
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:145
 msgid "150%"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:137
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:146
 msgid "200%"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:140
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:149
 msgid "Automatic (recommended)"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:141
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:150
 msgid "Vulkan"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:142
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:151
 msgid "Direct3D 11 (Windows only)"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:143
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:152
 msgid "OpenGL (compatibility)"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:146
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:155
 msgid "Default (auto)"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:147
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:156
 msgid "Force Stereo"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:148
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:157
 msgid "Optical Surround"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:149
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:158
 msgid "HDMI Passthrough"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:152
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:161
 msgid "Unset"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:153
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:162
 msgid "Dubbed (shows only)"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:154
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:163
 msgid "Subbed (shows only)"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:155
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:164
 msgid "Dubbed (all)"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:156
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:165
 msgid "Subbed (all)"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:157
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:166
 msgid "Custom (set in config)"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:162
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:171
 msgid "Download Folder"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:163
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:172
 msgid "Prefer Downloaded Copy"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:164
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:173
 msgid "Automatically Download Upcoming Episodes"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:165
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:174
 msgid "Include Next Up"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:166
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:175
 msgid "Next Up Entries to Consider"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:167
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:176
 msgid "Episodes to Keep Ahead (0 = off)"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:168
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:177
 msgid "Storage Limit for Automatic Downloads (GB)"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:169
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:178
 msgid "Delete Automatic Downloads Once Watched"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:170
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:179
 msgid "Delete Unwatched After (days, 0 = never)"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:171
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:180
 msgid "Check Every (minutes)"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:172
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:181
 msgid "Close to Tray (keep running)"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:173
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:182
 msgid "Keep Running in Background"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:174
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:183
 msgid "Remember Window Size"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:175
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:184
 msgid "Player Controls Style"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:176
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:185
 msgid "Show What You're Watching in Discord"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:177
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:186
 msgid "Interface Scale"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:178
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:187
 msgid "Cast-target mode (no library browsing)"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:179
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:188
 msgid "Casting Opens the Library Browser"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:180
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:189
 msgid "Fullscreen Library Browser"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:181
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:190
 msgid "Always Bind Arrow Keys to Player Controls"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:182
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:191
 msgid "Player Controls Activation Key"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:183
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:192
 msgid "Audio Output Mode"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:184
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:193
 msgid "Audio Output Device"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:185
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:194
 msgid "Take the Device Exclusively"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:187
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:196
 msgid "Enable Video Playback Profiles"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:188
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:197
 msgid "Profile Group"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:189
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:198
 msgid "Remember Last Used Profile"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:190
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:199
 msgid "Graphics API for Shaders"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:191
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:200
 msgid "Pass Through AC3"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:192
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:201
 msgid "Pass Through DTS"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:193
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:202
 msgid "Pass Through E-AC3"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:194
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:203
 msgid "Pass Through DTS-HD"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:195
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:204
 msgid "Pass Through TrueHD"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:196
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:205
 msgid "Re-encode Others to AC3"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:202
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:213
 msgid ""
-"MPV keybinds are used by default. Press ENTER to drive the player controls "
-"by keyboard."
+"With \"Start Minimized\" and \"Fullscreen\" this is the classic cast-target "
+"setup: the app waits out of the way, plays fullscreen when something casts "
+"to it, and goes back to waiting when the video ends or you press Q."
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:204
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:227
+msgid ""
+"Off means command-line mode: no window, no system tray and no settings "
+"screen, so the only way back is editing conf.json by hand. It is not how you "
+"get MPV's own on-screen controls — \"Player Controls Style\" under Interface "
+"does that."
+msgstr ""
+
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:234
+msgid ""
+"Show only what is cast to this machine — the library, including this "
+"settings screen, can't be reached from here. Without a system tray icon the "
+"only way back is editing conf.json. For the classic cast-target setup you "
+"want the Interface settings instead; this is for a shared TV nobody should "
+"be able to browse from."
+msgstr ""
+
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:240
+msgid ""
+"Requires restart to change. MPV keybinds are used by default. Press ENTER to "
+"drive the player controls by keyboard."
+msgstr ""
+
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:242
 msgid ""
 "Pixels one wheel notch scrolls. The scrollbar glides while the content snaps "
 "to the nearest row, so a trackpad or trackball no longer overshoots. Raise "
 "it to scroll faster, lower it for finer control."
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:209
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:247
 msgid ""
 "Make each wheel notch jump exactly one row (or one home-screen section) "
 "instead of gliding. Turn this on if you prefer the older stepped scrolling."
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:217
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:255
 msgid "Discord Rich Presence. Takes effect after a restart."
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:219
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:257
 msgid ""
 "Leave this to Default unless setting up passthrough. Note some audio servers "
 "like Pipewire don't like passthrough and will need to be disabled for a card "
@@ -958,57 +982,57 @@ msgid ""
 "silence otherwise, but results may vary."
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:225
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:263
 msgid ""
 "Stop anything else using the device while playing. Needed for passthrough on "
 "some systems, and it means other applications will be silent."
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:228
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:266
 msgid ""
 "Page the library and music tile grids instead of scrolling: each page is one "
 "screenful with First / Previous / Next / Last controls and a page number you "
 "can type into. Easier than precise scrolling on a trackpad."
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:232
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:270
 msgid ""
 "Takes effect after a restart. \"Follow display\" uses the scale your desktop "
 "reports, which is 100% on X11."
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:234
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:272
 msgid ""
 "\"Default\" changes nothing and lets MPV (and your own mpv.conf) decide. "
 "Pick a mode only if you are sending audio to a receiver."
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:237
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:275
 msgid ""
 "Audio your receiver can't be sent directly is encoded to AC3, which is the "
 "only way surround fits down an optical cable. Turn this off if the encoder "
 "causes audio delay — those tracks become stereo instead."
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:242
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:280
 msgid ""
 "\"hq\" offers heavier profiles. Pick it if you have a fast graphics card."
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:244
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:282
 msgid ""
 "Leave on Automatic unless video breaks when a profile is loaded. This only "
 "applies while a profile is active, and OpenGL can cost you HDR output."
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:248
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:286
 msgid ""
 "Evens out loud effects and quiet dialogue. This turns passthrough off while "
 "it is enabled, because the volume has to be adjusted before your receiver "
 "gets the audio."
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:330
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:368
 msgid "Advanced"
 msgstr ""
 
@@ -1186,7 +1210,7 @@ msgid "Automatic"
 msgstr ""
 
 #: jellyfin_mpv_shim/mpvtk_browser/downloads.py:51
-#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1355
+#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1288
 msgid "Episodes"
 msgstr ""
 
@@ -1195,7 +1219,7 @@ msgid "Season %s"
 msgstr ""
 
 #: jellyfin_mpv_shim/mpvtk_browser/downloads.py:52
-#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1351
+#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1284
 msgid "Specials"
 msgstr ""
 
@@ -1216,7 +1240,7 @@ msgid "Failed"
 msgstr ""
 
 #: jellyfin_mpv_shim/mpvtk_browser/downloads.py:185
-#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1105
+#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1038
 msgid "Playlist"
 msgstr ""
 
@@ -1228,30 +1252,30 @@ msgstr ""
 msgid "Movies & Videos"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/home_sections.py:103
+#: jellyfin_mpv_shim/mpvtk_browser/home_sections.py:104
 msgid "My Media"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/home_sections.py:104
-#: jellyfin_mpv_shim/mpvtk_browser/repository.py:352
+#: jellyfin_mpv_shim/mpvtk_browser/home_sections.py:105
+#: jellyfin_mpv_shim/mpvtk_browser/repository.py:350
 msgid "Continue Watching"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/home_sections.py:105
-#: jellyfin_mpv_shim/mpvtk_browser/repository.py:359
+#: jellyfin_mpv_shim/mpvtk_browser/home_sections.py:106
+#: jellyfin_mpv_shim/mpvtk_browser/repository.py:357
 msgid "Continue Listening"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/home_sections.py:106
-#: jellyfin_mpv_shim/mpvtk_browser/repository.py:366
+#: jellyfin_mpv_shim/mpvtk_browser/home_sections.py:107
+#: jellyfin_mpv_shim/mpvtk_browser/repository.py:364
 msgid "Next Up"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/home_sections.py:107
+#: jellyfin_mpv_shim/mpvtk_browser/home_sections.py:108
 msgid "Recently Added"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/home_sections.py:108
+#: jellyfin_mpv_shim/mpvtk_browser/home_sections.py:109
 msgid "Live TV"
 msgstr ""
 
@@ -1464,52 +1488,52 @@ msgstr ""
 msgid "Could not load this page."
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/repository.py:390
+#: jellyfin_mpv_shim/mpvtk_browser/repository.py:386
 msgid "On Now"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/repository.py:411
+#: jellyfin_mpv_shim/mpvtk_browser/repository.py:407
 msgid "Latest %s"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1119
+#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1052
 msgid "Downloaded"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1138
+#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1071
 msgid "Movies"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1143
+#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1076
 msgid "Videos"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1147
+#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1080
 msgid "TV Shows"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1151
+#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1084
 msgid "Playlists"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1168
-#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1441
+#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1101
+#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1374
 msgid "Series"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1212
+#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1145
 msgid "Downloaded Movies"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1216
+#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1149
 msgid "Downloaded Videos"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1220
+#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1153
 msgid "Downloaded Shows"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1353
+#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1286
 msgid "Season %d"
 msgstr ""
 

--- a/jellyfin_mpv_shim/messages/lt/LC_MESSAGES/base.po
+++ b/jellyfin_mpv_shim/messages/lt/LC_MESSAGES/base.po
@@ -5,7 +5,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2026-07-25 17:21-0400\n"
+"POT-Creation-Date: 2026-07-26 12:03-0400\n"
 "PO-Revision-Date: 2026-03-24 19:36+0000\n"
 "Last-Translator: Justas Pranauskis <justas.pranauskis@ktu.edu>\n"
 "Language-Team: Lithuanian <https://translate.jellyfin.org/projects/jellyfin/"
@@ -254,7 +254,7 @@ msgid "Select Subtitle Track"
 msgstr "Pasirinkti subtitrų takelį"
 
 #: jellyfin_mpv_shim/menu.py:341
-#: jellyfin_mpv_shim/mpvtk_browser/home_sections.py:102
+#: jellyfin_mpv_shim/mpvtk_browser/home_sections.py:103
 #: jellyfin_mpv_shim/osc_bridge.py:81 jellyfin_mpv_shim/osc_bridge.py:82
 #: jellyfin_mpv_shim/osc_bridge.py:104 jellyfin_mpv_shim/osc_bridge.py:140
 msgid "None"
@@ -405,7 +405,7 @@ msgstr "Klausti, ar praleisti pabaigos titrus"
 msgid "Enable thumbnail previews"
 msgstr "Įjungti miniatūrų peržiūrą"
 
-#: jellyfin_mpv_shim/menu.py:609 jellyfin_mpv_shim/mpvtk_browser/config.py:186
+#: jellyfin_mpv_shim/menu.py:609 jellyfin_mpv_shim/mpvtk_browser/config.py:195
 #: jellyfin_mpv_shim/mpvtk_browser/hud.py:375
 msgid "Night Mode (Auto Volume Adj)"
 msgstr ""
@@ -704,310 +704,334 @@ msgstr ""
 msgid "Or switch to another user"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/cast.py:317
+#: jellyfin_mpv_shim/mpvtk_browser/cast.py:314
 msgid "Ready to cast"
 msgstr "Pasiruošęs perduoti"
 
-#: jellyfin_mpv_shim/mpvtk_browser/cast.py:318
+#: jellyfin_mpv_shim/mpvtk_browser/cast.py:315
 #, fuzzy
 #| msgid "Select your media in Jellyfin and play it here"
 msgid "Select your media in Jellyfin and play it here."
 msgstr "Pasirink savo turinį Jellyfin ir leisk jį čia"
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:74
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:83
 msgid "Interface"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:83
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:92
 msgid "Playback"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:88
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:97
 msgid "Audio"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:92
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:101
 msgid "Subtitles & Languages"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:97
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:106
 #, fuzzy
 #| msgid " (Transcode)"
 msgid "Transcoding"
 msgstr " (transkoduota)"
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:102
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:111
 msgid "Video Enhancement"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:104
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:113
 #, fuzzy
 #| msgid "Seek to Skip Credits"
 msgid "Skip Intro / Credits"
 msgstr "Klausti, ar praleisti pabaigos titrus"
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:107
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:116
 msgid "Library Browser"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:109
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:118
 msgid "Downloads"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:128
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:137
 msgid "Jellyfin UI"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:129
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:138
 msgid "MPV UI with thumbnails"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:130
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:139
 msgid "MPV built-in default"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:133
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:142
 msgid "Follow display"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:134
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:143
 msgid "100% (no scaling)"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:135
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:144
 msgid "125%"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:136
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:145
 msgid "150%"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:137
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:146
 msgid "200%"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:140
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:149
 msgid "Automatic (recommended)"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:141
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:150
 msgid "Vulkan"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:142
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:151
 msgid "Direct3D 11 (Windows only)"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:143
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:152
 msgid "OpenGL (compatibility)"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:146
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:155
 msgid "Default (auto)"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:147
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:156
 msgid "Force Stereo"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:148
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:157
 msgid "Optical Surround"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:149
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:158
 msgid "HDMI Passthrough"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:152
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:161
 msgid "Unset"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:153
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:162
 msgid "Dubbed (shows only)"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:154
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:163
 msgid "Subbed (shows only)"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:155
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:164
 msgid "Dubbed (all)"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:156
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:165
 msgid "Subbed (all)"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:157
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:166
 msgid "Custom (set in config)"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:162
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:171
 msgid "Download Folder"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:163
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:172
 msgid "Prefer Downloaded Copy"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:164
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:173
 msgid "Automatically Download Upcoming Episodes"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:165
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:174
 msgid "Include Next Up"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:166
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:175
 msgid "Next Up Entries to Consider"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:167
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:176
 msgid "Episodes to Keep Ahead (0 = off)"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:168
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:177
 msgid "Storage Limit for Automatic Downloads (GB)"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:169
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:178
 #, fuzzy
 #| msgid "Remove Server"
 msgid "Delete Automatic Downloads Once Watched"
 msgstr "Pašalinti serverį"
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:170
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:179
 msgid "Delete Unwatched After (days, 0 = never)"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:171
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:180
 msgid "Check Every (minutes)"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:172
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:181
 msgid "Close to Tray (keep running)"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:173
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:182
 msgid "Keep Running in Background"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:174
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:183
 msgid "Remember Window Size"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:175
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:184
 msgid "Player Controls Style"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:176
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:185
 msgid "Show What You're Watching in Discord"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:177
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:186
 msgid "Interface Scale"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:178
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:187
 msgid "Cast-target mode (no library browsing)"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:179
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:188
 msgid "Casting Opens the Library Browser"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:180
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:189
 msgid "Fullscreen Library Browser"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:181
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:190
 msgid "Always Bind Arrow Keys to Player Controls"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:182
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:191
 msgid "Player Controls Activation Key"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:183
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:192
 msgid "Audio Output Mode"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:184
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:193
 msgid "Audio Output Device"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:185
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:194
 msgid "Take the Device Exclusively"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:187
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:196
 #, fuzzy
 #| msgid "Video Playback Profiles"
 msgid "Enable Video Playback Profiles"
 msgstr "Vaizdo atkūrimo profiliai"
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:188
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:197
 #, fuzzy
 #| msgid "New Group"
 msgid "Profile Group"
 msgstr "Nauja Grupė"
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:189
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:198
 msgid "Remember Last Used Profile"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:190
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:199
 msgid "Graphics API for Shaders"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:191
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:200
 msgid "Pass Through AC3"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:192
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:201
 msgid "Pass Through DTS"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:193
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:202
 msgid "Pass Through E-AC3"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:194
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:203
 msgid "Pass Through DTS-HD"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:195
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:204
 msgid "Pass Through TrueHD"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:196
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:205
 msgid "Re-encode Others to AC3"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:202
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:213
 msgid ""
-"MPV keybinds are used by default. Press ENTER to drive the player controls "
-"by keyboard."
+"With \"Start Minimized\" and \"Fullscreen\" this is the classic cast-target "
+"setup: the app waits out of the way, plays fullscreen when something casts "
+"to it, and goes back to waiting when the video ends or you press Q."
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:204
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:227
+msgid ""
+"Off means command-line mode: no window, no system tray and no settings "
+"screen, so the only way back is editing conf.json by hand. It is not how you "
+"get MPV's own on-screen controls — \"Player Controls Style\" under Interface "
+"does that."
+msgstr ""
+
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:234
+msgid ""
+"Show only what is cast to this machine — the library, including this "
+"settings screen, can't be reached from here. Without a system tray icon the "
+"only way back is editing conf.json. For the classic cast-target setup you "
+"want the Interface settings instead; this is for a shared TV nobody should "
+"be able to browse from."
+msgstr ""
+
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:240
+msgid ""
+"Requires restart to change. MPV keybinds are used by default. Press ENTER to "
+"drive the player controls by keyboard."
+msgstr ""
+
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:242
 msgid ""
 "Pixels one wheel notch scrolls. The scrollbar glides while the content snaps "
 "to the nearest row, so a trackpad or trackball no longer overshoots. Raise "
 "it to scroll faster, lower it for finer control."
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:209
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:247
 msgid ""
 "Make each wheel notch jump exactly one row (or one home-screen section) "
 "instead of gliding. Turn this on if you prefer the older stepped scrolling."
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:217
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:255
 msgid "Discord Rich Presence. Takes effect after a restart."
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:219
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:257
 msgid ""
 "Leave this to Default unless setting up passthrough. Note some audio servers "
 "like Pipewire don't like passthrough and will need to be disabled for a card "
@@ -1015,57 +1039,57 @@ msgid ""
 "silence otherwise, but results may vary."
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:225
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:263
 msgid ""
 "Stop anything else using the device while playing. Needed for passthrough on "
 "some systems, and it means other applications will be silent."
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:228
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:266
 msgid ""
 "Page the library and music tile grids instead of scrolling: each page is one "
 "screenful with First / Previous / Next / Last controls and a page number you "
 "can type into. Easier than precise scrolling on a trackpad."
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:232
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:270
 msgid ""
 "Takes effect after a restart. \"Follow display\" uses the scale your desktop "
 "reports, which is 100% on X11."
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:234
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:272
 msgid ""
 "\"Default\" changes nothing and lets MPV (and your own mpv.conf) decide. "
 "Pick a mode only if you are sending audio to a receiver."
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:237
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:275
 msgid ""
 "Audio your receiver can't be sent directly is encoded to AC3, which is the "
 "only way surround fits down an optical cable. Turn this off if the encoder "
 "causes audio delay — those tracks become stereo instead."
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:242
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:280
 msgid ""
 "\"hq\" offers heavier profiles. Pick it if you have a fast graphics card."
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:244
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:282
 msgid ""
 "Leave on Automatic unless video breaks when a profile is loaded. This only "
 "applies while a profile is active, and OpenGL can cost you HDR output."
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:248
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:286
 msgid ""
 "Evens out loud effects and quiet dialogue. This turns passthrough off while "
 "it is enabled, because the volume has to be adjusted before your receiver "
 "gets the audio."
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:330
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:368
 msgid "Advanced"
 msgstr ""
 
@@ -1291,7 +1315,7 @@ msgid "Automatic"
 msgstr "Automatinis"
 
 #: jellyfin_mpv_shim/mpvtk_browser/downloads.py:51
-#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1355
+#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1288
 msgid "Episodes"
 msgstr ""
 
@@ -1300,7 +1324,7 @@ msgid "Season %s"
 msgstr ""
 
 #: jellyfin_mpv_shim/mpvtk_browser/downloads.py:52
-#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1351
+#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1284
 msgid "Specials"
 msgstr ""
 
@@ -1325,7 +1349,7 @@ msgid "Failed"
 msgstr "Nepavyko"
 
 #: jellyfin_mpv_shim/mpvtk_browser/downloads.py:185
-#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1105
+#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1038
 msgid "Playlist"
 msgstr ""
 
@@ -1337,30 +1361,30 @@ msgstr ""
 msgid "Movies & Videos"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/home_sections.py:103
+#: jellyfin_mpv_shim/mpvtk_browser/home_sections.py:104
 msgid "My Media"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/home_sections.py:104
-#: jellyfin_mpv_shim/mpvtk_browser/repository.py:352
+#: jellyfin_mpv_shim/mpvtk_browser/home_sections.py:105
+#: jellyfin_mpv_shim/mpvtk_browser/repository.py:350
 msgid "Continue Watching"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/home_sections.py:105
-#: jellyfin_mpv_shim/mpvtk_browser/repository.py:359
+#: jellyfin_mpv_shim/mpvtk_browser/home_sections.py:106
+#: jellyfin_mpv_shim/mpvtk_browser/repository.py:357
 msgid "Continue Listening"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/home_sections.py:106
-#: jellyfin_mpv_shim/mpvtk_browser/repository.py:366
+#: jellyfin_mpv_shim/mpvtk_browser/home_sections.py:107
+#: jellyfin_mpv_shim/mpvtk_browser/repository.py:364
 msgid "Next Up"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/home_sections.py:107
+#: jellyfin_mpv_shim/mpvtk_browser/home_sections.py:108
 msgid "Recently Added"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/home_sections.py:108
+#: jellyfin_mpv_shim/mpvtk_browser/home_sections.py:109
 msgid "Live TV"
 msgstr ""
 
@@ -1613,52 +1637,52 @@ msgstr ""
 "Nepavyko pridėti serverio.\n"
 "Patikrinkite savo sąsajos informaciją."
 
-#: jellyfin_mpv_shim/mpvtk_browser/repository.py:390
+#: jellyfin_mpv_shim/mpvtk_browser/repository.py:386
 msgid "On Now"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/repository.py:411
+#: jellyfin_mpv_shim/mpvtk_browser/repository.py:407
 msgid "Latest %s"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1119
+#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1052
 msgid "Downloaded"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1138
+#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1071
 msgid "Movies"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1143
+#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1076
 msgid "Videos"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1147
+#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1080
 msgid "TV Shows"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1151
+#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1084
 msgid "Playlists"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1168
-#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1441
+#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1101
+#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1374
 msgid "Series"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1212
+#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1145
 msgid "Downloaded Movies"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1216
+#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1149
 msgid "Downloaded Videos"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1220
+#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1153
 msgid "Downloaded Shows"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1353
+#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1286
 msgid "Season %d"
 msgstr ""
 

--- a/jellyfin_mpv_shim/messages/lv/LC_MESSAGES/base.po
+++ b/jellyfin_mpv_shim/messages/lv/LC_MESSAGES/base.po
@@ -5,7 +5,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2026-07-25 17:21-0400\n"
+"POT-Creation-Date: 2026-07-26 12:03-0400\n"
 "PO-Revision-Date: 2025-01-26 07:41+0000\n"
 "Last-Translator: Anrijs Vitolins <salixzs@gmail.com>\n"
 "Language-Team: Latvian <https://translate.jellyfin.org/projects/jellyfin/"
@@ -253,7 +253,7 @@ msgid "Select Subtitle Track"
 msgstr "Izvēlēties subtitru celiņu"
 
 #: jellyfin_mpv_shim/menu.py:341
-#: jellyfin_mpv_shim/mpvtk_browser/home_sections.py:102
+#: jellyfin_mpv_shim/mpvtk_browser/home_sections.py:103
 #: jellyfin_mpv_shim/osc_bridge.py:81 jellyfin_mpv_shim/osc_bridge.py:82
 #: jellyfin_mpv_shim/osc_bridge.py:104 jellyfin_mpv_shim/osc_bridge.py:140
 msgid "None"
@@ -404,7 +404,7 @@ msgstr "Jautāt, vai izlaist afišas titrus"
 msgid "Enable thumbnail previews"
 msgstr "Ieslēgt sīktēlu priekšskatījumus"
 
-#: jellyfin_mpv_shim/menu.py:609 jellyfin_mpv_shim/mpvtk_browser/config.py:186
+#: jellyfin_mpv_shim/menu.py:609 jellyfin_mpv_shim/mpvtk_browser/config.py:195
 #: jellyfin_mpv_shim/mpvtk_browser/hud.py:375
 msgid "Night Mode (Auto Volume Adj)"
 msgstr ""
@@ -703,310 +703,334 @@ msgstr ""
 msgid "Or switch to another user"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/cast.py:317
+#: jellyfin_mpv_shim/mpvtk_browser/cast.py:314
 msgid "Ready to cast"
 msgstr "Gatavs raidīšanai"
 
-#: jellyfin_mpv_shim/mpvtk_browser/cast.py:318
+#: jellyfin_mpv_shim/mpvtk_browser/cast.py:315
 #, fuzzy
 #| msgid "Select your media in Jellyfin and play it here"
 msgid "Select your media in Jellyfin and play it here."
 msgstr "Izvēlieties multividi iekš Jellyfin un atskaņojiet to šeit"
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:74
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:83
 msgid "Interface"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:83
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:92
 msgid "Playback"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:88
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:97
 msgid "Audio"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:92
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:101
 msgid "Subtitles & Languages"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:97
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:106
 #, fuzzy
 #| msgid " (Transcode)"
 msgid "Transcoding"
 msgstr " (Transkodēt)"
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:102
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:111
 msgid "Video Enhancement"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:104
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:113
 #, fuzzy
 #| msgid "Seek to Skip Credits"
 msgid "Skip Intro / Credits"
 msgstr "Meklēt, lai Izlaistu afišas titrus"
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:107
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:116
 msgid "Library Browser"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:109
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:118
 msgid "Downloads"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:128
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:137
 msgid "Jellyfin UI"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:129
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:138
 msgid "MPV UI with thumbnails"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:130
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:139
 msgid "MPV built-in default"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:133
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:142
 msgid "Follow display"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:134
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:143
 msgid "100% (no scaling)"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:135
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:144
 msgid "125%"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:136
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:145
 msgid "150%"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:137
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:146
 msgid "200%"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:140
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:149
 msgid "Automatic (recommended)"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:141
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:150
 msgid "Vulkan"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:142
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:151
 msgid "Direct3D 11 (Windows only)"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:143
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:152
 msgid "OpenGL (compatibility)"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:146
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:155
 msgid "Default (auto)"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:147
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:156
 msgid "Force Stereo"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:148
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:157
 msgid "Optical Surround"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:149
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:158
 msgid "HDMI Passthrough"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:152
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:161
 msgid "Unset"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:153
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:162
 msgid "Dubbed (shows only)"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:154
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:163
 msgid "Subbed (shows only)"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:155
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:164
 msgid "Dubbed (all)"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:156
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:165
 msgid "Subbed (all)"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:157
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:166
 msgid "Custom (set in config)"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:162
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:171
 msgid "Download Folder"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:163
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:172
 msgid "Prefer Downloaded Copy"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:164
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:173
 msgid "Automatically Download Upcoming Episodes"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:165
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:174
 msgid "Include Next Up"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:166
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:175
 msgid "Next Up Entries to Consider"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:167
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:176
 msgid "Episodes to Keep Ahead (0 = off)"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:168
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:177
 msgid "Storage Limit for Automatic Downloads (GB)"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:169
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:178
 #, fuzzy
 #| msgid "Remove Server"
 msgid "Delete Automatic Downloads Once Watched"
 msgstr "Noņemt serveri"
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:170
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:179
 msgid "Delete Unwatched After (days, 0 = never)"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:171
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:180
 msgid "Check Every (minutes)"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:172
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:181
 msgid "Close to Tray (keep running)"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:173
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:182
 msgid "Keep Running in Background"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:174
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:183
 msgid "Remember Window Size"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:175
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:184
 msgid "Player Controls Style"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:176
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:185
 msgid "Show What You're Watching in Discord"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:177
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:186
 msgid "Interface Scale"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:178
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:187
 msgid "Cast-target mode (no library browsing)"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:179
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:188
 msgid "Casting Opens the Library Browser"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:180
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:189
 msgid "Fullscreen Library Browser"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:181
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:190
 msgid "Always Bind Arrow Keys to Player Controls"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:182
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:191
 msgid "Player Controls Activation Key"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:183
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:192
 msgid "Audio Output Mode"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:184
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:193
 msgid "Audio Output Device"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:185
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:194
 msgid "Take the Device Exclusively"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:187
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:196
 #, fuzzy
 #| msgid "Video Playback Profiles"
 msgid "Enable Video Playback Profiles"
 msgstr "Video atskaņošanas profili"
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:188
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:197
 #, fuzzy
 #| msgid "New Group"
 msgid "Profile Group"
 msgstr "Jauna grupa"
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:189
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:198
 msgid "Remember Last Used Profile"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:190
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:199
 msgid "Graphics API for Shaders"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:191
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:200
 msgid "Pass Through AC3"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:192
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:201
 msgid "Pass Through DTS"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:193
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:202
 msgid "Pass Through E-AC3"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:194
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:203
 msgid "Pass Through DTS-HD"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:195
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:204
 msgid "Pass Through TrueHD"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:196
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:205
 msgid "Re-encode Others to AC3"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:202
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:213
 msgid ""
-"MPV keybinds are used by default. Press ENTER to drive the player controls "
-"by keyboard."
+"With \"Start Minimized\" and \"Fullscreen\" this is the classic cast-target "
+"setup: the app waits out of the way, plays fullscreen when something casts "
+"to it, and goes back to waiting when the video ends or you press Q."
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:204
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:227
+msgid ""
+"Off means command-line mode: no window, no system tray and no settings "
+"screen, so the only way back is editing conf.json by hand. It is not how you "
+"get MPV's own on-screen controls — \"Player Controls Style\" under Interface "
+"does that."
+msgstr ""
+
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:234
+msgid ""
+"Show only what is cast to this machine — the library, including this "
+"settings screen, can't be reached from here. Without a system tray icon the "
+"only way back is editing conf.json. For the classic cast-target setup you "
+"want the Interface settings instead; this is for a shared TV nobody should "
+"be able to browse from."
+msgstr ""
+
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:240
+msgid ""
+"Requires restart to change. MPV keybinds are used by default. Press ENTER to "
+"drive the player controls by keyboard."
+msgstr ""
+
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:242
 msgid ""
 "Pixels one wheel notch scrolls. The scrollbar glides while the content snaps "
 "to the nearest row, so a trackpad or trackball no longer overshoots. Raise "
 "it to scroll faster, lower it for finer control."
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:209
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:247
 msgid ""
 "Make each wheel notch jump exactly one row (or one home-screen section) "
 "instead of gliding. Turn this on if you prefer the older stepped scrolling."
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:217
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:255
 msgid "Discord Rich Presence. Takes effect after a restart."
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:219
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:257
 msgid ""
 "Leave this to Default unless setting up passthrough. Note some audio servers "
 "like Pipewire don't like passthrough and will need to be disabled for a card "
@@ -1014,57 +1038,57 @@ msgid ""
 "silence otherwise, but results may vary."
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:225
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:263
 msgid ""
 "Stop anything else using the device while playing. Needed for passthrough on "
 "some systems, and it means other applications will be silent."
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:228
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:266
 msgid ""
 "Page the library and music tile grids instead of scrolling: each page is one "
 "screenful with First / Previous / Next / Last controls and a page number you "
 "can type into. Easier than precise scrolling on a trackpad."
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:232
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:270
 msgid ""
 "Takes effect after a restart. \"Follow display\" uses the scale your desktop "
 "reports, which is 100% on X11."
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:234
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:272
 msgid ""
 "\"Default\" changes nothing and lets MPV (and your own mpv.conf) decide. "
 "Pick a mode only if you are sending audio to a receiver."
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:237
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:275
 msgid ""
 "Audio your receiver can't be sent directly is encoded to AC3, which is the "
 "only way surround fits down an optical cable. Turn this off if the encoder "
 "causes audio delay — those tracks become stereo instead."
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:242
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:280
 msgid ""
 "\"hq\" offers heavier profiles. Pick it if you have a fast graphics card."
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:244
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:282
 msgid ""
 "Leave on Automatic unless video breaks when a profile is loaded. This only "
 "applies while a profile is active, and OpenGL can cost you HDR output."
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:248
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:286
 msgid ""
 "Evens out loud effects and quiet dialogue. This turns passthrough off while "
 "it is enabled, because the volume has to be adjusted before your receiver "
 "gets the audio."
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:330
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:368
 msgid "Advanced"
 msgstr ""
 
@@ -1290,7 +1314,7 @@ msgid "Automatic"
 msgstr "Automātiski"
 
 #: jellyfin_mpv_shim/mpvtk_browser/downloads.py:51
-#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1355
+#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1288
 msgid "Episodes"
 msgstr ""
 
@@ -1299,7 +1323,7 @@ msgid "Season %s"
 msgstr ""
 
 #: jellyfin_mpv_shim/mpvtk_browser/downloads.py:52
-#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1351
+#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1284
 msgid "Specials"
 msgstr ""
 
@@ -1324,7 +1348,7 @@ msgid "Failed"
 msgstr "Neizdevās"
 
 #: jellyfin_mpv_shim/mpvtk_browser/downloads.py:185
-#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1105
+#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1038
 msgid "Playlist"
 msgstr ""
 
@@ -1336,30 +1360,30 @@ msgstr ""
 msgid "Movies & Videos"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/home_sections.py:103
+#: jellyfin_mpv_shim/mpvtk_browser/home_sections.py:104
 msgid "My Media"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/home_sections.py:104
-#: jellyfin_mpv_shim/mpvtk_browser/repository.py:352
+#: jellyfin_mpv_shim/mpvtk_browser/home_sections.py:105
+#: jellyfin_mpv_shim/mpvtk_browser/repository.py:350
 msgid "Continue Watching"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/home_sections.py:105
-#: jellyfin_mpv_shim/mpvtk_browser/repository.py:359
+#: jellyfin_mpv_shim/mpvtk_browser/home_sections.py:106
+#: jellyfin_mpv_shim/mpvtk_browser/repository.py:357
 msgid "Continue Listening"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/home_sections.py:106
-#: jellyfin_mpv_shim/mpvtk_browser/repository.py:366
+#: jellyfin_mpv_shim/mpvtk_browser/home_sections.py:107
+#: jellyfin_mpv_shim/mpvtk_browser/repository.py:364
 msgid "Next Up"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/home_sections.py:107
+#: jellyfin_mpv_shim/mpvtk_browser/home_sections.py:108
 msgid "Recently Added"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/home_sections.py:108
+#: jellyfin_mpv_shim/mpvtk_browser/home_sections.py:109
 msgid "Live TV"
 msgstr ""
 
@@ -1612,52 +1636,52 @@ msgstr ""
 "Nevar pievienot serveri.\n"
 "Lūdzu, pārbaudiet savienojuma informāciju."
 
-#: jellyfin_mpv_shim/mpvtk_browser/repository.py:390
+#: jellyfin_mpv_shim/mpvtk_browser/repository.py:386
 msgid "On Now"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/repository.py:411
+#: jellyfin_mpv_shim/mpvtk_browser/repository.py:407
 msgid "Latest %s"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1119
+#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1052
 msgid "Downloaded"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1138
+#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1071
 msgid "Movies"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1143
+#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1076
 msgid "Videos"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1147
+#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1080
 msgid "TV Shows"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1151
+#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1084
 msgid "Playlists"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1168
-#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1441
+#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1101
+#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1374
 msgid "Series"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1212
+#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1145
 msgid "Downloaded Movies"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1216
+#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1149
 msgid "Downloaded Videos"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1220
+#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1153
 msgid "Downloaded Shows"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1353
+#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1286
 msgid "Season %d"
 msgstr ""
 

--- a/jellyfin_mpv_shim/messages/lzh/LC_MESSAGES/base.po
+++ b/jellyfin_mpv_shim/messages/lzh/LC_MESSAGES/base.po
@@ -5,7 +5,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2026-07-25 17:21-0400\n"
+"POT-Creation-Date: 2026-07-26 12:03-0400\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: Automatically generated\n"
 "Language-Team: none\n"
@@ -239,7 +239,7 @@ msgid "Select Subtitle Track"
 msgstr ""
 
 #: jellyfin_mpv_shim/menu.py:341
-#: jellyfin_mpv_shim/mpvtk_browser/home_sections.py:102
+#: jellyfin_mpv_shim/mpvtk_browser/home_sections.py:103
 #: jellyfin_mpv_shim/osc_bridge.py:81 jellyfin_mpv_shim/osc_bridge.py:82
 #: jellyfin_mpv_shim/osc_bridge.py:104 jellyfin_mpv_shim/osc_bridge.py:140
 msgid "None"
@@ -390,7 +390,7 @@ msgstr ""
 msgid "Enable thumbnail previews"
 msgstr ""
 
-#: jellyfin_mpv_shim/menu.py:609 jellyfin_mpv_shim/mpvtk_browser/config.py:186
+#: jellyfin_mpv_shim/menu.py:609 jellyfin_mpv_shim/mpvtk_browser/config.py:195
 #: jellyfin_mpv_shim/mpvtk_browser/hud.py:375
 msgid "Night Mode (Auto Volume Adj)"
 msgstr ""
@@ -655,298 +655,322 @@ msgstr ""
 msgid "Or switch to another user"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/cast.py:317
+#: jellyfin_mpv_shim/mpvtk_browser/cast.py:314
 msgid "Ready to cast"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/cast.py:318
+#: jellyfin_mpv_shim/mpvtk_browser/cast.py:315
 msgid "Select your media in Jellyfin and play it here."
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:74
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:83
 msgid "Interface"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:83
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:92
 msgid "Playback"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:88
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:97
 msgid "Audio"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:92
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:101
 msgid "Subtitles & Languages"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:97
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:106
 msgid "Transcoding"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:102
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:111
 msgid "Video Enhancement"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:104
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:113
 msgid "Skip Intro / Credits"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:107
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:116
 msgid "Library Browser"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:109
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:118
 msgid "Downloads"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:128
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:137
 msgid "Jellyfin UI"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:129
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:138
 msgid "MPV UI with thumbnails"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:130
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:139
 msgid "MPV built-in default"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:133
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:142
 msgid "Follow display"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:134
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:143
 msgid "100% (no scaling)"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:135
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:144
 msgid "125%"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:136
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:145
 msgid "150%"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:137
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:146
 msgid "200%"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:140
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:149
 msgid "Automatic (recommended)"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:141
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:150
 msgid "Vulkan"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:142
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:151
 msgid "Direct3D 11 (Windows only)"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:143
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:152
 msgid "OpenGL (compatibility)"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:146
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:155
 msgid "Default (auto)"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:147
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:156
 msgid "Force Stereo"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:148
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:157
 msgid "Optical Surround"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:149
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:158
 msgid "HDMI Passthrough"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:152
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:161
 msgid "Unset"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:153
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:162
 msgid "Dubbed (shows only)"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:154
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:163
 msgid "Subbed (shows only)"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:155
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:164
 msgid "Dubbed (all)"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:156
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:165
 msgid "Subbed (all)"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:157
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:166
 msgid "Custom (set in config)"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:162
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:171
 msgid "Download Folder"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:163
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:172
 msgid "Prefer Downloaded Copy"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:164
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:173
 msgid "Automatically Download Upcoming Episodes"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:165
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:174
 msgid "Include Next Up"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:166
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:175
 msgid "Next Up Entries to Consider"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:167
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:176
 msgid "Episodes to Keep Ahead (0 = off)"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:168
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:177
 msgid "Storage Limit for Automatic Downloads (GB)"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:169
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:178
 msgid "Delete Automatic Downloads Once Watched"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:170
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:179
 msgid "Delete Unwatched After (days, 0 = never)"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:171
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:180
 msgid "Check Every (minutes)"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:172
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:181
 msgid "Close to Tray (keep running)"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:173
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:182
 msgid "Keep Running in Background"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:174
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:183
 msgid "Remember Window Size"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:175
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:184
 msgid "Player Controls Style"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:176
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:185
 msgid "Show What You're Watching in Discord"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:177
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:186
 msgid "Interface Scale"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:178
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:187
 msgid "Cast-target mode (no library browsing)"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:179
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:188
 msgid "Casting Opens the Library Browser"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:180
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:189
 msgid "Fullscreen Library Browser"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:181
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:190
 msgid "Always Bind Arrow Keys to Player Controls"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:182
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:191
 msgid "Player Controls Activation Key"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:183
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:192
 msgid "Audio Output Mode"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:184
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:193
 msgid "Audio Output Device"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:185
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:194
 msgid "Take the Device Exclusively"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:187
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:196
 msgid "Enable Video Playback Profiles"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:188
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:197
 msgid "Profile Group"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:189
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:198
 msgid "Remember Last Used Profile"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:190
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:199
 msgid "Graphics API for Shaders"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:191
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:200
 msgid "Pass Through AC3"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:192
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:201
 msgid "Pass Through DTS"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:193
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:202
 msgid "Pass Through E-AC3"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:194
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:203
 msgid "Pass Through DTS-HD"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:195
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:204
 msgid "Pass Through TrueHD"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:196
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:205
 msgid "Re-encode Others to AC3"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:202
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:213
 msgid ""
-"MPV keybinds are used by default. Press ENTER to drive the player controls "
-"by keyboard."
+"With \"Start Minimized\" and \"Fullscreen\" this is the classic cast-target "
+"setup: the app waits out of the way, plays fullscreen when something casts "
+"to it, and goes back to waiting when the video ends or you press Q."
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:204
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:227
+msgid ""
+"Off means command-line mode: no window, no system tray and no settings "
+"screen, so the only way back is editing conf.json by hand. It is not how you "
+"get MPV's own on-screen controls — \"Player Controls Style\" under Interface "
+"does that."
+msgstr ""
+
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:234
+msgid ""
+"Show only what is cast to this machine — the library, including this "
+"settings screen, can't be reached from here. Without a system tray icon the "
+"only way back is editing conf.json. For the classic cast-target setup you "
+"want the Interface settings instead; this is for a shared TV nobody should "
+"be able to browse from."
+msgstr ""
+
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:240
+msgid ""
+"Requires restart to change. MPV keybinds are used by default. Press ENTER to "
+"drive the player controls by keyboard."
+msgstr ""
+
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:242
 msgid ""
 "Pixels one wheel notch scrolls. The scrollbar glides while the content snaps "
 "to the nearest row, so a trackpad or trackball no longer overshoots. Raise "
 "it to scroll faster, lower it for finer control."
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:209
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:247
 msgid ""
 "Make each wheel notch jump exactly one row (or one home-screen section) "
 "instead of gliding. Turn this on if you prefer the older stepped scrolling."
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:217
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:255
 msgid "Discord Rich Presence. Takes effect after a restart."
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:219
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:257
 msgid ""
 "Leave this to Default unless setting up passthrough. Note some audio servers "
 "like Pipewire don't like passthrough and will need to be disabled for a card "
@@ -954,57 +978,57 @@ msgid ""
 "silence otherwise, but results may vary."
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:225
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:263
 msgid ""
 "Stop anything else using the device while playing. Needed for passthrough on "
 "some systems, and it means other applications will be silent."
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:228
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:266
 msgid ""
 "Page the library and music tile grids instead of scrolling: each page is one "
 "screenful with First / Previous / Next / Last controls and a page number you "
 "can type into. Easier than precise scrolling on a trackpad."
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:232
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:270
 msgid ""
 "Takes effect after a restart. \"Follow display\" uses the scale your desktop "
 "reports, which is 100% on X11."
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:234
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:272
 msgid ""
 "\"Default\" changes nothing and lets MPV (and your own mpv.conf) decide. "
 "Pick a mode only if you are sending audio to a receiver."
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:237
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:275
 msgid ""
 "Audio your receiver can't be sent directly is encoded to AC3, which is the "
 "only way surround fits down an optical cable. Turn this off if the encoder "
 "causes audio delay — those tracks become stereo instead."
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:242
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:280
 msgid ""
 "\"hq\" offers heavier profiles. Pick it if you have a fast graphics card."
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:244
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:282
 msgid ""
 "Leave on Automatic unless video breaks when a profile is loaded. This only "
 "applies while a profile is active, and OpenGL can cost you HDR output."
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:248
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:286
 msgid ""
 "Evens out loud effects and quiet dialogue. This turns passthrough off while "
 "it is enabled, because the volume has to be adjusted before your receiver "
 "gets the audio."
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:330
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:368
 msgid "Advanced"
 msgstr ""
 
@@ -1182,7 +1206,7 @@ msgid "Automatic"
 msgstr ""
 
 #: jellyfin_mpv_shim/mpvtk_browser/downloads.py:51
-#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1355
+#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1288
 msgid "Episodes"
 msgstr ""
 
@@ -1191,7 +1215,7 @@ msgid "Season %s"
 msgstr ""
 
 #: jellyfin_mpv_shim/mpvtk_browser/downloads.py:52
-#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1351
+#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1284
 msgid "Specials"
 msgstr ""
 
@@ -1212,7 +1236,7 @@ msgid "Failed"
 msgstr ""
 
 #: jellyfin_mpv_shim/mpvtk_browser/downloads.py:185
-#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1105
+#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1038
 msgid "Playlist"
 msgstr ""
 
@@ -1224,30 +1248,30 @@ msgstr ""
 msgid "Movies & Videos"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/home_sections.py:103
+#: jellyfin_mpv_shim/mpvtk_browser/home_sections.py:104
 msgid "My Media"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/home_sections.py:104
-#: jellyfin_mpv_shim/mpvtk_browser/repository.py:352
+#: jellyfin_mpv_shim/mpvtk_browser/home_sections.py:105
+#: jellyfin_mpv_shim/mpvtk_browser/repository.py:350
 msgid "Continue Watching"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/home_sections.py:105
-#: jellyfin_mpv_shim/mpvtk_browser/repository.py:359
+#: jellyfin_mpv_shim/mpvtk_browser/home_sections.py:106
+#: jellyfin_mpv_shim/mpvtk_browser/repository.py:357
 msgid "Continue Listening"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/home_sections.py:106
-#: jellyfin_mpv_shim/mpvtk_browser/repository.py:366
+#: jellyfin_mpv_shim/mpvtk_browser/home_sections.py:107
+#: jellyfin_mpv_shim/mpvtk_browser/repository.py:364
 msgid "Next Up"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/home_sections.py:107
+#: jellyfin_mpv_shim/mpvtk_browser/home_sections.py:108
 msgid "Recently Added"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/home_sections.py:108
+#: jellyfin_mpv_shim/mpvtk_browser/home_sections.py:109
 msgid "Live TV"
 msgstr ""
 
@@ -1452,52 +1476,52 @@ msgstr ""
 msgid "Could not load this page."
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/repository.py:390
+#: jellyfin_mpv_shim/mpvtk_browser/repository.py:386
 msgid "On Now"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/repository.py:411
+#: jellyfin_mpv_shim/mpvtk_browser/repository.py:407
 msgid "Latest %s"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1119
+#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1052
 msgid "Downloaded"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1138
+#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1071
 msgid "Movies"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1143
+#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1076
 msgid "Videos"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1147
+#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1080
 msgid "TV Shows"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1151
+#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1084
 msgid "Playlists"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1168
-#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1441
+#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1101
+#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1374
 msgid "Series"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1212
+#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1145
 msgid "Downloaded Movies"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1216
+#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1149
 msgid "Downloaded Videos"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1220
+#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1153
 msgid "Downloaded Shows"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1353
+#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1286
 msgid "Season %d"
 msgstr ""
 

--- a/jellyfin_mpv_shim/messages/mi/LC_MESSAGES/base.po
+++ b/jellyfin_mpv_shim/messages/mi/LC_MESSAGES/base.po
@@ -5,7 +5,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2026-07-25 17:21-0400\n"
+"POT-Creation-Date: 2026-07-26 12:03-0400\n"
 "PO-Revision-Date: 2025-12-10 05:20+0000\n"
 "Last-Translator: Veldermon-rbg <burtjayden3@gmail.com>\n"
 "Language-Team: Maori <https://translate.jellyfin.org/projects/jellyfin/"
@@ -242,7 +242,7 @@ msgid "Select Subtitle Track"
 msgstr ""
 
 #: jellyfin_mpv_shim/menu.py:341
-#: jellyfin_mpv_shim/mpvtk_browser/home_sections.py:102
+#: jellyfin_mpv_shim/mpvtk_browser/home_sections.py:103
 #: jellyfin_mpv_shim/osc_bridge.py:81 jellyfin_mpv_shim/osc_bridge.py:82
 #: jellyfin_mpv_shim/osc_bridge.py:104 jellyfin_mpv_shim/osc_bridge.py:140
 msgid "None"
@@ -393,7 +393,7 @@ msgstr ""
 msgid "Enable thumbnail previews"
 msgstr ""
 
-#: jellyfin_mpv_shim/menu.py:609 jellyfin_mpv_shim/mpvtk_browser/config.py:186
+#: jellyfin_mpv_shim/menu.py:609 jellyfin_mpv_shim/mpvtk_browser/config.py:195
 #: jellyfin_mpv_shim/mpvtk_browser/hud.py:375
 msgid "Night Mode (Auto Volume Adj)"
 msgstr ""
@@ -658,298 +658,322 @@ msgstr ""
 msgid "Or switch to another user"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/cast.py:317
+#: jellyfin_mpv_shim/mpvtk_browser/cast.py:314
 msgid "Ready to cast"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/cast.py:318
+#: jellyfin_mpv_shim/mpvtk_browser/cast.py:315
 msgid "Select your media in Jellyfin and play it here."
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:74
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:83
 msgid "Interface"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:83
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:92
 msgid "Playback"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:88
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:97
 msgid "Audio"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:92
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:101
 msgid "Subtitles & Languages"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:97
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:106
 msgid "Transcoding"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:102
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:111
 msgid "Video Enhancement"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:104
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:113
 msgid "Skip Intro / Credits"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:107
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:116
 msgid "Library Browser"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:109
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:118
 msgid "Downloads"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:128
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:137
 msgid "Jellyfin UI"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:129
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:138
 msgid "MPV UI with thumbnails"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:130
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:139
 msgid "MPV built-in default"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:133
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:142
 msgid "Follow display"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:134
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:143
 msgid "100% (no scaling)"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:135
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:144
 msgid "125%"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:136
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:145
 msgid "150%"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:137
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:146
 msgid "200%"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:140
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:149
 msgid "Automatic (recommended)"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:141
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:150
 msgid "Vulkan"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:142
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:151
 msgid "Direct3D 11 (Windows only)"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:143
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:152
 msgid "OpenGL (compatibility)"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:146
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:155
 msgid "Default (auto)"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:147
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:156
 msgid "Force Stereo"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:148
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:157
 msgid "Optical Surround"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:149
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:158
 msgid "HDMI Passthrough"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:152
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:161
 msgid "Unset"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:153
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:162
 msgid "Dubbed (shows only)"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:154
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:163
 msgid "Subbed (shows only)"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:155
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:164
 msgid "Dubbed (all)"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:156
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:165
 msgid "Subbed (all)"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:157
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:166
 msgid "Custom (set in config)"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:162
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:171
 msgid "Download Folder"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:163
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:172
 msgid "Prefer Downloaded Copy"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:164
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:173
 msgid "Automatically Download Upcoming Episodes"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:165
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:174
 msgid "Include Next Up"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:166
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:175
 msgid "Next Up Entries to Consider"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:167
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:176
 msgid "Episodes to Keep Ahead (0 = off)"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:168
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:177
 msgid "Storage Limit for Automatic Downloads (GB)"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:169
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:178
 msgid "Delete Automatic Downloads Once Watched"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:170
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:179
 msgid "Delete Unwatched After (days, 0 = never)"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:171
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:180
 msgid "Check Every (minutes)"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:172
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:181
 msgid "Close to Tray (keep running)"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:173
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:182
 msgid "Keep Running in Background"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:174
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:183
 msgid "Remember Window Size"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:175
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:184
 msgid "Player Controls Style"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:176
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:185
 msgid "Show What You're Watching in Discord"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:177
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:186
 msgid "Interface Scale"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:178
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:187
 msgid "Cast-target mode (no library browsing)"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:179
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:188
 msgid "Casting Opens the Library Browser"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:180
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:189
 msgid "Fullscreen Library Browser"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:181
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:190
 msgid "Always Bind Arrow Keys to Player Controls"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:182
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:191
 msgid "Player Controls Activation Key"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:183
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:192
 msgid "Audio Output Mode"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:184
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:193
 msgid "Audio Output Device"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:185
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:194
 msgid "Take the Device Exclusively"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:187
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:196
 msgid "Enable Video Playback Profiles"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:188
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:197
 msgid "Profile Group"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:189
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:198
 msgid "Remember Last Used Profile"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:190
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:199
 msgid "Graphics API for Shaders"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:191
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:200
 msgid "Pass Through AC3"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:192
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:201
 msgid "Pass Through DTS"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:193
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:202
 msgid "Pass Through E-AC3"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:194
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:203
 msgid "Pass Through DTS-HD"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:195
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:204
 msgid "Pass Through TrueHD"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:196
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:205
 msgid "Re-encode Others to AC3"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:202
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:213
 msgid ""
-"MPV keybinds are used by default. Press ENTER to drive the player controls "
-"by keyboard."
+"With \"Start Minimized\" and \"Fullscreen\" this is the classic cast-target "
+"setup: the app waits out of the way, plays fullscreen when something casts "
+"to it, and goes back to waiting when the video ends or you press Q."
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:204
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:227
+msgid ""
+"Off means command-line mode: no window, no system tray and no settings "
+"screen, so the only way back is editing conf.json by hand. It is not how you "
+"get MPV's own on-screen controls — \"Player Controls Style\" under Interface "
+"does that."
+msgstr ""
+
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:234
+msgid ""
+"Show only what is cast to this machine — the library, including this "
+"settings screen, can't be reached from here. Without a system tray icon the "
+"only way back is editing conf.json. For the classic cast-target setup you "
+"want the Interface settings instead; this is for a shared TV nobody should "
+"be able to browse from."
+msgstr ""
+
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:240
+msgid ""
+"Requires restart to change. MPV keybinds are used by default. Press ENTER to "
+"drive the player controls by keyboard."
+msgstr ""
+
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:242
 msgid ""
 "Pixels one wheel notch scrolls. The scrollbar glides while the content snaps "
 "to the nearest row, so a trackpad or trackball no longer overshoots. Raise "
 "it to scroll faster, lower it for finer control."
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:209
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:247
 msgid ""
 "Make each wheel notch jump exactly one row (or one home-screen section) "
 "instead of gliding. Turn this on if you prefer the older stepped scrolling."
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:217
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:255
 msgid "Discord Rich Presence. Takes effect after a restart."
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:219
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:257
 msgid ""
 "Leave this to Default unless setting up passthrough. Note some audio servers "
 "like Pipewire don't like passthrough and will need to be disabled for a card "
@@ -957,57 +981,57 @@ msgid ""
 "silence otherwise, but results may vary."
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:225
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:263
 msgid ""
 "Stop anything else using the device while playing. Needed for passthrough on "
 "some systems, and it means other applications will be silent."
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:228
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:266
 msgid ""
 "Page the library and music tile grids instead of scrolling: each page is one "
 "screenful with First / Previous / Next / Last controls and a page number you "
 "can type into. Easier than precise scrolling on a trackpad."
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:232
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:270
 msgid ""
 "Takes effect after a restart. \"Follow display\" uses the scale your desktop "
 "reports, which is 100% on X11."
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:234
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:272
 msgid ""
 "\"Default\" changes nothing and lets MPV (and your own mpv.conf) decide. "
 "Pick a mode only if you are sending audio to a receiver."
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:237
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:275
 msgid ""
 "Audio your receiver can't be sent directly is encoded to AC3, which is the "
 "only way surround fits down an optical cable. Turn this off if the encoder "
 "causes audio delay — those tracks become stereo instead."
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:242
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:280
 msgid ""
 "\"hq\" offers heavier profiles. Pick it if you have a fast graphics card."
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:244
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:282
 msgid ""
 "Leave on Automatic unless video breaks when a profile is loaded. This only "
 "applies while a profile is active, and OpenGL can cost you HDR output."
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:248
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:286
 msgid ""
 "Evens out loud effects and quiet dialogue. This turns passthrough off while "
 "it is enabled, because the volume has to be adjusted before your receiver "
 "gets the audio."
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:330
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:368
 msgid "Advanced"
 msgstr ""
 
@@ -1185,7 +1209,7 @@ msgid "Automatic"
 msgstr ""
 
 #: jellyfin_mpv_shim/mpvtk_browser/downloads.py:51
-#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1355
+#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1288
 msgid "Episodes"
 msgstr ""
 
@@ -1194,7 +1218,7 @@ msgid "Season %s"
 msgstr ""
 
 #: jellyfin_mpv_shim/mpvtk_browser/downloads.py:52
-#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1351
+#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1284
 msgid "Specials"
 msgstr ""
 
@@ -1215,7 +1239,7 @@ msgid "Failed"
 msgstr ""
 
 #: jellyfin_mpv_shim/mpvtk_browser/downloads.py:185
-#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1105
+#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1038
 msgid "Playlist"
 msgstr ""
 
@@ -1227,30 +1251,30 @@ msgstr ""
 msgid "Movies & Videos"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/home_sections.py:103
+#: jellyfin_mpv_shim/mpvtk_browser/home_sections.py:104
 msgid "My Media"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/home_sections.py:104
-#: jellyfin_mpv_shim/mpvtk_browser/repository.py:352
+#: jellyfin_mpv_shim/mpvtk_browser/home_sections.py:105
+#: jellyfin_mpv_shim/mpvtk_browser/repository.py:350
 msgid "Continue Watching"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/home_sections.py:105
-#: jellyfin_mpv_shim/mpvtk_browser/repository.py:359
+#: jellyfin_mpv_shim/mpvtk_browser/home_sections.py:106
+#: jellyfin_mpv_shim/mpvtk_browser/repository.py:357
 msgid "Continue Listening"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/home_sections.py:106
-#: jellyfin_mpv_shim/mpvtk_browser/repository.py:366
+#: jellyfin_mpv_shim/mpvtk_browser/home_sections.py:107
+#: jellyfin_mpv_shim/mpvtk_browser/repository.py:364
 msgid "Next Up"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/home_sections.py:107
+#: jellyfin_mpv_shim/mpvtk_browser/home_sections.py:108
 msgid "Recently Added"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/home_sections.py:108
+#: jellyfin_mpv_shim/mpvtk_browser/home_sections.py:109
 msgid "Live TV"
 msgstr ""
 
@@ -1463,52 +1487,52 @@ msgstr ""
 msgid "Could not load this page."
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/repository.py:390
+#: jellyfin_mpv_shim/mpvtk_browser/repository.py:386
 msgid "On Now"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/repository.py:411
+#: jellyfin_mpv_shim/mpvtk_browser/repository.py:407
 msgid "Latest %s"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1119
+#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1052
 msgid "Downloaded"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1138
+#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1071
 msgid "Movies"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1143
+#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1076
 msgid "Videos"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1147
+#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1080
 msgid "TV Shows"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1151
+#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1084
 msgid "Playlists"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1168
-#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1441
+#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1101
+#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1374
 msgid "Series"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1212
+#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1145
 msgid "Downloaded Movies"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1216
+#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1149
 msgid "Downloaded Videos"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1220
+#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1153
 msgid "Downloaded Shows"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1353
+#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1286
 msgid "Season %d"
 msgstr ""
 

--- a/jellyfin_mpv_shim/messages/ml/LC_MESSAGES/base.po
+++ b/jellyfin_mpv_shim/messages/ml/LC_MESSAGES/base.po
@@ -5,7 +5,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2026-07-25 17:21-0400\n"
+"POT-Creation-Date: 2026-07-26 12:03-0400\n"
 "PO-Revision-Date: 2026-01-10 14:36+0000\n"
 "Last-Translator: Samuvel Paul <samuvalpaul@outlook.com>\n"
 "Language-Team: Malayalam <https://translate.jellyfin.org/projects/jellyfin/"
@@ -252,7 +252,7 @@ msgid "Select Subtitle Track"
 msgstr ""
 
 #: jellyfin_mpv_shim/menu.py:341
-#: jellyfin_mpv_shim/mpvtk_browser/home_sections.py:102
+#: jellyfin_mpv_shim/mpvtk_browser/home_sections.py:103
 #: jellyfin_mpv_shim/osc_bridge.py:81 jellyfin_mpv_shim/osc_bridge.py:82
 #: jellyfin_mpv_shim/osc_bridge.py:104 jellyfin_mpv_shim/osc_bridge.py:140
 msgid "None"
@@ -403,7 +403,7 @@ msgstr ""
 msgid "Enable thumbnail previews"
 msgstr ""
 
-#: jellyfin_mpv_shim/menu.py:609 jellyfin_mpv_shim/mpvtk_browser/config.py:186
+#: jellyfin_mpv_shim/menu.py:609 jellyfin_mpv_shim/mpvtk_browser/config.py:195
 #: jellyfin_mpv_shim/mpvtk_browser/hud.py:375
 msgid "Night Mode (Auto Volume Adj)"
 msgstr ""
@@ -698,301 +698,325 @@ msgstr ""
 msgid "Or switch to another user"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/cast.py:317
+#: jellyfin_mpv_shim/mpvtk_browser/cast.py:314
 msgid "Ready to cast"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/cast.py:318
+#: jellyfin_mpv_shim/mpvtk_browser/cast.py:315
 #, fuzzy
 #| msgid "Select your media in Jellyfin and play it here"
 msgid "Select your media in Jellyfin and play it here."
 msgstr ""
 "നിങ്ങളുടെ മീഡിയാ ഫയലുകൾ ജെല്ലീഫിന്നിൽ തിരഞ്ഞെടുക്കുകയും അവ ഇവിടെ പ്ലേ ചെയ്യുകയും ചെയ്യുക"
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:74
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:83
 msgid "Interface"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:83
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:92
 msgid "Playback"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:88
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:97
 msgid "Audio"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:92
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:101
 msgid "Subtitles & Languages"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:97
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:106
 msgid "Transcoding"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:102
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:111
 msgid "Video Enhancement"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:104
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:113
 msgid "Skip Intro / Credits"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:107
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:116
 msgid "Library Browser"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:109
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:118
 msgid "Downloads"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:128
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:137
 msgid "Jellyfin UI"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:129
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:138
 msgid "MPV UI with thumbnails"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:130
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:139
 msgid "MPV built-in default"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:133
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:142
 msgid "Follow display"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:134
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:143
 msgid "100% (no scaling)"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:135
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:144
 msgid "125%"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:136
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:145
 msgid "150%"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:137
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:146
 msgid "200%"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:140
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:149
 msgid "Automatic (recommended)"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:141
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:150
 msgid "Vulkan"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:142
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:151
 msgid "Direct3D 11 (Windows only)"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:143
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:152
 msgid "OpenGL (compatibility)"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:146
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:155
 msgid "Default (auto)"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:147
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:156
 msgid "Force Stereo"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:148
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:157
 msgid "Optical Surround"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:149
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:158
 msgid "HDMI Passthrough"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:152
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:161
 msgid "Unset"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:153
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:162
 msgid "Dubbed (shows only)"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:154
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:163
 msgid "Subbed (shows only)"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:155
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:164
 msgid "Dubbed (all)"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:156
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:165
 msgid "Subbed (all)"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:157
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:166
 msgid "Custom (set in config)"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:162
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:171
 msgid "Download Folder"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:163
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:172
 msgid "Prefer Downloaded Copy"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:164
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:173
 msgid "Automatically Download Upcoming Episodes"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:165
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:174
 msgid "Include Next Up"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:166
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:175
 msgid "Next Up Entries to Consider"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:167
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:176
 msgid "Episodes to Keep Ahead (0 = off)"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:168
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:177
 msgid "Storage Limit for Automatic Downloads (GB)"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:169
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:178
 msgid "Delete Automatic Downloads Once Watched"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:170
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:179
 msgid "Delete Unwatched After (days, 0 = never)"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:171
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:180
 msgid "Check Every (minutes)"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:172
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:181
 msgid "Close to Tray (keep running)"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:173
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:182
 msgid "Keep Running in Background"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:174
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:183
 msgid "Remember Window Size"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:175
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:184
 msgid "Player Controls Style"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:176
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:185
 msgid "Show What You're Watching in Discord"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:177
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:186
 msgid "Interface Scale"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:178
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:187
 msgid "Cast-target mode (no library browsing)"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:179
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:188
 msgid "Casting Opens the Library Browser"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:180
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:189
 msgid "Fullscreen Library Browser"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:181
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:190
 msgid "Always Bind Arrow Keys to Player Controls"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:182
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:191
 msgid "Player Controls Activation Key"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:183
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:192
 msgid "Audio Output Mode"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:184
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:193
 msgid "Audio Output Device"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:185
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:194
 msgid "Take the Device Exclusively"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:187
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:196
 msgid "Enable Video Playback Profiles"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:188
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:197
 msgid "Profile Group"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:189
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:198
 msgid "Remember Last Used Profile"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:190
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:199
 msgid "Graphics API for Shaders"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:191
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:200
 msgid "Pass Through AC3"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:192
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:201
 msgid "Pass Through DTS"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:193
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:202
 msgid "Pass Through E-AC3"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:194
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:203
 msgid "Pass Through DTS-HD"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:195
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:204
 msgid "Pass Through TrueHD"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:196
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:205
 msgid "Re-encode Others to AC3"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:202
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:213
 msgid ""
-"MPV keybinds are used by default. Press ENTER to drive the player controls "
-"by keyboard."
+"With \"Start Minimized\" and \"Fullscreen\" this is the classic cast-target "
+"setup: the app waits out of the way, plays fullscreen when something casts "
+"to it, and goes back to waiting when the video ends or you press Q."
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:204
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:227
+msgid ""
+"Off means command-line mode: no window, no system tray and no settings "
+"screen, so the only way back is editing conf.json by hand. It is not how you "
+"get MPV's own on-screen controls — \"Player Controls Style\" under Interface "
+"does that."
+msgstr ""
+
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:234
+msgid ""
+"Show only what is cast to this machine — the library, including this "
+"settings screen, can't be reached from here. Without a system tray icon the "
+"only way back is editing conf.json. For the classic cast-target setup you "
+"want the Interface settings instead; this is for a shared TV nobody should "
+"be able to browse from."
+msgstr ""
+
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:240
+msgid ""
+"Requires restart to change. MPV keybinds are used by default. Press ENTER to "
+"drive the player controls by keyboard."
+msgstr ""
+
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:242
 msgid ""
 "Pixels one wheel notch scrolls. The scrollbar glides while the content snaps "
 "to the nearest row, so a trackpad or trackball no longer overshoots. Raise "
 "it to scroll faster, lower it for finer control."
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:209
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:247
 msgid ""
 "Make each wheel notch jump exactly one row (or one home-screen section) "
 "instead of gliding. Turn this on if you prefer the older stepped scrolling."
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:217
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:255
 msgid "Discord Rich Presence. Takes effect after a restart."
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:219
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:257
 msgid ""
 "Leave this to Default unless setting up passthrough. Note some audio servers "
 "like Pipewire don't like passthrough and will need to be disabled for a card "
@@ -1000,57 +1024,57 @@ msgid ""
 "silence otherwise, but results may vary."
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:225
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:263
 msgid ""
 "Stop anything else using the device while playing. Needed for passthrough on "
 "some systems, and it means other applications will be silent."
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:228
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:266
 msgid ""
 "Page the library and music tile grids instead of scrolling: each page is one "
 "screenful with First / Previous / Next / Last controls and a page number you "
 "can type into. Easier than precise scrolling on a trackpad."
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:232
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:270
 msgid ""
 "Takes effect after a restart. \"Follow display\" uses the scale your desktop "
 "reports, which is 100% on X11."
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:234
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:272
 msgid ""
 "\"Default\" changes nothing and lets MPV (and your own mpv.conf) decide. "
 "Pick a mode only if you are sending audio to a receiver."
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:237
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:275
 msgid ""
 "Audio your receiver can't be sent directly is encoded to AC3, which is the "
 "only way surround fits down an optical cable. Turn this off if the encoder "
 "causes audio delay — those tracks become stereo instead."
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:242
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:280
 msgid ""
 "\"hq\" offers heavier profiles. Pick it if you have a fast graphics card."
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:244
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:282
 msgid ""
 "Leave on Automatic unless video breaks when a profile is loaded. This only "
 "applies while a profile is active, and OpenGL can cost you HDR output."
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:248
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:286
 msgid ""
 "Evens out loud effects and quiet dialogue. This turns passthrough off while "
 "it is enabled, because the volume has to be adjusted before your receiver "
 "gets the audio."
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:330
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:368
 msgid "Advanced"
 msgstr ""
 
@@ -1254,7 +1278,7 @@ msgid "Automatic"
 msgstr ""
 
 #: jellyfin_mpv_shim/mpvtk_browser/downloads.py:51
-#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1355
+#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1288
 msgid "Episodes"
 msgstr ""
 
@@ -1263,7 +1287,7 @@ msgid "Season %s"
 msgstr ""
 
 #: jellyfin_mpv_shim/mpvtk_browser/downloads.py:52
-#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1351
+#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1284
 msgid "Specials"
 msgstr ""
 
@@ -1286,7 +1310,7 @@ msgid "Failed"
 msgstr "പരാജയം"
 
 #: jellyfin_mpv_shim/mpvtk_browser/downloads.py:185
-#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1105
+#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1038
 msgid "Playlist"
 msgstr ""
 
@@ -1298,30 +1322,30 @@ msgstr ""
 msgid "Movies & Videos"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/home_sections.py:103
+#: jellyfin_mpv_shim/mpvtk_browser/home_sections.py:104
 msgid "My Media"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/home_sections.py:104
-#: jellyfin_mpv_shim/mpvtk_browser/repository.py:352
+#: jellyfin_mpv_shim/mpvtk_browser/home_sections.py:105
+#: jellyfin_mpv_shim/mpvtk_browser/repository.py:350
 msgid "Continue Watching"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/home_sections.py:105
-#: jellyfin_mpv_shim/mpvtk_browser/repository.py:359
+#: jellyfin_mpv_shim/mpvtk_browser/home_sections.py:106
+#: jellyfin_mpv_shim/mpvtk_browser/repository.py:357
 msgid "Continue Listening"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/home_sections.py:106
-#: jellyfin_mpv_shim/mpvtk_browser/repository.py:366
+#: jellyfin_mpv_shim/mpvtk_browser/home_sections.py:107
+#: jellyfin_mpv_shim/mpvtk_browser/repository.py:364
 msgid "Next Up"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/home_sections.py:107
+#: jellyfin_mpv_shim/mpvtk_browser/home_sections.py:108
 msgid "Recently Added"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/home_sections.py:108
+#: jellyfin_mpv_shim/mpvtk_browser/home_sections.py:109
 msgid "Live TV"
 msgstr ""
 
@@ -1558,52 +1582,52 @@ msgstr ""
 "സെർവർ ചേർക്കാൻ സാധിച്ചില്ല.\n"
 "ദയവായി നിങ്ങളുടെ ഇന്റർനെറ്റുമായി ബന്ധപ്പെട്ട വിവരങ്ങൾ പരിശോധിക്കുക."
 
-#: jellyfin_mpv_shim/mpvtk_browser/repository.py:390
+#: jellyfin_mpv_shim/mpvtk_browser/repository.py:386
 msgid "On Now"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/repository.py:411
+#: jellyfin_mpv_shim/mpvtk_browser/repository.py:407
 msgid "Latest %s"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1119
+#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1052
 msgid "Downloaded"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1138
+#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1071
 msgid "Movies"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1143
+#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1076
 msgid "Videos"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1147
+#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1080
 msgid "TV Shows"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1151
+#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1084
 msgid "Playlists"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1168
-#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1441
+#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1101
+#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1374
 msgid "Series"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1212
+#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1145
 msgid "Downloaded Movies"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1216
+#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1149
 msgid "Downloaded Videos"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1220
+#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1153
 msgid "Downloaded Shows"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1353
+#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1286
 msgid "Season %d"
 msgstr ""
 

--- a/jellyfin_mpv_shim/messages/mn/LC_MESSAGES/base.po
+++ b/jellyfin_mpv_shim/messages/mn/LC_MESSAGES/base.po
@@ -5,7 +5,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2026-07-25 17:21-0400\n"
+"POT-Creation-Date: 2026-07-26 12:03-0400\n"
 "PO-Revision-Date: 2025-10-29 22:47+0000\n"
 "Last-Translator: Battseren Badral <bbattseren88@gmail.com>\n"
 "Language-Team: Mongolian <https://translate.jellyfin.org/projects/jellyfin/"
@@ -252,7 +252,7 @@ msgid "Select Subtitle Track"
 msgstr "Хадмал орчуулгыг сонгоно уу"
 
 #: jellyfin_mpv_shim/menu.py:341
-#: jellyfin_mpv_shim/mpvtk_browser/home_sections.py:102
+#: jellyfin_mpv_shim/mpvtk_browser/home_sections.py:103
 #: jellyfin_mpv_shim/osc_bridge.py:81 jellyfin_mpv_shim/osc_bridge.py:82
 #: jellyfin_mpv_shim/osc_bridge.py:104 jellyfin_mpv_shim/osc_bridge.py:140
 msgid "None"
@@ -403,7 +403,7 @@ msgstr "Кредитыг алгасах эсэхийг асууx"
 msgid "Enable thumbnail previews"
 msgstr "Жижиг зургуудын урьдчилсан харагдац идэвхжүүлэх"
 
-#: jellyfin_mpv_shim/menu.py:609 jellyfin_mpv_shim/mpvtk_browser/config.py:186
+#: jellyfin_mpv_shim/menu.py:609 jellyfin_mpv_shim/mpvtk_browser/config.py:195
 #: jellyfin_mpv_shim/mpvtk_browser/hud.py:375
 msgid "Night Mode (Auto Volume Adj)"
 msgstr ""
@@ -702,310 +702,334 @@ msgstr ""
 msgid "Or switch to another user"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/cast.py:317
+#: jellyfin_mpv_shim/mpvtk_browser/cast.py:314
 msgid "Ready to cast"
 msgstr "Дамжуулахад бэлэн"
 
-#: jellyfin_mpv_shim/mpvtk_browser/cast.py:318
+#: jellyfin_mpv_shim/mpvtk_browser/cast.py:315
 #, fuzzy
 #| msgid "Select your media in Jellyfin and play it here"
 msgid "Select your media in Jellyfin and play it here."
 msgstr "Jellyfin медиа дотроос сонгоод энд тоглуулаарай"
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:74
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:83
 msgid "Interface"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:83
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:92
 msgid "Playback"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:88
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:97
 msgid "Audio"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:92
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:101
 msgid "Subtitles & Languages"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:97
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:106
 #, fuzzy
 #| msgid " (Transcode)"
 msgid "Transcoding"
 msgstr " (Хувиргах)"
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:102
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:111
 msgid "Video Enhancement"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:104
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:113
 #, fuzzy
 #| msgid "Seek to Skip Credits"
 msgid "Skip Intro / Credits"
 msgstr "Кредитыг алгасахаар шууд шилжих"
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:107
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:116
 msgid "Library Browser"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:109
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:118
 msgid "Downloads"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:128
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:137
 msgid "Jellyfin UI"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:129
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:138
 msgid "MPV UI with thumbnails"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:130
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:139
 msgid "MPV built-in default"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:133
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:142
 msgid "Follow display"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:134
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:143
 msgid "100% (no scaling)"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:135
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:144
 msgid "125%"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:136
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:145
 msgid "150%"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:137
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:146
 msgid "200%"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:140
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:149
 msgid "Automatic (recommended)"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:141
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:150
 msgid "Vulkan"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:142
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:151
 msgid "Direct3D 11 (Windows only)"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:143
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:152
 msgid "OpenGL (compatibility)"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:146
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:155
 msgid "Default (auto)"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:147
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:156
 msgid "Force Stereo"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:148
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:157
 msgid "Optical Surround"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:149
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:158
 msgid "HDMI Passthrough"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:152
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:161
 msgid "Unset"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:153
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:162
 msgid "Dubbed (shows only)"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:154
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:163
 msgid "Subbed (shows only)"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:155
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:164
 msgid "Dubbed (all)"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:156
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:165
 msgid "Subbed (all)"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:157
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:166
 msgid "Custom (set in config)"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:162
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:171
 msgid "Download Folder"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:163
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:172
 msgid "Prefer Downloaded Copy"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:164
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:173
 msgid "Automatically Download Upcoming Episodes"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:165
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:174
 msgid "Include Next Up"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:166
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:175
 msgid "Next Up Entries to Consider"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:167
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:176
 msgid "Episodes to Keep Ahead (0 = off)"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:168
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:177
 msgid "Storage Limit for Automatic Downloads (GB)"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:169
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:178
 #, fuzzy
 #| msgid "Remove Server"
 msgid "Delete Automatic Downloads Once Watched"
 msgstr "Серверийг устгах"
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:170
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:179
 msgid "Delete Unwatched After (days, 0 = never)"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:171
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:180
 msgid "Check Every (minutes)"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:172
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:181
 msgid "Close to Tray (keep running)"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:173
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:182
 msgid "Keep Running in Background"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:174
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:183
 msgid "Remember Window Size"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:175
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:184
 msgid "Player Controls Style"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:176
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:185
 msgid "Show What You're Watching in Discord"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:177
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:186
 msgid "Interface Scale"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:178
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:187
 msgid "Cast-target mode (no library browsing)"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:179
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:188
 msgid "Casting Opens the Library Browser"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:180
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:189
 msgid "Fullscreen Library Browser"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:181
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:190
 msgid "Always Bind Arrow Keys to Player Controls"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:182
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:191
 msgid "Player Controls Activation Key"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:183
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:192
 msgid "Audio Output Mode"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:184
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:193
 msgid "Audio Output Device"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:185
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:194
 msgid "Take the Device Exclusively"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:187
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:196
 #, fuzzy
 #| msgid "Video Playback Profiles"
 msgid "Enable Video Playback Profiles"
 msgstr "Видео тоглуулах профайл"
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:188
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:197
 #, fuzzy
 #| msgid "New Group"
 msgid "Profile Group"
 msgstr "Шинэ бүлэг"
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:189
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:198
 msgid "Remember Last Used Profile"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:190
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:199
 msgid "Graphics API for Shaders"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:191
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:200
 msgid "Pass Through AC3"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:192
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:201
 msgid "Pass Through DTS"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:193
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:202
 msgid "Pass Through E-AC3"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:194
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:203
 msgid "Pass Through DTS-HD"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:195
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:204
 msgid "Pass Through TrueHD"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:196
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:205
 msgid "Re-encode Others to AC3"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:202
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:213
 msgid ""
-"MPV keybinds are used by default. Press ENTER to drive the player controls "
-"by keyboard."
+"With \"Start Minimized\" and \"Fullscreen\" this is the classic cast-target "
+"setup: the app waits out of the way, plays fullscreen when something casts "
+"to it, and goes back to waiting when the video ends or you press Q."
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:204
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:227
+msgid ""
+"Off means command-line mode: no window, no system tray and no settings "
+"screen, so the only way back is editing conf.json by hand. It is not how you "
+"get MPV's own on-screen controls — \"Player Controls Style\" under Interface "
+"does that."
+msgstr ""
+
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:234
+msgid ""
+"Show only what is cast to this machine — the library, including this "
+"settings screen, can't be reached from here. Without a system tray icon the "
+"only way back is editing conf.json. For the classic cast-target setup you "
+"want the Interface settings instead; this is for a shared TV nobody should "
+"be able to browse from."
+msgstr ""
+
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:240
+msgid ""
+"Requires restart to change. MPV keybinds are used by default. Press ENTER to "
+"drive the player controls by keyboard."
+msgstr ""
+
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:242
 msgid ""
 "Pixels one wheel notch scrolls. The scrollbar glides while the content snaps "
 "to the nearest row, so a trackpad or trackball no longer overshoots. Raise "
 "it to scroll faster, lower it for finer control."
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:209
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:247
 msgid ""
 "Make each wheel notch jump exactly one row (or one home-screen section) "
 "instead of gliding. Turn this on if you prefer the older stepped scrolling."
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:217
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:255
 msgid "Discord Rich Presence. Takes effect after a restart."
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:219
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:257
 msgid ""
 "Leave this to Default unless setting up passthrough. Note some audio servers "
 "like Pipewire don't like passthrough and will need to be disabled for a card "
@@ -1013,57 +1037,57 @@ msgid ""
 "silence otherwise, but results may vary."
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:225
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:263
 msgid ""
 "Stop anything else using the device while playing. Needed for passthrough on "
 "some systems, and it means other applications will be silent."
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:228
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:266
 msgid ""
 "Page the library and music tile grids instead of scrolling: each page is one "
 "screenful with First / Previous / Next / Last controls and a page number you "
 "can type into. Easier than precise scrolling on a trackpad."
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:232
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:270
 msgid ""
 "Takes effect after a restart. \"Follow display\" uses the scale your desktop "
 "reports, which is 100% on X11."
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:234
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:272
 msgid ""
 "\"Default\" changes nothing and lets MPV (and your own mpv.conf) decide. "
 "Pick a mode only if you are sending audio to a receiver."
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:237
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:275
 msgid ""
 "Audio your receiver can't be sent directly is encoded to AC3, which is the "
 "only way surround fits down an optical cable. Turn this off if the encoder "
 "causes audio delay — those tracks become stereo instead."
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:242
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:280
 msgid ""
 "\"hq\" offers heavier profiles. Pick it if you have a fast graphics card."
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:244
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:282
 msgid ""
 "Leave on Automatic unless video breaks when a profile is loaded. This only "
 "applies while a profile is active, and OpenGL can cost you HDR output."
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:248
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:286
 msgid ""
 "Evens out loud effects and quiet dialogue. This turns passthrough off while "
 "it is enabled, because the volume has to be adjusted before your receiver "
 "gets the audio."
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:330
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:368
 msgid "Advanced"
 msgstr ""
 
@@ -1289,7 +1313,7 @@ msgid "Automatic"
 msgstr "Автомат"
 
 #: jellyfin_mpv_shim/mpvtk_browser/downloads.py:51
-#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1355
+#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1288
 msgid "Episodes"
 msgstr ""
 
@@ -1298,7 +1322,7 @@ msgid "Season %s"
 msgstr ""
 
 #: jellyfin_mpv_shim/mpvtk_browser/downloads.py:52
-#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1351
+#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1284
 msgid "Specials"
 msgstr ""
 
@@ -1323,7 +1347,7 @@ msgid "Failed"
 msgstr "Амжилтгүй"
 
 #: jellyfin_mpv_shim/mpvtk_browser/downloads.py:185
-#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1105
+#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1038
 msgid "Playlist"
 msgstr ""
 
@@ -1335,30 +1359,30 @@ msgstr ""
 msgid "Movies & Videos"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/home_sections.py:103
+#: jellyfin_mpv_shim/mpvtk_browser/home_sections.py:104
 msgid "My Media"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/home_sections.py:104
-#: jellyfin_mpv_shim/mpvtk_browser/repository.py:352
+#: jellyfin_mpv_shim/mpvtk_browser/home_sections.py:105
+#: jellyfin_mpv_shim/mpvtk_browser/repository.py:350
 msgid "Continue Watching"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/home_sections.py:105
-#: jellyfin_mpv_shim/mpvtk_browser/repository.py:359
+#: jellyfin_mpv_shim/mpvtk_browser/home_sections.py:106
+#: jellyfin_mpv_shim/mpvtk_browser/repository.py:357
 msgid "Continue Listening"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/home_sections.py:106
-#: jellyfin_mpv_shim/mpvtk_browser/repository.py:366
+#: jellyfin_mpv_shim/mpvtk_browser/home_sections.py:107
+#: jellyfin_mpv_shim/mpvtk_browser/repository.py:364
 msgid "Next Up"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/home_sections.py:107
+#: jellyfin_mpv_shim/mpvtk_browser/home_sections.py:108
 msgid "Recently Added"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/home_sections.py:108
+#: jellyfin_mpv_shim/mpvtk_browser/home_sections.py:109
 msgid "Live TV"
 msgstr ""
 
@@ -1611,52 +1635,52 @@ msgstr ""
 "Сервер нэмж чадсангүй.\n"
 "Холболтоо шалгана уу."
 
-#: jellyfin_mpv_shim/mpvtk_browser/repository.py:390
+#: jellyfin_mpv_shim/mpvtk_browser/repository.py:386
 msgid "On Now"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/repository.py:411
+#: jellyfin_mpv_shim/mpvtk_browser/repository.py:407
 msgid "Latest %s"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1119
+#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1052
 msgid "Downloaded"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1138
+#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1071
 msgid "Movies"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1143
+#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1076
 msgid "Videos"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1147
+#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1080
 msgid "TV Shows"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1151
+#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1084
 msgid "Playlists"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1168
-#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1441
+#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1101
+#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1374
 msgid "Series"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1212
+#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1145
 msgid "Downloaded Movies"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1216
+#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1149
 msgid "Downloaded Videos"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1220
+#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1153
 msgid "Downloaded Shows"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1353
+#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1286
 msgid "Season %d"
 msgstr ""
 

--- a/jellyfin_mpv_shim/messages/mr/LC_MESSAGES/base.po
+++ b/jellyfin_mpv_shim/messages/mr/LC_MESSAGES/base.po
@@ -5,7 +5,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2026-07-25 17:21-0400\n"
+"POT-Creation-Date: 2026-07-26 12:03-0400\n"
 "PO-Revision-Date: 2025-12-16 05:55+0000\n"
 "Last-Translator: sabretou <sabretou@gmail.com>\n"
 "Language-Team: Marathi <https://translate.jellyfin.org/projects/jellyfin/"
@@ -244,7 +244,7 @@ msgid "Select Subtitle Track"
 msgstr "सबटायटल ट्रॅक निवडा"
 
 #: jellyfin_mpv_shim/menu.py:341
-#: jellyfin_mpv_shim/mpvtk_browser/home_sections.py:102
+#: jellyfin_mpv_shim/mpvtk_browser/home_sections.py:103
 #: jellyfin_mpv_shim/osc_bridge.py:81 jellyfin_mpv_shim/osc_bridge.py:82
 #: jellyfin_mpv_shim/osc_bridge.py:104 jellyfin_mpv_shim/osc_bridge.py:140
 msgid "None"
@@ -395,7 +395,7 @@ msgstr ""
 msgid "Enable thumbnail previews"
 msgstr ""
 
-#: jellyfin_mpv_shim/menu.py:609 jellyfin_mpv_shim/mpvtk_browser/config.py:186
+#: jellyfin_mpv_shim/menu.py:609 jellyfin_mpv_shim/mpvtk_browser/config.py:195
 #: jellyfin_mpv_shim/mpvtk_browser/hud.py:375
 msgid "Night Mode (Auto Volume Adj)"
 msgstr ""
@@ -668,304 +668,328 @@ msgstr ""
 msgid "Or switch to another user"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/cast.py:317
+#: jellyfin_mpv_shim/mpvtk_browser/cast.py:314
 msgid "Ready to cast"
 msgstr "कास्ट करण्यास तयार"
 
-#: jellyfin_mpv_shim/mpvtk_browser/cast.py:318
+#: jellyfin_mpv_shim/mpvtk_browser/cast.py:315
 msgid "Select your media in Jellyfin and play it here."
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:74
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:83
 msgid "Interface"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:83
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:92
 msgid "Playback"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:88
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:97
 msgid "Audio"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:92
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:101
 msgid "Subtitles & Languages"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:97
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:106
 #, fuzzy
 #| msgid "No Transcode"
 msgid "Transcoding"
 msgstr "ट्रान्सकोड नको"
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:102
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:111
 msgid "Video Enhancement"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:104
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:113
 msgid "Skip Intro / Credits"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:107
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:116
 msgid "Library Browser"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:109
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:118
 msgid "Downloads"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:128
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:137
 msgid "Jellyfin UI"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:129
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:138
 msgid "MPV UI with thumbnails"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:130
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:139
 msgid "MPV built-in default"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:133
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:142
 msgid "Follow display"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:134
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:143
 msgid "100% (no scaling)"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:135
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:144
 msgid "125%"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:136
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:145
 msgid "150%"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:137
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:146
 msgid "200%"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:140
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:149
 msgid "Automatic (recommended)"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:141
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:150
 msgid "Vulkan"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:142
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:151
 msgid "Direct3D 11 (Windows only)"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:143
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:152
 msgid "OpenGL (compatibility)"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:146
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:155
 msgid "Default (auto)"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:147
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:156
 msgid "Force Stereo"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:148
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:157
 msgid "Optical Surround"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:149
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:158
 msgid "HDMI Passthrough"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:152
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:161
 msgid "Unset"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:153
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:162
 msgid "Dubbed (shows only)"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:154
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:163
 msgid "Subbed (shows only)"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:155
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:164
 msgid "Dubbed (all)"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:156
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:165
 msgid "Subbed (all)"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:157
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:166
 msgid "Custom (set in config)"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:162
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:171
 msgid "Download Folder"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:163
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:172
 msgid "Prefer Downloaded Copy"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:164
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:173
 msgid "Automatically Download Upcoming Episodes"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:165
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:174
 msgid "Include Next Up"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:166
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:175
 msgid "Next Up Entries to Consider"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:167
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:176
 msgid "Episodes to Keep Ahead (0 = off)"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:168
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:177
 msgid "Storage Limit for Automatic Downloads (GB)"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:169
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:178
 #, fuzzy
 #| msgid "Remove Server"
 msgid "Delete Automatic Downloads Once Watched"
 msgstr "सर्व्हर काढून टाका"
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:170
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:179
 msgid "Delete Unwatched After (days, 0 = never)"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:171
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:180
 msgid "Check Every (minutes)"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:172
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:181
 msgid "Close to Tray (keep running)"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:173
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:182
 msgid "Keep Running in Background"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:174
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:183
 msgid "Remember Window Size"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:175
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:184
 msgid "Player Controls Style"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:176
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:185
 msgid "Show What You're Watching in Discord"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:177
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:186
 msgid "Interface Scale"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:178
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:187
 msgid "Cast-target mode (no library browsing)"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:179
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:188
 msgid "Casting Opens the Library Browser"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:180
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:189
 msgid "Fullscreen Library Browser"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:181
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:190
 msgid "Always Bind Arrow Keys to Player Controls"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:182
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:191
 msgid "Player Controls Activation Key"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:183
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:192
 msgid "Audio Output Mode"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:184
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:193
 msgid "Audio Output Device"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:185
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:194
 msgid "Take the Device Exclusively"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:187
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:196
 msgid "Enable Video Playback Profiles"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:188
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:197
 #, fuzzy
 #| msgid "New Group"
 msgid "Profile Group"
 msgstr "नवीन गट"
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:189
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:198
 msgid "Remember Last Used Profile"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:190
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:199
 msgid "Graphics API for Shaders"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:191
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:200
 msgid "Pass Through AC3"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:192
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:201
 msgid "Pass Through DTS"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:193
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:202
 msgid "Pass Through E-AC3"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:194
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:203
 msgid "Pass Through DTS-HD"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:195
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:204
 msgid "Pass Through TrueHD"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:196
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:205
 msgid "Re-encode Others to AC3"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:202
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:213
 msgid ""
-"MPV keybinds are used by default. Press ENTER to drive the player controls "
-"by keyboard."
+"With \"Start Minimized\" and \"Fullscreen\" this is the classic cast-target "
+"setup: the app waits out of the way, plays fullscreen when something casts "
+"to it, and goes back to waiting when the video ends or you press Q."
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:204
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:227
+msgid ""
+"Off means command-line mode: no window, no system tray and no settings "
+"screen, so the only way back is editing conf.json by hand. It is not how you "
+"get MPV's own on-screen controls — \"Player Controls Style\" under Interface "
+"does that."
+msgstr ""
+
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:234
+msgid ""
+"Show only what is cast to this machine — the library, including this "
+"settings screen, can't be reached from here. Without a system tray icon the "
+"only way back is editing conf.json. For the classic cast-target setup you "
+"want the Interface settings instead; this is for a shared TV nobody should "
+"be able to browse from."
+msgstr ""
+
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:240
+msgid ""
+"Requires restart to change. MPV keybinds are used by default. Press ENTER to "
+"drive the player controls by keyboard."
+msgstr ""
+
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:242
 msgid ""
 "Pixels one wheel notch scrolls. The scrollbar glides while the content snaps "
 "to the nearest row, so a trackpad or trackball no longer overshoots. Raise "
 "it to scroll faster, lower it for finer control."
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:209
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:247
 msgid ""
 "Make each wheel notch jump exactly one row (or one home-screen section) "
 "instead of gliding. Turn this on if you prefer the older stepped scrolling."
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:217
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:255
 msgid "Discord Rich Presence. Takes effect after a restart."
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:219
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:257
 msgid ""
 "Leave this to Default unless setting up passthrough. Note some audio servers "
 "like Pipewire don't like passthrough and will need to be disabled for a card "
@@ -973,57 +997,57 @@ msgid ""
 "silence otherwise, but results may vary."
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:225
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:263
 msgid ""
 "Stop anything else using the device while playing. Needed for passthrough on "
 "some systems, and it means other applications will be silent."
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:228
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:266
 msgid ""
 "Page the library and music tile grids instead of scrolling: each page is one "
 "screenful with First / Previous / Next / Last controls and a page number you "
 "can type into. Easier than precise scrolling on a trackpad."
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:232
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:270
 msgid ""
 "Takes effect after a restart. \"Follow display\" uses the scale your desktop "
 "reports, which is 100% on X11."
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:234
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:272
 msgid ""
 "\"Default\" changes nothing and lets MPV (and your own mpv.conf) decide. "
 "Pick a mode only if you are sending audio to a receiver."
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:237
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:275
 msgid ""
 "Audio your receiver can't be sent directly is encoded to AC3, which is the "
 "only way surround fits down an optical cable. Turn this off if the encoder "
 "causes audio delay — those tracks become stereo instead."
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:242
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:280
 msgid ""
 "\"hq\" offers heavier profiles. Pick it if you have a fast graphics card."
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:244
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:282
 msgid ""
 "Leave on Automatic unless video breaks when a profile is loaded. This only "
 "applies while a profile is active, and OpenGL can cost you HDR output."
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:248
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:286
 msgid ""
 "Evens out loud effects and quiet dialogue. This turns passthrough off while "
 "it is enabled, because the volume has to be adjusted before your receiver "
 "gets the audio."
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:330
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:368
 msgid "Advanced"
 msgstr ""
 
@@ -1221,7 +1245,7 @@ msgid "Automatic"
 msgstr "आपोआप"
 
 #: jellyfin_mpv_shim/mpvtk_browser/downloads.py:51
-#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1355
+#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1288
 msgid "Episodes"
 msgstr ""
 
@@ -1230,7 +1254,7 @@ msgid "Season %s"
 msgstr ""
 
 #: jellyfin_mpv_shim/mpvtk_browser/downloads.py:52
-#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1351
+#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1284
 msgid "Specials"
 msgstr ""
 
@@ -1255,7 +1279,7 @@ msgid "Failed"
 msgstr "अपयशी"
 
 #: jellyfin_mpv_shim/mpvtk_browser/downloads.py:185
-#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1105
+#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1038
 msgid "Playlist"
 msgstr ""
 
@@ -1267,30 +1291,30 @@ msgstr ""
 msgid "Movies & Videos"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/home_sections.py:103
+#: jellyfin_mpv_shim/mpvtk_browser/home_sections.py:104
 msgid "My Media"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/home_sections.py:104
-#: jellyfin_mpv_shim/mpvtk_browser/repository.py:352
+#: jellyfin_mpv_shim/mpvtk_browser/home_sections.py:105
+#: jellyfin_mpv_shim/mpvtk_browser/repository.py:350
 msgid "Continue Watching"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/home_sections.py:105
-#: jellyfin_mpv_shim/mpvtk_browser/repository.py:359
+#: jellyfin_mpv_shim/mpvtk_browser/home_sections.py:106
+#: jellyfin_mpv_shim/mpvtk_browser/repository.py:357
 msgid "Continue Listening"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/home_sections.py:106
-#: jellyfin_mpv_shim/mpvtk_browser/repository.py:366
+#: jellyfin_mpv_shim/mpvtk_browser/home_sections.py:107
+#: jellyfin_mpv_shim/mpvtk_browser/repository.py:364
 msgid "Next Up"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/home_sections.py:107
+#: jellyfin_mpv_shim/mpvtk_browser/home_sections.py:108
 msgid "Recently Added"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/home_sections.py:108
+#: jellyfin_mpv_shim/mpvtk_browser/home_sections.py:109
 msgid "Live TV"
 msgstr ""
 
@@ -1517,52 +1541,52 @@ msgstr ""
 msgid "Could not load this page."
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/repository.py:390
+#: jellyfin_mpv_shim/mpvtk_browser/repository.py:386
 msgid "On Now"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/repository.py:411
+#: jellyfin_mpv_shim/mpvtk_browser/repository.py:407
 msgid "Latest %s"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1119
+#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1052
 msgid "Downloaded"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1138
+#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1071
 msgid "Movies"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1143
+#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1076
 msgid "Videos"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1147
+#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1080
 msgid "TV Shows"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1151
+#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1084
 msgid "Playlists"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1168
-#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1441
+#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1101
+#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1374
 msgid "Series"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1212
+#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1145
 msgid "Downloaded Movies"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1216
+#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1149
 msgid "Downloaded Videos"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1220
+#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1153
 msgid "Downloaded Shows"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1353
+#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1286
 msgid "Season %d"
 msgstr ""
 

--- a/jellyfin_mpv_shim/messages/ms/LC_MESSAGES/base.po
+++ b/jellyfin_mpv_shim/messages/ms/LC_MESSAGES/base.po
@@ -5,7 +5,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2026-07-25 17:21-0400\n"
+"POT-Creation-Date: 2026-07-26 12:03-0400\n"
 "PO-Revision-Date: 2025-11-15 02:16+0000\n"
 "Last-Translator: Gopinath Muruti <gopinath.muruti@gmail.com>\n"
 "Language-Team: Malay <https://translate.jellyfin.org/projects/jellyfin/"
@@ -252,7 +252,7 @@ msgid "Select Subtitle Track"
 msgstr ""
 
 #: jellyfin_mpv_shim/menu.py:341
-#: jellyfin_mpv_shim/mpvtk_browser/home_sections.py:102
+#: jellyfin_mpv_shim/mpvtk_browser/home_sections.py:103
 #: jellyfin_mpv_shim/osc_bridge.py:81 jellyfin_mpv_shim/osc_bridge.py:82
 #: jellyfin_mpv_shim/osc_bridge.py:104 jellyfin_mpv_shim/osc_bridge.py:140
 msgid "None"
@@ -403,7 +403,7 @@ msgstr ""
 msgid "Enable thumbnail previews"
 msgstr ""
 
-#: jellyfin_mpv_shim/menu.py:609 jellyfin_mpv_shim/mpvtk_browser/config.py:186
+#: jellyfin_mpv_shim/menu.py:609 jellyfin_mpv_shim/mpvtk_browser/config.py:195
 #: jellyfin_mpv_shim/mpvtk_browser/hud.py:375
 msgid "Night Mode (Auto Volume Adj)"
 msgstr ""
@@ -700,304 +700,328 @@ msgstr ""
 msgid "Or switch to another user"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/cast.py:317
+#: jellyfin_mpv_shim/mpvtk_browser/cast.py:314
 msgid "Ready to cast"
 msgstr "Sedia untuk pemancaran"
 
-#: jellyfin_mpv_shim/mpvtk_browser/cast.py:318
+#: jellyfin_mpv_shim/mpvtk_browser/cast.py:315
 #, fuzzy
 #| msgid "Select your media in Jellyfin and play it here"
 msgid "Select your media in Jellyfin and play it here."
 msgstr "Pilih media anda dalam Jellyfin dan mainkannya di sini"
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:74
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:83
 msgid "Interface"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:83
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:92
 msgid "Playback"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:88
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:97
 msgid "Audio"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:92
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:101
 msgid "Subtitles & Languages"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:97
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:106
 #, fuzzy
 #| msgid " (Transcode)"
 msgid "Transcoding"
 msgstr " (Transkod)"
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:102
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:111
 msgid "Video Enhancement"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:104
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:113
 msgid "Skip Intro / Credits"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:107
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:116
 msgid "Library Browser"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:109
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:118
 msgid "Downloads"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:128
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:137
 msgid "Jellyfin UI"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:129
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:138
 msgid "MPV UI with thumbnails"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:130
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:139
 msgid "MPV built-in default"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:133
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:142
 msgid "Follow display"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:134
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:143
 msgid "100% (no scaling)"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:135
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:144
 msgid "125%"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:136
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:145
 msgid "150%"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:137
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:146
 msgid "200%"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:140
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:149
 msgid "Automatic (recommended)"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:141
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:150
 msgid "Vulkan"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:142
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:151
 msgid "Direct3D 11 (Windows only)"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:143
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:152
 msgid "OpenGL (compatibility)"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:146
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:155
 msgid "Default (auto)"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:147
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:156
 msgid "Force Stereo"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:148
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:157
 msgid "Optical Surround"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:149
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:158
 msgid "HDMI Passthrough"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:152
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:161
 msgid "Unset"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:153
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:162
 msgid "Dubbed (shows only)"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:154
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:163
 msgid "Subbed (shows only)"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:155
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:164
 msgid "Dubbed (all)"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:156
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:165
 msgid "Subbed (all)"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:157
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:166
 msgid "Custom (set in config)"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:162
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:171
 msgid "Download Folder"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:163
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:172
 msgid "Prefer Downloaded Copy"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:164
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:173
 msgid "Automatically Download Upcoming Episodes"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:165
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:174
 msgid "Include Next Up"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:166
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:175
 msgid "Next Up Entries to Consider"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:167
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:176
 msgid "Episodes to Keep Ahead (0 = off)"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:168
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:177
 msgid "Storage Limit for Automatic Downloads (GB)"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:169
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:178
 #, fuzzy
 #| msgid "Remove Server"
 msgid "Delete Automatic Downloads Once Watched"
 msgstr "Buang Pelayan"
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:170
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:179
 msgid "Delete Unwatched After (days, 0 = never)"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:171
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:180
 msgid "Check Every (minutes)"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:172
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:181
 msgid "Close to Tray (keep running)"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:173
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:182
 msgid "Keep Running in Background"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:174
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:183
 msgid "Remember Window Size"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:175
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:184
 msgid "Player Controls Style"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:176
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:185
 msgid "Show What You're Watching in Discord"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:177
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:186
 msgid "Interface Scale"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:178
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:187
 msgid "Cast-target mode (no library browsing)"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:179
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:188
 msgid "Casting Opens the Library Browser"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:180
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:189
 msgid "Fullscreen Library Browser"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:181
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:190
 msgid "Always Bind Arrow Keys to Player Controls"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:182
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:191
 msgid "Player Controls Activation Key"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:183
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:192
 msgid "Audio Output Mode"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:184
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:193
 msgid "Audio Output Device"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:185
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:194
 msgid "Take the Device Exclusively"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:187
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:196
 msgid "Enable Video Playback Profiles"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:188
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:197
 msgid "Profile Group"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:189
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:198
 msgid "Remember Last Used Profile"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:190
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:199
 msgid "Graphics API for Shaders"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:191
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:200
 msgid "Pass Through AC3"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:192
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:201
 msgid "Pass Through DTS"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:193
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:202
 msgid "Pass Through E-AC3"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:194
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:203
 msgid "Pass Through DTS-HD"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:195
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:204
 msgid "Pass Through TrueHD"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:196
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:205
 msgid "Re-encode Others to AC3"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:202
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:213
 msgid ""
-"MPV keybinds are used by default. Press ENTER to drive the player controls "
-"by keyboard."
+"With \"Start Minimized\" and \"Fullscreen\" this is the classic cast-target "
+"setup: the app waits out of the way, plays fullscreen when something casts "
+"to it, and goes back to waiting when the video ends or you press Q."
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:204
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:227
+msgid ""
+"Off means command-line mode: no window, no system tray and no settings "
+"screen, so the only way back is editing conf.json by hand. It is not how you "
+"get MPV's own on-screen controls — \"Player Controls Style\" under Interface "
+"does that."
+msgstr ""
+
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:234
+msgid ""
+"Show only what is cast to this machine — the library, including this "
+"settings screen, can't be reached from here. Without a system tray icon the "
+"only way back is editing conf.json. For the classic cast-target setup you "
+"want the Interface settings instead; this is for a shared TV nobody should "
+"be able to browse from."
+msgstr ""
+
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:240
+msgid ""
+"Requires restart to change. MPV keybinds are used by default. Press ENTER to "
+"drive the player controls by keyboard."
+msgstr ""
+
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:242
 msgid ""
 "Pixels one wheel notch scrolls. The scrollbar glides while the content snaps "
 "to the nearest row, so a trackpad or trackball no longer overshoots. Raise "
 "it to scroll faster, lower it for finer control."
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:209
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:247
 msgid ""
 "Make each wheel notch jump exactly one row (or one home-screen section) "
 "instead of gliding. Turn this on if you prefer the older stepped scrolling."
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:217
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:255
 msgid "Discord Rich Presence. Takes effect after a restart."
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:219
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:257
 msgid ""
 "Leave this to Default unless setting up passthrough. Note some audio servers "
 "like Pipewire don't like passthrough and will need to be disabled for a card "
@@ -1005,57 +1029,57 @@ msgid ""
 "silence otherwise, but results may vary."
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:225
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:263
 msgid ""
 "Stop anything else using the device while playing. Needed for passthrough on "
 "some systems, and it means other applications will be silent."
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:228
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:266
 msgid ""
 "Page the library and music tile grids instead of scrolling: each page is one "
 "screenful with First / Previous / Next / Last controls and a page number you "
 "can type into. Easier than precise scrolling on a trackpad."
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:232
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:270
 msgid ""
 "Takes effect after a restart. \"Follow display\" uses the scale your desktop "
 "reports, which is 100% on X11."
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:234
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:272
 msgid ""
 "\"Default\" changes nothing and lets MPV (and your own mpv.conf) decide. "
 "Pick a mode only if you are sending audio to a receiver."
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:237
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:275
 msgid ""
 "Audio your receiver can't be sent directly is encoded to AC3, which is the "
 "only way surround fits down an optical cable. Turn this off if the encoder "
 "causes audio delay — those tracks become stereo instead."
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:242
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:280
 msgid ""
 "\"hq\" offers heavier profiles. Pick it if you have a fast graphics card."
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:244
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:282
 msgid ""
 "Leave on Automatic unless video breaks when a profile is loaded. This only "
 "applies while a profile is active, and OpenGL can cost you HDR output."
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:248
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:286
 msgid ""
 "Evens out loud effects and quiet dialogue. This turns passthrough off while "
 "it is enabled, because the volume has to be adjusted before your receiver "
 "gets the audio."
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:330
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:368
 msgid "Advanced"
 msgstr ""
 
@@ -1269,7 +1293,7 @@ msgid "Automatic"
 msgstr ""
 
 #: jellyfin_mpv_shim/mpvtk_browser/downloads.py:51
-#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1355
+#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1288
 msgid "Episodes"
 msgstr ""
 
@@ -1278,7 +1302,7 @@ msgid "Season %s"
 msgstr ""
 
 #: jellyfin_mpv_shim/mpvtk_browser/downloads.py:52
-#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1351
+#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1284
 msgid "Specials"
 msgstr ""
 
@@ -1303,7 +1327,7 @@ msgid "Failed"
 msgstr "Gagal"
 
 #: jellyfin_mpv_shim/mpvtk_browser/downloads.py:185
-#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1105
+#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1038
 msgid "Playlist"
 msgstr ""
 
@@ -1315,30 +1339,30 @@ msgstr ""
 msgid "Movies & Videos"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/home_sections.py:103
+#: jellyfin_mpv_shim/mpvtk_browser/home_sections.py:104
 msgid "My Media"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/home_sections.py:104
-#: jellyfin_mpv_shim/mpvtk_browser/repository.py:352
+#: jellyfin_mpv_shim/mpvtk_browser/home_sections.py:105
+#: jellyfin_mpv_shim/mpvtk_browser/repository.py:350
 msgid "Continue Watching"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/home_sections.py:105
-#: jellyfin_mpv_shim/mpvtk_browser/repository.py:359
+#: jellyfin_mpv_shim/mpvtk_browser/home_sections.py:106
+#: jellyfin_mpv_shim/mpvtk_browser/repository.py:357
 msgid "Continue Listening"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/home_sections.py:106
-#: jellyfin_mpv_shim/mpvtk_browser/repository.py:366
+#: jellyfin_mpv_shim/mpvtk_browser/home_sections.py:107
+#: jellyfin_mpv_shim/mpvtk_browser/repository.py:364
 msgid "Next Up"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/home_sections.py:107
+#: jellyfin_mpv_shim/mpvtk_browser/home_sections.py:108
 msgid "Recently Added"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/home_sections.py:108
+#: jellyfin_mpv_shim/mpvtk_browser/home_sections.py:109
 msgid "Live TV"
 msgstr ""
 
@@ -1583,52 +1607,52 @@ msgstr ""
 "Tidak dapat menambah pelayan.\n"
 "Sila semak maklumat sambungan anda."
 
-#: jellyfin_mpv_shim/mpvtk_browser/repository.py:390
+#: jellyfin_mpv_shim/mpvtk_browser/repository.py:386
 msgid "On Now"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/repository.py:411
+#: jellyfin_mpv_shim/mpvtk_browser/repository.py:407
 msgid "Latest %s"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1119
+#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1052
 msgid "Downloaded"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1138
+#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1071
 msgid "Movies"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1143
+#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1076
 msgid "Videos"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1147
+#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1080
 msgid "TV Shows"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1151
+#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1084
 msgid "Playlists"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1168
-#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1441
+#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1101
+#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1374
 msgid "Series"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1212
+#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1145
 msgid "Downloaded Movies"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1216
+#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1149
 msgid "Downloaded Videos"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1220
+#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1153
 msgid "Downloaded Shows"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1353
+#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1286
 msgid "Season %d"
 msgstr ""
 

--- a/jellyfin_mpv_shim/messages/nb_NO/LC_MESSAGES/base.po
+++ b/jellyfin_mpv_shim/messages/nb_NO/LC_MESSAGES/base.po
@@ -5,7 +5,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2026-07-25 17:21-0400\n"
+"POT-Creation-Date: 2026-07-26 12:03-0400\n"
 "PO-Revision-Date: 2024-10-11 07:53+0000\n"
 "Last-Translator: BromTeque <github@bromteque.com>\n"
 "Language-Team: Norwegian Bokmål <https://translate.jellyfin.org/projects/"
@@ -252,7 +252,7 @@ msgid "Select Subtitle Track"
 msgstr "Velg tekstspor"
 
 #: jellyfin_mpv_shim/menu.py:341
-#: jellyfin_mpv_shim/mpvtk_browser/home_sections.py:102
+#: jellyfin_mpv_shim/mpvtk_browser/home_sections.py:103
 #: jellyfin_mpv_shim/osc_bridge.py:81 jellyfin_mpv_shim/osc_bridge.py:82
 #: jellyfin_mpv_shim/osc_bridge.py:104 jellyfin_mpv_shim/osc_bridge.py:140
 msgid "None"
@@ -403,7 +403,7 @@ msgstr "Spør om å hoppe over introduksjoner"
 msgid "Enable thumbnail previews"
 msgstr "Aktiver forhåndsvisning av miniatyrbilder"
 
-#: jellyfin_mpv_shim/menu.py:609 jellyfin_mpv_shim/mpvtk_browser/config.py:186
+#: jellyfin_mpv_shim/menu.py:609 jellyfin_mpv_shim/mpvtk_browser/config.py:195
 #: jellyfin_mpv_shim/mpvtk_browser/hud.py:375
 msgid "Night Mode (Auto Volume Adj)"
 msgstr ""
@@ -702,310 +702,334 @@ msgstr ""
 msgid "Or switch to another user"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/cast.py:317
+#: jellyfin_mpv_shim/mpvtk_browser/cast.py:314
 msgid "Ready to cast"
 msgstr "Klar til å caste"
 
-#: jellyfin_mpv_shim/mpvtk_browser/cast.py:318
+#: jellyfin_mpv_shim/mpvtk_browser/cast.py:315
 #, fuzzy
 #| msgid "Select your media in Jellyfin and play it here"
 msgid "Select your media in Jellyfin and play it here."
 msgstr "Velg mediet i Jellyfin og spill det av her"
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:74
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:83
 msgid "Interface"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:83
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:92
 msgid "Playback"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:88
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:97
 msgid "Audio"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:92
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:101
 msgid "Subtitles & Languages"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:97
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:106
 #, fuzzy
 #| msgid " (Transcode)"
 msgid "Transcoding"
 msgstr " (Omkod)"
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:102
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:111
 msgid "Video Enhancement"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:104
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:113
 #, fuzzy
 #| msgid "Seek to Skip Credits"
 msgid "Skip Intro / Credits"
 msgstr "Søk for å hoppe over rulletekst"
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:107
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:116
 msgid "Library Browser"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:109
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:118
 msgid "Downloads"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:128
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:137
 msgid "Jellyfin UI"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:129
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:138
 msgid "MPV UI with thumbnails"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:130
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:139
 msgid "MPV built-in default"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:133
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:142
 msgid "Follow display"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:134
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:143
 msgid "100% (no scaling)"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:135
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:144
 msgid "125%"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:136
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:145
 msgid "150%"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:137
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:146
 msgid "200%"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:140
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:149
 msgid "Automatic (recommended)"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:141
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:150
 msgid "Vulkan"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:142
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:151
 msgid "Direct3D 11 (Windows only)"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:143
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:152
 msgid "OpenGL (compatibility)"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:146
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:155
 msgid "Default (auto)"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:147
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:156
 msgid "Force Stereo"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:148
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:157
 msgid "Optical Surround"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:149
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:158
 msgid "HDMI Passthrough"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:152
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:161
 msgid "Unset"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:153
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:162
 msgid "Dubbed (shows only)"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:154
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:163
 msgid "Subbed (shows only)"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:155
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:164
 msgid "Dubbed (all)"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:156
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:165
 msgid "Subbed (all)"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:157
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:166
 msgid "Custom (set in config)"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:162
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:171
 msgid "Download Folder"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:163
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:172
 msgid "Prefer Downloaded Copy"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:164
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:173
 msgid "Automatically Download Upcoming Episodes"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:165
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:174
 msgid "Include Next Up"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:166
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:175
 msgid "Next Up Entries to Consider"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:167
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:176
 msgid "Episodes to Keep Ahead (0 = off)"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:168
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:177
 msgid "Storage Limit for Automatic Downloads (GB)"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:169
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:178
 #, fuzzy
 #| msgid "Remove Server"
 msgid "Delete Automatic Downloads Once Watched"
 msgstr "Fjern server"
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:170
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:179
 msgid "Delete Unwatched After (days, 0 = never)"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:171
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:180
 msgid "Check Every (minutes)"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:172
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:181
 msgid "Close to Tray (keep running)"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:173
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:182
 msgid "Keep Running in Background"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:174
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:183
 msgid "Remember Window Size"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:175
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:184
 msgid "Player Controls Style"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:176
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:185
 msgid "Show What You're Watching in Discord"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:177
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:186
 msgid "Interface Scale"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:178
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:187
 msgid "Cast-target mode (no library browsing)"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:179
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:188
 msgid "Casting Opens the Library Browser"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:180
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:189
 msgid "Fullscreen Library Browser"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:181
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:190
 msgid "Always Bind Arrow Keys to Player Controls"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:182
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:191
 msgid "Player Controls Activation Key"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:183
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:192
 msgid "Audio Output Mode"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:184
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:193
 msgid "Audio Output Device"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:185
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:194
 msgid "Take the Device Exclusively"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:187
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:196
 #, fuzzy
 #| msgid "Video Playback Profiles"
 msgid "Enable Video Playback Profiles"
 msgstr "Videoavspillingsprofiler"
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:188
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:197
 #, fuzzy
 #| msgid "New Group"
 msgid "Profile Group"
 msgstr "Ny gruppe"
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:189
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:198
 msgid "Remember Last Used Profile"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:190
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:199
 msgid "Graphics API for Shaders"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:191
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:200
 msgid "Pass Through AC3"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:192
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:201
 msgid "Pass Through DTS"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:193
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:202
 msgid "Pass Through E-AC3"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:194
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:203
 msgid "Pass Through DTS-HD"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:195
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:204
 msgid "Pass Through TrueHD"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:196
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:205
 msgid "Re-encode Others to AC3"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:202
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:213
 msgid ""
-"MPV keybinds are used by default. Press ENTER to drive the player controls "
-"by keyboard."
+"With \"Start Minimized\" and \"Fullscreen\" this is the classic cast-target "
+"setup: the app waits out of the way, plays fullscreen when something casts "
+"to it, and goes back to waiting when the video ends or you press Q."
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:204
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:227
+msgid ""
+"Off means command-line mode: no window, no system tray and no settings "
+"screen, so the only way back is editing conf.json by hand. It is not how you "
+"get MPV's own on-screen controls — \"Player Controls Style\" under Interface "
+"does that."
+msgstr ""
+
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:234
+msgid ""
+"Show only what is cast to this machine — the library, including this "
+"settings screen, can't be reached from here. Without a system tray icon the "
+"only way back is editing conf.json. For the classic cast-target setup you "
+"want the Interface settings instead; this is for a shared TV nobody should "
+"be able to browse from."
+msgstr ""
+
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:240
+msgid ""
+"Requires restart to change. MPV keybinds are used by default. Press ENTER to "
+"drive the player controls by keyboard."
+msgstr ""
+
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:242
 msgid ""
 "Pixels one wheel notch scrolls. The scrollbar glides while the content snaps "
 "to the nearest row, so a trackpad or trackball no longer overshoots. Raise "
 "it to scroll faster, lower it for finer control."
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:209
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:247
 msgid ""
 "Make each wheel notch jump exactly one row (or one home-screen section) "
 "instead of gliding. Turn this on if you prefer the older stepped scrolling."
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:217
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:255
 msgid "Discord Rich Presence. Takes effect after a restart."
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:219
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:257
 msgid ""
 "Leave this to Default unless setting up passthrough. Note some audio servers "
 "like Pipewire don't like passthrough and will need to be disabled for a card "
@@ -1013,57 +1037,57 @@ msgid ""
 "silence otherwise, but results may vary."
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:225
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:263
 msgid ""
 "Stop anything else using the device while playing. Needed for passthrough on "
 "some systems, and it means other applications will be silent."
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:228
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:266
 msgid ""
 "Page the library and music tile grids instead of scrolling: each page is one "
 "screenful with First / Previous / Next / Last controls and a page number you "
 "can type into. Easier than precise scrolling on a trackpad."
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:232
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:270
 msgid ""
 "Takes effect after a restart. \"Follow display\" uses the scale your desktop "
 "reports, which is 100% on X11."
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:234
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:272
 msgid ""
 "\"Default\" changes nothing and lets MPV (and your own mpv.conf) decide. "
 "Pick a mode only if you are sending audio to a receiver."
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:237
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:275
 msgid ""
 "Audio your receiver can't be sent directly is encoded to AC3, which is the "
 "only way surround fits down an optical cable. Turn this off if the encoder "
 "causes audio delay — those tracks become stereo instead."
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:242
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:280
 msgid ""
 "\"hq\" offers heavier profiles. Pick it if you have a fast graphics card."
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:244
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:282
 msgid ""
 "Leave on Automatic unless video breaks when a profile is loaded. This only "
 "applies while a profile is active, and OpenGL can cost you HDR output."
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:248
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:286
 msgid ""
 "Evens out loud effects and quiet dialogue. This turns passthrough off while "
 "it is enabled, because the volume has to be adjusted before your receiver "
 "gets the audio."
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:330
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:368
 msgid "Advanced"
 msgstr ""
 
@@ -1289,7 +1313,7 @@ msgid "Automatic"
 msgstr "Automatisk"
 
 #: jellyfin_mpv_shim/mpvtk_browser/downloads.py:51
-#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1355
+#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1288
 msgid "Episodes"
 msgstr ""
 
@@ -1298,7 +1322,7 @@ msgid "Season %s"
 msgstr ""
 
 #: jellyfin_mpv_shim/mpvtk_browser/downloads.py:52
-#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1351
+#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1284
 msgid "Specials"
 msgstr ""
 
@@ -1323,7 +1347,7 @@ msgid "Failed"
 msgstr "Feil"
 
 #: jellyfin_mpv_shim/mpvtk_browser/downloads.py:185
-#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1105
+#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1038
 msgid "Playlist"
 msgstr ""
 
@@ -1335,30 +1359,30 @@ msgstr ""
 msgid "Movies & Videos"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/home_sections.py:103
+#: jellyfin_mpv_shim/mpvtk_browser/home_sections.py:104
 msgid "My Media"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/home_sections.py:104
-#: jellyfin_mpv_shim/mpvtk_browser/repository.py:352
+#: jellyfin_mpv_shim/mpvtk_browser/home_sections.py:105
+#: jellyfin_mpv_shim/mpvtk_browser/repository.py:350
 msgid "Continue Watching"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/home_sections.py:105
-#: jellyfin_mpv_shim/mpvtk_browser/repository.py:359
+#: jellyfin_mpv_shim/mpvtk_browser/home_sections.py:106
+#: jellyfin_mpv_shim/mpvtk_browser/repository.py:357
 msgid "Continue Listening"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/home_sections.py:106
-#: jellyfin_mpv_shim/mpvtk_browser/repository.py:366
+#: jellyfin_mpv_shim/mpvtk_browser/home_sections.py:107
+#: jellyfin_mpv_shim/mpvtk_browser/repository.py:364
 msgid "Next Up"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/home_sections.py:107
+#: jellyfin_mpv_shim/mpvtk_browser/home_sections.py:108
 msgid "Recently Added"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/home_sections.py:108
+#: jellyfin_mpv_shim/mpvtk_browser/home_sections.py:109
 msgid "Live TV"
 msgstr ""
 
@@ -1611,52 +1635,52 @@ msgstr ""
 "Kunne ikke legge til server.\n"
 "Vennligst sjekk tilkoblingsinformasjonen din."
 
-#: jellyfin_mpv_shim/mpvtk_browser/repository.py:390
+#: jellyfin_mpv_shim/mpvtk_browser/repository.py:386
 msgid "On Now"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/repository.py:411
+#: jellyfin_mpv_shim/mpvtk_browser/repository.py:407
 msgid "Latest %s"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1119
+#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1052
 msgid "Downloaded"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1138
+#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1071
 msgid "Movies"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1143
+#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1076
 msgid "Videos"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1147
+#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1080
 msgid "TV Shows"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1151
+#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1084
 msgid "Playlists"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1168
-#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1441
+#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1101
+#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1374
 msgid "Series"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1212
+#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1145
 msgid "Downloaded Movies"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1216
+#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1149
 msgid "Downloaded Videos"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1220
+#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1153
 msgid "Downloaded Shows"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1353
+#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1286
 msgid "Season %d"
 msgstr ""
 

--- a/jellyfin_mpv_shim/messages/nds/LC_MESSAGES/base.po
+++ b/jellyfin_mpv_shim/messages/nds/LC_MESSAGES/base.po
@@ -5,7 +5,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2026-07-25 17:21-0400\n"
+"POT-Creation-Date: 2026-07-26 12:03-0400\n"
 "PO-Revision-Date: 2026-05-01 09:29+0000\n"
 "Last-Translator: \"@reco-tec\" <mods_vincas_2s@icloud.com>\n"
 "Language-Team: German (Low) <https://translate.jellyfin.org/projects/"
@@ -254,7 +254,7 @@ msgid "Select Subtitle Track"
 msgstr "Untertitel Track auswählen"
 
 #: jellyfin_mpv_shim/menu.py:341
-#: jellyfin_mpv_shim/mpvtk_browser/home_sections.py:102
+#: jellyfin_mpv_shim/mpvtk_browser/home_sections.py:103
 #: jellyfin_mpv_shim/osc_bridge.py:81 jellyfin_mpv_shim/osc_bridge.py:82
 #: jellyfin_mpv_shim/osc_bridge.py:104 jellyfin_mpv_shim/osc_bridge.py:140
 msgid "None"
@@ -409,7 +409,7 @@ msgstr "nachfragen, ob Credits übersprungen werden sollen"
 msgid "Enable thumbnail previews"
 msgstr "Thumbnail-Vorschau aktivieren"
 
-#: jellyfin_mpv_shim/menu.py:609 jellyfin_mpv_shim/mpvtk_browser/config.py:186
+#: jellyfin_mpv_shim/menu.py:609 jellyfin_mpv_shim/mpvtk_browser/config.py:195
 #: jellyfin_mpv_shim/mpvtk_browser/hud.py:375
 msgid "Night Mode (Auto Volume Adj)"
 msgstr ""
@@ -697,310 +697,334 @@ msgstr ""
 msgid "Or switch to another user"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/cast.py:317
+#: jellyfin_mpv_shim/mpvtk_browser/cast.py:314
 msgid "Ready to cast"
 msgstr "Bereit zum Spiegeln"
 
-#: jellyfin_mpv_shim/mpvtk_browser/cast.py:318
+#: jellyfin_mpv_shim/mpvtk_browser/cast.py:315
 #, fuzzy
 #| msgid "Select your media in Jellyfin and play it here"
 msgid "Select your media in Jellyfin and play it here."
 msgstr "Wähle deine Inhalte in Jellyfin und spiel sie hier"
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:74
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:83
 msgid "Interface"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:83
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:92
 msgid "Playback"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:88
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:97
 msgid "Audio"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:92
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:101
 msgid "Subtitles & Languages"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:97
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:106
 #, fuzzy
 #| msgid "No Transcode"
 msgid "Transcoding"
 msgstr "Keine Transkodierung"
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:102
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:111
 msgid "Video Enhancement"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:104
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:113
 #, fuzzy
 #| msgid "Skipped Credits"
 msgid "Skip Intro / Credits"
 msgstr "Credits übersprungen"
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:107
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:116
 msgid "Library Browser"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:109
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:118
 msgid "Downloads"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:128
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:137
 msgid "Jellyfin UI"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:129
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:138
 msgid "MPV UI with thumbnails"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:130
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:139
 msgid "MPV built-in default"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:133
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:142
 msgid "Follow display"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:134
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:143
 msgid "100% (no scaling)"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:135
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:144
 msgid "125%"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:136
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:145
 msgid "150%"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:137
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:146
 msgid "200%"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:140
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:149
 msgid "Automatic (recommended)"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:141
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:150
 msgid "Vulkan"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:142
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:151
 msgid "Direct3D 11 (Windows only)"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:143
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:152
 msgid "OpenGL (compatibility)"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:146
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:155
 msgid "Default (auto)"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:147
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:156
 msgid "Force Stereo"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:148
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:157
 msgid "Optical Surround"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:149
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:158
 msgid "HDMI Passthrough"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:152
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:161
 msgid "Unset"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:153
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:162
 msgid "Dubbed (shows only)"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:154
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:163
 msgid "Subbed (shows only)"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:155
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:164
 msgid "Dubbed (all)"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:156
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:165
 msgid "Subbed (all)"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:157
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:166
 msgid "Custom (set in config)"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:162
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:171
 msgid "Download Folder"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:163
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:172
 msgid "Prefer Downloaded Copy"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:164
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:173
 msgid "Automatically Download Upcoming Episodes"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:165
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:174
 msgid "Include Next Up"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:166
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:175
 msgid "Next Up Entries to Consider"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:167
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:176
 msgid "Episodes to Keep Ahead (0 = off)"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:168
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:177
 msgid "Storage Limit for Automatic Downloads (GB)"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:169
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:178
 #, fuzzy
 #| msgid "Remove Server"
 msgid "Delete Automatic Downloads Once Watched"
 msgstr "Server entfernen"
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:170
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:179
 msgid "Delete Unwatched After (days, 0 = never)"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:171
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:180
 msgid "Check Every (minutes)"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:172
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:181
 msgid "Close to Tray (keep running)"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:173
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:182
 msgid "Keep Running in Background"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:174
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:183
 msgid "Remember Window Size"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:175
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:184
 msgid "Player Controls Style"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:176
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:185
 msgid "Show What You're Watching in Discord"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:177
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:186
 msgid "Interface Scale"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:178
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:187
 msgid "Cast-target mode (no library browsing)"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:179
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:188
 msgid "Casting Opens the Library Browser"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:180
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:189
 msgid "Fullscreen Library Browser"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:181
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:190
 msgid "Always Bind Arrow Keys to Player Controls"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:182
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:191
 msgid "Player Controls Activation Key"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:183
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:192
 msgid "Audio Output Mode"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:184
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:193
 msgid "Audio Output Device"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:185
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:194
 msgid "Take the Device Exclusively"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:187
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:196
 #, fuzzy
 #| msgid "Video Playback Profiles"
 msgid "Enable Video Playback Profiles"
 msgstr "Videowiedergabeprofile"
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:188
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:197
 #, fuzzy
 #| msgid "New Group"
 msgid "Profile Group"
 msgstr "Neue Gruppe"
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:189
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:198
 msgid "Remember Last Used Profile"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:190
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:199
 msgid "Graphics API for Shaders"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:191
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:200
 msgid "Pass Through AC3"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:192
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:201
 msgid "Pass Through DTS"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:193
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:202
 msgid "Pass Through E-AC3"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:194
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:203
 msgid "Pass Through DTS-HD"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:195
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:204
 msgid "Pass Through TrueHD"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:196
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:205
 msgid "Re-encode Others to AC3"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:202
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:213
 msgid ""
-"MPV keybinds are used by default. Press ENTER to drive the player controls "
-"by keyboard."
+"With \"Start Minimized\" and \"Fullscreen\" this is the classic cast-target "
+"setup: the app waits out of the way, plays fullscreen when something casts "
+"to it, and goes back to waiting when the video ends or you press Q."
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:204
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:227
+msgid ""
+"Off means command-line mode: no window, no system tray and no settings "
+"screen, so the only way back is editing conf.json by hand. It is not how you "
+"get MPV's own on-screen controls — \"Player Controls Style\" under Interface "
+"does that."
+msgstr ""
+
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:234
+msgid ""
+"Show only what is cast to this machine — the library, including this "
+"settings screen, can't be reached from here. Without a system tray icon the "
+"only way back is editing conf.json. For the classic cast-target setup you "
+"want the Interface settings instead; this is for a shared TV nobody should "
+"be able to browse from."
+msgstr ""
+
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:240
+msgid ""
+"Requires restart to change. MPV keybinds are used by default. Press ENTER to "
+"drive the player controls by keyboard."
+msgstr ""
+
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:242
 msgid ""
 "Pixels one wheel notch scrolls. The scrollbar glides while the content snaps "
 "to the nearest row, so a trackpad or trackball no longer overshoots. Raise "
 "it to scroll faster, lower it for finer control."
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:209
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:247
 msgid ""
 "Make each wheel notch jump exactly one row (or one home-screen section) "
 "instead of gliding. Turn this on if you prefer the older stepped scrolling."
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:217
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:255
 msgid "Discord Rich Presence. Takes effect after a restart."
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:219
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:257
 msgid ""
 "Leave this to Default unless setting up passthrough. Note some audio servers "
 "like Pipewire don't like passthrough and will need to be disabled for a card "
@@ -1008,57 +1032,57 @@ msgid ""
 "silence otherwise, but results may vary."
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:225
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:263
 msgid ""
 "Stop anything else using the device while playing. Needed for passthrough on "
 "some systems, and it means other applications will be silent."
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:228
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:266
 msgid ""
 "Page the library and music tile grids instead of scrolling: each page is one "
 "screenful with First / Previous / Next / Last controls and a page number you "
 "can type into. Easier than precise scrolling on a trackpad."
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:232
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:270
 msgid ""
 "Takes effect after a restart. \"Follow display\" uses the scale your desktop "
 "reports, which is 100% on X11."
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:234
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:272
 msgid ""
 "\"Default\" changes nothing and lets MPV (and your own mpv.conf) decide. "
 "Pick a mode only if you are sending audio to a receiver."
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:237
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:275
 msgid ""
 "Audio your receiver can't be sent directly is encoded to AC3, which is the "
 "only way surround fits down an optical cable. Turn this off if the encoder "
 "causes audio delay — those tracks become stereo instead."
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:242
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:280
 msgid ""
 "\"hq\" offers heavier profiles. Pick it if you have a fast graphics card."
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:244
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:282
 msgid ""
 "Leave on Automatic unless video breaks when a profile is loaded. This only "
 "applies while a profile is active, and OpenGL can cost you HDR output."
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:248
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:286
 msgid ""
 "Evens out loud effects and quiet dialogue. This turns passthrough off while "
 "it is enabled, because the volume has to be adjusted before your receiver "
 "gets the audio."
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:330
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:368
 msgid "Advanced"
 msgstr ""
 
@@ -1268,7 +1292,7 @@ msgid "Automatic"
 msgstr "Automatisch"
 
 #: jellyfin_mpv_shim/mpvtk_browser/downloads.py:51
-#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1355
+#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1288
 msgid "Episodes"
 msgstr ""
 
@@ -1277,7 +1301,7 @@ msgid "Season %s"
 msgstr ""
 
 #: jellyfin_mpv_shim/mpvtk_browser/downloads.py:52
-#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1351
+#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1284
 msgid "Specials"
 msgstr ""
 
@@ -1302,7 +1326,7 @@ msgid "Failed"
 msgstr "Fehler"
 
 #: jellyfin_mpv_shim/mpvtk_browser/downloads.py:185
-#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1105
+#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1038
 msgid "Playlist"
 msgstr ""
 
@@ -1314,30 +1338,30 @@ msgstr ""
 msgid "Movies & Videos"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/home_sections.py:103
+#: jellyfin_mpv_shim/mpvtk_browser/home_sections.py:104
 msgid "My Media"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/home_sections.py:104
-#: jellyfin_mpv_shim/mpvtk_browser/repository.py:352
+#: jellyfin_mpv_shim/mpvtk_browser/home_sections.py:105
+#: jellyfin_mpv_shim/mpvtk_browser/repository.py:350
 msgid "Continue Watching"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/home_sections.py:105
-#: jellyfin_mpv_shim/mpvtk_browser/repository.py:359
+#: jellyfin_mpv_shim/mpvtk_browser/home_sections.py:106
+#: jellyfin_mpv_shim/mpvtk_browser/repository.py:357
 msgid "Continue Listening"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/home_sections.py:106
-#: jellyfin_mpv_shim/mpvtk_browser/repository.py:366
+#: jellyfin_mpv_shim/mpvtk_browser/home_sections.py:107
+#: jellyfin_mpv_shim/mpvtk_browser/repository.py:364
 msgid "Next Up"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/home_sections.py:107
+#: jellyfin_mpv_shim/mpvtk_browser/home_sections.py:108
 msgid "Recently Added"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/home_sections.py:108
+#: jellyfin_mpv_shim/mpvtk_browser/home_sections.py:109
 msgid "Live TV"
 msgstr ""
 
@@ -1577,52 +1601,52 @@ msgstr ""
 "Hinzufügen vom Server fehlgeschlagen.\n"
 "Bitte überprüfe deine Verbindungsinformationen."
 
-#: jellyfin_mpv_shim/mpvtk_browser/repository.py:390
+#: jellyfin_mpv_shim/mpvtk_browser/repository.py:386
 msgid "On Now"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/repository.py:411
+#: jellyfin_mpv_shim/mpvtk_browser/repository.py:407
 msgid "Latest %s"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1119
+#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1052
 msgid "Downloaded"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1138
+#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1071
 msgid "Movies"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1143
+#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1076
 msgid "Videos"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1147
+#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1080
 msgid "TV Shows"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1151
+#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1084
 msgid "Playlists"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1168
-#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1441
+#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1101
+#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1374
 msgid "Series"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1212
+#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1145
 msgid "Downloaded Movies"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1216
+#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1149
 msgid "Downloaded Videos"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1220
+#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1153
 msgid "Downloaded Shows"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1353
+#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1286
 msgid "Season %d"
 msgstr ""
 

--- a/jellyfin_mpv_shim/messages/ne/LC_MESSAGES/base.po
+++ b/jellyfin_mpv_shim/messages/ne/LC_MESSAGES/base.po
@@ -5,7 +5,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2026-07-25 17:21-0400\n"
+"POT-Creation-Date: 2026-07-26 12:03-0400\n"
 "PO-Revision-Date: 2023-12-04 03:30+0000\n"
 "Last-Translator: Kristopher Roller <akjroller@gmail.com>\n"
 "Language-Team: Nepali <https://translate.jellyfin.org/projects/jellyfin/"
@@ -252,7 +252,7 @@ msgid "Select Subtitle Track"
 msgstr "उपशीर्षक ट्र्याक चयन गर्नुहोस्"
 
 #: jellyfin_mpv_shim/menu.py:341
-#: jellyfin_mpv_shim/mpvtk_browser/home_sections.py:102
+#: jellyfin_mpv_shim/mpvtk_browser/home_sections.py:103
 #: jellyfin_mpv_shim/osc_bridge.py:81 jellyfin_mpv_shim/osc_bridge.py:82
 #: jellyfin_mpv_shim/osc_bridge.py:104 jellyfin_mpv_shim/osc_bridge.py:140
 msgid "None"
@@ -407,7 +407,7 @@ msgstr "परिचयहरु छोड्न सोध्नुहोस्"
 msgid "Enable thumbnail previews"
 msgstr "थम्बनेल पूर्वावलोकन सक्षम गर्नुहोस्"
 
-#: jellyfin_mpv_shim/menu.py:609 jellyfin_mpv_shim/mpvtk_browser/config.py:186
+#: jellyfin_mpv_shim/menu.py:609 jellyfin_mpv_shim/mpvtk_browser/config.py:195
 #: jellyfin_mpv_shim/mpvtk_browser/hud.py:375
 msgid "Night Mode (Auto Volume Adj)"
 msgstr ""
@@ -706,310 +706,334 @@ msgstr ""
 msgid "Or switch to another user"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/cast.py:317
+#: jellyfin_mpv_shim/mpvtk_browser/cast.py:314
 msgid "Ready to cast"
 msgstr "कास्ट गर्न तयार छ"
 
-#: jellyfin_mpv_shim/mpvtk_browser/cast.py:318
+#: jellyfin_mpv_shim/mpvtk_browser/cast.py:315
 #, fuzzy
 #| msgid "Select your media in Jellyfin and play it here"
 msgid "Select your media in Jellyfin and play it here."
 msgstr "Jellyfin मा आफ्नो मिडिया चयन गर्नुहोस् र यसलाई यहाँ प्ले गर्नुहोस्"
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:74
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:83
 msgid "Interface"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:83
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:92
 msgid "Playback"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:88
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:97
 msgid "Audio"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:92
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:101
 msgid "Subtitles & Languages"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:97
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:106
 #, fuzzy
 #| msgid " (Transcode)"
 msgid "Transcoding"
 msgstr " (ट्रान्सकोड)"
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:102
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:111
 msgid "Video Enhancement"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:104
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:113
 #, fuzzy
 #| msgid "Ask to Skip Intros"
 msgid "Skip Intro / Credits"
 msgstr "परिचयहरु छोड्न सोध्नुहोस्"
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:107
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:116
 msgid "Library Browser"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:109
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:118
 msgid "Downloads"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:128
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:137
 msgid "Jellyfin UI"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:129
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:138
 msgid "MPV UI with thumbnails"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:130
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:139
 msgid "MPV built-in default"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:133
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:142
 msgid "Follow display"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:134
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:143
 msgid "100% (no scaling)"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:135
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:144
 msgid "125%"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:136
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:145
 msgid "150%"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:137
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:146
 msgid "200%"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:140
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:149
 msgid "Automatic (recommended)"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:141
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:150
 msgid "Vulkan"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:142
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:151
 msgid "Direct3D 11 (Windows only)"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:143
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:152
 msgid "OpenGL (compatibility)"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:146
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:155
 msgid "Default (auto)"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:147
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:156
 msgid "Force Stereo"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:148
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:157
 msgid "Optical Surround"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:149
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:158
 msgid "HDMI Passthrough"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:152
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:161
 msgid "Unset"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:153
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:162
 msgid "Dubbed (shows only)"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:154
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:163
 msgid "Subbed (shows only)"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:155
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:164
 msgid "Dubbed (all)"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:156
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:165
 msgid "Subbed (all)"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:157
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:166
 msgid "Custom (set in config)"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:162
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:171
 msgid "Download Folder"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:163
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:172
 msgid "Prefer Downloaded Copy"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:164
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:173
 msgid "Automatically Download Upcoming Episodes"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:165
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:174
 msgid "Include Next Up"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:166
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:175
 msgid "Next Up Entries to Consider"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:167
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:176
 msgid "Episodes to Keep Ahead (0 = off)"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:168
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:177
 msgid "Storage Limit for Automatic Downloads (GB)"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:169
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:178
 #, fuzzy
 #| msgid "Remove Server"
 msgid "Delete Automatic Downloads Once Watched"
 msgstr "सर्भर हटाउनुहोस्"
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:170
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:179
 msgid "Delete Unwatched After (days, 0 = never)"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:171
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:180
 msgid "Check Every (minutes)"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:172
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:181
 msgid "Close to Tray (keep running)"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:173
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:182
 msgid "Keep Running in Background"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:174
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:183
 msgid "Remember Window Size"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:175
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:184
 msgid "Player Controls Style"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:176
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:185
 msgid "Show What You're Watching in Discord"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:177
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:186
 msgid "Interface Scale"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:178
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:187
 msgid "Cast-target mode (no library browsing)"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:179
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:188
 msgid "Casting Opens the Library Browser"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:180
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:189
 msgid "Fullscreen Library Browser"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:181
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:190
 msgid "Always Bind Arrow Keys to Player Controls"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:182
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:191
 msgid "Player Controls Activation Key"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:183
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:192
 msgid "Audio Output Mode"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:184
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:193
 msgid "Audio Output Device"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:185
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:194
 msgid "Take the Device Exclusively"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:187
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:196
 #, fuzzy
 #| msgid "Video Playback Profiles"
 msgid "Enable Video Playback Profiles"
 msgstr "भिडियो प्लेब्याक प्रोफाइलहरू"
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:188
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:197
 #, fuzzy
 #| msgid "New Group"
 msgid "Profile Group"
 msgstr "नयाँ समूह"
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:189
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:198
 msgid "Remember Last Used Profile"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:190
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:199
 msgid "Graphics API for Shaders"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:191
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:200
 msgid "Pass Through AC3"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:192
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:201
 msgid "Pass Through DTS"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:193
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:202
 msgid "Pass Through E-AC3"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:194
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:203
 msgid "Pass Through DTS-HD"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:195
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:204
 msgid "Pass Through TrueHD"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:196
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:205
 msgid "Re-encode Others to AC3"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:202
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:213
 msgid ""
-"MPV keybinds are used by default. Press ENTER to drive the player controls "
-"by keyboard."
+"With \"Start Minimized\" and \"Fullscreen\" this is the classic cast-target "
+"setup: the app waits out of the way, plays fullscreen when something casts "
+"to it, and goes back to waiting when the video ends or you press Q."
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:204
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:227
+msgid ""
+"Off means command-line mode: no window, no system tray and no settings "
+"screen, so the only way back is editing conf.json by hand. It is not how you "
+"get MPV's own on-screen controls — \"Player Controls Style\" under Interface "
+"does that."
+msgstr ""
+
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:234
+msgid ""
+"Show only what is cast to this machine — the library, including this "
+"settings screen, can't be reached from here. Without a system tray icon the "
+"only way back is editing conf.json. For the classic cast-target setup you "
+"want the Interface settings instead; this is for a shared TV nobody should "
+"be able to browse from."
+msgstr ""
+
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:240
+msgid ""
+"Requires restart to change. MPV keybinds are used by default. Press ENTER to "
+"drive the player controls by keyboard."
+msgstr ""
+
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:242
 msgid ""
 "Pixels one wheel notch scrolls. The scrollbar glides while the content snaps "
 "to the nearest row, so a trackpad or trackball no longer overshoots. Raise "
 "it to scroll faster, lower it for finer control."
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:209
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:247
 msgid ""
 "Make each wheel notch jump exactly one row (or one home-screen section) "
 "instead of gliding. Turn this on if you prefer the older stepped scrolling."
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:217
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:255
 msgid "Discord Rich Presence. Takes effect after a restart."
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:219
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:257
 msgid ""
 "Leave this to Default unless setting up passthrough. Note some audio servers "
 "like Pipewire don't like passthrough and will need to be disabled for a card "
@@ -1017,57 +1041,57 @@ msgid ""
 "silence otherwise, but results may vary."
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:225
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:263
 msgid ""
 "Stop anything else using the device while playing. Needed for passthrough on "
 "some systems, and it means other applications will be silent."
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:228
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:266
 msgid ""
 "Page the library and music tile grids instead of scrolling: each page is one "
 "screenful with First / Previous / Next / Last controls and a page number you "
 "can type into. Easier than precise scrolling on a trackpad."
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:232
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:270
 msgid ""
 "Takes effect after a restart. \"Follow display\" uses the scale your desktop "
 "reports, which is 100% on X11."
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:234
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:272
 msgid ""
 "\"Default\" changes nothing and lets MPV (and your own mpv.conf) decide. "
 "Pick a mode only if you are sending audio to a receiver."
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:237
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:275
 msgid ""
 "Audio your receiver can't be sent directly is encoded to AC3, which is the "
 "only way surround fits down an optical cable. Turn this off if the encoder "
 "causes audio delay — those tracks become stereo instead."
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:242
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:280
 msgid ""
 "\"hq\" offers heavier profiles. Pick it if you have a fast graphics card."
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:244
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:282
 msgid ""
 "Leave on Automatic unless video breaks when a profile is loaded. This only "
 "applies while a profile is active, and OpenGL can cost you HDR output."
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:248
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:286
 msgid ""
 "Evens out loud effects and quiet dialogue. This turns passthrough off while "
 "it is enabled, because the volume has to be adjusted before your receiver "
 "gets the audio."
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:330
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:368
 msgid "Advanced"
 msgstr ""
 
@@ -1293,7 +1317,7 @@ msgid "Automatic"
 msgstr "स्वचालित"
 
 #: jellyfin_mpv_shim/mpvtk_browser/downloads.py:51
-#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1355
+#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1288
 msgid "Episodes"
 msgstr ""
 
@@ -1302,7 +1326,7 @@ msgid "Season %s"
 msgstr ""
 
 #: jellyfin_mpv_shim/mpvtk_browser/downloads.py:52
-#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1351
+#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1284
 msgid "Specials"
 msgstr ""
 
@@ -1327,7 +1351,7 @@ msgid "Failed"
 msgstr "असफल"
 
 #: jellyfin_mpv_shim/mpvtk_browser/downloads.py:185
-#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1105
+#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1038
 msgid "Playlist"
 msgstr ""
 
@@ -1339,30 +1363,30 @@ msgstr ""
 msgid "Movies & Videos"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/home_sections.py:103
+#: jellyfin_mpv_shim/mpvtk_browser/home_sections.py:104
 msgid "My Media"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/home_sections.py:104
-#: jellyfin_mpv_shim/mpvtk_browser/repository.py:352
+#: jellyfin_mpv_shim/mpvtk_browser/home_sections.py:105
+#: jellyfin_mpv_shim/mpvtk_browser/repository.py:350
 msgid "Continue Watching"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/home_sections.py:105
-#: jellyfin_mpv_shim/mpvtk_browser/repository.py:359
+#: jellyfin_mpv_shim/mpvtk_browser/home_sections.py:106
+#: jellyfin_mpv_shim/mpvtk_browser/repository.py:357
 msgid "Continue Listening"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/home_sections.py:106
-#: jellyfin_mpv_shim/mpvtk_browser/repository.py:366
+#: jellyfin_mpv_shim/mpvtk_browser/home_sections.py:107
+#: jellyfin_mpv_shim/mpvtk_browser/repository.py:364
 msgid "Next Up"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/home_sections.py:107
+#: jellyfin_mpv_shim/mpvtk_browser/home_sections.py:108
 msgid "Recently Added"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/home_sections.py:108
+#: jellyfin_mpv_shim/mpvtk_browser/home_sections.py:109
 msgid "Live TV"
 msgstr ""
 
@@ -1615,52 +1639,52 @@ msgstr ""
 "सर्भर थप्न सकिएन।\n"
 "कृपया आफ्नो जडान जानकारी जाँच गर्नुहोस्।"
 
-#: jellyfin_mpv_shim/mpvtk_browser/repository.py:390
+#: jellyfin_mpv_shim/mpvtk_browser/repository.py:386
 msgid "On Now"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/repository.py:411
+#: jellyfin_mpv_shim/mpvtk_browser/repository.py:407
 msgid "Latest %s"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1119
+#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1052
 msgid "Downloaded"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1138
+#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1071
 msgid "Movies"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1143
+#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1076
 msgid "Videos"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1147
+#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1080
 msgid "TV Shows"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1151
+#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1084
 msgid "Playlists"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1168
-#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1441
+#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1101
+#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1374
 msgid "Series"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1212
+#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1145
 msgid "Downloaded Movies"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1216
+#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1149
 msgid "Downloaded Videos"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1220
+#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1153
 msgid "Downloaded Shows"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1353
+#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1286
 msgid "Season %d"
 msgstr ""
 

--- a/jellyfin_mpv_shim/messages/nl/LC_MESSAGES/base.po
+++ b/jellyfin_mpv_shim/messages/nl/LC_MESSAGES/base.po
@@ -5,17 +5,17 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2026-07-25 17:21-0400\n"
-"PO-Revision-Date: 2026-07-26 15:36+0000\n"
-"Last-Translator: Bas <44002186+854562@users.noreply.github.com>\n"
+"POT-Creation-Date: 2026-07-26 12:03-0400\n"
+"PO-Revision-Date: 2024-08-13 14:30+0000\n"
+"Last-Translator: Freespirit297 <freespirit2907@gmail.com>\n"
 "Language-Team: Dutch <https://translate.jellyfin.org/projects/jellyfin/"
-"jellyfin-mpv-shim/nl/>\n"
+"jellyfin-desktop/nl/>\n"
 "Language: nl\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=n != 1;\n"
-"X-Generator: Weblate 5.15.1\n"
+"X-Generator: Weblate 5.4.2\n"
 "Generated-By: pygettext.py 1.5\n"
 
 #: jellyfin_mpv_shim/bulk_subtitle.py:29
@@ -252,7 +252,7 @@ msgid "Select Subtitle Track"
 msgstr "Ondertitelspoor selecteren"
 
 #: jellyfin_mpv_shim/menu.py:341
-#: jellyfin_mpv_shim/mpvtk_browser/home_sections.py:102
+#: jellyfin_mpv_shim/mpvtk_browser/home_sections.py:103
 #: jellyfin_mpv_shim/osc_bridge.py:81 jellyfin_mpv_shim/osc_bridge.py:82
 #: jellyfin_mpv_shim/osc_bridge.py:104 jellyfin_mpv_shim/osc_bridge.py:140
 msgid "None"
@@ -403,7 +403,7 @@ msgstr "Vragen om aftiteling over te slaan"
 msgid "Enable thumbnail previews"
 msgstr "Miniatuurvoorbeelden inschakelen"
 
-#: jellyfin_mpv_shim/menu.py:609 jellyfin_mpv_shim/mpvtk_browser/config.py:186
+#: jellyfin_mpv_shim/menu.py:609 jellyfin_mpv_shim/mpvtk_browser/config.py:195
 #: jellyfin_mpv_shim/mpvtk_browser/hud.py:375
 msgid "Night Mode (Auto Volume Adj)"
 msgstr ""
@@ -702,310 +702,334 @@ msgstr ""
 msgid "Or switch to another user"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/cast.py:317
+#: jellyfin_mpv_shim/mpvtk_browser/cast.py:314
 msgid "Ready to cast"
 msgstr "Klaar om te casten"
 
-#: jellyfin_mpv_shim/mpvtk_browser/cast.py:318
+#: jellyfin_mpv_shim/mpvtk_browser/cast.py:315
 #, fuzzy
 #| msgid "Select your media in Jellyfin and play it here"
 msgid "Select your media in Jellyfin and play it here."
 msgstr "Selecteer je media in Jellyfin en speel het hier af"
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:74
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:83
 msgid "Interface"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:83
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:92
 msgid "Playback"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:88
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:97
 msgid "Audio"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:92
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:101
 msgid "Subtitles & Languages"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:97
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:106
 #, fuzzy
 #| msgid " (Transcode)"
 msgid "Transcoding"
 msgstr " (transcoderen)"
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:102
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:111
 msgid "Video Enhancement"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:104
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:113
 #, fuzzy
 #| msgid "Seek to Skip Credits"
 msgid "Skip Intro / Credits"
 msgstr "Terug- of vooruitspoelen om aftiteling over te slaan"
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:107
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:116
 msgid "Library Browser"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:109
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:118
 msgid "Downloads"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:128
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:137
 msgid "Jellyfin UI"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:129
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:138
 msgid "MPV UI with thumbnails"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:130
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:139
 msgid "MPV built-in default"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:133
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:142
 msgid "Follow display"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:134
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:143
 msgid "100% (no scaling)"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:135
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:144
 msgid "125%"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:136
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:145
 msgid "150%"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:137
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:146
 msgid "200%"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:140
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:149
 msgid "Automatic (recommended)"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:141
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:150
 msgid "Vulkan"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:142
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:151
 msgid "Direct3D 11 (Windows only)"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:143
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:152
 msgid "OpenGL (compatibility)"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:146
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:155
 msgid "Default (auto)"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:147
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:156
 msgid "Force Stereo"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:148
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:157
 msgid "Optical Surround"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:149
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:158
 msgid "HDMI Passthrough"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:152
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:161
 msgid "Unset"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:153
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:162
 msgid "Dubbed (shows only)"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:154
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:163
 msgid "Subbed (shows only)"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:155
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:164
 msgid "Dubbed (all)"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:156
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:165
 msgid "Subbed (all)"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:157
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:166
 msgid "Custom (set in config)"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:162
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:171
 msgid "Download Folder"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:163
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:172
 msgid "Prefer Downloaded Copy"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:164
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:173
 msgid "Automatically Download Upcoming Episodes"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:165
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:174
 msgid "Include Next Up"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:166
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:175
 msgid "Next Up Entries to Consider"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:167
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:176
 msgid "Episodes to Keep Ahead (0 = off)"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:168
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:177
 msgid "Storage Limit for Automatic Downloads (GB)"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:169
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:178
 #, fuzzy
 #| msgid "Remove Server"
 msgid "Delete Automatic Downloads Once Watched"
 msgstr "Server verwijderen"
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:170
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:179
 msgid "Delete Unwatched After (days, 0 = never)"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:171
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:180
 msgid "Check Every (minutes)"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:172
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:181
 msgid "Close to Tray (keep running)"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:173
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:182
 msgid "Keep Running in Background"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:174
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:183
 msgid "Remember Window Size"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:175
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:184
 msgid "Player Controls Style"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:176
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:185
 msgid "Show What You're Watching in Discord"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:177
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:186
 msgid "Interface Scale"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:178
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:187
 msgid "Cast-target mode (no library browsing)"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:179
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:188
 msgid "Casting Opens the Library Browser"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:180
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:189
 msgid "Fullscreen Library Browser"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:181
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:190
 msgid "Always Bind Arrow Keys to Player Controls"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:182
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:191
 msgid "Player Controls Activation Key"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:183
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:192
 msgid "Audio Output Mode"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:184
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:193
 msgid "Audio Output Device"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:185
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:194
 msgid "Take the Device Exclusively"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:187
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:196
 #, fuzzy
 #| msgid "Video Playback Profiles"
 msgid "Enable Video Playback Profiles"
 msgstr "Video afspeelprofielen"
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:188
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:197
 #, fuzzy
 #| msgid "New Group"
 msgid "Profile Group"
 msgstr "Nieuwe Groep"
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:189
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:198
 msgid "Remember Last Used Profile"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:190
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:199
 msgid "Graphics API for Shaders"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:191
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:200
 msgid "Pass Through AC3"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:192
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:201
 msgid "Pass Through DTS"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:193
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:202
 msgid "Pass Through E-AC3"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:194
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:203
 msgid "Pass Through DTS-HD"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:195
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:204
 msgid "Pass Through TrueHD"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:196
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:205
 msgid "Re-encode Others to AC3"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:202
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:213
 msgid ""
-"MPV keybinds are used by default. Press ENTER to drive the player controls "
-"by keyboard."
+"With \"Start Minimized\" and \"Fullscreen\" this is the classic cast-target "
+"setup: the app waits out of the way, plays fullscreen when something casts "
+"to it, and goes back to waiting when the video ends or you press Q."
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:204
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:227
+msgid ""
+"Off means command-line mode: no window, no system tray and no settings "
+"screen, so the only way back is editing conf.json by hand. It is not how you "
+"get MPV's own on-screen controls — \"Player Controls Style\" under Interface "
+"does that."
+msgstr ""
+
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:234
+msgid ""
+"Show only what is cast to this machine — the library, including this "
+"settings screen, can't be reached from here. Without a system tray icon the "
+"only way back is editing conf.json. For the classic cast-target setup you "
+"want the Interface settings instead; this is for a shared TV nobody should "
+"be able to browse from."
+msgstr ""
+
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:240
+msgid ""
+"Requires restart to change. MPV keybinds are used by default. Press ENTER to "
+"drive the player controls by keyboard."
+msgstr ""
+
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:242
 msgid ""
 "Pixels one wheel notch scrolls. The scrollbar glides while the content snaps "
 "to the nearest row, so a trackpad or trackball no longer overshoots. Raise "
 "it to scroll faster, lower it for finer control."
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:209
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:247
 msgid ""
 "Make each wheel notch jump exactly one row (or one home-screen section) "
 "instead of gliding. Turn this on if you prefer the older stepped scrolling."
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:217
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:255
 msgid "Discord Rich Presence. Takes effect after a restart."
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:219
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:257
 msgid ""
 "Leave this to Default unless setting up passthrough. Note some audio servers "
 "like Pipewire don't like passthrough and will need to be disabled for a card "
@@ -1013,57 +1037,57 @@ msgid ""
 "silence otherwise, but results may vary."
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:225
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:263
 msgid ""
 "Stop anything else using the device while playing. Needed for passthrough on "
 "some systems, and it means other applications will be silent."
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:228
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:266
 msgid ""
 "Page the library and music tile grids instead of scrolling: each page is one "
 "screenful with First / Previous / Next / Last controls and a page number you "
 "can type into. Easier than precise scrolling on a trackpad."
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:232
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:270
 msgid ""
 "Takes effect after a restart. \"Follow display\" uses the scale your desktop "
 "reports, which is 100% on X11."
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:234
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:272
 msgid ""
 "\"Default\" changes nothing and lets MPV (and your own mpv.conf) decide. "
 "Pick a mode only if you are sending audio to a receiver."
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:237
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:275
 msgid ""
 "Audio your receiver can't be sent directly is encoded to AC3, which is the "
 "only way surround fits down an optical cable. Turn this off if the encoder "
 "causes audio delay — those tracks become stereo instead."
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:242
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:280
 msgid ""
 "\"hq\" offers heavier profiles. Pick it if you have a fast graphics card."
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:244
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:282
 msgid ""
 "Leave on Automatic unless video breaks when a profile is loaded. This only "
 "applies while a profile is active, and OpenGL can cost you HDR output."
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:248
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:286
 msgid ""
 "Evens out loud effects and quiet dialogue. This turns passthrough off while "
 "it is enabled, because the volume has to be adjusted before your receiver "
 "gets the audio."
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:330
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:368
 msgid "Advanced"
 msgstr ""
 
@@ -1289,7 +1313,7 @@ msgid "Automatic"
 msgstr "Automatisch"
 
 #: jellyfin_mpv_shim/mpvtk_browser/downloads.py:51
-#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1355
+#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1288
 msgid "Episodes"
 msgstr ""
 
@@ -1298,7 +1322,7 @@ msgid "Season %s"
 msgstr ""
 
 #: jellyfin_mpv_shim/mpvtk_browser/downloads.py:52
-#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1351
+#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1284
 msgid "Specials"
 msgstr ""
 
@@ -1323,7 +1347,7 @@ msgid "Failed"
 msgstr "Mislukt"
 
 #: jellyfin_mpv_shim/mpvtk_browser/downloads.py:185
-#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1105
+#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1038
 msgid "Playlist"
 msgstr ""
 
@@ -1335,30 +1359,30 @@ msgstr ""
 msgid "Movies & Videos"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/home_sections.py:103
+#: jellyfin_mpv_shim/mpvtk_browser/home_sections.py:104
 msgid "My Media"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/home_sections.py:104
-#: jellyfin_mpv_shim/mpvtk_browser/repository.py:352
+#: jellyfin_mpv_shim/mpvtk_browser/home_sections.py:105
+#: jellyfin_mpv_shim/mpvtk_browser/repository.py:350
 msgid "Continue Watching"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/home_sections.py:105
-#: jellyfin_mpv_shim/mpvtk_browser/repository.py:359
+#: jellyfin_mpv_shim/mpvtk_browser/home_sections.py:106
+#: jellyfin_mpv_shim/mpvtk_browser/repository.py:357
 msgid "Continue Listening"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/home_sections.py:106
-#: jellyfin_mpv_shim/mpvtk_browser/repository.py:366
+#: jellyfin_mpv_shim/mpvtk_browser/home_sections.py:107
+#: jellyfin_mpv_shim/mpvtk_browser/repository.py:364
 msgid "Next Up"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/home_sections.py:107
+#: jellyfin_mpv_shim/mpvtk_browser/home_sections.py:108
 msgid "Recently Added"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/home_sections.py:108
+#: jellyfin_mpv_shim/mpvtk_browser/home_sections.py:109
 msgid "Live TV"
 msgstr ""
 
@@ -1611,52 +1635,52 @@ msgstr ""
 "Kon server niet toevoegen.\n"
 "Controleer alstublieft je verbinding."
 
-#: jellyfin_mpv_shim/mpvtk_browser/repository.py:390
+#: jellyfin_mpv_shim/mpvtk_browser/repository.py:386
 msgid "On Now"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/repository.py:411
+#: jellyfin_mpv_shim/mpvtk_browser/repository.py:407
 msgid "Latest %s"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1119
+#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1052
 msgid "Downloaded"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1138
+#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1071
 msgid "Movies"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1143
+#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1076
 msgid "Videos"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1147
+#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1080
 msgid "TV Shows"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1151
+#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1084
 msgid "Playlists"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1168
-#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1441
+#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1101
+#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1374
 msgid "Series"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1212
+#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1145
 msgid "Downloaded Movies"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1216
+#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1149
 msgid "Downloaded Videos"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1220
+#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1153
 msgid "Downloaded Shows"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1353
+#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1286
 msgid "Season %d"
 msgstr ""
 

--- a/jellyfin_mpv_shim/messages/nn/LC_MESSAGES/base.po
+++ b/jellyfin_mpv_shim/messages/nn/LC_MESSAGES/base.po
@@ -5,7 +5,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2026-07-25 17:21-0400\n"
+"POT-Creation-Date: 2026-07-26 12:03-0400\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: Automatically generated\n"
 "Language-Team: none\n"
@@ -239,7 +239,7 @@ msgid "Select Subtitle Track"
 msgstr ""
 
 #: jellyfin_mpv_shim/menu.py:341
-#: jellyfin_mpv_shim/mpvtk_browser/home_sections.py:102
+#: jellyfin_mpv_shim/mpvtk_browser/home_sections.py:103
 #: jellyfin_mpv_shim/osc_bridge.py:81 jellyfin_mpv_shim/osc_bridge.py:82
 #: jellyfin_mpv_shim/osc_bridge.py:104 jellyfin_mpv_shim/osc_bridge.py:140
 msgid "None"
@@ -390,7 +390,7 @@ msgstr ""
 msgid "Enable thumbnail previews"
 msgstr ""
 
-#: jellyfin_mpv_shim/menu.py:609 jellyfin_mpv_shim/mpvtk_browser/config.py:186
+#: jellyfin_mpv_shim/menu.py:609 jellyfin_mpv_shim/mpvtk_browser/config.py:195
 #: jellyfin_mpv_shim/mpvtk_browser/hud.py:375
 msgid "Night Mode (Auto Volume Adj)"
 msgstr ""
@@ -655,298 +655,322 @@ msgstr ""
 msgid "Or switch to another user"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/cast.py:317
+#: jellyfin_mpv_shim/mpvtk_browser/cast.py:314
 msgid "Ready to cast"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/cast.py:318
+#: jellyfin_mpv_shim/mpvtk_browser/cast.py:315
 msgid "Select your media in Jellyfin and play it here."
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:74
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:83
 msgid "Interface"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:83
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:92
 msgid "Playback"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:88
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:97
 msgid "Audio"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:92
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:101
 msgid "Subtitles & Languages"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:97
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:106
 msgid "Transcoding"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:102
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:111
 msgid "Video Enhancement"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:104
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:113
 msgid "Skip Intro / Credits"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:107
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:116
 msgid "Library Browser"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:109
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:118
 msgid "Downloads"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:128
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:137
 msgid "Jellyfin UI"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:129
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:138
 msgid "MPV UI with thumbnails"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:130
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:139
 msgid "MPV built-in default"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:133
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:142
 msgid "Follow display"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:134
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:143
 msgid "100% (no scaling)"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:135
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:144
 msgid "125%"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:136
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:145
 msgid "150%"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:137
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:146
 msgid "200%"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:140
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:149
 msgid "Automatic (recommended)"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:141
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:150
 msgid "Vulkan"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:142
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:151
 msgid "Direct3D 11 (Windows only)"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:143
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:152
 msgid "OpenGL (compatibility)"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:146
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:155
 msgid "Default (auto)"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:147
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:156
 msgid "Force Stereo"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:148
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:157
 msgid "Optical Surround"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:149
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:158
 msgid "HDMI Passthrough"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:152
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:161
 msgid "Unset"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:153
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:162
 msgid "Dubbed (shows only)"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:154
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:163
 msgid "Subbed (shows only)"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:155
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:164
 msgid "Dubbed (all)"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:156
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:165
 msgid "Subbed (all)"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:157
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:166
 msgid "Custom (set in config)"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:162
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:171
 msgid "Download Folder"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:163
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:172
 msgid "Prefer Downloaded Copy"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:164
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:173
 msgid "Automatically Download Upcoming Episodes"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:165
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:174
 msgid "Include Next Up"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:166
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:175
 msgid "Next Up Entries to Consider"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:167
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:176
 msgid "Episodes to Keep Ahead (0 = off)"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:168
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:177
 msgid "Storage Limit for Automatic Downloads (GB)"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:169
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:178
 msgid "Delete Automatic Downloads Once Watched"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:170
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:179
 msgid "Delete Unwatched After (days, 0 = never)"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:171
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:180
 msgid "Check Every (minutes)"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:172
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:181
 msgid "Close to Tray (keep running)"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:173
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:182
 msgid "Keep Running in Background"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:174
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:183
 msgid "Remember Window Size"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:175
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:184
 msgid "Player Controls Style"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:176
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:185
 msgid "Show What You're Watching in Discord"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:177
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:186
 msgid "Interface Scale"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:178
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:187
 msgid "Cast-target mode (no library browsing)"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:179
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:188
 msgid "Casting Opens the Library Browser"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:180
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:189
 msgid "Fullscreen Library Browser"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:181
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:190
 msgid "Always Bind Arrow Keys to Player Controls"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:182
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:191
 msgid "Player Controls Activation Key"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:183
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:192
 msgid "Audio Output Mode"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:184
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:193
 msgid "Audio Output Device"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:185
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:194
 msgid "Take the Device Exclusively"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:187
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:196
 msgid "Enable Video Playback Profiles"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:188
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:197
 msgid "Profile Group"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:189
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:198
 msgid "Remember Last Used Profile"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:190
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:199
 msgid "Graphics API for Shaders"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:191
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:200
 msgid "Pass Through AC3"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:192
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:201
 msgid "Pass Through DTS"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:193
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:202
 msgid "Pass Through E-AC3"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:194
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:203
 msgid "Pass Through DTS-HD"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:195
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:204
 msgid "Pass Through TrueHD"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:196
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:205
 msgid "Re-encode Others to AC3"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:202
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:213
 msgid ""
-"MPV keybinds are used by default. Press ENTER to drive the player controls "
-"by keyboard."
+"With \"Start Minimized\" and \"Fullscreen\" this is the classic cast-target "
+"setup: the app waits out of the way, plays fullscreen when something casts "
+"to it, and goes back to waiting when the video ends or you press Q."
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:204
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:227
+msgid ""
+"Off means command-line mode: no window, no system tray and no settings "
+"screen, so the only way back is editing conf.json by hand. It is not how you "
+"get MPV's own on-screen controls — \"Player Controls Style\" under Interface "
+"does that."
+msgstr ""
+
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:234
+msgid ""
+"Show only what is cast to this machine — the library, including this "
+"settings screen, can't be reached from here. Without a system tray icon the "
+"only way back is editing conf.json. For the classic cast-target setup you "
+"want the Interface settings instead; this is for a shared TV nobody should "
+"be able to browse from."
+msgstr ""
+
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:240
+msgid ""
+"Requires restart to change. MPV keybinds are used by default. Press ENTER to "
+"drive the player controls by keyboard."
+msgstr ""
+
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:242
 msgid ""
 "Pixels one wheel notch scrolls. The scrollbar glides while the content snaps "
 "to the nearest row, so a trackpad or trackball no longer overshoots. Raise "
 "it to scroll faster, lower it for finer control."
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:209
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:247
 msgid ""
 "Make each wheel notch jump exactly one row (or one home-screen section) "
 "instead of gliding. Turn this on if you prefer the older stepped scrolling."
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:217
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:255
 msgid "Discord Rich Presence. Takes effect after a restart."
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:219
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:257
 msgid ""
 "Leave this to Default unless setting up passthrough. Note some audio servers "
 "like Pipewire don't like passthrough and will need to be disabled for a card "
@@ -954,57 +978,57 @@ msgid ""
 "silence otherwise, but results may vary."
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:225
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:263
 msgid ""
 "Stop anything else using the device while playing. Needed for passthrough on "
 "some systems, and it means other applications will be silent."
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:228
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:266
 msgid ""
 "Page the library and music tile grids instead of scrolling: each page is one "
 "screenful with First / Previous / Next / Last controls and a page number you "
 "can type into. Easier than precise scrolling on a trackpad."
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:232
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:270
 msgid ""
 "Takes effect after a restart. \"Follow display\" uses the scale your desktop "
 "reports, which is 100% on X11."
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:234
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:272
 msgid ""
 "\"Default\" changes nothing and lets MPV (and your own mpv.conf) decide. "
 "Pick a mode only if you are sending audio to a receiver."
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:237
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:275
 msgid ""
 "Audio your receiver can't be sent directly is encoded to AC3, which is the "
 "only way surround fits down an optical cable. Turn this off if the encoder "
 "causes audio delay — those tracks become stereo instead."
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:242
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:280
 msgid ""
 "\"hq\" offers heavier profiles. Pick it if you have a fast graphics card."
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:244
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:282
 msgid ""
 "Leave on Automatic unless video breaks when a profile is loaded. This only "
 "applies while a profile is active, and OpenGL can cost you HDR output."
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:248
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:286
 msgid ""
 "Evens out loud effects and quiet dialogue. This turns passthrough off while "
 "it is enabled, because the volume has to be adjusted before your receiver "
 "gets the audio."
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:330
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:368
 msgid "Advanced"
 msgstr ""
 
@@ -1182,7 +1206,7 @@ msgid "Automatic"
 msgstr ""
 
 #: jellyfin_mpv_shim/mpvtk_browser/downloads.py:51
-#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1355
+#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1288
 msgid "Episodes"
 msgstr ""
 
@@ -1191,7 +1215,7 @@ msgid "Season %s"
 msgstr ""
 
 #: jellyfin_mpv_shim/mpvtk_browser/downloads.py:52
-#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1351
+#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1284
 msgid "Specials"
 msgstr ""
 
@@ -1212,7 +1236,7 @@ msgid "Failed"
 msgstr ""
 
 #: jellyfin_mpv_shim/mpvtk_browser/downloads.py:185
-#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1105
+#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1038
 msgid "Playlist"
 msgstr ""
 
@@ -1224,30 +1248,30 @@ msgstr ""
 msgid "Movies & Videos"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/home_sections.py:103
+#: jellyfin_mpv_shim/mpvtk_browser/home_sections.py:104
 msgid "My Media"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/home_sections.py:104
-#: jellyfin_mpv_shim/mpvtk_browser/repository.py:352
+#: jellyfin_mpv_shim/mpvtk_browser/home_sections.py:105
+#: jellyfin_mpv_shim/mpvtk_browser/repository.py:350
 msgid "Continue Watching"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/home_sections.py:105
-#: jellyfin_mpv_shim/mpvtk_browser/repository.py:359
+#: jellyfin_mpv_shim/mpvtk_browser/home_sections.py:106
+#: jellyfin_mpv_shim/mpvtk_browser/repository.py:357
 msgid "Continue Listening"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/home_sections.py:106
-#: jellyfin_mpv_shim/mpvtk_browser/repository.py:366
+#: jellyfin_mpv_shim/mpvtk_browser/home_sections.py:107
+#: jellyfin_mpv_shim/mpvtk_browser/repository.py:364
 msgid "Next Up"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/home_sections.py:107
+#: jellyfin_mpv_shim/mpvtk_browser/home_sections.py:108
 msgid "Recently Added"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/home_sections.py:108
+#: jellyfin_mpv_shim/mpvtk_browser/home_sections.py:109
 msgid "Live TV"
 msgstr ""
 
@@ -1452,52 +1476,52 @@ msgstr ""
 msgid "Could not load this page."
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/repository.py:390
+#: jellyfin_mpv_shim/mpvtk_browser/repository.py:386
 msgid "On Now"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/repository.py:411
+#: jellyfin_mpv_shim/mpvtk_browser/repository.py:407
 msgid "Latest %s"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1119
+#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1052
 msgid "Downloaded"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1138
+#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1071
 msgid "Movies"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1143
+#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1076
 msgid "Videos"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1147
+#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1080
 msgid "TV Shows"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1151
+#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1084
 msgid "Playlists"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1168
-#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1441
+#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1101
+#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1374
 msgid "Series"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1212
+#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1145
 msgid "Downloaded Movies"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1216
+#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1149
 msgid "Downloaded Videos"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1220
+#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1153
 msgid "Downloaded Shows"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1353
+#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1286
 msgid "Season %d"
 msgstr ""
 

--- a/jellyfin_mpv_shim/messages/oc/LC_MESSAGES/base.po
+++ b/jellyfin_mpv_shim/messages/oc/LC_MESSAGES/base.po
@@ -5,7 +5,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2026-07-25 17:21-0400\n"
+"POT-Creation-Date: 2026-07-26 12:03-0400\n"
 "PO-Revision-Date: 2026-05-24 14:38+0000\n"
 "Last-Translator: joanluc <oc.linux@free.fr>\n"
 "Language-Team: Occitan <https://translate.jellyfin.org/projects/jellyfin/"
@@ -242,7 +242,7 @@ msgid "Select Subtitle Track"
 msgstr ""
 
 #: jellyfin_mpv_shim/menu.py:341
-#: jellyfin_mpv_shim/mpvtk_browser/home_sections.py:102
+#: jellyfin_mpv_shim/mpvtk_browser/home_sections.py:103
 #: jellyfin_mpv_shim/osc_bridge.py:81 jellyfin_mpv_shim/osc_bridge.py:82
 #: jellyfin_mpv_shim/osc_bridge.py:104 jellyfin_mpv_shim/osc_bridge.py:140
 msgid "None"
@@ -393,7 +393,7 @@ msgstr ""
 msgid "Enable thumbnail previews"
 msgstr ""
 
-#: jellyfin_mpv_shim/menu.py:609 jellyfin_mpv_shim/mpvtk_browser/config.py:186
+#: jellyfin_mpv_shim/menu.py:609 jellyfin_mpv_shim/mpvtk_browser/config.py:195
 #: jellyfin_mpv_shim/mpvtk_browser/hud.py:375
 msgid "Night Mode (Auto Volume Adj)"
 msgstr ""
@@ -658,298 +658,322 @@ msgstr ""
 msgid "Or switch to another user"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/cast.py:317
+#: jellyfin_mpv_shim/mpvtk_browser/cast.py:314
 msgid "Ready to cast"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/cast.py:318
+#: jellyfin_mpv_shim/mpvtk_browser/cast.py:315
 msgid "Select your media in Jellyfin and play it here."
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:74
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:83
 msgid "Interface"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:83
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:92
 msgid "Playback"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:88
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:97
 msgid "Audio"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:92
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:101
 msgid "Subtitles & Languages"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:97
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:106
 msgid "Transcoding"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:102
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:111
 msgid "Video Enhancement"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:104
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:113
 msgid "Skip Intro / Credits"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:107
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:116
 msgid "Library Browser"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:109
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:118
 msgid "Downloads"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:128
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:137
 msgid "Jellyfin UI"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:129
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:138
 msgid "MPV UI with thumbnails"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:130
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:139
 msgid "MPV built-in default"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:133
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:142
 msgid "Follow display"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:134
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:143
 msgid "100% (no scaling)"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:135
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:144
 msgid "125%"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:136
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:145
 msgid "150%"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:137
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:146
 msgid "200%"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:140
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:149
 msgid "Automatic (recommended)"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:141
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:150
 msgid "Vulkan"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:142
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:151
 msgid "Direct3D 11 (Windows only)"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:143
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:152
 msgid "OpenGL (compatibility)"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:146
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:155
 msgid "Default (auto)"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:147
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:156
 msgid "Force Stereo"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:148
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:157
 msgid "Optical Surround"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:149
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:158
 msgid "HDMI Passthrough"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:152
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:161
 msgid "Unset"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:153
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:162
 msgid "Dubbed (shows only)"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:154
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:163
 msgid "Subbed (shows only)"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:155
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:164
 msgid "Dubbed (all)"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:156
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:165
 msgid "Subbed (all)"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:157
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:166
 msgid "Custom (set in config)"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:162
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:171
 msgid "Download Folder"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:163
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:172
 msgid "Prefer Downloaded Copy"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:164
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:173
 msgid "Automatically Download Upcoming Episodes"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:165
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:174
 msgid "Include Next Up"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:166
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:175
 msgid "Next Up Entries to Consider"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:167
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:176
 msgid "Episodes to Keep Ahead (0 = off)"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:168
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:177
 msgid "Storage Limit for Automatic Downloads (GB)"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:169
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:178
 msgid "Delete Automatic Downloads Once Watched"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:170
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:179
 msgid "Delete Unwatched After (days, 0 = never)"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:171
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:180
 msgid "Check Every (minutes)"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:172
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:181
 msgid "Close to Tray (keep running)"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:173
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:182
 msgid "Keep Running in Background"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:174
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:183
 msgid "Remember Window Size"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:175
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:184
 msgid "Player Controls Style"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:176
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:185
 msgid "Show What You're Watching in Discord"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:177
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:186
 msgid "Interface Scale"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:178
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:187
 msgid "Cast-target mode (no library browsing)"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:179
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:188
 msgid "Casting Opens the Library Browser"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:180
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:189
 msgid "Fullscreen Library Browser"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:181
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:190
 msgid "Always Bind Arrow Keys to Player Controls"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:182
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:191
 msgid "Player Controls Activation Key"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:183
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:192
 msgid "Audio Output Mode"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:184
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:193
 msgid "Audio Output Device"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:185
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:194
 msgid "Take the Device Exclusively"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:187
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:196
 msgid "Enable Video Playback Profiles"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:188
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:197
 msgid "Profile Group"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:189
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:198
 msgid "Remember Last Used Profile"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:190
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:199
 msgid "Graphics API for Shaders"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:191
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:200
 msgid "Pass Through AC3"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:192
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:201
 msgid "Pass Through DTS"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:193
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:202
 msgid "Pass Through E-AC3"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:194
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:203
 msgid "Pass Through DTS-HD"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:195
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:204
 msgid "Pass Through TrueHD"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:196
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:205
 msgid "Re-encode Others to AC3"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:202
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:213
 msgid ""
-"MPV keybinds are used by default. Press ENTER to drive the player controls "
-"by keyboard."
+"With \"Start Minimized\" and \"Fullscreen\" this is the classic cast-target "
+"setup: the app waits out of the way, plays fullscreen when something casts "
+"to it, and goes back to waiting when the video ends or you press Q."
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:204
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:227
+msgid ""
+"Off means command-line mode: no window, no system tray and no settings "
+"screen, so the only way back is editing conf.json by hand. It is not how you "
+"get MPV's own on-screen controls — \"Player Controls Style\" under Interface "
+"does that."
+msgstr ""
+
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:234
+msgid ""
+"Show only what is cast to this machine — the library, including this "
+"settings screen, can't be reached from here. Without a system tray icon the "
+"only way back is editing conf.json. For the classic cast-target setup you "
+"want the Interface settings instead; this is for a shared TV nobody should "
+"be able to browse from."
+msgstr ""
+
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:240
+msgid ""
+"Requires restart to change. MPV keybinds are used by default. Press ENTER to "
+"drive the player controls by keyboard."
+msgstr ""
+
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:242
 msgid ""
 "Pixels one wheel notch scrolls. The scrollbar glides while the content snaps "
 "to the nearest row, so a trackpad or trackball no longer overshoots. Raise "
 "it to scroll faster, lower it for finer control."
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:209
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:247
 msgid ""
 "Make each wheel notch jump exactly one row (or one home-screen section) "
 "instead of gliding. Turn this on if you prefer the older stepped scrolling."
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:217
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:255
 msgid "Discord Rich Presence. Takes effect after a restart."
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:219
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:257
 msgid ""
 "Leave this to Default unless setting up passthrough. Note some audio servers "
 "like Pipewire don't like passthrough and will need to be disabled for a card "
@@ -957,57 +981,57 @@ msgid ""
 "silence otherwise, but results may vary."
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:225
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:263
 msgid ""
 "Stop anything else using the device while playing. Needed for passthrough on "
 "some systems, and it means other applications will be silent."
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:228
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:266
 msgid ""
 "Page the library and music tile grids instead of scrolling: each page is one "
 "screenful with First / Previous / Next / Last controls and a page number you "
 "can type into. Easier than precise scrolling on a trackpad."
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:232
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:270
 msgid ""
 "Takes effect after a restart. \"Follow display\" uses the scale your desktop "
 "reports, which is 100% on X11."
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:234
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:272
 msgid ""
 "\"Default\" changes nothing and lets MPV (and your own mpv.conf) decide. "
 "Pick a mode only if you are sending audio to a receiver."
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:237
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:275
 msgid ""
 "Audio your receiver can't be sent directly is encoded to AC3, which is the "
 "only way surround fits down an optical cable. Turn this off if the encoder "
 "causes audio delay — those tracks become stereo instead."
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:242
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:280
 msgid ""
 "\"hq\" offers heavier profiles. Pick it if you have a fast graphics card."
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:244
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:282
 msgid ""
 "Leave on Automatic unless video breaks when a profile is loaded. This only "
 "applies while a profile is active, and OpenGL can cost you HDR output."
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:248
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:286
 msgid ""
 "Evens out loud effects and quiet dialogue. This turns passthrough off while "
 "it is enabled, because the volume has to be adjusted before your receiver "
 "gets the audio."
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:330
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:368
 msgid "Advanced"
 msgstr ""
 
@@ -1185,7 +1209,7 @@ msgid "Automatic"
 msgstr ""
 
 #: jellyfin_mpv_shim/mpvtk_browser/downloads.py:51
-#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1355
+#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1288
 msgid "Episodes"
 msgstr ""
 
@@ -1194,7 +1218,7 @@ msgid "Season %s"
 msgstr ""
 
 #: jellyfin_mpv_shim/mpvtk_browser/downloads.py:52
-#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1351
+#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1284
 msgid "Specials"
 msgstr ""
 
@@ -1215,7 +1239,7 @@ msgid "Failed"
 msgstr ""
 
 #: jellyfin_mpv_shim/mpvtk_browser/downloads.py:185
-#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1105
+#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1038
 msgid "Playlist"
 msgstr ""
 
@@ -1227,30 +1251,30 @@ msgstr ""
 msgid "Movies & Videos"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/home_sections.py:103
+#: jellyfin_mpv_shim/mpvtk_browser/home_sections.py:104
 msgid "My Media"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/home_sections.py:104
-#: jellyfin_mpv_shim/mpvtk_browser/repository.py:352
+#: jellyfin_mpv_shim/mpvtk_browser/home_sections.py:105
+#: jellyfin_mpv_shim/mpvtk_browser/repository.py:350
 msgid "Continue Watching"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/home_sections.py:105
-#: jellyfin_mpv_shim/mpvtk_browser/repository.py:359
+#: jellyfin_mpv_shim/mpvtk_browser/home_sections.py:106
+#: jellyfin_mpv_shim/mpvtk_browser/repository.py:357
 msgid "Continue Listening"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/home_sections.py:106
-#: jellyfin_mpv_shim/mpvtk_browser/repository.py:366
+#: jellyfin_mpv_shim/mpvtk_browser/home_sections.py:107
+#: jellyfin_mpv_shim/mpvtk_browser/repository.py:364
 msgid "Next Up"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/home_sections.py:107
+#: jellyfin_mpv_shim/mpvtk_browser/home_sections.py:108
 msgid "Recently Added"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/home_sections.py:108
+#: jellyfin_mpv_shim/mpvtk_browser/home_sections.py:109
 msgid "Live TV"
 msgstr ""
 
@@ -1455,52 +1479,52 @@ msgstr ""
 msgid "Could not load this page."
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/repository.py:390
+#: jellyfin_mpv_shim/mpvtk_browser/repository.py:386
 msgid "On Now"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/repository.py:411
+#: jellyfin_mpv_shim/mpvtk_browser/repository.py:407
 msgid "Latest %s"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1119
+#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1052
 msgid "Downloaded"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1138
+#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1071
 msgid "Movies"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1143
+#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1076
 msgid "Videos"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1147
+#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1080
 msgid "TV Shows"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1151
+#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1084
 msgid "Playlists"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1168
-#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1441
+#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1101
+#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1374
 msgid "Series"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1212
+#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1145
 msgid "Downloaded Movies"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1216
+#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1149
 msgid "Downloaded Videos"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1220
+#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1153
 msgid "Downloaded Shows"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1353
+#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1286
 msgid "Season %d"
 msgstr ""
 

--- a/jellyfin_mpv_shim/messages/pl/LC_MESSAGES/base.po
+++ b/jellyfin_mpv_shim/messages/pl/LC_MESSAGES/base.po
@@ -5,18 +5,18 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2026-07-25 17:21-0400\n"
-"PO-Revision-Date: 2026-07-26 06:33+0000\n"
+"POT-Creation-Date: 2026-07-26 12:03-0400\n"
+"PO-Revision-Date: 2025-02-27 11:39+0000\n"
 "Last-Translator: Kityn <kitynska@gmail.com>\n"
 "Language-Team: Polish <https://translate.jellyfin.org/projects/jellyfin/"
-"jellyfin-mpv-shim/pl/>\n"
+"jellyfin-desktop/pl/>\n"
 "Language: pl\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=3; plural=n==1 ? 0 : n%10>=2 && n%10<=4 && (n%100<10 "
 "|| n%100>=20) ? 1 : 2;\n"
-"X-Generator: Weblate 5.15.1\n"
+"X-Generator: Weblate 5.7.2\n"
 "Generated-By: pygettext.py 1.5\n"
 
 #: jellyfin_mpv_shim/bulk_subtitle.py:29
@@ -253,7 +253,7 @@ msgid "Select Subtitle Track"
 msgstr "Wybierz ścieżkę napisów"
 
 #: jellyfin_mpv_shim/menu.py:341
-#: jellyfin_mpv_shim/mpvtk_browser/home_sections.py:102
+#: jellyfin_mpv_shim/mpvtk_browser/home_sections.py:103
 #: jellyfin_mpv_shim/osc_bridge.py:81 jellyfin_mpv_shim/osc_bridge.py:82
 #: jellyfin_mpv_shim/osc_bridge.py:104 jellyfin_mpv_shim/osc_bridge.py:140
 msgid "None"
@@ -404,7 +404,7 @@ msgstr "Pytaj o pominięcie napisów końcowych"
 msgid "Enable thumbnail previews"
 msgstr "Włącz podgląd miniatur"
 
-#: jellyfin_mpv_shim/menu.py:609 jellyfin_mpv_shim/mpvtk_browser/config.py:186
+#: jellyfin_mpv_shim/menu.py:609 jellyfin_mpv_shim/mpvtk_browser/config.py:195
 #: jellyfin_mpv_shim/mpvtk_browser/hud.py:375
 msgid "Night Mode (Auto Volume Adj)"
 msgstr ""
@@ -596,12 +596,16 @@ msgid "Enter this code in the Jellyfin app or web client:"
 msgstr ""
 
 #: jellyfin_mpv_shim/mpvtk_browser/auth.py:276
+#, fuzzy
+#| msgid "SVP Settings"
 msgid "Requesting…"
-msgstr "Żądanie…"
+msgstr "Ustawienia SVP"
 
 #: jellyfin_mpv_shim/mpvtk_browser/auth.py:287
+#, fuzzy
+#| msgid "Server URL: "
 msgid "Server URL"
-msgstr "Serwer URL"
+msgstr "Serwer URL: "
 
 #: jellyfin_mpv_shim/mpvtk_browser/auth.py:288
 #, fuzzy
@@ -628,8 +632,14 @@ msgid "Enter the server URL first."
 msgstr ""
 
 #: jellyfin_mpv_shim/mpvtk_browser/auth.py:330
+#, fuzzy
+#| msgid ""
+#| "Could not add server.\n"
+#| "Please check your connection information."
 msgid "Contacting the server…"
-msgstr "Łączenie z serwerem…"
+msgstr ""
+"Nie można dodać serwera.\n"
+"Proszę sprawdzić informacje o połączeniu."
 
 #: jellyfin_mpv_shim/mpvtk_browser/auth.py:339
 msgid "Waiting for approval…"
@@ -693,308 +703,334 @@ msgstr ""
 msgid "Or switch to another user"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/cast.py:317
+#: jellyfin_mpv_shim/mpvtk_browser/cast.py:314
 msgid "Ready to cast"
 msgstr "Gotowy do castowania"
 
-#: jellyfin_mpv_shim/mpvtk_browser/cast.py:318
+#: jellyfin_mpv_shim/mpvtk_browser/cast.py:315
 #, fuzzy
 #| msgid "Select your media in Jellyfin and play it here"
 msgid "Select your media in Jellyfin and play it here."
 msgstr "Wybierz swoje multimedia w Jellyfin i odtwarzaj je tutaj"
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:74
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:83
 msgid "Interface"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:83
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:92
 msgid "Playback"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:88
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:97
 msgid "Audio"
 msgstr "Dźwięk"
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:92
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:101
 msgid "Subtitles & Languages"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:97
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:106
+#, fuzzy
+#| msgid " (Transcode)"
 msgid "Transcoding"
-msgstr "Transkodowanie"
+msgstr " (Transkoduj)"
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:102
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:111
 msgid "Video Enhancement"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:104
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:113
 #, fuzzy
 #| msgid "Seek to Skip Credits"
 msgid "Skip Intro / Credits"
 msgstr "Przewiń, aby pominąć napisy końcowe"
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:107
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:116
 msgid "Library Browser"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:109
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:118
 msgid "Downloads"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:128
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:137
 msgid "Jellyfin UI"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:129
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:138
 msgid "MPV UI with thumbnails"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:130
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:139
 msgid "MPV built-in default"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:133
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:142
 msgid "Follow display"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:134
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:143
 msgid "100% (no scaling)"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:135
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:144
 msgid "125%"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:136
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:145
 msgid "150%"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:137
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:146
 msgid "200%"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:140
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:149
 msgid "Automatic (recommended)"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:141
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:150
 msgid "Vulkan"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:142
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:151
 msgid "Direct3D 11 (Windows only)"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:143
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:152
 msgid "OpenGL (compatibility)"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:146
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:155
 msgid "Default (auto)"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:147
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:156
 msgid "Force Stereo"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:148
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:157
 msgid "Optical Surround"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:149
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:158
 msgid "HDMI Passthrough"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:152
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:161
 msgid "Unset"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:153
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:162
 msgid "Dubbed (shows only)"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:154
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:163
 msgid "Subbed (shows only)"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:155
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:164
 msgid "Dubbed (all)"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:156
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:165
 msgid "Subbed (all)"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:157
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:166
 msgid "Custom (set in config)"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:162
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:171
 msgid "Download Folder"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:163
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:172
 msgid "Prefer Downloaded Copy"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:164
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:173
 msgid "Automatically Download Upcoming Episodes"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:165
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:174
 msgid "Include Next Up"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:166
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:175
 msgid "Next Up Entries to Consider"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:167
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:176
 msgid "Episodes to Keep Ahead (0 = off)"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:168
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:177
 msgid "Storage Limit for Automatic Downloads (GB)"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:169
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:178
 #, fuzzy
 #| msgid "Remove Server"
 msgid "Delete Automatic Downloads Once Watched"
 msgstr "Usuń serwer"
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:170
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:179
 msgid "Delete Unwatched After (days, 0 = never)"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:171
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:180
 msgid "Check Every (minutes)"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:172
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:181
 msgid "Close to Tray (keep running)"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:173
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:182
 msgid "Keep Running in Background"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:174
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:183
 msgid "Remember Window Size"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:175
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:184
 msgid "Player Controls Style"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:176
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:185
 msgid "Show What You're Watching in Discord"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:177
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:186
 msgid "Interface Scale"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:178
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:187
 msgid "Cast-target mode (no library browsing)"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:179
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:188
 msgid "Casting Opens the Library Browser"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:180
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:189
 msgid "Fullscreen Library Browser"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:181
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:190
 msgid "Always Bind Arrow Keys to Player Controls"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:182
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:191
 msgid "Player Controls Activation Key"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:183
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:192
 msgid "Audio Output Mode"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:184
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:193
 msgid "Audio Output Device"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:185
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:194
 msgid "Take the Device Exclusively"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:187
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:196
 #, fuzzy
 #| msgid "Video Playback Profiles"
 msgid "Enable Video Playback Profiles"
 msgstr "Profile odtwarzania wideo"
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:188
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:197
 #, fuzzy
 #| msgid "New Group"
 msgid "Profile Group"
 msgstr "Nowa grupa"
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:189
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:198
 msgid "Remember Last Used Profile"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:190
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:199
 msgid "Graphics API for Shaders"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:191
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:200
 msgid "Pass Through AC3"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:192
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:201
 msgid "Pass Through DTS"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:193
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:202
 msgid "Pass Through E-AC3"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:194
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:203
 msgid "Pass Through DTS-HD"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:195
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:204
 msgid "Pass Through TrueHD"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:196
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:205
 msgid "Re-encode Others to AC3"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:202
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:213
 msgid ""
-"MPV keybinds are used by default. Press ENTER to drive the player controls "
-"by keyboard."
+"With \"Start Minimized\" and \"Fullscreen\" this is the classic cast-target "
+"setup: the app waits out of the way, plays fullscreen when something casts "
+"to it, and goes back to waiting when the video ends or you press Q."
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:204
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:227
+msgid ""
+"Off means command-line mode: no window, no system tray and no settings "
+"screen, so the only way back is editing conf.json by hand. It is not how you "
+"get MPV's own on-screen controls — \"Player Controls Style\" under Interface "
+"does that."
+msgstr ""
+
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:234
+msgid ""
+"Show only what is cast to this machine — the library, including this "
+"settings screen, can't be reached from here. Without a system tray icon the "
+"only way back is editing conf.json. For the classic cast-target setup you "
+"want the Interface settings instead; this is for a shared TV nobody should "
+"be able to browse from."
+msgstr ""
+
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:240
+msgid ""
+"Requires restart to change. MPV keybinds are used by default. Press ENTER to "
+"drive the player controls by keyboard."
+msgstr ""
+
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:242
 msgid ""
 "Pixels one wheel notch scrolls. The scrollbar glides while the content snaps "
 "to the nearest row, so a trackpad or trackball no longer overshoots. Raise "
 "it to scroll faster, lower it for finer control."
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:209
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:247
 msgid ""
 "Make each wheel notch jump exactly one row (or one home-screen section) "
 "instead of gliding. Turn this on if you prefer the older stepped scrolling."
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:217
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:255
 msgid "Discord Rich Presence. Takes effect after a restart."
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:219
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:257
 msgid ""
 "Leave this to Default unless setting up passthrough. Note some audio servers "
 "like Pipewire don't like passthrough and will need to be disabled for a card "
@@ -1002,57 +1038,57 @@ msgid ""
 "silence otherwise, but results may vary."
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:225
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:263
 msgid ""
 "Stop anything else using the device while playing. Needed for passthrough on "
 "some systems, and it means other applications will be silent."
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:228
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:266
 msgid ""
 "Page the library and music tile grids instead of scrolling: each page is one "
 "screenful with First / Previous / Next / Last controls and a page number you "
 "can type into. Easier than precise scrolling on a trackpad."
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:232
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:270
 msgid ""
 "Takes effect after a restart. \"Follow display\" uses the scale your desktop "
 "reports, which is 100% on X11."
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:234
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:272
 msgid ""
 "\"Default\" changes nothing and lets MPV (and your own mpv.conf) decide. "
 "Pick a mode only if you are sending audio to a receiver."
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:237
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:275
 msgid ""
 "Audio your receiver can't be sent directly is encoded to AC3, which is the "
 "only way surround fits down an optical cable. Turn this off if the encoder "
 "causes audio delay — those tracks become stereo instead."
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:242
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:280
 msgid ""
 "\"hq\" offers heavier profiles. Pick it if you have a fast graphics card."
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:244
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:282
 msgid ""
 "Leave on Automatic unless video breaks when a profile is loaded. This only "
 "applies while a profile is active, and OpenGL can cost you HDR output."
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:248
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:286
 msgid ""
 "Evens out loud effects and quiet dialogue. This turns passthrough off while "
 "it is enabled, because the volume has to be adjusted before your receiver "
 "gets the audio."
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:330
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:368
 msgid "Advanced"
 msgstr ""
 
@@ -1081,8 +1117,10 @@ msgid "Private (only you can see it)"
 msgstr ""
 
 #: jellyfin_mpv_shim/mpvtk_browser/dialogs.py:120
+#, fuzzy
+#| msgid "Remove Server"
 msgid "Collections…"
-msgstr "Kolekcje…"
+msgstr "Usuń serwer"
 
 #: jellyfin_mpv_shim/mpvtk_browser/dialogs.py:123
 #: jellyfin_mpv_shim/mpvtk_browser/dialogs.py:169
@@ -1103,8 +1141,10 @@ msgid "No collections yet."
 msgstr "Usuń serwer"
 
 #: jellyfin_mpv_shim/mpvtk_browser/dialogs.py:156
+#, fuzzy
+#| msgid "Username: "
 msgid "New collection name…"
-msgstr "Nazwa nowej kolekcji…"
+msgstr "Nazwa użytkownika: "
 
 #: jellyfin_mpv_shim/mpvtk_browser/dialogs.py:166
 #: jellyfin_mpv_shim/mpvtk_browser/hud.py:393
@@ -1125,8 +1165,10 @@ msgstr ""
 
 #: jellyfin_mpv_shim/mpvtk_browser/dialogs.py:270
 #: jellyfin_mpv_shim/mpvtk_browser/dialogs.py:303
+#, fuzzy
+#| msgid "SVP Settings"
 msgid "Estimating…"
-msgstr "Szacowanie…"
+msgstr "Ustawienia SVP"
 
 #: jellyfin_mpv_shim/mpvtk_browser/dialogs.py:272
 msgid "%(count)d items · %(size)s"
@@ -1272,7 +1314,7 @@ msgid "Automatic"
 msgstr "Automatycznie"
 
 #: jellyfin_mpv_shim/mpvtk_browser/downloads.py:51
-#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1355
+#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1288
 msgid "Episodes"
 msgstr ""
 
@@ -1281,7 +1323,7 @@ msgid "Season %s"
 msgstr ""
 
 #: jellyfin_mpv_shim/mpvtk_browser/downloads.py:52
-#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1351
+#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1284
 msgid "Specials"
 msgstr ""
 
@@ -1306,7 +1348,7 @@ msgid "Failed"
 msgstr "Błąd"
 
 #: jellyfin_mpv_shim/mpvtk_browser/downloads.py:185
-#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1105
+#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1038
 msgid "Playlist"
 msgstr ""
 
@@ -1318,30 +1360,30 @@ msgstr ""
 msgid "Movies & Videos"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/home_sections.py:103
+#: jellyfin_mpv_shim/mpvtk_browser/home_sections.py:104
 msgid "My Media"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/home_sections.py:104
-#: jellyfin_mpv_shim/mpvtk_browser/repository.py:352
+#: jellyfin_mpv_shim/mpvtk_browser/home_sections.py:105
+#: jellyfin_mpv_shim/mpvtk_browser/repository.py:350
 msgid "Continue Watching"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/home_sections.py:105
-#: jellyfin_mpv_shim/mpvtk_browser/repository.py:359
+#: jellyfin_mpv_shim/mpvtk_browser/home_sections.py:106
+#: jellyfin_mpv_shim/mpvtk_browser/repository.py:357
 msgid "Continue Listening"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/home_sections.py:106
-#: jellyfin_mpv_shim/mpvtk_browser/repository.py:366
+#: jellyfin_mpv_shim/mpvtk_browser/home_sections.py:107
+#: jellyfin_mpv_shim/mpvtk_browser/repository.py:364
 msgid "Next Up"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/home_sections.py:107
+#: jellyfin_mpv_shim/mpvtk_browser/home_sections.py:108
 msgid "Recently Added"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/home_sections.py:108
+#: jellyfin_mpv_shim/mpvtk_browser/home_sections.py:109
 msgid "Live TV"
 msgstr ""
 
@@ -1594,52 +1636,52 @@ msgstr ""
 "Nie można dodać serwera.\n"
 "Proszę sprawdzić informacje o połączeniu."
 
-#: jellyfin_mpv_shim/mpvtk_browser/repository.py:390
+#: jellyfin_mpv_shim/mpvtk_browser/repository.py:386
 msgid "On Now"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/repository.py:411
+#: jellyfin_mpv_shim/mpvtk_browser/repository.py:407
 msgid "Latest %s"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1119
+#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1052
 msgid "Downloaded"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1138
+#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1071
 msgid "Movies"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1143
+#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1076
 msgid "Videos"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1147
+#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1080
 msgid "TV Shows"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1151
+#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1084
 msgid "Playlists"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1168
-#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1441
+#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1101
+#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1374
 msgid "Series"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1212
+#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1145
 msgid "Downloaded Movies"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1216
+#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1149
 msgid "Downloaded Videos"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1220
+#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1153
 msgid "Downloaded Shows"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1353
+#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1286
 msgid "Season %d"
 msgstr ""
 
@@ -1780,8 +1822,10 @@ msgid "unknown"
 msgstr ""
 
 #: jellyfin_mpv_shim/osc_bridge.py:123
+#, fuzzy
+#| msgid " (Transcode)"
 msgid "Transcode"
-msgstr "Transkoduj"
+msgstr " (Transkoduj)"
 
 #: jellyfin_mpv_shim/osc_bridge.py:125 jellyfin_mpv_shim/osc_bridge.py:161
 msgid "External"

--- a/jellyfin_mpv_shim/messages/pon/LC_MESSAGES/base.po
+++ b/jellyfin_mpv_shim/messages/pon/LC_MESSAGES/base.po
@@ -5,7 +5,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2026-07-25 17:21-0400\n"
+"POT-Creation-Date: 2026-07-26 12:03-0400\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: Automatically generated\n"
 "Language-Team: none\n"
@@ -239,7 +239,7 @@ msgid "Select Subtitle Track"
 msgstr ""
 
 #: jellyfin_mpv_shim/menu.py:341
-#: jellyfin_mpv_shim/mpvtk_browser/home_sections.py:102
+#: jellyfin_mpv_shim/mpvtk_browser/home_sections.py:103
 #: jellyfin_mpv_shim/osc_bridge.py:81 jellyfin_mpv_shim/osc_bridge.py:82
 #: jellyfin_mpv_shim/osc_bridge.py:104 jellyfin_mpv_shim/osc_bridge.py:140
 msgid "None"
@@ -390,7 +390,7 @@ msgstr ""
 msgid "Enable thumbnail previews"
 msgstr ""
 
-#: jellyfin_mpv_shim/menu.py:609 jellyfin_mpv_shim/mpvtk_browser/config.py:186
+#: jellyfin_mpv_shim/menu.py:609 jellyfin_mpv_shim/mpvtk_browser/config.py:195
 #: jellyfin_mpv_shim/mpvtk_browser/hud.py:375
 msgid "Night Mode (Auto Volume Adj)"
 msgstr ""
@@ -655,298 +655,322 @@ msgstr ""
 msgid "Or switch to another user"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/cast.py:317
+#: jellyfin_mpv_shim/mpvtk_browser/cast.py:314
 msgid "Ready to cast"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/cast.py:318
+#: jellyfin_mpv_shim/mpvtk_browser/cast.py:315
 msgid "Select your media in Jellyfin and play it here."
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:74
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:83
 msgid "Interface"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:83
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:92
 msgid "Playback"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:88
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:97
 msgid "Audio"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:92
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:101
 msgid "Subtitles & Languages"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:97
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:106
 msgid "Transcoding"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:102
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:111
 msgid "Video Enhancement"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:104
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:113
 msgid "Skip Intro / Credits"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:107
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:116
 msgid "Library Browser"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:109
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:118
 msgid "Downloads"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:128
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:137
 msgid "Jellyfin UI"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:129
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:138
 msgid "MPV UI with thumbnails"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:130
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:139
 msgid "MPV built-in default"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:133
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:142
 msgid "Follow display"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:134
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:143
 msgid "100% (no scaling)"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:135
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:144
 msgid "125%"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:136
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:145
 msgid "150%"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:137
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:146
 msgid "200%"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:140
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:149
 msgid "Automatic (recommended)"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:141
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:150
 msgid "Vulkan"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:142
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:151
 msgid "Direct3D 11 (Windows only)"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:143
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:152
 msgid "OpenGL (compatibility)"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:146
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:155
 msgid "Default (auto)"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:147
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:156
 msgid "Force Stereo"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:148
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:157
 msgid "Optical Surround"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:149
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:158
 msgid "HDMI Passthrough"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:152
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:161
 msgid "Unset"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:153
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:162
 msgid "Dubbed (shows only)"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:154
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:163
 msgid "Subbed (shows only)"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:155
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:164
 msgid "Dubbed (all)"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:156
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:165
 msgid "Subbed (all)"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:157
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:166
 msgid "Custom (set in config)"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:162
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:171
 msgid "Download Folder"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:163
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:172
 msgid "Prefer Downloaded Copy"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:164
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:173
 msgid "Automatically Download Upcoming Episodes"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:165
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:174
 msgid "Include Next Up"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:166
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:175
 msgid "Next Up Entries to Consider"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:167
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:176
 msgid "Episodes to Keep Ahead (0 = off)"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:168
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:177
 msgid "Storage Limit for Automatic Downloads (GB)"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:169
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:178
 msgid "Delete Automatic Downloads Once Watched"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:170
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:179
 msgid "Delete Unwatched After (days, 0 = never)"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:171
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:180
 msgid "Check Every (minutes)"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:172
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:181
 msgid "Close to Tray (keep running)"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:173
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:182
 msgid "Keep Running in Background"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:174
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:183
 msgid "Remember Window Size"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:175
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:184
 msgid "Player Controls Style"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:176
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:185
 msgid "Show What You're Watching in Discord"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:177
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:186
 msgid "Interface Scale"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:178
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:187
 msgid "Cast-target mode (no library browsing)"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:179
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:188
 msgid "Casting Opens the Library Browser"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:180
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:189
 msgid "Fullscreen Library Browser"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:181
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:190
 msgid "Always Bind Arrow Keys to Player Controls"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:182
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:191
 msgid "Player Controls Activation Key"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:183
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:192
 msgid "Audio Output Mode"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:184
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:193
 msgid "Audio Output Device"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:185
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:194
 msgid "Take the Device Exclusively"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:187
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:196
 msgid "Enable Video Playback Profiles"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:188
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:197
 msgid "Profile Group"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:189
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:198
 msgid "Remember Last Used Profile"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:190
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:199
 msgid "Graphics API for Shaders"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:191
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:200
 msgid "Pass Through AC3"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:192
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:201
 msgid "Pass Through DTS"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:193
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:202
 msgid "Pass Through E-AC3"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:194
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:203
 msgid "Pass Through DTS-HD"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:195
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:204
 msgid "Pass Through TrueHD"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:196
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:205
 msgid "Re-encode Others to AC3"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:202
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:213
 msgid ""
-"MPV keybinds are used by default. Press ENTER to drive the player controls "
-"by keyboard."
+"With \"Start Minimized\" and \"Fullscreen\" this is the classic cast-target "
+"setup: the app waits out of the way, plays fullscreen when something casts "
+"to it, and goes back to waiting when the video ends or you press Q."
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:204
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:227
+msgid ""
+"Off means command-line mode: no window, no system tray and no settings "
+"screen, so the only way back is editing conf.json by hand. It is not how you "
+"get MPV's own on-screen controls — \"Player Controls Style\" under Interface "
+"does that."
+msgstr ""
+
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:234
+msgid ""
+"Show only what is cast to this machine — the library, including this "
+"settings screen, can't be reached from here. Without a system tray icon the "
+"only way back is editing conf.json. For the classic cast-target setup you "
+"want the Interface settings instead; this is for a shared TV nobody should "
+"be able to browse from."
+msgstr ""
+
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:240
+msgid ""
+"Requires restart to change. MPV keybinds are used by default. Press ENTER to "
+"drive the player controls by keyboard."
+msgstr ""
+
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:242
 msgid ""
 "Pixels one wheel notch scrolls. The scrollbar glides while the content snaps "
 "to the nearest row, so a trackpad or trackball no longer overshoots. Raise "
 "it to scroll faster, lower it for finer control."
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:209
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:247
 msgid ""
 "Make each wheel notch jump exactly one row (or one home-screen section) "
 "instead of gliding. Turn this on if you prefer the older stepped scrolling."
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:217
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:255
 msgid "Discord Rich Presence. Takes effect after a restart."
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:219
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:257
 msgid ""
 "Leave this to Default unless setting up passthrough. Note some audio servers "
 "like Pipewire don't like passthrough and will need to be disabled for a card "
@@ -954,57 +978,57 @@ msgid ""
 "silence otherwise, but results may vary."
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:225
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:263
 msgid ""
 "Stop anything else using the device while playing. Needed for passthrough on "
 "some systems, and it means other applications will be silent."
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:228
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:266
 msgid ""
 "Page the library and music tile grids instead of scrolling: each page is one "
 "screenful with First / Previous / Next / Last controls and a page number you "
 "can type into. Easier than precise scrolling on a trackpad."
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:232
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:270
 msgid ""
 "Takes effect after a restart. \"Follow display\" uses the scale your desktop "
 "reports, which is 100% on X11."
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:234
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:272
 msgid ""
 "\"Default\" changes nothing and lets MPV (and your own mpv.conf) decide. "
 "Pick a mode only if you are sending audio to a receiver."
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:237
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:275
 msgid ""
 "Audio your receiver can't be sent directly is encoded to AC3, which is the "
 "only way surround fits down an optical cable. Turn this off if the encoder "
 "causes audio delay — those tracks become stereo instead."
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:242
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:280
 msgid ""
 "\"hq\" offers heavier profiles. Pick it if you have a fast graphics card."
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:244
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:282
 msgid ""
 "Leave on Automatic unless video breaks when a profile is loaded. This only "
 "applies while a profile is active, and OpenGL can cost you HDR output."
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:248
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:286
 msgid ""
 "Evens out loud effects and quiet dialogue. This turns passthrough off while "
 "it is enabled, because the volume has to be adjusted before your receiver "
 "gets the audio."
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:330
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:368
 msgid "Advanced"
 msgstr ""
 
@@ -1182,7 +1206,7 @@ msgid "Automatic"
 msgstr ""
 
 #: jellyfin_mpv_shim/mpvtk_browser/downloads.py:51
-#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1355
+#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1288
 msgid "Episodes"
 msgstr ""
 
@@ -1191,7 +1215,7 @@ msgid "Season %s"
 msgstr ""
 
 #: jellyfin_mpv_shim/mpvtk_browser/downloads.py:52
-#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1351
+#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1284
 msgid "Specials"
 msgstr ""
 
@@ -1212,7 +1236,7 @@ msgid "Failed"
 msgstr ""
 
 #: jellyfin_mpv_shim/mpvtk_browser/downloads.py:185
-#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1105
+#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1038
 msgid "Playlist"
 msgstr ""
 
@@ -1224,30 +1248,30 @@ msgstr ""
 msgid "Movies & Videos"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/home_sections.py:103
+#: jellyfin_mpv_shim/mpvtk_browser/home_sections.py:104
 msgid "My Media"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/home_sections.py:104
-#: jellyfin_mpv_shim/mpvtk_browser/repository.py:352
+#: jellyfin_mpv_shim/mpvtk_browser/home_sections.py:105
+#: jellyfin_mpv_shim/mpvtk_browser/repository.py:350
 msgid "Continue Watching"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/home_sections.py:105
-#: jellyfin_mpv_shim/mpvtk_browser/repository.py:359
+#: jellyfin_mpv_shim/mpvtk_browser/home_sections.py:106
+#: jellyfin_mpv_shim/mpvtk_browser/repository.py:357
 msgid "Continue Listening"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/home_sections.py:106
-#: jellyfin_mpv_shim/mpvtk_browser/repository.py:366
+#: jellyfin_mpv_shim/mpvtk_browser/home_sections.py:107
+#: jellyfin_mpv_shim/mpvtk_browser/repository.py:364
 msgid "Next Up"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/home_sections.py:107
+#: jellyfin_mpv_shim/mpvtk_browser/home_sections.py:108
 msgid "Recently Added"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/home_sections.py:108
+#: jellyfin_mpv_shim/mpvtk_browser/home_sections.py:109
 msgid "Live TV"
 msgstr ""
 
@@ -1452,52 +1476,52 @@ msgstr ""
 msgid "Could not load this page."
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/repository.py:390
+#: jellyfin_mpv_shim/mpvtk_browser/repository.py:386
 msgid "On Now"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/repository.py:411
+#: jellyfin_mpv_shim/mpvtk_browser/repository.py:407
 msgid "Latest %s"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1119
+#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1052
 msgid "Downloaded"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1138
+#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1071
 msgid "Movies"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1143
+#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1076
 msgid "Videos"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1147
+#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1080
 msgid "TV Shows"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1151
+#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1084
 msgid "Playlists"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1168
-#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1441
+#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1101
+#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1374
 msgid "Series"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1212
+#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1145
 msgid "Downloaded Movies"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1216
+#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1149
 msgid "Downloaded Videos"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1220
+#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1153
 msgid "Downloaded Shows"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1353
+#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1286
 msgid "Season %d"
 msgstr ""
 

--- a/jellyfin_mpv_shim/messages/pt/LC_MESSAGES/base.po
+++ b/jellyfin_mpv_shim/messages/pt/LC_MESSAGES/base.po
@@ -5,7 +5,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2026-07-25 17:21-0400\n"
+"POT-Creation-Date: 2026-07-26 12:03-0400\n"
 "PO-Revision-Date: 2026-04-06 18:59+0000\n"
 "Last-Translator: Blackspirits <blackspirits@gmail.com>\n"
 "Language-Team: Portuguese <https://translate.jellyfin.org/projects/jellyfin/"
@@ -252,7 +252,7 @@ msgid "Select Subtitle Track"
 msgstr "Selecionar Faixa de Legendas"
 
 #: jellyfin_mpv_shim/menu.py:341
-#: jellyfin_mpv_shim/mpvtk_browser/home_sections.py:102
+#: jellyfin_mpv_shim/mpvtk_browser/home_sections.py:103
 #: jellyfin_mpv_shim/osc_bridge.py:81 jellyfin_mpv_shim/osc_bridge.py:82
 #: jellyfin_mpv_shim/osc_bridge.py:104 jellyfin_mpv_shim/osc_bridge.py:140
 msgid "None"
@@ -403,7 +403,7 @@ msgstr "Perguntar para saltar os créditos"
 msgid "Enable thumbnail previews"
 msgstr "Ativar visualizações de miniaturas"
 
-#: jellyfin_mpv_shim/menu.py:609 jellyfin_mpv_shim/mpvtk_browser/config.py:186
+#: jellyfin_mpv_shim/menu.py:609 jellyfin_mpv_shim/mpvtk_browser/config.py:195
 #: jellyfin_mpv_shim/mpvtk_browser/hud.py:375
 msgid "Night Mode (Auto Volume Adj)"
 msgstr ""
@@ -702,310 +702,334 @@ msgstr ""
 msgid "Or switch to another user"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/cast.py:317
+#: jellyfin_mpv_shim/mpvtk_browser/cast.py:314
 msgid "Ready to cast"
 msgstr "Pronto para transmitir"
 
-#: jellyfin_mpv_shim/mpvtk_browser/cast.py:318
+#: jellyfin_mpv_shim/mpvtk_browser/cast.py:315
 #, fuzzy
 #| msgid "Select your media in Jellyfin and play it here"
 msgid "Select your media in Jellyfin and play it here."
 msgstr "Selecione o seu conteúdo no Jellyfin e reproduza-o aqui"
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:74
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:83
 msgid "Interface"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:83
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:92
 msgid "Playback"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:88
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:97
 msgid "Audio"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:92
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:101
 msgid "Subtitles & Languages"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:97
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:106
 #, fuzzy
 #| msgid " (Transcode)"
 msgid "Transcoding"
 msgstr " (Transcodificação)"
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:102
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:111
 msgid "Video Enhancement"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:104
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:113
 #, fuzzy
 #| msgid "Seek to Skip Credits"
 msgid "Skip Intro / Credits"
 msgstr "Avançar para saltar créditos"
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:107
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:116
 msgid "Library Browser"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:109
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:118
 msgid "Downloads"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:128
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:137
 msgid "Jellyfin UI"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:129
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:138
 msgid "MPV UI with thumbnails"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:130
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:139
 msgid "MPV built-in default"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:133
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:142
 msgid "Follow display"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:134
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:143
 msgid "100% (no scaling)"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:135
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:144
 msgid "125%"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:136
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:145
 msgid "150%"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:137
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:146
 msgid "200%"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:140
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:149
 msgid "Automatic (recommended)"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:141
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:150
 msgid "Vulkan"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:142
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:151
 msgid "Direct3D 11 (Windows only)"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:143
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:152
 msgid "OpenGL (compatibility)"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:146
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:155
 msgid "Default (auto)"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:147
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:156
 msgid "Force Stereo"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:148
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:157
 msgid "Optical Surround"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:149
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:158
 msgid "HDMI Passthrough"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:152
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:161
 msgid "Unset"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:153
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:162
 msgid "Dubbed (shows only)"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:154
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:163
 msgid "Subbed (shows only)"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:155
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:164
 msgid "Dubbed (all)"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:156
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:165
 msgid "Subbed (all)"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:157
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:166
 msgid "Custom (set in config)"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:162
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:171
 msgid "Download Folder"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:163
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:172
 msgid "Prefer Downloaded Copy"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:164
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:173
 msgid "Automatically Download Upcoming Episodes"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:165
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:174
 msgid "Include Next Up"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:166
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:175
 msgid "Next Up Entries to Consider"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:167
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:176
 msgid "Episodes to Keep Ahead (0 = off)"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:168
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:177
 msgid "Storage Limit for Automatic Downloads (GB)"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:169
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:178
 #, fuzzy
 #| msgid "Remove Server"
 msgid "Delete Automatic Downloads Once Watched"
 msgstr "Eliminar servidor"
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:170
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:179
 msgid "Delete Unwatched After (days, 0 = never)"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:171
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:180
 msgid "Check Every (minutes)"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:172
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:181
 msgid "Close to Tray (keep running)"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:173
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:182
 msgid "Keep Running in Background"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:174
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:183
 msgid "Remember Window Size"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:175
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:184
 msgid "Player Controls Style"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:176
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:185
 msgid "Show What You're Watching in Discord"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:177
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:186
 msgid "Interface Scale"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:178
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:187
 msgid "Cast-target mode (no library browsing)"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:179
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:188
 msgid "Casting Opens the Library Browser"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:180
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:189
 msgid "Fullscreen Library Browser"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:181
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:190
 msgid "Always Bind Arrow Keys to Player Controls"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:182
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:191
 msgid "Player Controls Activation Key"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:183
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:192
 msgid "Audio Output Mode"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:184
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:193
 msgid "Audio Output Device"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:185
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:194
 msgid "Take the Device Exclusively"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:187
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:196
 #, fuzzy
 #| msgid "Video Playback Profiles"
 msgid "Enable Video Playback Profiles"
 msgstr "Perfis de Reprodução de Vídeo"
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:188
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:197
 #, fuzzy
 #| msgid "New Group"
 msgid "Profile Group"
 msgstr "Novo Grupo"
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:189
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:198
 msgid "Remember Last Used Profile"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:190
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:199
 msgid "Graphics API for Shaders"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:191
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:200
 msgid "Pass Through AC3"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:192
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:201
 msgid "Pass Through DTS"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:193
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:202
 msgid "Pass Through E-AC3"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:194
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:203
 msgid "Pass Through DTS-HD"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:195
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:204
 msgid "Pass Through TrueHD"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:196
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:205
 msgid "Re-encode Others to AC3"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:202
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:213
 msgid ""
-"MPV keybinds are used by default. Press ENTER to drive the player controls "
-"by keyboard."
+"With \"Start Minimized\" and \"Fullscreen\" this is the classic cast-target "
+"setup: the app waits out of the way, plays fullscreen when something casts "
+"to it, and goes back to waiting when the video ends or you press Q."
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:204
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:227
+msgid ""
+"Off means command-line mode: no window, no system tray and no settings "
+"screen, so the only way back is editing conf.json by hand. It is not how you "
+"get MPV's own on-screen controls — \"Player Controls Style\" under Interface "
+"does that."
+msgstr ""
+
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:234
+msgid ""
+"Show only what is cast to this machine — the library, including this "
+"settings screen, can't be reached from here. Without a system tray icon the "
+"only way back is editing conf.json. For the classic cast-target setup you "
+"want the Interface settings instead; this is for a shared TV nobody should "
+"be able to browse from."
+msgstr ""
+
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:240
+msgid ""
+"Requires restart to change. MPV keybinds are used by default. Press ENTER to "
+"drive the player controls by keyboard."
+msgstr ""
+
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:242
 msgid ""
 "Pixels one wheel notch scrolls. The scrollbar glides while the content snaps "
 "to the nearest row, so a trackpad or trackball no longer overshoots. Raise "
 "it to scroll faster, lower it for finer control."
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:209
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:247
 msgid ""
 "Make each wheel notch jump exactly one row (or one home-screen section) "
 "instead of gliding. Turn this on if you prefer the older stepped scrolling."
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:217
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:255
 msgid "Discord Rich Presence. Takes effect after a restart."
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:219
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:257
 msgid ""
 "Leave this to Default unless setting up passthrough. Note some audio servers "
 "like Pipewire don't like passthrough and will need to be disabled for a card "
@@ -1013,57 +1037,57 @@ msgid ""
 "silence otherwise, but results may vary."
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:225
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:263
 msgid ""
 "Stop anything else using the device while playing. Needed for passthrough on "
 "some systems, and it means other applications will be silent."
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:228
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:266
 msgid ""
 "Page the library and music tile grids instead of scrolling: each page is one "
 "screenful with First / Previous / Next / Last controls and a page number you "
 "can type into. Easier than precise scrolling on a trackpad."
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:232
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:270
 msgid ""
 "Takes effect after a restart. \"Follow display\" uses the scale your desktop "
 "reports, which is 100% on X11."
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:234
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:272
 msgid ""
 "\"Default\" changes nothing and lets MPV (and your own mpv.conf) decide. "
 "Pick a mode only if you are sending audio to a receiver."
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:237
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:275
 msgid ""
 "Audio your receiver can't be sent directly is encoded to AC3, which is the "
 "only way surround fits down an optical cable. Turn this off if the encoder "
 "causes audio delay — those tracks become stereo instead."
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:242
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:280
 msgid ""
 "\"hq\" offers heavier profiles. Pick it if you have a fast graphics card."
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:244
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:282
 msgid ""
 "Leave on Automatic unless video breaks when a profile is loaded. This only "
 "applies while a profile is active, and OpenGL can cost you HDR output."
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:248
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:286
 msgid ""
 "Evens out loud effects and quiet dialogue. This turns passthrough off while "
 "it is enabled, because the volume has to be adjusted before your receiver "
 "gets the audio."
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:330
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:368
 msgid "Advanced"
 msgstr ""
 
@@ -1289,7 +1313,7 @@ msgid "Automatic"
 msgstr "Automático"
 
 #: jellyfin_mpv_shim/mpvtk_browser/downloads.py:51
-#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1355
+#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1288
 msgid "Episodes"
 msgstr ""
 
@@ -1298,7 +1322,7 @@ msgid "Season %s"
 msgstr ""
 
 #: jellyfin_mpv_shim/mpvtk_browser/downloads.py:52
-#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1351
+#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1284
 msgid "Specials"
 msgstr ""
 
@@ -1323,7 +1347,7 @@ msgid "Failed"
 msgstr "Falhou"
 
 #: jellyfin_mpv_shim/mpvtk_browser/downloads.py:185
-#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1105
+#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1038
 msgid "Playlist"
 msgstr ""
 
@@ -1335,30 +1359,30 @@ msgstr ""
 msgid "Movies & Videos"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/home_sections.py:103
+#: jellyfin_mpv_shim/mpvtk_browser/home_sections.py:104
 msgid "My Media"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/home_sections.py:104
-#: jellyfin_mpv_shim/mpvtk_browser/repository.py:352
+#: jellyfin_mpv_shim/mpvtk_browser/home_sections.py:105
+#: jellyfin_mpv_shim/mpvtk_browser/repository.py:350
 msgid "Continue Watching"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/home_sections.py:105
-#: jellyfin_mpv_shim/mpvtk_browser/repository.py:359
+#: jellyfin_mpv_shim/mpvtk_browser/home_sections.py:106
+#: jellyfin_mpv_shim/mpvtk_browser/repository.py:357
 msgid "Continue Listening"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/home_sections.py:106
-#: jellyfin_mpv_shim/mpvtk_browser/repository.py:366
+#: jellyfin_mpv_shim/mpvtk_browser/home_sections.py:107
+#: jellyfin_mpv_shim/mpvtk_browser/repository.py:364
 msgid "Next Up"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/home_sections.py:107
+#: jellyfin_mpv_shim/mpvtk_browser/home_sections.py:108
 msgid "Recently Added"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/home_sections.py:108
+#: jellyfin_mpv_shim/mpvtk_browser/home_sections.py:109
 msgid "Live TV"
 msgstr ""
 
@@ -1611,52 +1635,52 @@ msgstr ""
 "Não foi possível adicionar o servidor.\n"
 "Verifique os dados de ligação."
 
-#: jellyfin_mpv_shim/mpvtk_browser/repository.py:390
+#: jellyfin_mpv_shim/mpvtk_browser/repository.py:386
 msgid "On Now"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/repository.py:411
+#: jellyfin_mpv_shim/mpvtk_browser/repository.py:407
 msgid "Latest %s"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1119
+#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1052
 msgid "Downloaded"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1138
+#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1071
 msgid "Movies"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1143
+#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1076
 msgid "Videos"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1147
+#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1080
 msgid "TV Shows"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1151
+#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1084
 msgid "Playlists"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1168
-#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1441
+#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1101
+#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1374
 msgid "Series"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1212
+#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1145
 msgid "Downloaded Movies"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1216
+#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1149
 msgid "Downloaded Videos"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1220
+#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1153
 msgid "Downloaded Shows"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1353
+#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1286
 msgid "Season %d"
 msgstr ""
 

--- a/jellyfin_mpv_shim/messages/pt_BR/LC_MESSAGES/base.po
+++ b/jellyfin_mpv_shim/messages/pt_BR/LC_MESSAGES/base.po
@@ -5,7 +5,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2026-07-25 17:21-0400\n"
+"POT-Creation-Date: 2026-07-26 12:03-0400\n"
 "PO-Revision-Date: 2024-06-30 02:41+0000\n"
 "Last-Translator: Leonardo de Macedo Sartorello <leo.sartorello98@gmail.com>\n"
 "Language-Team: Portuguese (Brazil) <https://translate.jellyfin.org/projects/"
@@ -252,7 +252,7 @@ msgid "Select Subtitle Track"
 msgstr "Selecionar faixa de legenda"
 
 #: jellyfin_mpv_shim/menu.py:341
-#: jellyfin_mpv_shim/mpvtk_browser/home_sections.py:102
+#: jellyfin_mpv_shim/mpvtk_browser/home_sections.py:103
 #: jellyfin_mpv_shim/osc_bridge.py:81 jellyfin_mpv_shim/osc_bridge.py:82
 #: jellyfin_mpv_shim/osc_bridge.py:104 jellyfin_mpv_shim/osc_bridge.py:140
 msgid "None"
@@ -403,7 +403,7 @@ msgstr "Pergunte Sobre Pular Créditos"
 msgid "Enable thumbnail previews"
 msgstr "Habilitar miniaturas de imagens"
 
-#: jellyfin_mpv_shim/menu.py:609 jellyfin_mpv_shim/mpvtk_browser/config.py:186
+#: jellyfin_mpv_shim/menu.py:609 jellyfin_mpv_shim/mpvtk_browser/config.py:195
 #: jellyfin_mpv_shim/mpvtk_browser/hud.py:375
 msgid "Night Mode (Auto Volume Adj)"
 msgstr ""
@@ -702,310 +702,334 @@ msgstr ""
 msgid "Or switch to another user"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/cast.py:317
+#: jellyfin_mpv_shim/mpvtk_browser/cast.py:314
 msgid "Ready to cast"
 msgstr "Pronto para transmitir"
 
-#: jellyfin_mpv_shim/mpvtk_browser/cast.py:318
+#: jellyfin_mpv_shim/mpvtk_browser/cast.py:315
 #, fuzzy
 #| msgid "Select your media in Jellyfin and play it here"
 msgid "Select your media in Jellyfin and play it here."
 msgstr "Selecione sua mídia no Jellyfin e reproduza-a aqui"
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:74
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:83
 msgid "Interface"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:83
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:92
 msgid "Playback"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:88
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:97
 msgid "Audio"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:92
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:101
 msgid "Subtitles & Languages"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:97
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:106
 #, fuzzy
 #| msgid " (Transcode)"
 msgid "Transcoding"
 msgstr " (Transcodificar)"
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:102
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:111
 msgid "Video Enhancement"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:104
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:113
 #, fuzzy
 #| msgid "Seek to Skip Credits"
 msgid "Skip Intro / Credits"
 msgstr "Tentar pular créditos"
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:107
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:116
 msgid "Library Browser"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:109
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:118
 msgid "Downloads"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:128
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:137
 msgid "Jellyfin UI"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:129
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:138
 msgid "MPV UI with thumbnails"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:130
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:139
 msgid "MPV built-in default"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:133
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:142
 msgid "Follow display"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:134
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:143
 msgid "100% (no scaling)"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:135
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:144
 msgid "125%"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:136
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:145
 msgid "150%"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:137
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:146
 msgid "200%"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:140
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:149
 msgid "Automatic (recommended)"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:141
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:150
 msgid "Vulkan"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:142
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:151
 msgid "Direct3D 11 (Windows only)"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:143
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:152
 msgid "OpenGL (compatibility)"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:146
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:155
 msgid "Default (auto)"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:147
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:156
 msgid "Force Stereo"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:148
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:157
 msgid "Optical Surround"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:149
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:158
 msgid "HDMI Passthrough"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:152
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:161
 msgid "Unset"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:153
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:162
 msgid "Dubbed (shows only)"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:154
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:163
 msgid "Subbed (shows only)"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:155
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:164
 msgid "Dubbed (all)"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:156
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:165
 msgid "Subbed (all)"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:157
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:166
 msgid "Custom (set in config)"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:162
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:171
 msgid "Download Folder"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:163
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:172
 msgid "Prefer Downloaded Copy"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:164
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:173
 msgid "Automatically Download Upcoming Episodes"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:165
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:174
 msgid "Include Next Up"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:166
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:175
 msgid "Next Up Entries to Consider"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:167
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:176
 msgid "Episodes to Keep Ahead (0 = off)"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:168
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:177
 msgid "Storage Limit for Automatic Downloads (GB)"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:169
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:178
 #, fuzzy
 #| msgid "Remove Server"
 msgid "Delete Automatic Downloads Once Watched"
 msgstr "Remover servidor"
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:170
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:179
 msgid "Delete Unwatched After (days, 0 = never)"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:171
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:180
 msgid "Check Every (minutes)"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:172
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:181
 msgid "Close to Tray (keep running)"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:173
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:182
 msgid "Keep Running in Background"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:174
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:183
 msgid "Remember Window Size"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:175
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:184
 msgid "Player Controls Style"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:176
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:185
 msgid "Show What You're Watching in Discord"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:177
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:186
 msgid "Interface Scale"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:178
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:187
 msgid "Cast-target mode (no library browsing)"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:179
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:188
 msgid "Casting Opens the Library Browser"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:180
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:189
 msgid "Fullscreen Library Browser"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:181
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:190
 msgid "Always Bind Arrow Keys to Player Controls"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:182
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:191
 msgid "Player Controls Activation Key"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:183
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:192
 msgid "Audio Output Mode"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:184
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:193
 msgid "Audio Output Device"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:185
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:194
 msgid "Take the Device Exclusively"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:187
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:196
 #, fuzzy
 #| msgid "Video Playback Profiles"
 msgid "Enable Video Playback Profiles"
 msgstr "Perfis de reprodução de vídeo"
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:188
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:197
 #, fuzzy
 #| msgid "New Group"
 msgid "Profile Group"
 msgstr "Novo grupo"
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:189
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:198
 msgid "Remember Last Used Profile"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:190
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:199
 msgid "Graphics API for Shaders"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:191
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:200
 msgid "Pass Through AC3"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:192
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:201
 msgid "Pass Through DTS"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:193
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:202
 msgid "Pass Through E-AC3"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:194
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:203
 msgid "Pass Through DTS-HD"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:195
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:204
 msgid "Pass Through TrueHD"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:196
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:205
 msgid "Re-encode Others to AC3"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:202
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:213
 msgid ""
-"MPV keybinds are used by default. Press ENTER to drive the player controls "
-"by keyboard."
+"With \"Start Minimized\" and \"Fullscreen\" this is the classic cast-target "
+"setup: the app waits out of the way, plays fullscreen when something casts "
+"to it, and goes back to waiting when the video ends or you press Q."
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:204
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:227
+msgid ""
+"Off means command-line mode: no window, no system tray and no settings "
+"screen, so the only way back is editing conf.json by hand. It is not how you "
+"get MPV's own on-screen controls — \"Player Controls Style\" under Interface "
+"does that."
+msgstr ""
+
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:234
+msgid ""
+"Show only what is cast to this machine — the library, including this "
+"settings screen, can't be reached from here. Without a system tray icon the "
+"only way back is editing conf.json. For the classic cast-target setup you "
+"want the Interface settings instead; this is for a shared TV nobody should "
+"be able to browse from."
+msgstr ""
+
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:240
+msgid ""
+"Requires restart to change. MPV keybinds are used by default. Press ENTER to "
+"drive the player controls by keyboard."
+msgstr ""
+
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:242
 msgid ""
 "Pixels one wheel notch scrolls. The scrollbar glides while the content snaps "
 "to the nearest row, so a trackpad or trackball no longer overshoots. Raise "
 "it to scroll faster, lower it for finer control."
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:209
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:247
 msgid ""
 "Make each wheel notch jump exactly one row (or one home-screen section) "
 "instead of gliding. Turn this on if you prefer the older stepped scrolling."
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:217
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:255
 msgid "Discord Rich Presence. Takes effect after a restart."
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:219
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:257
 msgid ""
 "Leave this to Default unless setting up passthrough. Note some audio servers "
 "like Pipewire don't like passthrough and will need to be disabled for a card "
@@ -1013,57 +1037,57 @@ msgid ""
 "silence otherwise, but results may vary."
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:225
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:263
 msgid ""
 "Stop anything else using the device while playing. Needed for passthrough on "
 "some systems, and it means other applications will be silent."
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:228
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:266
 msgid ""
 "Page the library and music tile grids instead of scrolling: each page is one "
 "screenful with First / Previous / Next / Last controls and a page number you "
 "can type into. Easier than precise scrolling on a trackpad."
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:232
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:270
 msgid ""
 "Takes effect after a restart. \"Follow display\" uses the scale your desktop "
 "reports, which is 100% on X11."
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:234
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:272
 msgid ""
 "\"Default\" changes nothing and lets MPV (and your own mpv.conf) decide. "
 "Pick a mode only if you are sending audio to a receiver."
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:237
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:275
 msgid ""
 "Audio your receiver can't be sent directly is encoded to AC3, which is the "
 "only way surround fits down an optical cable. Turn this off if the encoder "
 "causes audio delay — those tracks become stereo instead."
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:242
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:280
 msgid ""
 "\"hq\" offers heavier profiles. Pick it if you have a fast graphics card."
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:244
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:282
 msgid ""
 "Leave on Automatic unless video breaks when a profile is loaded. This only "
 "applies while a profile is active, and OpenGL can cost you HDR output."
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:248
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:286
 msgid ""
 "Evens out loud effects and quiet dialogue. This turns passthrough off while "
 "it is enabled, because the volume has to be adjusted before your receiver "
 "gets the audio."
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:330
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:368
 msgid "Advanced"
 msgstr ""
 
@@ -1289,7 +1313,7 @@ msgid "Automatic"
 msgstr "Automático"
 
 #: jellyfin_mpv_shim/mpvtk_browser/downloads.py:51
-#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1355
+#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1288
 msgid "Episodes"
 msgstr ""
 
@@ -1298,7 +1322,7 @@ msgid "Season %s"
 msgstr ""
 
 #: jellyfin_mpv_shim/mpvtk_browser/downloads.py:52
-#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1351
+#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1284
 msgid "Specials"
 msgstr ""
 
@@ -1323,7 +1347,7 @@ msgid "Failed"
 msgstr "Falhou"
 
 #: jellyfin_mpv_shim/mpvtk_browser/downloads.py:185
-#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1105
+#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1038
 msgid "Playlist"
 msgstr ""
 
@@ -1335,30 +1359,30 @@ msgstr ""
 msgid "Movies & Videos"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/home_sections.py:103
+#: jellyfin_mpv_shim/mpvtk_browser/home_sections.py:104
 msgid "My Media"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/home_sections.py:104
-#: jellyfin_mpv_shim/mpvtk_browser/repository.py:352
+#: jellyfin_mpv_shim/mpvtk_browser/home_sections.py:105
+#: jellyfin_mpv_shim/mpvtk_browser/repository.py:350
 msgid "Continue Watching"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/home_sections.py:105
-#: jellyfin_mpv_shim/mpvtk_browser/repository.py:359
+#: jellyfin_mpv_shim/mpvtk_browser/home_sections.py:106
+#: jellyfin_mpv_shim/mpvtk_browser/repository.py:357
 msgid "Continue Listening"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/home_sections.py:106
-#: jellyfin_mpv_shim/mpvtk_browser/repository.py:366
+#: jellyfin_mpv_shim/mpvtk_browser/home_sections.py:107
+#: jellyfin_mpv_shim/mpvtk_browser/repository.py:364
 msgid "Next Up"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/home_sections.py:107
+#: jellyfin_mpv_shim/mpvtk_browser/home_sections.py:108
 msgid "Recently Added"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/home_sections.py:108
+#: jellyfin_mpv_shim/mpvtk_browser/home_sections.py:109
 msgid "Live TV"
 msgstr ""
 
@@ -1611,52 +1635,52 @@ msgstr ""
 "Não foi possível adicionar o servidor.\n"
 "Por favor verifique os dados da conexão."
 
-#: jellyfin_mpv_shim/mpvtk_browser/repository.py:390
+#: jellyfin_mpv_shim/mpvtk_browser/repository.py:386
 msgid "On Now"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/repository.py:411
+#: jellyfin_mpv_shim/mpvtk_browser/repository.py:407
 msgid "Latest %s"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1119
+#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1052
 msgid "Downloaded"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1138
+#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1071
 msgid "Movies"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1143
+#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1076
 msgid "Videos"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1147
+#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1080
 msgid "TV Shows"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1151
+#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1084
 msgid "Playlists"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1168
-#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1441
+#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1101
+#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1374
 msgid "Series"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1212
+#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1145
 msgid "Downloaded Movies"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1216
+#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1149
 msgid "Downloaded Videos"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1220
+#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1153
 msgid "Downloaded Shows"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1353
+#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1286
 msgid "Season %d"
 msgstr ""
 

--- a/jellyfin_mpv_shim/messages/pt_PT/LC_MESSAGES/base.po
+++ b/jellyfin_mpv_shim/messages/pt_PT/LC_MESSAGES/base.po
@@ -5,7 +5,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2026-07-25 17:21-0400\n"
+"POT-Creation-Date: 2026-07-26 12:03-0400\n"
 "PO-Revision-Date: 2026-04-06 18:59+0000\n"
 "Last-Translator: Blackspirits <blackspirits@gmail.com>\n"
 "Language-Team: Portuguese (Portugal) <https://translate.jellyfin.org/"
@@ -252,7 +252,7 @@ msgid "Select Subtitle Track"
 msgstr "Selecionar Faixa de Legendas"
 
 #: jellyfin_mpv_shim/menu.py:341
-#: jellyfin_mpv_shim/mpvtk_browser/home_sections.py:102
+#: jellyfin_mpv_shim/mpvtk_browser/home_sections.py:103
 #: jellyfin_mpv_shim/osc_bridge.py:81 jellyfin_mpv_shim/osc_bridge.py:82
 #: jellyfin_mpv_shim/osc_bridge.py:104 jellyfin_mpv_shim/osc_bridge.py:140
 msgid "None"
@@ -403,7 +403,7 @@ msgstr "Perguntar para saltar os créditos"
 msgid "Enable thumbnail previews"
 msgstr "Activar previsão de miniatura"
 
-#: jellyfin_mpv_shim/menu.py:609 jellyfin_mpv_shim/mpvtk_browser/config.py:186
+#: jellyfin_mpv_shim/menu.py:609 jellyfin_mpv_shim/mpvtk_browser/config.py:195
 #: jellyfin_mpv_shim/mpvtk_browser/hud.py:375
 msgid "Night Mode (Auto Volume Adj)"
 msgstr ""
@@ -702,310 +702,334 @@ msgstr ""
 msgid "Or switch to another user"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/cast.py:317
+#: jellyfin_mpv_shim/mpvtk_browser/cast.py:314
 msgid "Ready to cast"
 msgstr "Pronto para transmitir"
 
-#: jellyfin_mpv_shim/mpvtk_browser/cast.py:318
+#: jellyfin_mpv_shim/mpvtk_browser/cast.py:315
 #, fuzzy
 #| msgid "Select your media in Jellyfin and play it here"
 msgid "Select your media in Jellyfin and play it here."
 msgstr "Selecione o seu conteúdo no Jellyfin e reproduza-o aqui"
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:74
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:83
 msgid "Interface"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:83
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:92
 msgid "Playback"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:88
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:97
 msgid "Audio"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:92
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:101
 msgid "Subtitles & Languages"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:97
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:106
 #, fuzzy
 #| msgid " (Transcode)"
 msgid "Transcoding"
 msgstr " ·(Transcodificar)"
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:102
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:111
 msgid "Video Enhancement"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:104
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:113
 #, fuzzy
 #| msgid "Seek to Skip Credits"
 msgid "Skip Intro / Credits"
 msgstr "Avançar para saltar créditos"
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:107
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:116
 msgid "Library Browser"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:109
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:118
 msgid "Downloads"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:128
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:137
 msgid "Jellyfin UI"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:129
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:138
 msgid "MPV UI with thumbnails"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:130
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:139
 msgid "MPV built-in default"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:133
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:142
 msgid "Follow display"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:134
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:143
 msgid "100% (no scaling)"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:135
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:144
 msgid "125%"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:136
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:145
 msgid "150%"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:137
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:146
 msgid "200%"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:140
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:149
 msgid "Automatic (recommended)"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:141
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:150
 msgid "Vulkan"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:142
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:151
 msgid "Direct3D 11 (Windows only)"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:143
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:152
 msgid "OpenGL (compatibility)"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:146
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:155
 msgid "Default (auto)"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:147
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:156
 msgid "Force Stereo"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:148
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:157
 msgid "Optical Surround"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:149
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:158
 msgid "HDMI Passthrough"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:152
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:161
 msgid "Unset"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:153
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:162
 msgid "Dubbed (shows only)"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:154
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:163
 msgid "Subbed (shows only)"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:155
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:164
 msgid "Dubbed (all)"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:156
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:165
 msgid "Subbed (all)"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:157
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:166
 msgid "Custom (set in config)"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:162
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:171
 msgid "Download Folder"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:163
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:172
 msgid "Prefer Downloaded Copy"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:164
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:173
 msgid "Automatically Download Upcoming Episodes"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:165
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:174
 msgid "Include Next Up"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:166
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:175
 msgid "Next Up Entries to Consider"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:167
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:176
 msgid "Episodes to Keep Ahead (0 = off)"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:168
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:177
 msgid "Storage Limit for Automatic Downloads (GB)"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:169
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:178
 #, fuzzy
 #| msgid "Remove Server"
 msgid "Delete Automatic Downloads Once Watched"
 msgstr "Eliminar servidor"
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:170
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:179
 msgid "Delete Unwatched After (days, 0 = never)"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:171
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:180
 msgid "Check Every (minutes)"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:172
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:181
 msgid "Close to Tray (keep running)"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:173
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:182
 msgid "Keep Running in Background"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:174
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:183
 msgid "Remember Window Size"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:175
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:184
 msgid "Player Controls Style"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:176
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:185
 msgid "Show What You're Watching in Discord"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:177
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:186
 msgid "Interface Scale"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:178
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:187
 msgid "Cast-target mode (no library browsing)"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:179
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:188
 msgid "Casting Opens the Library Browser"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:180
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:189
 msgid "Fullscreen Library Browser"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:181
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:190
 msgid "Always Bind Arrow Keys to Player Controls"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:182
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:191
 msgid "Player Controls Activation Key"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:183
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:192
 msgid "Audio Output Mode"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:184
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:193
 msgid "Audio Output Device"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:185
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:194
 msgid "Take the Device Exclusively"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:187
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:196
 #, fuzzy
 #| msgid "Video Playback Profiles"
 msgid "Enable Video Playback Profiles"
 msgstr "Perfis de Reprodução de Vídeo"
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:188
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:197
 #, fuzzy
 #| msgid "New Group"
 msgid "Profile Group"
 msgstr "Novo Grupo"
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:189
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:198
 msgid "Remember Last Used Profile"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:190
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:199
 msgid "Graphics API for Shaders"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:191
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:200
 msgid "Pass Through AC3"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:192
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:201
 msgid "Pass Through DTS"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:193
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:202
 msgid "Pass Through E-AC3"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:194
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:203
 msgid "Pass Through DTS-HD"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:195
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:204
 msgid "Pass Through TrueHD"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:196
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:205
 msgid "Re-encode Others to AC3"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:202
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:213
 msgid ""
-"MPV keybinds are used by default. Press ENTER to drive the player controls "
-"by keyboard."
+"With \"Start Minimized\" and \"Fullscreen\" this is the classic cast-target "
+"setup: the app waits out of the way, plays fullscreen when something casts "
+"to it, and goes back to waiting when the video ends or you press Q."
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:204
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:227
+msgid ""
+"Off means command-line mode: no window, no system tray and no settings "
+"screen, so the only way back is editing conf.json by hand. It is not how you "
+"get MPV's own on-screen controls — \"Player Controls Style\" under Interface "
+"does that."
+msgstr ""
+
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:234
+msgid ""
+"Show only what is cast to this machine — the library, including this "
+"settings screen, can't be reached from here. Without a system tray icon the "
+"only way back is editing conf.json. For the classic cast-target setup you "
+"want the Interface settings instead; this is for a shared TV nobody should "
+"be able to browse from."
+msgstr ""
+
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:240
+msgid ""
+"Requires restart to change. MPV keybinds are used by default. Press ENTER to "
+"drive the player controls by keyboard."
+msgstr ""
+
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:242
 msgid ""
 "Pixels one wheel notch scrolls. The scrollbar glides while the content snaps "
 "to the nearest row, so a trackpad or trackball no longer overshoots. Raise "
 "it to scroll faster, lower it for finer control."
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:209
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:247
 msgid ""
 "Make each wheel notch jump exactly one row (or one home-screen section) "
 "instead of gliding. Turn this on if you prefer the older stepped scrolling."
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:217
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:255
 msgid "Discord Rich Presence. Takes effect after a restart."
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:219
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:257
 msgid ""
 "Leave this to Default unless setting up passthrough. Note some audio servers "
 "like Pipewire don't like passthrough and will need to be disabled for a card "
@@ -1013,57 +1037,57 @@ msgid ""
 "silence otherwise, but results may vary."
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:225
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:263
 msgid ""
 "Stop anything else using the device while playing. Needed for passthrough on "
 "some systems, and it means other applications will be silent."
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:228
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:266
 msgid ""
 "Page the library and music tile grids instead of scrolling: each page is one "
 "screenful with First / Previous / Next / Last controls and a page number you "
 "can type into. Easier than precise scrolling on a trackpad."
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:232
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:270
 msgid ""
 "Takes effect after a restart. \"Follow display\" uses the scale your desktop "
 "reports, which is 100% on X11."
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:234
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:272
 msgid ""
 "\"Default\" changes nothing and lets MPV (and your own mpv.conf) decide. "
 "Pick a mode only if you are sending audio to a receiver."
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:237
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:275
 msgid ""
 "Audio your receiver can't be sent directly is encoded to AC3, which is the "
 "only way surround fits down an optical cable. Turn this off if the encoder "
 "causes audio delay — those tracks become stereo instead."
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:242
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:280
 msgid ""
 "\"hq\" offers heavier profiles. Pick it if you have a fast graphics card."
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:244
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:282
 msgid ""
 "Leave on Automatic unless video breaks when a profile is loaded. This only "
 "applies while a profile is active, and OpenGL can cost you HDR output."
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:248
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:286
 msgid ""
 "Evens out loud effects and quiet dialogue. This turns passthrough off while "
 "it is enabled, because the volume has to be adjusted before your receiver "
 "gets the audio."
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:330
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:368
 msgid "Advanced"
 msgstr ""
 
@@ -1289,7 +1313,7 @@ msgid "Automatic"
 msgstr "Automático"
 
 #: jellyfin_mpv_shim/mpvtk_browser/downloads.py:51
-#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1355
+#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1288
 msgid "Episodes"
 msgstr ""
 
@@ -1298,7 +1322,7 @@ msgid "Season %s"
 msgstr ""
 
 #: jellyfin_mpv_shim/mpvtk_browser/downloads.py:52
-#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1351
+#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1284
 msgid "Specials"
 msgstr ""
 
@@ -1323,7 +1347,7 @@ msgid "Failed"
 msgstr "Falhou"
 
 #: jellyfin_mpv_shim/mpvtk_browser/downloads.py:185
-#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1105
+#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1038
 msgid "Playlist"
 msgstr ""
 
@@ -1335,30 +1359,30 @@ msgstr ""
 msgid "Movies & Videos"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/home_sections.py:103
+#: jellyfin_mpv_shim/mpvtk_browser/home_sections.py:104
 msgid "My Media"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/home_sections.py:104
-#: jellyfin_mpv_shim/mpvtk_browser/repository.py:352
+#: jellyfin_mpv_shim/mpvtk_browser/home_sections.py:105
+#: jellyfin_mpv_shim/mpvtk_browser/repository.py:350
 msgid "Continue Watching"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/home_sections.py:105
-#: jellyfin_mpv_shim/mpvtk_browser/repository.py:359
+#: jellyfin_mpv_shim/mpvtk_browser/home_sections.py:106
+#: jellyfin_mpv_shim/mpvtk_browser/repository.py:357
 msgid "Continue Listening"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/home_sections.py:106
-#: jellyfin_mpv_shim/mpvtk_browser/repository.py:366
+#: jellyfin_mpv_shim/mpvtk_browser/home_sections.py:107
+#: jellyfin_mpv_shim/mpvtk_browser/repository.py:364
 msgid "Next Up"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/home_sections.py:107
+#: jellyfin_mpv_shim/mpvtk_browser/home_sections.py:108
 msgid "Recently Added"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/home_sections.py:108
+#: jellyfin_mpv_shim/mpvtk_browser/home_sections.py:109
 msgid "Live TV"
 msgstr ""
 
@@ -1611,52 +1635,52 @@ msgstr ""
 "Não foi possível adicionar o servidor.\n"
 "Verifique os dados de ligação."
 
-#: jellyfin_mpv_shim/mpvtk_browser/repository.py:390
+#: jellyfin_mpv_shim/mpvtk_browser/repository.py:386
 msgid "On Now"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/repository.py:411
+#: jellyfin_mpv_shim/mpvtk_browser/repository.py:407
 msgid "Latest %s"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1119
+#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1052
 msgid "Downloaded"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1138
+#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1071
 msgid "Movies"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1143
+#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1076
 msgid "Videos"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1147
+#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1080
 msgid "TV Shows"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1151
+#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1084
 msgid "Playlists"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1168
-#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1441
+#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1101
+#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1374
 msgid "Series"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1212
+#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1145
 msgid "Downloaded Movies"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1216
+#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1149
 msgid "Downloaded Videos"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1220
+#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1153
 msgid "Downloaded Shows"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1353
+#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1286
 msgid "Season %d"
 msgstr ""
 

--- a/jellyfin_mpv_shim/messages/ro/LC_MESSAGES/base.po
+++ b/jellyfin_mpv_shim/messages/ro/LC_MESSAGES/base.po
@@ -5,7 +5,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2026-07-25 17:21-0400\n"
+"POT-Creation-Date: 2026-07-26 12:03-0400\n"
 "PO-Revision-Date: 2024-09-16 00:41+0000\n"
 "Last-Translator: sand14 <sand.avrigeanu@yahoo.com>\n"
 "Language-Team: Romanian <https://translate.jellyfin.org/projects/jellyfin/"
@@ -253,7 +253,7 @@ msgid "Select Subtitle Track"
 msgstr "Selectați Pistă Subtitrare"
 
 #: jellyfin_mpv_shim/menu.py:341
-#: jellyfin_mpv_shim/mpvtk_browser/home_sections.py:102
+#: jellyfin_mpv_shim/mpvtk_browser/home_sections.py:103
 #: jellyfin_mpv_shim/osc_bridge.py:81 jellyfin_mpv_shim/osc_bridge.py:82
 #: jellyfin_mpv_shim/osc_bridge.py:104 jellyfin_mpv_shim/osc_bridge.py:140
 msgid "None"
@@ -404,7 +404,7 @@ msgstr "Întreabă înainte să treci peste credite"
 msgid "Enable thumbnail previews"
 msgstr "Activați previzualizările în miniatură"
 
-#: jellyfin_mpv_shim/menu.py:609 jellyfin_mpv_shim/mpvtk_browser/config.py:186
+#: jellyfin_mpv_shim/menu.py:609 jellyfin_mpv_shim/mpvtk_browser/config.py:195
 #: jellyfin_mpv_shim/mpvtk_browser/hud.py:375
 msgid "Night Mode (Auto Volume Adj)"
 msgstr ""
@@ -703,310 +703,334 @@ msgstr ""
 msgid "Or switch to another user"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/cast.py:317
+#: jellyfin_mpv_shim/mpvtk_browser/cast.py:314
 msgid "Ready to cast"
 msgstr "Gata de proiectat"
 
-#: jellyfin_mpv_shim/mpvtk_browser/cast.py:318
+#: jellyfin_mpv_shim/mpvtk_browser/cast.py:315
 #, fuzzy
 #| msgid "Select your media in Jellyfin and play it here"
 msgid "Select your media in Jellyfin and play it here."
 msgstr "Selectați-vă conținutul media în Jellyfin și redați-l aici"
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:74
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:83
 msgid "Interface"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:83
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:92
 msgid "Playback"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:88
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:97
 msgid "Audio"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:92
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:101
 msgid "Subtitles & Languages"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:97
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:106
 #, fuzzy
 #| msgid " (Transcode)"
 msgid "Transcoding"
 msgstr " (Transcodare)"
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:102
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:111
 msgid "Video Enhancement"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:104
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:113
 #, fuzzy
 #| msgid "Seek to Skip Credits"
 msgid "Skip Intro / Credits"
 msgstr "Căutați pentru a sări peste credite"
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:107
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:116
 msgid "Library Browser"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:109
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:118
 msgid "Downloads"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:128
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:137
 msgid "Jellyfin UI"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:129
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:138
 msgid "MPV UI with thumbnails"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:130
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:139
 msgid "MPV built-in default"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:133
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:142
 msgid "Follow display"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:134
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:143
 msgid "100% (no scaling)"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:135
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:144
 msgid "125%"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:136
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:145
 msgid "150%"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:137
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:146
 msgid "200%"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:140
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:149
 msgid "Automatic (recommended)"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:141
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:150
 msgid "Vulkan"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:142
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:151
 msgid "Direct3D 11 (Windows only)"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:143
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:152
 msgid "OpenGL (compatibility)"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:146
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:155
 msgid "Default (auto)"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:147
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:156
 msgid "Force Stereo"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:148
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:157
 msgid "Optical Surround"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:149
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:158
 msgid "HDMI Passthrough"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:152
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:161
 msgid "Unset"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:153
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:162
 msgid "Dubbed (shows only)"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:154
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:163
 msgid "Subbed (shows only)"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:155
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:164
 msgid "Dubbed (all)"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:156
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:165
 msgid "Subbed (all)"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:157
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:166
 msgid "Custom (set in config)"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:162
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:171
 msgid "Download Folder"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:163
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:172
 msgid "Prefer Downloaded Copy"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:164
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:173
 msgid "Automatically Download Upcoming Episodes"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:165
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:174
 msgid "Include Next Up"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:166
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:175
 msgid "Next Up Entries to Consider"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:167
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:176
 msgid "Episodes to Keep Ahead (0 = off)"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:168
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:177
 msgid "Storage Limit for Automatic Downloads (GB)"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:169
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:178
 #, fuzzy
 #| msgid "Remove Server"
 msgid "Delete Automatic Downloads Once Watched"
 msgstr "Eliminați Serverul"
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:170
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:179
 msgid "Delete Unwatched After (days, 0 = never)"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:171
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:180
 msgid "Check Every (minutes)"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:172
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:181
 msgid "Close to Tray (keep running)"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:173
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:182
 msgid "Keep Running in Background"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:174
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:183
 msgid "Remember Window Size"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:175
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:184
 msgid "Player Controls Style"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:176
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:185
 msgid "Show What You're Watching in Discord"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:177
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:186
 msgid "Interface Scale"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:178
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:187
 msgid "Cast-target mode (no library browsing)"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:179
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:188
 msgid "Casting Opens the Library Browser"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:180
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:189
 msgid "Fullscreen Library Browser"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:181
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:190
 msgid "Always Bind Arrow Keys to Player Controls"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:182
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:191
 msgid "Player Controls Activation Key"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:183
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:192
 msgid "Audio Output Mode"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:184
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:193
 msgid "Audio Output Device"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:185
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:194
 msgid "Take the Device Exclusively"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:187
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:196
 #, fuzzy
 #| msgid "Video Playback Profiles"
 msgid "Enable Video Playback Profiles"
 msgstr "Profiluri de Redare Video"
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:188
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:197
 #, fuzzy
 #| msgid "New Group"
 msgid "Profile Group"
 msgstr "Grup nou"
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:189
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:198
 msgid "Remember Last Used Profile"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:190
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:199
 msgid "Graphics API for Shaders"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:191
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:200
 msgid "Pass Through AC3"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:192
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:201
 msgid "Pass Through DTS"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:193
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:202
 msgid "Pass Through E-AC3"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:194
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:203
 msgid "Pass Through DTS-HD"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:195
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:204
 msgid "Pass Through TrueHD"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:196
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:205
 msgid "Re-encode Others to AC3"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:202
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:213
 msgid ""
-"MPV keybinds are used by default. Press ENTER to drive the player controls "
-"by keyboard."
+"With \"Start Minimized\" and \"Fullscreen\" this is the classic cast-target "
+"setup: the app waits out of the way, plays fullscreen when something casts "
+"to it, and goes back to waiting when the video ends or you press Q."
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:204
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:227
+msgid ""
+"Off means command-line mode: no window, no system tray and no settings "
+"screen, so the only way back is editing conf.json by hand. It is not how you "
+"get MPV's own on-screen controls — \"Player Controls Style\" under Interface "
+"does that."
+msgstr ""
+
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:234
+msgid ""
+"Show only what is cast to this machine — the library, including this "
+"settings screen, can't be reached from here. Without a system tray icon the "
+"only way back is editing conf.json. For the classic cast-target setup you "
+"want the Interface settings instead; this is for a shared TV nobody should "
+"be able to browse from."
+msgstr ""
+
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:240
+msgid ""
+"Requires restart to change. MPV keybinds are used by default. Press ENTER to "
+"drive the player controls by keyboard."
+msgstr ""
+
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:242
 msgid ""
 "Pixels one wheel notch scrolls. The scrollbar glides while the content snaps "
 "to the nearest row, so a trackpad or trackball no longer overshoots. Raise "
 "it to scroll faster, lower it for finer control."
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:209
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:247
 msgid ""
 "Make each wheel notch jump exactly one row (or one home-screen section) "
 "instead of gliding. Turn this on if you prefer the older stepped scrolling."
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:217
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:255
 msgid "Discord Rich Presence. Takes effect after a restart."
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:219
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:257
 msgid ""
 "Leave this to Default unless setting up passthrough. Note some audio servers "
 "like Pipewire don't like passthrough and will need to be disabled for a card "
@@ -1014,57 +1038,57 @@ msgid ""
 "silence otherwise, but results may vary."
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:225
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:263
 msgid ""
 "Stop anything else using the device while playing. Needed for passthrough on "
 "some systems, and it means other applications will be silent."
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:228
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:266
 msgid ""
 "Page the library and music tile grids instead of scrolling: each page is one "
 "screenful with First / Previous / Next / Last controls and a page number you "
 "can type into. Easier than precise scrolling on a trackpad."
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:232
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:270
 msgid ""
 "Takes effect after a restart. \"Follow display\" uses the scale your desktop "
 "reports, which is 100% on X11."
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:234
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:272
 msgid ""
 "\"Default\" changes nothing and lets MPV (and your own mpv.conf) decide. "
 "Pick a mode only if you are sending audio to a receiver."
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:237
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:275
 msgid ""
 "Audio your receiver can't be sent directly is encoded to AC3, which is the "
 "only way surround fits down an optical cable. Turn this off if the encoder "
 "causes audio delay — those tracks become stereo instead."
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:242
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:280
 msgid ""
 "\"hq\" offers heavier profiles. Pick it if you have a fast graphics card."
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:244
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:282
 msgid ""
 "Leave on Automatic unless video breaks when a profile is loaded. This only "
 "applies while a profile is active, and OpenGL can cost you HDR output."
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:248
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:286
 msgid ""
 "Evens out loud effects and quiet dialogue. This turns passthrough off while "
 "it is enabled, because the volume has to be adjusted before your receiver "
 "gets the audio."
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:330
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:368
 msgid "Advanced"
 msgstr ""
 
@@ -1290,7 +1314,7 @@ msgid "Automatic"
 msgstr "Automat"
 
 #: jellyfin_mpv_shim/mpvtk_browser/downloads.py:51
-#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1355
+#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1288
 msgid "Episodes"
 msgstr ""
 
@@ -1299,7 +1323,7 @@ msgid "Season %s"
 msgstr ""
 
 #: jellyfin_mpv_shim/mpvtk_browser/downloads.py:52
-#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1351
+#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1284
 msgid "Specials"
 msgstr ""
 
@@ -1324,7 +1348,7 @@ msgid "Failed"
 msgstr "Eșuat"
 
 #: jellyfin_mpv_shim/mpvtk_browser/downloads.py:185
-#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1105
+#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1038
 msgid "Playlist"
 msgstr ""
 
@@ -1336,30 +1360,30 @@ msgstr ""
 msgid "Movies & Videos"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/home_sections.py:103
+#: jellyfin_mpv_shim/mpvtk_browser/home_sections.py:104
 msgid "My Media"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/home_sections.py:104
-#: jellyfin_mpv_shim/mpvtk_browser/repository.py:352
+#: jellyfin_mpv_shim/mpvtk_browser/home_sections.py:105
+#: jellyfin_mpv_shim/mpvtk_browser/repository.py:350
 msgid "Continue Watching"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/home_sections.py:105
-#: jellyfin_mpv_shim/mpvtk_browser/repository.py:359
+#: jellyfin_mpv_shim/mpvtk_browser/home_sections.py:106
+#: jellyfin_mpv_shim/mpvtk_browser/repository.py:357
 msgid "Continue Listening"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/home_sections.py:106
-#: jellyfin_mpv_shim/mpvtk_browser/repository.py:366
+#: jellyfin_mpv_shim/mpvtk_browser/home_sections.py:107
+#: jellyfin_mpv_shim/mpvtk_browser/repository.py:364
 msgid "Next Up"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/home_sections.py:107
+#: jellyfin_mpv_shim/mpvtk_browser/home_sections.py:108
 msgid "Recently Added"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/home_sections.py:108
+#: jellyfin_mpv_shim/mpvtk_browser/home_sections.py:109
 msgid "Live TV"
 msgstr ""
 
@@ -1612,52 +1636,52 @@ msgstr ""
 "Nu s-a putut adăuga serverul.\n"
 "Vă rugăm să verificați informațiile conexiunii."
 
-#: jellyfin_mpv_shim/mpvtk_browser/repository.py:390
+#: jellyfin_mpv_shim/mpvtk_browser/repository.py:386
 msgid "On Now"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/repository.py:411
+#: jellyfin_mpv_shim/mpvtk_browser/repository.py:407
 msgid "Latest %s"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1119
+#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1052
 msgid "Downloaded"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1138
+#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1071
 msgid "Movies"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1143
+#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1076
 msgid "Videos"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1147
+#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1080
 msgid "TV Shows"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1151
+#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1084
 msgid "Playlists"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1168
-#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1441
+#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1101
+#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1374
 msgid "Series"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1212
+#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1145
 msgid "Downloaded Movies"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1216
+#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1149
 msgid "Downloaded Videos"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1220
+#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1153
 msgid "Downloaded Shows"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1353
+#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1286
 msgid "Season %d"
 msgstr ""
 

--- a/jellyfin_mpv_shim/messages/ru/LC_MESSAGES/base.po
+++ b/jellyfin_mpv_shim/messages/ru/LC_MESSAGES/base.po
@@ -5,7 +5,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2026-07-25 17:21-0400\n"
+"POT-Creation-Date: 2026-07-26 12:03-0400\n"
 "PO-Revision-Date: 2024-08-25 07:12+0000\n"
 "Last-Translator: \"Fedor M.\" <k930bx@gmail.com>\n"
 "Language-Team: Russian <https://translate.jellyfin.org/projects/jellyfin/"
@@ -253,7 +253,7 @@ msgid "Select Subtitle Track"
 msgstr "Выбрать дорожку субтитров"
 
 #: jellyfin_mpv_shim/menu.py:341
-#: jellyfin_mpv_shim/mpvtk_browser/home_sections.py:102
+#: jellyfin_mpv_shim/mpvtk_browser/home_sections.py:103
 #: jellyfin_mpv_shim/osc_bridge.py:81 jellyfin_mpv_shim/osc_bridge.py:82
 #: jellyfin_mpv_shim/osc_bridge.py:104 jellyfin_mpv_shim/osc_bridge.py:140
 msgid "None"
@@ -404,7 +404,7 @@ msgstr "Спрашивать, пропускать ли титры"
 msgid "Enable thumbnail previews"
 msgstr "Включить предварительный просмотр миниатюр"
 
-#: jellyfin_mpv_shim/menu.py:609 jellyfin_mpv_shim/mpvtk_browser/config.py:186
+#: jellyfin_mpv_shim/menu.py:609 jellyfin_mpv_shim/mpvtk_browser/config.py:195
 #: jellyfin_mpv_shim/mpvtk_browser/hud.py:375
 msgid "Night Mode (Auto Volume Adj)"
 msgstr ""
@@ -703,310 +703,334 @@ msgstr ""
 msgid "Or switch to another user"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/cast.py:317
+#: jellyfin_mpv_shim/mpvtk_browser/cast.py:314
 msgid "Ready to cast"
 msgstr "Готово к вещанию"
 
-#: jellyfin_mpv_shim/mpvtk_browser/cast.py:318
+#: jellyfin_mpv_shim/mpvtk_browser/cast.py:315
 #, fuzzy
 #| msgid "Select your media in Jellyfin and play it here"
 msgid "Select your media in Jellyfin and play it here."
 msgstr "Выберите медиафайлы в Jellyfin и воспроизведите их здесь"
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:74
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:83
 msgid "Interface"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:83
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:92
 msgid "Playback"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:88
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:97
 msgid "Audio"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:92
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:101
 msgid "Subtitles & Languages"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:97
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:106
 #, fuzzy
 #| msgid " (Transcode)"
 msgid "Transcoding"
 msgstr " (Перекодирование)"
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:102
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:111
 msgid "Video Enhancement"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:104
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:113
 #, fuzzy
 #| msgid "Seek to Skip Credits"
 msgid "Skip Intro / Credits"
 msgstr "Пропустить титры"
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:107
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:116
 msgid "Library Browser"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:109
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:118
 msgid "Downloads"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:128
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:137
 msgid "Jellyfin UI"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:129
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:138
 msgid "MPV UI with thumbnails"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:130
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:139
 msgid "MPV built-in default"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:133
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:142
 msgid "Follow display"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:134
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:143
 msgid "100% (no scaling)"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:135
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:144
 msgid "125%"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:136
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:145
 msgid "150%"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:137
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:146
 msgid "200%"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:140
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:149
 msgid "Automatic (recommended)"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:141
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:150
 msgid "Vulkan"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:142
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:151
 msgid "Direct3D 11 (Windows only)"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:143
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:152
 msgid "OpenGL (compatibility)"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:146
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:155
 msgid "Default (auto)"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:147
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:156
 msgid "Force Stereo"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:148
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:157
 msgid "Optical Surround"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:149
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:158
 msgid "HDMI Passthrough"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:152
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:161
 msgid "Unset"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:153
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:162
 msgid "Dubbed (shows only)"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:154
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:163
 msgid "Subbed (shows only)"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:155
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:164
 msgid "Dubbed (all)"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:156
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:165
 msgid "Subbed (all)"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:157
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:166
 msgid "Custom (set in config)"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:162
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:171
 msgid "Download Folder"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:163
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:172
 msgid "Prefer Downloaded Copy"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:164
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:173
 msgid "Automatically Download Upcoming Episodes"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:165
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:174
 msgid "Include Next Up"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:166
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:175
 msgid "Next Up Entries to Consider"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:167
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:176
 msgid "Episodes to Keep Ahead (0 = off)"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:168
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:177
 msgid "Storage Limit for Automatic Downloads (GB)"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:169
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:178
 #, fuzzy
 #| msgid "Remove Server"
 msgid "Delete Automatic Downloads Once Watched"
 msgstr "Убрать сервер"
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:170
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:179
 msgid "Delete Unwatched After (days, 0 = never)"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:171
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:180
 msgid "Check Every (minutes)"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:172
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:181
 msgid "Close to Tray (keep running)"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:173
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:182
 msgid "Keep Running in Background"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:174
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:183
 msgid "Remember Window Size"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:175
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:184
 msgid "Player Controls Style"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:176
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:185
 msgid "Show What You're Watching in Discord"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:177
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:186
 msgid "Interface Scale"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:178
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:187
 msgid "Cast-target mode (no library browsing)"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:179
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:188
 msgid "Casting Opens the Library Browser"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:180
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:189
 msgid "Fullscreen Library Browser"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:181
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:190
 msgid "Always Bind Arrow Keys to Player Controls"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:182
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:191
 msgid "Player Controls Activation Key"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:183
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:192
 msgid "Audio Output Mode"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:184
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:193
 msgid "Audio Output Device"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:185
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:194
 msgid "Take the Device Exclusively"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:187
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:196
 #, fuzzy
 #| msgid "Video Playback Profiles"
 msgid "Enable Video Playback Profiles"
 msgstr "Профили воспроизведения видео"
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:188
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:197
 #, fuzzy
 #| msgid "New Group"
 msgid "Profile Group"
 msgstr "Новая группа"
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:189
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:198
 msgid "Remember Last Used Profile"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:190
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:199
 msgid "Graphics API for Shaders"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:191
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:200
 msgid "Pass Through AC3"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:192
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:201
 msgid "Pass Through DTS"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:193
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:202
 msgid "Pass Through E-AC3"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:194
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:203
 msgid "Pass Through DTS-HD"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:195
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:204
 msgid "Pass Through TrueHD"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:196
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:205
 msgid "Re-encode Others to AC3"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:202
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:213
 msgid ""
-"MPV keybinds are used by default. Press ENTER to drive the player controls "
-"by keyboard."
+"With \"Start Minimized\" and \"Fullscreen\" this is the classic cast-target "
+"setup: the app waits out of the way, plays fullscreen when something casts "
+"to it, and goes back to waiting when the video ends or you press Q."
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:204
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:227
+msgid ""
+"Off means command-line mode: no window, no system tray and no settings "
+"screen, so the only way back is editing conf.json by hand. It is not how you "
+"get MPV's own on-screen controls — \"Player Controls Style\" under Interface "
+"does that."
+msgstr ""
+
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:234
+msgid ""
+"Show only what is cast to this machine — the library, including this "
+"settings screen, can't be reached from here. Without a system tray icon the "
+"only way back is editing conf.json. For the classic cast-target setup you "
+"want the Interface settings instead; this is for a shared TV nobody should "
+"be able to browse from."
+msgstr ""
+
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:240
+msgid ""
+"Requires restart to change. MPV keybinds are used by default. Press ENTER to "
+"drive the player controls by keyboard."
+msgstr ""
+
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:242
 msgid ""
 "Pixels one wheel notch scrolls. The scrollbar glides while the content snaps "
 "to the nearest row, so a trackpad or trackball no longer overshoots. Raise "
 "it to scroll faster, lower it for finer control."
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:209
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:247
 msgid ""
 "Make each wheel notch jump exactly one row (or one home-screen section) "
 "instead of gliding. Turn this on if you prefer the older stepped scrolling."
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:217
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:255
 msgid "Discord Rich Presence. Takes effect after a restart."
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:219
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:257
 msgid ""
 "Leave this to Default unless setting up passthrough. Note some audio servers "
 "like Pipewire don't like passthrough and will need to be disabled for a card "
@@ -1014,57 +1038,57 @@ msgid ""
 "silence otherwise, but results may vary."
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:225
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:263
 msgid ""
 "Stop anything else using the device while playing. Needed for passthrough on "
 "some systems, and it means other applications will be silent."
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:228
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:266
 msgid ""
 "Page the library and music tile grids instead of scrolling: each page is one "
 "screenful with First / Previous / Next / Last controls and a page number you "
 "can type into. Easier than precise scrolling on a trackpad."
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:232
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:270
 msgid ""
 "Takes effect after a restart. \"Follow display\" uses the scale your desktop "
 "reports, which is 100% on X11."
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:234
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:272
 msgid ""
 "\"Default\" changes nothing and lets MPV (and your own mpv.conf) decide. "
 "Pick a mode only if you are sending audio to a receiver."
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:237
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:275
 msgid ""
 "Audio your receiver can't be sent directly is encoded to AC3, which is the "
 "only way surround fits down an optical cable. Turn this off if the encoder "
 "causes audio delay — those tracks become stereo instead."
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:242
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:280
 msgid ""
 "\"hq\" offers heavier profiles. Pick it if you have a fast graphics card."
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:244
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:282
 msgid ""
 "Leave on Automatic unless video breaks when a profile is loaded. This only "
 "applies while a profile is active, and OpenGL can cost you HDR output."
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:248
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:286
 msgid ""
 "Evens out loud effects and quiet dialogue. This turns passthrough off while "
 "it is enabled, because the volume has to be adjusted before your receiver "
 "gets the audio."
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:330
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:368
 msgid "Advanced"
 msgstr ""
 
@@ -1290,7 +1314,7 @@ msgid "Automatic"
 msgstr "Автоматически"
 
 #: jellyfin_mpv_shim/mpvtk_browser/downloads.py:51
-#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1355
+#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1288
 msgid "Episodes"
 msgstr ""
 
@@ -1299,7 +1323,7 @@ msgid "Season %s"
 msgstr ""
 
 #: jellyfin_mpv_shim/mpvtk_browser/downloads.py:52
-#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1351
+#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1284
 msgid "Specials"
 msgstr ""
 
@@ -1324,7 +1348,7 @@ msgid "Failed"
 msgstr "Неудачно"
 
 #: jellyfin_mpv_shim/mpvtk_browser/downloads.py:185
-#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1105
+#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1038
 msgid "Playlist"
 msgstr ""
 
@@ -1336,30 +1360,30 @@ msgstr ""
 msgid "Movies & Videos"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/home_sections.py:103
+#: jellyfin_mpv_shim/mpvtk_browser/home_sections.py:104
 msgid "My Media"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/home_sections.py:104
-#: jellyfin_mpv_shim/mpvtk_browser/repository.py:352
+#: jellyfin_mpv_shim/mpvtk_browser/home_sections.py:105
+#: jellyfin_mpv_shim/mpvtk_browser/repository.py:350
 msgid "Continue Watching"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/home_sections.py:105
-#: jellyfin_mpv_shim/mpvtk_browser/repository.py:359
+#: jellyfin_mpv_shim/mpvtk_browser/home_sections.py:106
+#: jellyfin_mpv_shim/mpvtk_browser/repository.py:357
 msgid "Continue Listening"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/home_sections.py:106
-#: jellyfin_mpv_shim/mpvtk_browser/repository.py:366
+#: jellyfin_mpv_shim/mpvtk_browser/home_sections.py:107
+#: jellyfin_mpv_shim/mpvtk_browser/repository.py:364
 msgid "Next Up"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/home_sections.py:107
+#: jellyfin_mpv_shim/mpvtk_browser/home_sections.py:108
 msgid "Recently Added"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/home_sections.py:108
+#: jellyfin_mpv_shim/mpvtk_browser/home_sections.py:109
 msgid "Live TV"
 msgstr ""
 
@@ -1612,52 +1636,52 @@ msgstr ""
 "Не удалось добавить сервер.\n"
 "Проверьте информацию о подключении."
 
-#: jellyfin_mpv_shim/mpvtk_browser/repository.py:390
+#: jellyfin_mpv_shim/mpvtk_browser/repository.py:386
 msgid "On Now"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/repository.py:411
+#: jellyfin_mpv_shim/mpvtk_browser/repository.py:407
 msgid "Latest %s"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1119
+#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1052
 msgid "Downloaded"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1138
+#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1071
 msgid "Movies"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1143
+#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1076
 msgid "Videos"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1147
+#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1080
 msgid "TV Shows"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1151
+#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1084
 msgid "Playlists"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1168
-#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1441
+#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1101
+#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1374
 msgid "Series"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1212
+#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1145
 msgid "Downloaded Movies"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1216
+#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1149
 msgid "Downloaded Videos"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1220
+#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1153
 msgid "Downloaded Shows"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1353
+#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1286
 msgid "Season %d"
 msgstr ""
 

--- a/jellyfin_mpv_shim/messages/sdh/LC_MESSAGES/base.po
+++ b/jellyfin_mpv_shim/messages/sdh/LC_MESSAGES/base.po
@@ -5,7 +5,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2026-07-25 17:21-0400\n"
+"POT-Creation-Date: 2026-07-26 12:03-0400\n"
 "PO-Revision-Date: 2025-07-26 19:59+0000\n"
 "Last-Translator: Djwarf <djwar.fettah@outlook.com>\n"
 "Language-Team: Kurdish (Southern) <https://translate.jellyfin.org/projects/"
@@ -252,7 +252,7 @@ msgid "Select Subtitle Track"
 msgstr ""
 
 #: jellyfin_mpv_shim/menu.py:341
-#: jellyfin_mpv_shim/mpvtk_browser/home_sections.py:102
+#: jellyfin_mpv_shim/mpvtk_browser/home_sections.py:103
 #: jellyfin_mpv_shim/osc_bridge.py:81 jellyfin_mpv_shim/osc_bridge.py:82
 #: jellyfin_mpv_shim/osc_bridge.py:104 jellyfin_mpv_shim/osc_bridge.py:140
 msgid "None"
@@ -403,7 +403,7 @@ msgstr ""
 msgid "Enable thumbnail previews"
 msgstr ""
 
-#: jellyfin_mpv_shim/menu.py:609 jellyfin_mpv_shim/mpvtk_browser/config.py:186
+#: jellyfin_mpv_shim/menu.py:609 jellyfin_mpv_shim/mpvtk_browser/config.py:195
 #: jellyfin_mpv_shim/mpvtk_browser/hud.py:375
 msgid "Night Mode (Auto Volume Adj)"
 msgstr ""
@@ -698,300 +698,324 @@ msgstr ""
 msgid "Or switch to another user"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/cast.py:317
+#: jellyfin_mpv_shim/mpvtk_browser/cast.py:314
 msgid "Ready to cast"
 msgstr "Ji bo avêtinê amade ye"
 
-#: jellyfin_mpv_shim/mpvtk_browser/cast.py:318
+#: jellyfin_mpv_shim/mpvtk_browser/cast.py:315
 #, fuzzy
 #| msgid "Select your media in Jellyfin and play it here"
 msgid "Select your media in Jellyfin and play it here."
 msgstr "Medyaya xwe di Jellyfin de hilbijêre û li vir bilîze"
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:74
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:83
 msgid "Interface"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:83
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:92
 msgid "Playback"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:88
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:97
 msgid "Audio"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:92
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:101
 msgid "Subtitles & Languages"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:97
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:106
 msgid "Transcoding"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:102
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:111
 msgid "Video Enhancement"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:104
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:113
 msgid "Skip Intro / Credits"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:107
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:116
 msgid "Library Browser"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:109
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:118
 msgid "Downloads"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:128
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:137
 msgid "Jellyfin UI"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:129
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:138
 msgid "MPV UI with thumbnails"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:130
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:139
 msgid "MPV built-in default"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:133
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:142
 msgid "Follow display"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:134
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:143
 msgid "100% (no scaling)"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:135
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:144
 msgid "125%"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:136
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:145
 msgid "150%"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:137
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:146
 msgid "200%"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:140
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:149
 msgid "Automatic (recommended)"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:141
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:150
 msgid "Vulkan"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:142
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:151
 msgid "Direct3D 11 (Windows only)"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:143
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:152
 msgid "OpenGL (compatibility)"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:146
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:155
 msgid "Default (auto)"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:147
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:156
 msgid "Force Stereo"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:148
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:157
 msgid "Optical Surround"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:149
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:158
 msgid "HDMI Passthrough"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:152
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:161
 msgid "Unset"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:153
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:162
 msgid "Dubbed (shows only)"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:154
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:163
 msgid "Subbed (shows only)"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:155
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:164
 msgid "Dubbed (all)"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:156
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:165
 msgid "Subbed (all)"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:157
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:166
 msgid "Custom (set in config)"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:162
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:171
 msgid "Download Folder"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:163
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:172
 msgid "Prefer Downloaded Copy"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:164
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:173
 msgid "Automatically Download Upcoming Episodes"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:165
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:174
 msgid "Include Next Up"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:166
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:175
 msgid "Next Up Entries to Consider"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:167
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:176
 msgid "Episodes to Keep Ahead (0 = off)"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:168
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:177
 msgid "Storage Limit for Automatic Downloads (GB)"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:169
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:178
 msgid "Delete Automatic Downloads Once Watched"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:170
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:179
 msgid "Delete Unwatched After (days, 0 = never)"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:171
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:180
 msgid "Check Every (minutes)"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:172
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:181
 msgid "Close to Tray (keep running)"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:173
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:182
 msgid "Keep Running in Background"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:174
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:183
 msgid "Remember Window Size"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:175
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:184
 msgid "Player Controls Style"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:176
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:185
 msgid "Show What You're Watching in Discord"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:177
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:186
 msgid "Interface Scale"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:178
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:187
 msgid "Cast-target mode (no library browsing)"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:179
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:188
 msgid "Casting Opens the Library Browser"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:180
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:189
 msgid "Fullscreen Library Browser"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:181
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:190
 msgid "Always Bind Arrow Keys to Player Controls"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:182
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:191
 msgid "Player Controls Activation Key"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:183
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:192
 msgid "Audio Output Mode"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:184
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:193
 msgid "Audio Output Device"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:185
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:194
 msgid "Take the Device Exclusively"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:187
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:196
 msgid "Enable Video Playback Profiles"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:188
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:197
 msgid "Profile Group"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:189
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:198
 msgid "Remember Last Used Profile"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:190
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:199
 msgid "Graphics API for Shaders"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:191
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:200
 msgid "Pass Through AC3"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:192
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:201
 msgid "Pass Through DTS"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:193
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:202
 msgid "Pass Through E-AC3"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:194
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:203
 msgid "Pass Through DTS-HD"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:195
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:204
 msgid "Pass Through TrueHD"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:196
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:205
 msgid "Re-encode Others to AC3"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:202
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:213
 msgid ""
-"MPV keybinds are used by default. Press ENTER to drive the player controls "
-"by keyboard."
+"With \"Start Minimized\" and \"Fullscreen\" this is the classic cast-target "
+"setup: the app waits out of the way, plays fullscreen when something casts "
+"to it, and goes back to waiting when the video ends or you press Q."
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:204
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:227
+msgid ""
+"Off means command-line mode: no window, no system tray and no settings "
+"screen, so the only way back is editing conf.json by hand. It is not how you "
+"get MPV's own on-screen controls — \"Player Controls Style\" under Interface "
+"does that."
+msgstr ""
+
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:234
+msgid ""
+"Show only what is cast to this machine — the library, including this "
+"settings screen, can't be reached from here. Without a system tray icon the "
+"only way back is editing conf.json. For the classic cast-target setup you "
+"want the Interface settings instead; this is for a shared TV nobody should "
+"be able to browse from."
+msgstr ""
+
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:240
+msgid ""
+"Requires restart to change. MPV keybinds are used by default. Press ENTER to "
+"drive the player controls by keyboard."
+msgstr ""
+
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:242
 msgid ""
 "Pixels one wheel notch scrolls. The scrollbar glides while the content snaps "
 "to the nearest row, so a trackpad or trackball no longer overshoots. Raise "
 "it to scroll faster, lower it for finer control."
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:209
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:247
 msgid ""
 "Make each wheel notch jump exactly one row (or one home-screen section) "
 "instead of gliding. Turn this on if you prefer the older stepped scrolling."
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:217
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:255
 msgid "Discord Rich Presence. Takes effect after a restart."
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:219
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:257
 msgid ""
 "Leave this to Default unless setting up passthrough. Note some audio servers "
 "like Pipewire don't like passthrough and will need to be disabled for a card "
@@ -999,57 +1023,57 @@ msgid ""
 "silence otherwise, but results may vary."
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:225
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:263
 msgid ""
 "Stop anything else using the device while playing. Needed for passthrough on "
 "some systems, and it means other applications will be silent."
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:228
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:266
 msgid ""
 "Page the library and music tile grids instead of scrolling: each page is one "
 "screenful with First / Previous / Next / Last controls and a page number you "
 "can type into. Easier than precise scrolling on a trackpad."
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:232
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:270
 msgid ""
 "Takes effect after a restart. \"Follow display\" uses the scale your desktop "
 "reports, which is 100% on X11."
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:234
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:272
 msgid ""
 "\"Default\" changes nothing and lets MPV (and your own mpv.conf) decide. "
 "Pick a mode only if you are sending audio to a receiver."
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:237
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:275
 msgid ""
 "Audio your receiver can't be sent directly is encoded to AC3, which is the "
 "only way surround fits down an optical cable. Turn this off if the encoder "
 "causes audio delay — those tracks become stereo instead."
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:242
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:280
 msgid ""
 "\"hq\" offers heavier profiles. Pick it if you have a fast graphics card."
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:244
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:282
 msgid ""
 "Leave on Automatic unless video breaks when a profile is loaded. This only "
 "applies while a profile is active, and OpenGL can cost you HDR output."
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:248
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:286
 msgid ""
 "Evens out loud effects and quiet dialogue. This turns passthrough off while "
 "it is enabled, because the volume has to be adjusted before your receiver "
 "gets the audio."
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:330
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:368
 msgid "Advanced"
 msgstr ""
 
@@ -1253,7 +1277,7 @@ msgid "Automatic"
 msgstr ""
 
 #: jellyfin_mpv_shim/mpvtk_browser/downloads.py:51
-#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1355
+#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1288
 msgid "Episodes"
 msgstr ""
 
@@ -1262,7 +1286,7 @@ msgid "Season %s"
 msgstr ""
 
 #: jellyfin_mpv_shim/mpvtk_browser/downloads.py:52
-#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1351
+#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1284
 msgid "Specials"
 msgstr ""
 
@@ -1285,7 +1309,7 @@ msgid "Failed"
 msgstr "Biserîneçûn"
 
 #: jellyfin_mpv_shim/mpvtk_browser/downloads.py:185
-#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1105
+#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1038
 msgid "Playlist"
 msgstr ""
 
@@ -1297,30 +1321,30 @@ msgstr ""
 msgid "Movies & Videos"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/home_sections.py:103
+#: jellyfin_mpv_shim/mpvtk_browser/home_sections.py:104
 msgid "My Media"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/home_sections.py:104
-#: jellyfin_mpv_shim/mpvtk_browser/repository.py:352
+#: jellyfin_mpv_shim/mpvtk_browser/home_sections.py:105
+#: jellyfin_mpv_shim/mpvtk_browser/repository.py:350
 msgid "Continue Watching"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/home_sections.py:105
-#: jellyfin_mpv_shim/mpvtk_browser/repository.py:359
+#: jellyfin_mpv_shim/mpvtk_browser/home_sections.py:106
+#: jellyfin_mpv_shim/mpvtk_browser/repository.py:357
 msgid "Continue Listening"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/home_sections.py:106
-#: jellyfin_mpv_shim/mpvtk_browser/repository.py:366
+#: jellyfin_mpv_shim/mpvtk_browser/home_sections.py:107
+#: jellyfin_mpv_shim/mpvtk_browser/repository.py:364
 msgid "Next Up"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/home_sections.py:107
+#: jellyfin_mpv_shim/mpvtk_browser/home_sections.py:108
 msgid "Recently Added"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/home_sections.py:108
+#: jellyfin_mpv_shim/mpvtk_browser/home_sections.py:109
 msgid "Live TV"
 msgstr ""
 
@@ -1553,52 +1577,52 @@ msgstr ""
 "Nekarî serverê lê zêde bike.\n"
 "Ji kerema xwe agahiyên girêdana xwe kontrol bikin."
 
-#: jellyfin_mpv_shim/mpvtk_browser/repository.py:390
+#: jellyfin_mpv_shim/mpvtk_browser/repository.py:386
 msgid "On Now"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/repository.py:411
+#: jellyfin_mpv_shim/mpvtk_browser/repository.py:407
 msgid "Latest %s"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1119
+#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1052
 msgid "Downloaded"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1138
+#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1071
 msgid "Movies"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1143
+#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1076
 msgid "Videos"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1147
+#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1080
 msgid "TV Shows"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1151
+#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1084
 msgid "Playlists"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1168
-#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1441
+#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1101
+#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1374
 msgid "Series"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1212
+#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1145
 msgid "Downloaded Movies"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1216
+#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1149
 msgid "Downloaded Videos"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1220
+#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1153
 msgid "Downloaded Shows"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1353
+#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1286
 msgid "Season %d"
 msgstr ""
 

--- a/jellyfin_mpv_shim/messages/sk/LC_MESSAGES/base.po
+++ b/jellyfin_mpv_shim/messages/sk/LC_MESSAGES/base.po
@@ -5,7 +5,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2026-07-25 17:21-0400\n"
+"POT-Creation-Date: 2026-07-26 12:03-0400\n"
 "PO-Revision-Date: 2024-06-11 08:41+0000\n"
 "Last-Translator: nextlooper42 <nextlooper42@protonmail.com>\n"
 "Language-Team: Slovak <https://translate.jellyfin.org/projects/jellyfin/"
@@ -252,7 +252,7 @@ msgid "Select Subtitle Track"
 msgstr "Vybrať titulkovú stopu"
 
 #: jellyfin_mpv_shim/menu.py:341
-#: jellyfin_mpv_shim/mpvtk_browser/home_sections.py:102
+#: jellyfin_mpv_shim/mpvtk_browser/home_sections.py:103
 #: jellyfin_mpv_shim/osc_bridge.py:81 jellyfin_mpv_shim/osc_bridge.py:82
 #: jellyfin_mpv_shim/osc_bridge.py:104 jellyfin_mpv_shim/osc_bridge.py:140
 msgid "None"
@@ -403,7 +403,7 @@ msgstr "Spýtať sa, či preskočiť titulky"
 msgid "Enable thumbnail previews"
 msgstr "Zapnúť zobrazenie miniatúr"
 
-#: jellyfin_mpv_shim/menu.py:609 jellyfin_mpv_shim/mpvtk_browser/config.py:186
+#: jellyfin_mpv_shim/menu.py:609 jellyfin_mpv_shim/mpvtk_browser/config.py:195
 #: jellyfin_mpv_shim/mpvtk_browser/hud.py:375
 msgid "Night Mode (Auto Volume Adj)"
 msgstr ""
@@ -702,310 +702,334 @@ msgstr ""
 msgid "Or switch to another user"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/cast.py:317
+#: jellyfin_mpv_shim/mpvtk_browser/cast.py:314
 msgid "Ready to cast"
 msgstr "Pripravené k prenosu"
 
-#: jellyfin_mpv_shim/mpvtk_browser/cast.py:318
+#: jellyfin_mpv_shim/mpvtk_browser/cast.py:315
 #, fuzzy
 #| msgid "Select your media in Jellyfin and play it here"
 msgid "Select your media in Jellyfin and play it here."
 msgstr "Vyberte médium v Jellyfine a pustite ho"
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:74
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:83
 msgid "Interface"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:83
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:92
 msgid "Playback"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:88
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:97
 msgid "Audio"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:92
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:101
 msgid "Subtitles & Languages"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:97
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:106
 #, fuzzy
 #| msgid " (Transcode)"
 msgid "Transcoding"
 msgstr " (Prekódovať)"
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:102
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:111
 msgid "Video Enhancement"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:104
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:113
 #, fuzzy
 #| msgid "Seek to Skip Credits"
 msgid "Skip Intro / Credits"
 msgstr "Preskočiť titulky"
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:107
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:116
 msgid "Library Browser"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:109
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:118
 msgid "Downloads"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:128
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:137
 msgid "Jellyfin UI"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:129
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:138
 msgid "MPV UI with thumbnails"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:130
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:139
 msgid "MPV built-in default"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:133
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:142
 msgid "Follow display"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:134
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:143
 msgid "100% (no scaling)"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:135
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:144
 msgid "125%"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:136
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:145
 msgid "150%"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:137
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:146
 msgid "200%"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:140
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:149
 msgid "Automatic (recommended)"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:141
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:150
 msgid "Vulkan"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:142
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:151
 msgid "Direct3D 11 (Windows only)"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:143
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:152
 msgid "OpenGL (compatibility)"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:146
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:155
 msgid "Default (auto)"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:147
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:156
 msgid "Force Stereo"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:148
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:157
 msgid "Optical Surround"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:149
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:158
 msgid "HDMI Passthrough"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:152
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:161
 msgid "Unset"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:153
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:162
 msgid "Dubbed (shows only)"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:154
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:163
 msgid "Subbed (shows only)"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:155
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:164
 msgid "Dubbed (all)"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:156
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:165
 msgid "Subbed (all)"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:157
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:166
 msgid "Custom (set in config)"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:162
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:171
 msgid "Download Folder"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:163
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:172
 msgid "Prefer Downloaded Copy"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:164
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:173
 msgid "Automatically Download Upcoming Episodes"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:165
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:174
 msgid "Include Next Up"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:166
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:175
 msgid "Next Up Entries to Consider"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:167
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:176
 msgid "Episodes to Keep Ahead (0 = off)"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:168
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:177
 msgid "Storage Limit for Automatic Downloads (GB)"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:169
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:178
 #, fuzzy
 #| msgid "Remove Server"
 msgid "Delete Automatic Downloads Once Watched"
 msgstr "Odstrániť server"
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:170
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:179
 msgid "Delete Unwatched After (days, 0 = never)"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:171
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:180
 msgid "Check Every (minutes)"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:172
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:181
 msgid "Close to Tray (keep running)"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:173
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:182
 msgid "Keep Running in Background"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:174
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:183
 msgid "Remember Window Size"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:175
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:184
 msgid "Player Controls Style"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:176
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:185
 msgid "Show What You're Watching in Discord"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:177
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:186
 msgid "Interface Scale"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:178
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:187
 msgid "Cast-target mode (no library browsing)"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:179
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:188
 msgid "Casting Opens the Library Browser"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:180
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:189
 msgid "Fullscreen Library Browser"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:181
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:190
 msgid "Always Bind Arrow Keys to Player Controls"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:182
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:191
 msgid "Player Controls Activation Key"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:183
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:192
 msgid "Audio Output Mode"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:184
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:193
 msgid "Audio Output Device"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:185
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:194
 msgid "Take the Device Exclusively"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:187
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:196
 #, fuzzy
 #| msgid "Video Playback Profiles"
 msgid "Enable Video Playback Profiles"
 msgstr "Profily prehrávania videa"
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:188
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:197
 #, fuzzy
 #| msgid "New Group"
 msgid "Profile Group"
 msgstr "Nová skupina"
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:189
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:198
 msgid "Remember Last Used Profile"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:190
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:199
 msgid "Graphics API for Shaders"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:191
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:200
 msgid "Pass Through AC3"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:192
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:201
 msgid "Pass Through DTS"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:193
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:202
 msgid "Pass Through E-AC3"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:194
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:203
 msgid "Pass Through DTS-HD"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:195
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:204
 msgid "Pass Through TrueHD"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:196
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:205
 msgid "Re-encode Others to AC3"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:202
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:213
 msgid ""
-"MPV keybinds are used by default. Press ENTER to drive the player controls "
-"by keyboard."
+"With \"Start Minimized\" and \"Fullscreen\" this is the classic cast-target "
+"setup: the app waits out of the way, plays fullscreen when something casts "
+"to it, and goes back to waiting when the video ends or you press Q."
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:204
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:227
+msgid ""
+"Off means command-line mode: no window, no system tray and no settings "
+"screen, so the only way back is editing conf.json by hand. It is not how you "
+"get MPV's own on-screen controls — \"Player Controls Style\" under Interface "
+"does that."
+msgstr ""
+
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:234
+msgid ""
+"Show only what is cast to this machine — the library, including this "
+"settings screen, can't be reached from here. Without a system tray icon the "
+"only way back is editing conf.json. For the classic cast-target setup you "
+"want the Interface settings instead; this is for a shared TV nobody should "
+"be able to browse from."
+msgstr ""
+
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:240
+msgid ""
+"Requires restart to change. MPV keybinds are used by default. Press ENTER to "
+"drive the player controls by keyboard."
+msgstr ""
+
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:242
 msgid ""
 "Pixels one wheel notch scrolls. The scrollbar glides while the content snaps "
 "to the nearest row, so a trackpad or trackball no longer overshoots. Raise "
 "it to scroll faster, lower it for finer control."
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:209
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:247
 msgid ""
 "Make each wheel notch jump exactly one row (or one home-screen section) "
 "instead of gliding. Turn this on if you prefer the older stepped scrolling."
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:217
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:255
 msgid "Discord Rich Presence. Takes effect after a restart."
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:219
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:257
 msgid ""
 "Leave this to Default unless setting up passthrough. Note some audio servers "
 "like Pipewire don't like passthrough and will need to be disabled for a card "
@@ -1013,57 +1037,57 @@ msgid ""
 "silence otherwise, but results may vary."
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:225
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:263
 msgid ""
 "Stop anything else using the device while playing. Needed for passthrough on "
 "some systems, and it means other applications will be silent."
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:228
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:266
 msgid ""
 "Page the library and music tile grids instead of scrolling: each page is one "
 "screenful with First / Previous / Next / Last controls and a page number you "
 "can type into. Easier than precise scrolling on a trackpad."
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:232
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:270
 msgid ""
 "Takes effect after a restart. \"Follow display\" uses the scale your desktop "
 "reports, which is 100% on X11."
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:234
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:272
 msgid ""
 "\"Default\" changes nothing and lets MPV (and your own mpv.conf) decide. "
 "Pick a mode only if you are sending audio to a receiver."
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:237
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:275
 msgid ""
 "Audio your receiver can't be sent directly is encoded to AC3, which is the "
 "only way surround fits down an optical cable. Turn this off if the encoder "
 "causes audio delay — those tracks become stereo instead."
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:242
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:280
 msgid ""
 "\"hq\" offers heavier profiles. Pick it if you have a fast graphics card."
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:244
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:282
 msgid ""
 "Leave on Automatic unless video breaks when a profile is loaded. This only "
 "applies while a profile is active, and OpenGL can cost you HDR output."
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:248
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:286
 msgid ""
 "Evens out loud effects and quiet dialogue. This turns passthrough off while "
 "it is enabled, because the volume has to be adjusted before your receiver "
 "gets the audio."
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:330
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:368
 msgid "Advanced"
 msgstr ""
 
@@ -1289,7 +1313,7 @@ msgid "Automatic"
 msgstr "Automaticky"
 
 #: jellyfin_mpv_shim/mpvtk_browser/downloads.py:51
-#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1355
+#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1288
 msgid "Episodes"
 msgstr ""
 
@@ -1298,7 +1322,7 @@ msgid "Season %s"
 msgstr ""
 
 #: jellyfin_mpv_shim/mpvtk_browser/downloads.py:52
-#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1351
+#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1284
 msgid "Specials"
 msgstr ""
 
@@ -1323,7 +1347,7 @@ msgid "Failed"
 msgstr "Zlyhanie"
 
 #: jellyfin_mpv_shim/mpvtk_browser/downloads.py:185
-#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1105
+#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1038
 msgid "Playlist"
 msgstr ""
 
@@ -1335,30 +1359,30 @@ msgstr ""
 msgid "Movies & Videos"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/home_sections.py:103
+#: jellyfin_mpv_shim/mpvtk_browser/home_sections.py:104
 msgid "My Media"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/home_sections.py:104
-#: jellyfin_mpv_shim/mpvtk_browser/repository.py:352
+#: jellyfin_mpv_shim/mpvtk_browser/home_sections.py:105
+#: jellyfin_mpv_shim/mpvtk_browser/repository.py:350
 msgid "Continue Watching"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/home_sections.py:105
-#: jellyfin_mpv_shim/mpvtk_browser/repository.py:359
+#: jellyfin_mpv_shim/mpvtk_browser/home_sections.py:106
+#: jellyfin_mpv_shim/mpvtk_browser/repository.py:357
 msgid "Continue Listening"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/home_sections.py:106
-#: jellyfin_mpv_shim/mpvtk_browser/repository.py:366
+#: jellyfin_mpv_shim/mpvtk_browser/home_sections.py:107
+#: jellyfin_mpv_shim/mpvtk_browser/repository.py:364
 msgid "Next Up"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/home_sections.py:107
+#: jellyfin_mpv_shim/mpvtk_browser/home_sections.py:108
 msgid "Recently Added"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/home_sections.py:108
+#: jellyfin_mpv_shim/mpvtk_browser/home_sections.py:109
 msgid "Live TV"
 msgstr ""
 
@@ -1611,52 +1635,52 @@ msgstr ""
 "Nebolo možné pridať server.\n"
 "Skontrolujte prosím informácie o pripojení."
 
-#: jellyfin_mpv_shim/mpvtk_browser/repository.py:390
+#: jellyfin_mpv_shim/mpvtk_browser/repository.py:386
 msgid "On Now"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/repository.py:411
+#: jellyfin_mpv_shim/mpvtk_browser/repository.py:407
 msgid "Latest %s"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1119
+#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1052
 msgid "Downloaded"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1138
+#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1071
 msgid "Movies"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1143
+#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1076
 msgid "Videos"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1147
+#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1080
 msgid "TV Shows"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1151
+#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1084
 msgid "Playlists"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1168
-#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1441
+#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1101
+#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1374
 msgid "Series"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1212
+#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1145
 msgid "Downloaded Movies"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1216
+#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1149
 msgid "Downloaded Videos"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1220
+#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1153
 msgid "Downloaded Shows"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1353
+#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1286
 msgid "Season %d"
 msgstr ""
 

--- a/jellyfin_mpv_shim/messages/sl/LC_MESSAGES/base.po
+++ b/jellyfin_mpv_shim/messages/sl/LC_MESSAGES/base.po
@@ -5,7 +5,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2026-07-25 17:21-0400\n"
+"POT-Creation-Date: 2026-07-26 12:03-0400\n"
 "PO-Revision-Date: 2026-06-20 12:46+0000\n"
 "Last-Translator: Žiga Ules <ziga.ules@gmail.com>\n"
 "Language-Team: Slovenian <https://translate.jellyfin.org/projects/jellyfin/"
@@ -253,7 +253,7 @@ msgid "Select Subtitle Track"
 msgstr "Izberi sled podnapisov"
 
 #: jellyfin_mpv_shim/menu.py:341
-#: jellyfin_mpv_shim/mpvtk_browser/home_sections.py:102
+#: jellyfin_mpv_shim/mpvtk_browser/home_sections.py:103
 #: jellyfin_mpv_shim/osc_bridge.py:81 jellyfin_mpv_shim/osc_bridge.py:82
 #: jellyfin_mpv_shim/osc_bridge.py:104 jellyfin_mpv_shim/osc_bridge.py:140
 msgid "None"
@@ -404,7 +404,7 @@ msgstr "Vprašaj za preskok končne špice"
 msgid "Enable thumbnail previews"
 msgstr "Omogoči predogledne sličice"
 
-#: jellyfin_mpv_shim/menu.py:609 jellyfin_mpv_shim/mpvtk_browser/config.py:186
+#: jellyfin_mpv_shim/menu.py:609 jellyfin_mpv_shim/mpvtk_browser/config.py:195
 #: jellyfin_mpv_shim/mpvtk_browser/hud.py:375
 msgid "Night Mode (Auto Volume Adj)"
 msgstr ""
@@ -703,310 +703,334 @@ msgstr ""
 msgid "Or switch to another user"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/cast.py:317
+#: jellyfin_mpv_shim/mpvtk_browser/cast.py:314
 msgid "Ready to cast"
 msgstr "Pripravljen za deljenje"
 
-#: jellyfin_mpv_shim/mpvtk_browser/cast.py:318
+#: jellyfin_mpv_shim/mpvtk_browser/cast.py:315
 #, fuzzy
 #| msgid "Select your media in Jellyfin and play it here"
 msgid "Select your media in Jellyfin and play it here."
 msgstr "Izberite predstavnost v Jellyfin in jo predvajajte tu"
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:74
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:83
 msgid "Interface"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:83
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:92
 msgid "Playback"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:88
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:97
 msgid "Audio"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:92
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:101
 msgid "Subtitles & Languages"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:97
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:106
 #, fuzzy
 #| msgid " (Transcode)"
 msgid "Transcoding"
 msgstr " (Prekodiranje)"
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:102
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:111
 msgid "Video Enhancement"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:104
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:113
 #, fuzzy
 #| msgid "Seek to Skip Credits"
 msgid "Skip Intro / Credits"
 msgstr "Poišči za preskok končne špice"
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:107
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:116
 msgid "Library Browser"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:109
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:118
 msgid "Downloads"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:128
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:137
 msgid "Jellyfin UI"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:129
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:138
 msgid "MPV UI with thumbnails"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:130
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:139
 msgid "MPV built-in default"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:133
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:142
 msgid "Follow display"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:134
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:143
 msgid "100% (no scaling)"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:135
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:144
 msgid "125%"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:136
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:145
 msgid "150%"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:137
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:146
 msgid "200%"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:140
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:149
 msgid "Automatic (recommended)"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:141
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:150
 msgid "Vulkan"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:142
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:151
 msgid "Direct3D 11 (Windows only)"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:143
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:152
 msgid "OpenGL (compatibility)"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:146
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:155
 msgid "Default (auto)"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:147
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:156
 msgid "Force Stereo"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:148
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:157
 msgid "Optical Surround"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:149
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:158
 msgid "HDMI Passthrough"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:152
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:161
 msgid "Unset"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:153
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:162
 msgid "Dubbed (shows only)"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:154
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:163
 msgid "Subbed (shows only)"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:155
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:164
 msgid "Dubbed (all)"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:156
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:165
 msgid "Subbed (all)"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:157
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:166
 msgid "Custom (set in config)"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:162
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:171
 msgid "Download Folder"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:163
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:172
 msgid "Prefer Downloaded Copy"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:164
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:173
 msgid "Automatically Download Upcoming Episodes"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:165
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:174
 msgid "Include Next Up"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:166
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:175
 msgid "Next Up Entries to Consider"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:167
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:176
 msgid "Episodes to Keep Ahead (0 = off)"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:168
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:177
 msgid "Storage Limit for Automatic Downloads (GB)"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:169
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:178
 #, fuzzy
 #| msgid "Remove Server"
 msgid "Delete Automatic Downloads Once Watched"
 msgstr "Odstrani strežnik"
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:170
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:179
 msgid "Delete Unwatched After (days, 0 = never)"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:171
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:180
 msgid "Check Every (minutes)"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:172
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:181
 msgid "Close to Tray (keep running)"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:173
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:182
 msgid "Keep Running in Background"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:174
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:183
 msgid "Remember Window Size"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:175
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:184
 msgid "Player Controls Style"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:176
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:185
 msgid "Show What You're Watching in Discord"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:177
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:186
 msgid "Interface Scale"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:178
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:187
 msgid "Cast-target mode (no library browsing)"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:179
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:188
 msgid "Casting Opens the Library Browser"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:180
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:189
 msgid "Fullscreen Library Browser"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:181
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:190
 msgid "Always Bind Arrow Keys to Player Controls"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:182
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:191
 msgid "Player Controls Activation Key"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:183
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:192
 msgid "Audio Output Mode"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:184
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:193
 msgid "Audio Output Device"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:185
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:194
 msgid "Take the Device Exclusively"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:187
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:196
 #, fuzzy
 #| msgid "Video Playback Profiles"
 msgid "Enable Video Playback Profiles"
 msgstr "Profili predvajanja videa"
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:188
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:197
 #, fuzzy
 #| msgid "New Group"
 msgid "Profile Group"
 msgstr "Nova skupina"
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:189
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:198
 msgid "Remember Last Used Profile"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:190
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:199
 msgid "Graphics API for Shaders"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:191
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:200
 msgid "Pass Through AC3"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:192
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:201
 msgid "Pass Through DTS"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:193
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:202
 msgid "Pass Through E-AC3"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:194
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:203
 msgid "Pass Through DTS-HD"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:195
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:204
 msgid "Pass Through TrueHD"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:196
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:205
 msgid "Re-encode Others to AC3"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:202
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:213
 msgid ""
-"MPV keybinds are used by default. Press ENTER to drive the player controls "
-"by keyboard."
+"With \"Start Minimized\" and \"Fullscreen\" this is the classic cast-target "
+"setup: the app waits out of the way, plays fullscreen when something casts "
+"to it, and goes back to waiting when the video ends or you press Q."
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:204
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:227
+msgid ""
+"Off means command-line mode: no window, no system tray and no settings "
+"screen, so the only way back is editing conf.json by hand. It is not how you "
+"get MPV's own on-screen controls — \"Player Controls Style\" under Interface "
+"does that."
+msgstr ""
+
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:234
+msgid ""
+"Show only what is cast to this machine — the library, including this "
+"settings screen, can't be reached from here. Without a system tray icon the "
+"only way back is editing conf.json. For the classic cast-target setup you "
+"want the Interface settings instead; this is for a shared TV nobody should "
+"be able to browse from."
+msgstr ""
+
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:240
+msgid ""
+"Requires restart to change. MPV keybinds are used by default. Press ENTER to "
+"drive the player controls by keyboard."
+msgstr ""
+
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:242
 msgid ""
 "Pixels one wheel notch scrolls. The scrollbar glides while the content snaps "
 "to the nearest row, so a trackpad or trackball no longer overshoots. Raise "
 "it to scroll faster, lower it for finer control."
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:209
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:247
 msgid ""
 "Make each wheel notch jump exactly one row (or one home-screen section) "
 "instead of gliding. Turn this on if you prefer the older stepped scrolling."
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:217
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:255
 msgid "Discord Rich Presence. Takes effect after a restart."
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:219
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:257
 msgid ""
 "Leave this to Default unless setting up passthrough. Note some audio servers "
 "like Pipewire don't like passthrough and will need to be disabled for a card "
@@ -1014,57 +1038,57 @@ msgid ""
 "silence otherwise, but results may vary."
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:225
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:263
 msgid ""
 "Stop anything else using the device while playing. Needed for passthrough on "
 "some systems, and it means other applications will be silent."
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:228
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:266
 msgid ""
 "Page the library and music tile grids instead of scrolling: each page is one "
 "screenful with First / Previous / Next / Last controls and a page number you "
 "can type into. Easier than precise scrolling on a trackpad."
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:232
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:270
 msgid ""
 "Takes effect after a restart. \"Follow display\" uses the scale your desktop "
 "reports, which is 100% on X11."
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:234
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:272
 msgid ""
 "\"Default\" changes nothing and lets MPV (and your own mpv.conf) decide. "
 "Pick a mode only if you are sending audio to a receiver."
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:237
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:275
 msgid ""
 "Audio your receiver can't be sent directly is encoded to AC3, which is the "
 "only way surround fits down an optical cable. Turn this off if the encoder "
 "causes audio delay — those tracks become stereo instead."
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:242
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:280
 msgid ""
 "\"hq\" offers heavier profiles. Pick it if you have a fast graphics card."
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:244
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:282
 msgid ""
 "Leave on Automatic unless video breaks when a profile is loaded. This only "
 "applies while a profile is active, and OpenGL can cost you HDR output."
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:248
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:286
 msgid ""
 "Evens out loud effects and quiet dialogue. This turns passthrough off while "
 "it is enabled, because the volume has to be adjusted before your receiver "
 "gets the audio."
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:330
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:368
 msgid "Advanced"
 msgstr ""
 
@@ -1290,7 +1314,7 @@ msgid "Automatic"
 msgstr "Samodejno"
 
 #: jellyfin_mpv_shim/mpvtk_browser/downloads.py:51
-#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1355
+#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1288
 msgid "Episodes"
 msgstr ""
 
@@ -1299,7 +1323,7 @@ msgid "Season %s"
 msgstr ""
 
 #: jellyfin_mpv_shim/mpvtk_browser/downloads.py:52
-#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1351
+#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1284
 msgid "Specials"
 msgstr ""
 
@@ -1324,7 +1348,7 @@ msgid "Failed"
 msgstr "Napaka"
 
 #: jellyfin_mpv_shim/mpvtk_browser/downloads.py:185
-#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1105
+#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1038
 msgid "Playlist"
 msgstr ""
 
@@ -1336,30 +1360,30 @@ msgstr ""
 msgid "Movies & Videos"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/home_sections.py:103
+#: jellyfin_mpv_shim/mpvtk_browser/home_sections.py:104
 msgid "My Media"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/home_sections.py:104
-#: jellyfin_mpv_shim/mpvtk_browser/repository.py:352
+#: jellyfin_mpv_shim/mpvtk_browser/home_sections.py:105
+#: jellyfin_mpv_shim/mpvtk_browser/repository.py:350
 msgid "Continue Watching"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/home_sections.py:105
-#: jellyfin_mpv_shim/mpvtk_browser/repository.py:359
+#: jellyfin_mpv_shim/mpvtk_browser/home_sections.py:106
+#: jellyfin_mpv_shim/mpvtk_browser/repository.py:357
 msgid "Continue Listening"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/home_sections.py:106
-#: jellyfin_mpv_shim/mpvtk_browser/repository.py:366
+#: jellyfin_mpv_shim/mpvtk_browser/home_sections.py:107
+#: jellyfin_mpv_shim/mpvtk_browser/repository.py:364
 msgid "Next Up"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/home_sections.py:107
+#: jellyfin_mpv_shim/mpvtk_browser/home_sections.py:108
 msgid "Recently Added"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/home_sections.py:108
+#: jellyfin_mpv_shim/mpvtk_browser/home_sections.py:109
 msgid "Live TV"
 msgstr ""
 
@@ -1612,52 +1636,52 @@ msgstr ""
 "Strežnika ni bilo mogoče dodati.\n"
 "Preverite vaše nastavitve povezave."
 
-#: jellyfin_mpv_shim/mpvtk_browser/repository.py:390
+#: jellyfin_mpv_shim/mpvtk_browser/repository.py:386
 msgid "On Now"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/repository.py:411
+#: jellyfin_mpv_shim/mpvtk_browser/repository.py:407
 msgid "Latest %s"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1119
+#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1052
 msgid "Downloaded"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1138
+#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1071
 msgid "Movies"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1143
+#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1076
 msgid "Videos"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1147
+#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1080
 msgid "TV Shows"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1151
+#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1084
 msgid "Playlists"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1168
-#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1441
+#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1101
+#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1374
 msgid "Series"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1212
+#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1145
 msgid "Downloaded Movies"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1216
+#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1149
 msgid "Downloaded Videos"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1220
+#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1153
 msgid "Downloaded Shows"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1353
+#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1286
 msgid "Season %d"
 msgstr ""
 

--- a/jellyfin_mpv_shim/messages/sq/LC_MESSAGES/base.po
+++ b/jellyfin_mpv_shim/messages/sq/LC_MESSAGES/base.po
@@ -5,7 +5,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2026-07-25 17:21-0400\n"
+"POT-Creation-Date: 2026-07-26 12:03-0400\n"
 "PO-Revision-Date: 2024-07-13 22:07+0000\n"
 "Last-Translator: Filan Fisteku <motto_schillernd_01@icloud.com>\n"
 "Language-Team: Albanian <https://translate.jellyfin.org/projects/jellyfin/"
@@ -252,7 +252,7 @@ msgid "Select Subtitle Track"
 msgstr "Zgjidh gjurmën e titrave"
 
 #: jellyfin_mpv_shim/menu.py:341
-#: jellyfin_mpv_shim/mpvtk_browser/home_sections.py:102
+#: jellyfin_mpv_shim/mpvtk_browser/home_sections.py:103
 #: jellyfin_mpv_shim/osc_bridge.py:81 jellyfin_mpv_shim/osc_bridge.py:82
 #: jellyfin_mpv_shim/osc_bridge.py:104 jellyfin_mpv_shim/osc_bridge.py:140
 msgid "None"
@@ -403,7 +403,7 @@ msgstr "Pyet për të anashkaluar hyrjet"
 msgid "Enable thumbnail previews"
 msgstr "Aktivizo pamjet paraprake"
 
-#: jellyfin_mpv_shim/menu.py:609 jellyfin_mpv_shim/mpvtk_browser/config.py:186
+#: jellyfin_mpv_shim/menu.py:609 jellyfin_mpv_shim/mpvtk_browser/config.py:195
 #: jellyfin_mpv_shim/mpvtk_browser/hud.py:375
 msgid "Night Mode (Auto Volume Adj)"
 msgstr ""
@@ -702,310 +702,334 @@ msgstr ""
 msgid "Or switch to another user"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/cast.py:317
+#: jellyfin_mpv_shim/mpvtk_browser/cast.py:314
 msgid "Ready to cast"
 msgstr "Gati për të shfaqur"
 
-#: jellyfin_mpv_shim/mpvtk_browser/cast.py:318
+#: jellyfin_mpv_shim/mpvtk_browser/cast.py:315
 #, fuzzy
 #| msgid "Select your media in Jellyfin and play it here"
 msgid "Select your media in Jellyfin and play it here."
 msgstr "Zgjidh median tënde në Jellyfin dhe luaje këtu"
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:74
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:83
 msgid "Interface"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:83
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:92
 msgid "Playback"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:88
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:97
 msgid "Audio"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:92
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:101
 msgid "Subtitles & Languages"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:97
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:106
 #, fuzzy
 #| msgid " (Transcode)"
 msgid "Transcoding"
 msgstr " {Transkodo}"
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:102
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:111
 msgid "Video Enhancement"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:104
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:113
 #, fuzzy
 #| msgid "Seek to Skip Credits"
 msgid "Skip Intro / Credits"
 msgstr "Kërko të kalosh hyrjen"
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:107
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:116
 msgid "Library Browser"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:109
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:118
 msgid "Downloads"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:128
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:137
 msgid "Jellyfin UI"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:129
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:138
 msgid "MPV UI with thumbnails"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:130
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:139
 msgid "MPV built-in default"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:133
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:142
 msgid "Follow display"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:134
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:143
 msgid "100% (no scaling)"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:135
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:144
 msgid "125%"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:136
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:145
 msgid "150%"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:137
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:146
 msgid "200%"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:140
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:149
 msgid "Automatic (recommended)"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:141
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:150
 msgid "Vulkan"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:142
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:151
 msgid "Direct3D 11 (Windows only)"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:143
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:152
 msgid "OpenGL (compatibility)"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:146
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:155
 msgid "Default (auto)"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:147
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:156
 msgid "Force Stereo"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:148
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:157
 msgid "Optical Surround"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:149
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:158
 msgid "HDMI Passthrough"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:152
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:161
 msgid "Unset"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:153
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:162
 msgid "Dubbed (shows only)"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:154
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:163
 msgid "Subbed (shows only)"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:155
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:164
 msgid "Dubbed (all)"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:156
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:165
 msgid "Subbed (all)"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:157
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:166
 msgid "Custom (set in config)"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:162
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:171
 msgid "Download Folder"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:163
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:172
 msgid "Prefer Downloaded Copy"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:164
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:173
 msgid "Automatically Download Upcoming Episodes"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:165
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:174
 msgid "Include Next Up"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:166
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:175
 msgid "Next Up Entries to Consider"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:167
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:176
 msgid "Episodes to Keep Ahead (0 = off)"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:168
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:177
 msgid "Storage Limit for Automatic Downloads (GB)"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:169
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:178
 #, fuzzy
 #| msgid "Remove Server"
 msgid "Delete Automatic Downloads Once Watched"
 msgstr "Hiq Serverin"
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:170
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:179
 msgid "Delete Unwatched After (days, 0 = never)"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:171
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:180
 msgid "Check Every (minutes)"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:172
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:181
 msgid "Close to Tray (keep running)"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:173
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:182
 msgid "Keep Running in Background"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:174
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:183
 msgid "Remember Window Size"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:175
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:184
 msgid "Player Controls Style"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:176
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:185
 msgid "Show What You're Watching in Discord"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:177
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:186
 msgid "Interface Scale"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:178
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:187
 msgid "Cast-target mode (no library browsing)"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:179
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:188
 msgid "Casting Opens the Library Browser"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:180
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:189
 msgid "Fullscreen Library Browser"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:181
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:190
 msgid "Always Bind Arrow Keys to Player Controls"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:182
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:191
 msgid "Player Controls Activation Key"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:183
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:192
 msgid "Audio Output Mode"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:184
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:193
 msgid "Audio Output Device"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:185
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:194
 msgid "Take the Device Exclusively"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:187
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:196
 #, fuzzy
 #| msgid "Video Playback Profiles"
 msgid "Enable Video Playback Profiles"
 msgstr "Profilet e luajtjes së videos"
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:188
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:197
 #, fuzzy
 #| msgid "New Group"
 msgid "Profile Group"
 msgstr "Grup i ri"
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:189
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:198
 msgid "Remember Last Used Profile"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:190
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:199
 msgid "Graphics API for Shaders"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:191
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:200
 msgid "Pass Through AC3"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:192
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:201
 msgid "Pass Through DTS"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:193
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:202
 msgid "Pass Through E-AC3"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:194
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:203
 msgid "Pass Through DTS-HD"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:195
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:204
 msgid "Pass Through TrueHD"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:196
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:205
 msgid "Re-encode Others to AC3"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:202
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:213
 msgid ""
-"MPV keybinds are used by default. Press ENTER to drive the player controls "
-"by keyboard."
+"With \"Start Minimized\" and \"Fullscreen\" this is the classic cast-target "
+"setup: the app waits out of the way, plays fullscreen when something casts "
+"to it, and goes back to waiting when the video ends or you press Q."
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:204
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:227
+msgid ""
+"Off means command-line mode: no window, no system tray and no settings "
+"screen, so the only way back is editing conf.json by hand. It is not how you "
+"get MPV's own on-screen controls — \"Player Controls Style\" under Interface "
+"does that."
+msgstr ""
+
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:234
+msgid ""
+"Show only what is cast to this machine — the library, including this "
+"settings screen, can't be reached from here. Without a system tray icon the "
+"only way back is editing conf.json. For the classic cast-target setup you "
+"want the Interface settings instead; this is for a shared TV nobody should "
+"be able to browse from."
+msgstr ""
+
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:240
+msgid ""
+"Requires restart to change. MPV keybinds are used by default. Press ENTER to "
+"drive the player controls by keyboard."
+msgstr ""
+
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:242
 msgid ""
 "Pixels one wheel notch scrolls. The scrollbar glides while the content snaps "
 "to the nearest row, so a trackpad or trackball no longer overshoots. Raise "
 "it to scroll faster, lower it for finer control."
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:209
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:247
 msgid ""
 "Make each wheel notch jump exactly one row (or one home-screen section) "
 "instead of gliding. Turn this on if you prefer the older stepped scrolling."
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:217
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:255
 msgid "Discord Rich Presence. Takes effect after a restart."
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:219
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:257
 msgid ""
 "Leave this to Default unless setting up passthrough. Note some audio servers "
 "like Pipewire don't like passthrough and will need to be disabled for a card "
@@ -1013,57 +1037,57 @@ msgid ""
 "silence otherwise, but results may vary."
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:225
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:263
 msgid ""
 "Stop anything else using the device while playing. Needed for passthrough on "
 "some systems, and it means other applications will be silent."
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:228
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:266
 msgid ""
 "Page the library and music tile grids instead of scrolling: each page is one "
 "screenful with First / Previous / Next / Last controls and a page number you "
 "can type into. Easier than precise scrolling on a trackpad."
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:232
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:270
 msgid ""
 "Takes effect after a restart. \"Follow display\" uses the scale your desktop "
 "reports, which is 100% on X11."
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:234
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:272
 msgid ""
 "\"Default\" changes nothing and lets MPV (and your own mpv.conf) decide. "
 "Pick a mode only if you are sending audio to a receiver."
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:237
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:275
 msgid ""
 "Audio your receiver can't be sent directly is encoded to AC3, which is the "
 "only way surround fits down an optical cable. Turn this off if the encoder "
 "causes audio delay — those tracks become stereo instead."
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:242
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:280
 msgid ""
 "\"hq\" offers heavier profiles. Pick it if you have a fast graphics card."
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:244
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:282
 msgid ""
 "Leave on Automatic unless video breaks when a profile is loaded. This only "
 "applies while a profile is active, and OpenGL can cost you HDR output."
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:248
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:286
 msgid ""
 "Evens out loud effects and quiet dialogue. This turns passthrough off while "
 "it is enabled, because the volume has to be adjusted before your receiver "
 "gets the audio."
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:330
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:368
 msgid "Advanced"
 msgstr ""
 
@@ -1289,7 +1313,7 @@ msgid "Automatic"
 msgstr "Automatik"
 
 #: jellyfin_mpv_shim/mpvtk_browser/downloads.py:51
-#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1355
+#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1288
 msgid "Episodes"
 msgstr ""
 
@@ -1298,7 +1322,7 @@ msgid "Season %s"
 msgstr ""
 
 #: jellyfin_mpv_shim/mpvtk_browser/downloads.py:52
-#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1351
+#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1284
 msgid "Specials"
 msgstr ""
 
@@ -1323,7 +1347,7 @@ msgid "Failed"
 msgstr "Dështoi"
 
 #: jellyfin_mpv_shim/mpvtk_browser/downloads.py:185
-#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1105
+#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1038
 msgid "Playlist"
 msgstr ""
 
@@ -1335,30 +1359,30 @@ msgstr ""
 msgid "Movies & Videos"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/home_sections.py:103
+#: jellyfin_mpv_shim/mpvtk_browser/home_sections.py:104
 msgid "My Media"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/home_sections.py:104
-#: jellyfin_mpv_shim/mpvtk_browser/repository.py:352
+#: jellyfin_mpv_shim/mpvtk_browser/home_sections.py:105
+#: jellyfin_mpv_shim/mpvtk_browser/repository.py:350
 msgid "Continue Watching"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/home_sections.py:105
-#: jellyfin_mpv_shim/mpvtk_browser/repository.py:359
+#: jellyfin_mpv_shim/mpvtk_browser/home_sections.py:106
+#: jellyfin_mpv_shim/mpvtk_browser/repository.py:357
 msgid "Continue Listening"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/home_sections.py:106
-#: jellyfin_mpv_shim/mpvtk_browser/repository.py:366
+#: jellyfin_mpv_shim/mpvtk_browser/home_sections.py:107
+#: jellyfin_mpv_shim/mpvtk_browser/repository.py:364
 msgid "Next Up"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/home_sections.py:107
+#: jellyfin_mpv_shim/mpvtk_browser/home_sections.py:108
 msgid "Recently Added"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/home_sections.py:108
+#: jellyfin_mpv_shim/mpvtk_browser/home_sections.py:109
 msgid "Live TV"
 msgstr ""
 
@@ -1611,52 +1635,52 @@ msgstr ""
 "Nuk mund të shtohet serveri.\n"
 "Ju lutem shikoni informacionin e lidhjes."
 
-#: jellyfin_mpv_shim/mpvtk_browser/repository.py:390
+#: jellyfin_mpv_shim/mpvtk_browser/repository.py:386
 msgid "On Now"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/repository.py:411
+#: jellyfin_mpv_shim/mpvtk_browser/repository.py:407
 msgid "Latest %s"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1119
+#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1052
 msgid "Downloaded"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1138
+#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1071
 msgid "Movies"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1143
+#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1076
 msgid "Videos"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1147
+#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1080
 msgid "TV Shows"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1151
+#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1084
 msgid "Playlists"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1168
-#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1441
+#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1101
+#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1374
 msgid "Series"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1212
+#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1145
 msgid "Downloaded Movies"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1216
+#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1149
 msgid "Downloaded Videos"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1220
+#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1153
 msgid "Downloaded Shows"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1353
+#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1286
 msgid "Season %d"
 msgstr ""
 

--- a/jellyfin_mpv_shim/messages/sr/LC_MESSAGES/base.po
+++ b/jellyfin_mpv_shim/messages/sr/LC_MESSAGES/base.po
@@ -5,7 +5,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2026-07-25 17:21-0400\n"
+"POT-Creation-Date: 2026-07-26 12:03-0400\n"
 "PO-Revision-Date: 2026-04-17 12:45+0000\n"
 "Last-Translator: SecularSteve <fairfull.playing@gmail.com>\n"
 "Language-Team: Serbian <https://translate.jellyfin.org/projects/jellyfin/"
@@ -253,7 +253,7 @@ msgid "Select Subtitle Track"
 msgstr "Одабир титлa"
 
 #: jellyfin_mpv_shim/menu.py:341
-#: jellyfin_mpv_shim/mpvtk_browser/home_sections.py:102
+#: jellyfin_mpv_shim/mpvtk_browser/home_sections.py:103
 #: jellyfin_mpv_shim/osc_bridge.py:81 jellyfin_mpv_shim/osc_bridge.py:82
 #: jellyfin_mpv_shim/osc_bridge.py:104 jellyfin_mpv_shim/osc_bridge.py:140
 msgid "None"
@@ -404,7 +404,7 @@ msgstr "Питај да ли да се прескочи одјавна шпиц�
 msgid "Enable thumbnail previews"
 msgstr "Омогући преглед сличица"
 
-#: jellyfin_mpv_shim/menu.py:609 jellyfin_mpv_shim/mpvtk_browser/config.py:186
+#: jellyfin_mpv_shim/menu.py:609 jellyfin_mpv_shim/mpvtk_browser/config.py:195
 #: jellyfin_mpv_shim/mpvtk_browser/hud.py:375
 msgid "Night Mode (Auto Volume Adj)"
 msgstr ""
@@ -703,310 +703,334 @@ msgstr ""
 msgid "Or switch to another user"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/cast.py:317
+#: jellyfin_mpv_shim/mpvtk_browser/cast.py:314
 msgid "Ready to cast"
 msgstr "Спремно за емитовање"
 
-#: jellyfin_mpv_shim/mpvtk_browser/cast.py:318
+#: jellyfin_mpv_shim/mpvtk_browser/cast.py:315
 #, fuzzy
 #| msgid "Select your media in Jellyfin and play it here"
 msgid "Select your media in Jellyfin and play it here."
 msgstr "Изаберите свој медиј у Jellyfin-у и пустите га овде"
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:74
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:83
 msgid "Interface"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:83
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:92
 msgid "Playback"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:88
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:97
 msgid "Audio"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:92
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:101
 msgid "Subtitles & Languages"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:97
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:106
 #, fuzzy
 #| msgid " (Transcode)"
 msgid "Transcoding"
 msgstr " (Транскодуј)"
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:102
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:111
 msgid "Video Enhancement"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:104
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:113
 #, fuzzy
 #| msgid "Seek to Skip Credits"
 msgid "Skip Intro / Credits"
 msgstr "Прескочи одјавну шпицу"
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:107
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:116
 msgid "Library Browser"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:109
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:118
 msgid "Downloads"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:128
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:137
 msgid "Jellyfin UI"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:129
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:138
 msgid "MPV UI with thumbnails"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:130
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:139
 msgid "MPV built-in default"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:133
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:142
 msgid "Follow display"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:134
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:143
 msgid "100% (no scaling)"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:135
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:144
 msgid "125%"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:136
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:145
 msgid "150%"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:137
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:146
 msgid "200%"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:140
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:149
 msgid "Automatic (recommended)"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:141
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:150
 msgid "Vulkan"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:142
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:151
 msgid "Direct3D 11 (Windows only)"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:143
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:152
 msgid "OpenGL (compatibility)"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:146
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:155
 msgid "Default (auto)"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:147
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:156
 msgid "Force Stereo"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:148
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:157
 msgid "Optical Surround"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:149
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:158
 msgid "HDMI Passthrough"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:152
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:161
 msgid "Unset"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:153
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:162
 msgid "Dubbed (shows only)"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:154
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:163
 msgid "Subbed (shows only)"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:155
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:164
 msgid "Dubbed (all)"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:156
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:165
 msgid "Subbed (all)"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:157
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:166
 msgid "Custom (set in config)"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:162
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:171
 msgid "Download Folder"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:163
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:172
 msgid "Prefer Downloaded Copy"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:164
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:173
 msgid "Automatically Download Upcoming Episodes"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:165
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:174
 msgid "Include Next Up"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:166
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:175
 msgid "Next Up Entries to Consider"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:167
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:176
 msgid "Episodes to Keep Ahead (0 = off)"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:168
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:177
 msgid "Storage Limit for Automatic Downloads (GB)"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:169
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:178
 #, fuzzy
 #| msgid "Remove Server"
 msgid "Delete Automatic Downloads Once Watched"
 msgstr "Уклоните сервер"
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:170
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:179
 msgid "Delete Unwatched After (days, 0 = never)"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:171
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:180
 msgid "Check Every (minutes)"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:172
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:181
 msgid "Close to Tray (keep running)"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:173
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:182
 msgid "Keep Running in Background"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:174
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:183
 msgid "Remember Window Size"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:175
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:184
 msgid "Player Controls Style"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:176
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:185
 msgid "Show What You're Watching in Discord"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:177
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:186
 msgid "Interface Scale"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:178
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:187
 msgid "Cast-target mode (no library browsing)"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:179
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:188
 msgid "Casting Opens the Library Browser"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:180
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:189
 msgid "Fullscreen Library Browser"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:181
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:190
 msgid "Always Bind Arrow Keys to Player Controls"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:182
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:191
 msgid "Player Controls Activation Key"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:183
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:192
 msgid "Audio Output Mode"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:184
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:193
 msgid "Audio Output Device"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:185
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:194
 msgid "Take the Device Exclusively"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:187
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:196
 #, fuzzy
 #| msgid "Video Playback Profiles"
 msgid "Enable Video Playback Profiles"
 msgstr "Профил репродукције снимка"
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:188
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:197
 #, fuzzy
 #| msgid "New Group"
 msgid "Profile Group"
 msgstr "Нова група"
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:189
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:198
 msgid "Remember Last Used Profile"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:190
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:199
 msgid "Graphics API for Shaders"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:191
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:200
 msgid "Pass Through AC3"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:192
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:201
 msgid "Pass Through DTS"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:193
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:202
 msgid "Pass Through E-AC3"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:194
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:203
 msgid "Pass Through DTS-HD"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:195
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:204
 msgid "Pass Through TrueHD"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:196
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:205
 msgid "Re-encode Others to AC3"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:202
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:213
 msgid ""
-"MPV keybinds are used by default. Press ENTER to drive the player controls "
-"by keyboard."
+"With \"Start Minimized\" and \"Fullscreen\" this is the classic cast-target "
+"setup: the app waits out of the way, plays fullscreen when something casts "
+"to it, and goes back to waiting when the video ends or you press Q."
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:204
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:227
+msgid ""
+"Off means command-line mode: no window, no system tray and no settings "
+"screen, so the only way back is editing conf.json by hand. It is not how you "
+"get MPV's own on-screen controls — \"Player Controls Style\" under Interface "
+"does that."
+msgstr ""
+
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:234
+msgid ""
+"Show only what is cast to this machine — the library, including this "
+"settings screen, can't be reached from here. Without a system tray icon the "
+"only way back is editing conf.json. For the classic cast-target setup you "
+"want the Interface settings instead; this is for a shared TV nobody should "
+"be able to browse from."
+msgstr ""
+
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:240
+msgid ""
+"Requires restart to change. MPV keybinds are used by default. Press ENTER to "
+"drive the player controls by keyboard."
+msgstr ""
+
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:242
 msgid ""
 "Pixels one wheel notch scrolls. The scrollbar glides while the content snaps "
 "to the nearest row, so a trackpad or trackball no longer overshoots. Raise "
 "it to scroll faster, lower it for finer control."
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:209
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:247
 msgid ""
 "Make each wheel notch jump exactly one row (or one home-screen section) "
 "instead of gliding. Turn this on if you prefer the older stepped scrolling."
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:217
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:255
 msgid "Discord Rich Presence. Takes effect after a restart."
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:219
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:257
 msgid ""
 "Leave this to Default unless setting up passthrough. Note some audio servers "
 "like Pipewire don't like passthrough and will need to be disabled for a card "
@@ -1014,57 +1038,57 @@ msgid ""
 "silence otherwise, but results may vary."
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:225
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:263
 msgid ""
 "Stop anything else using the device while playing. Needed for passthrough on "
 "some systems, and it means other applications will be silent."
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:228
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:266
 msgid ""
 "Page the library and music tile grids instead of scrolling: each page is one "
 "screenful with First / Previous / Next / Last controls and a page number you "
 "can type into. Easier than precise scrolling on a trackpad."
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:232
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:270
 msgid ""
 "Takes effect after a restart. \"Follow display\" uses the scale your desktop "
 "reports, which is 100% on X11."
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:234
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:272
 msgid ""
 "\"Default\" changes nothing and lets MPV (and your own mpv.conf) decide. "
 "Pick a mode only if you are sending audio to a receiver."
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:237
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:275
 msgid ""
 "Audio your receiver can't be sent directly is encoded to AC3, which is the "
 "only way surround fits down an optical cable. Turn this off if the encoder "
 "causes audio delay — those tracks become stereo instead."
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:242
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:280
 msgid ""
 "\"hq\" offers heavier profiles. Pick it if you have a fast graphics card."
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:244
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:282
 msgid ""
 "Leave on Automatic unless video breaks when a profile is loaded. This only "
 "applies while a profile is active, and OpenGL can cost you HDR output."
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:248
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:286
 msgid ""
 "Evens out loud effects and quiet dialogue. This turns passthrough off while "
 "it is enabled, because the volume has to be adjusted before your receiver "
 "gets the audio."
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:330
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:368
 msgid "Advanced"
 msgstr ""
 
@@ -1290,7 +1314,7 @@ msgid "Automatic"
 msgstr "Аутоматски"
 
 #: jellyfin_mpv_shim/mpvtk_browser/downloads.py:51
-#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1355
+#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1288
 msgid "Episodes"
 msgstr ""
 
@@ -1299,7 +1323,7 @@ msgid "Season %s"
 msgstr ""
 
 #: jellyfin_mpv_shim/mpvtk_browser/downloads.py:52
-#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1351
+#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1284
 msgid "Specials"
 msgstr ""
 
@@ -1324,7 +1348,7 @@ msgid "Failed"
 msgstr "Неуспешно"
 
 #: jellyfin_mpv_shim/mpvtk_browser/downloads.py:185
-#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1105
+#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1038
 msgid "Playlist"
 msgstr ""
 
@@ -1336,30 +1360,30 @@ msgstr ""
 msgid "Movies & Videos"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/home_sections.py:103
+#: jellyfin_mpv_shim/mpvtk_browser/home_sections.py:104
 msgid "My Media"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/home_sections.py:104
-#: jellyfin_mpv_shim/mpvtk_browser/repository.py:352
+#: jellyfin_mpv_shim/mpvtk_browser/home_sections.py:105
+#: jellyfin_mpv_shim/mpvtk_browser/repository.py:350
 msgid "Continue Watching"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/home_sections.py:105
-#: jellyfin_mpv_shim/mpvtk_browser/repository.py:359
+#: jellyfin_mpv_shim/mpvtk_browser/home_sections.py:106
+#: jellyfin_mpv_shim/mpvtk_browser/repository.py:357
 msgid "Continue Listening"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/home_sections.py:106
-#: jellyfin_mpv_shim/mpvtk_browser/repository.py:366
+#: jellyfin_mpv_shim/mpvtk_browser/home_sections.py:107
+#: jellyfin_mpv_shim/mpvtk_browser/repository.py:364
 msgid "Next Up"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/home_sections.py:107
+#: jellyfin_mpv_shim/mpvtk_browser/home_sections.py:108
 msgid "Recently Added"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/home_sections.py:108
+#: jellyfin_mpv_shim/mpvtk_browser/home_sections.py:109
 msgid "Live TV"
 msgstr ""
 
@@ -1612,52 +1636,52 @@ msgstr ""
 "Додавање сервера није успело.\n"
 "Молимо проверите податке о вези."
 
-#: jellyfin_mpv_shim/mpvtk_browser/repository.py:390
+#: jellyfin_mpv_shim/mpvtk_browser/repository.py:386
 msgid "On Now"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/repository.py:411
+#: jellyfin_mpv_shim/mpvtk_browser/repository.py:407
 msgid "Latest %s"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1119
+#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1052
 msgid "Downloaded"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1138
+#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1071
 msgid "Movies"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1143
+#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1076
 msgid "Videos"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1147
+#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1080
 msgid "TV Shows"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1151
+#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1084
 msgid "Playlists"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1168
-#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1441
+#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1101
+#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1374
 msgid "Series"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1212
+#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1145
 msgid "Downloaded Movies"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1216
+#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1149
 msgid "Downloaded Videos"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1220
+#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1153
 msgid "Downloaded Shows"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1353
+#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1286
 msgid "Season %d"
 msgstr ""
 

--- a/jellyfin_mpv_shim/messages/sv/LC_MESSAGES/base.po
+++ b/jellyfin_mpv_shim/messages/sv/LC_MESSAGES/base.po
@@ -5,7 +5,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2026-07-25 17:21-0400\n"
+"POT-Creation-Date: 2026-07-26 12:03-0400\n"
 "PO-Revision-Date: 2026-05-23 07:46+0000\n"
 "Last-Translator: Viktor <viktor.engkvist@rivig.net>\n"
 "Language-Team: Swedish <https://translate.jellyfin.org/projects/jellyfin/"
@@ -252,7 +252,7 @@ msgid "Select Subtitle Track"
 msgstr "Välj undertext"
 
 #: jellyfin_mpv_shim/menu.py:341
-#: jellyfin_mpv_shim/mpvtk_browser/home_sections.py:102
+#: jellyfin_mpv_shim/mpvtk_browser/home_sections.py:103
 #: jellyfin_mpv_shim/osc_bridge.py:81 jellyfin_mpv_shim/osc_bridge.py:82
 #: jellyfin_mpv_shim/osc_bridge.py:104 jellyfin_mpv_shim/osc_bridge.py:140
 msgid "None"
@@ -403,7 +403,7 @@ msgstr "Fråga om att hoppa över eftertexter"
 msgid "Enable thumbnail previews"
 msgstr "Använd miniatyr-förhandsvisning"
 
-#: jellyfin_mpv_shim/menu.py:609 jellyfin_mpv_shim/mpvtk_browser/config.py:186
+#: jellyfin_mpv_shim/menu.py:609 jellyfin_mpv_shim/mpvtk_browser/config.py:195
 #: jellyfin_mpv_shim/mpvtk_browser/hud.py:375
 msgid "Night Mode (Auto Volume Adj)"
 msgstr ""
@@ -702,310 +702,334 @@ msgstr ""
 msgid "Or switch to another user"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/cast.py:317
+#: jellyfin_mpv_shim/mpvtk_browser/cast.py:314
 msgid "Ready to cast"
 msgstr "Redo att casta"
 
-#: jellyfin_mpv_shim/mpvtk_browser/cast.py:318
+#: jellyfin_mpv_shim/mpvtk_browser/cast.py:315
 #, fuzzy
 #| msgid "Select your media in Jellyfin and play it here"
 msgid "Select your media in Jellyfin and play it here."
 msgstr "Välj din media i Jellyfin och spela upp det här"
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:74
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:83
 msgid "Interface"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:83
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:92
 msgid "Playback"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:88
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:97
 msgid "Audio"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:92
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:101
 msgid "Subtitles & Languages"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:97
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:106
 #, fuzzy
 #| msgid " (Transcode)"
 msgid "Transcoding"
 msgstr " (Omkoda)"
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:102
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:111
 msgid "Video Enhancement"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:104
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:113
 #, fuzzy
 #| msgid "Seek to Skip Credits"
 msgid "Skip Intro / Credits"
 msgstr "Sök för att hopa över eftertexter"
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:107
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:116
 msgid "Library Browser"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:109
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:118
 msgid "Downloads"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:128
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:137
 msgid "Jellyfin UI"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:129
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:138
 msgid "MPV UI with thumbnails"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:130
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:139
 msgid "MPV built-in default"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:133
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:142
 msgid "Follow display"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:134
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:143
 msgid "100% (no scaling)"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:135
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:144
 msgid "125%"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:136
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:145
 msgid "150%"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:137
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:146
 msgid "200%"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:140
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:149
 msgid "Automatic (recommended)"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:141
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:150
 msgid "Vulkan"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:142
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:151
 msgid "Direct3D 11 (Windows only)"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:143
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:152
 msgid "OpenGL (compatibility)"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:146
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:155
 msgid "Default (auto)"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:147
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:156
 msgid "Force Stereo"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:148
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:157
 msgid "Optical Surround"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:149
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:158
 msgid "HDMI Passthrough"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:152
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:161
 msgid "Unset"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:153
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:162
 msgid "Dubbed (shows only)"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:154
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:163
 msgid "Subbed (shows only)"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:155
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:164
 msgid "Dubbed (all)"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:156
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:165
 msgid "Subbed (all)"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:157
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:166
 msgid "Custom (set in config)"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:162
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:171
 msgid "Download Folder"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:163
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:172
 msgid "Prefer Downloaded Copy"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:164
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:173
 msgid "Automatically Download Upcoming Episodes"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:165
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:174
 msgid "Include Next Up"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:166
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:175
 msgid "Next Up Entries to Consider"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:167
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:176
 msgid "Episodes to Keep Ahead (0 = off)"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:168
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:177
 msgid "Storage Limit for Automatic Downloads (GB)"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:169
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:178
 #, fuzzy
 #| msgid "Remove Server"
 msgid "Delete Automatic Downloads Once Watched"
 msgstr "Ta bort server"
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:170
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:179
 msgid "Delete Unwatched After (days, 0 = never)"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:171
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:180
 msgid "Check Every (minutes)"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:172
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:181
 msgid "Close to Tray (keep running)"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:173
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:182
 msgid "Keep Running in Background"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:174
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:183
 msgid "Remember Window Size"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:175
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:184
 msgid "Player Controls Style"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:176
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:185
 msgid "Show What You're Watching in Discord"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:177
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:186
 msgid "Interface Scale"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:178
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:187
 msgid "Cast-target mode (no library browsing)"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:179
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:188
 msgid "Casting Opens the Library Browser"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:180
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:189
 msgid "Fullscreen Library Browser"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:181
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:190
 msgid "Always Bind Arrow Keys to Player Controls"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:182
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:191
 msgid "Player Controls Activation Key"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:183
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:192
 msgid "Audio Output Mode"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:184
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:193
 msgid "Audio Output Device"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:185
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:194
 msgid "Take the Device Exclusively"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:187
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:196
 #, fuzzy
 #| msgid "Video Playback Profiles"
 msgid "Enable Video Playback Profiles"
 msgstr "Uppspelningsprofiler"
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:188
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:197
 #, fuzzy
 #| msgid "New Group"
 msgid "Profile Group"
 msgstr "Ny grupp"
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:189
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:198
 msgid "Remember Last Used Profile"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:190
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:199
 msgid "Graphics API for Shaders"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:191
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:200
 msgid "Pass Through AC3"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:192
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:201
 msgid "Pass Through DTS"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:193
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:202
 msgid "Pass Through E-AC3"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:194
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:203
 msgid "Pass Through DTS-HD"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:195
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:204
 msgid "Pass Through TrueHD"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:196
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:205
 msgid "Re-encode Others to AC3"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:202
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:213
 msgid ""
-"MPV keybinds are used by default. Press ENTER to drive the player controls "
-"by keyboard."
+"With \"Start Minimized\" and \"Fullscreen\" this is the classic cast-target "
+"setup: the app waits out of the way, plays fullscreen when something casts "
+"to it, and goes back to waiting when the video ends or you press Q."
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:204
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:227
+msgid ""
+"Off means command-line mode: no window, no system tray and no settings "
+"screen, so the only way back is editing conf.json by hand. It is not how you "
+"get MPV's own on-screen controls — \"Player Controls Style\" under Interface "
+"does that."
+msgstr ""
+
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:234
+msgid ""
+"Show only what is cast to this machine — the library, including this "
+"settings screen, can't be reached from here. Without a system tray icon the "
+"only way back is editing conf.json. For the classic cast-target setup you "
+"want the Interface settings instead; this is for a shared TV nobody should "
+"be able to browse from."
+msgstr ""
+
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:240
+msgid ""
+"Requires restart to change. MPV keybinds are used by default. Press ENTER to "
+"drive the player controls by keyboard."
+msgstr ""
+
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:242
 msgid ""
 "Pixels one wheel notch scrolls. The scrollbar glides while the content snaps "
 "to the nearest row, so a trackpad or trackball no longer overshoots. Raise "
 "it to scroll faster, lower it for finer control."
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:209
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:247
 msgid ""
 "Make each wheel notch jump exactly one row (or one home-screen section) "
 "instead of gliding. Turn this on if you prefer the older stepped scrolling."
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:217
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:255
 msgid "Discord Rich Presence. Takes effect after a restart."
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:219
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:257
 msgid ""
 "Leave this to Default unless setting up passthrough. Note some audio servers "
 "like Pipewire don't like passthrough and will need to be disabled for a card "
@@ -1013,57 +1037,57 @@ msgid ""
 "silence otherwise, but results may vary."
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:225
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:263
 msgid ""
 "Stop anything else using the device while playing. Needed for passthrough on "
 "some systems, and it means other applications will be silent."
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:228
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:266
 msgid ""
 "Page the library and music tile grids instead of scrolling: each page is one "
 "screenful with First / Previous / Next / Last controls and a page number you "
 "can type into. Easier than precise scrolling on a trackpad."
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:232
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:270
 msgid ""
 "Takes effect after a restart. \"Follow display\" uses the scale your desktop "
 "reports, which is 100% on X11."
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:234
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:272
 msgid ""
 "\"Default\" changes nothing and lets MPV (and your own mpv.conf) decide. "
 "Pick a mode only if you are sending audio to a receiver."
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:237
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:275
 msgid ""
 "Audio your receiver can't be sent directly is encoded to AC3, which is the "
 "only way surround fits down an optical cable. Turn this off if the encoder "
 "causes audio delay — those tracks become stereo instead."
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:242
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:280
 msgid ""
 "\"hq\" offers heavier profiles. Pick it if you have a fast graphics card."
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:244
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:282
 msgid ""
 "Leave on Automatic unless video breaks when a profile is loaded. This only "
 "applies while a profile is active, and OpenGL can cost you HDR output."
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:248
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:286
 msgid ""
 "Evens out loud effects and quiet dialogue. This turns passthrough off while "
 "it is enabled, because the volume has to be adjusted before your receiver "
 "gets the audio."
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:330
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:368
 msgid "Advanced"
 msgstr ""
 
@@ -1289,7 +1313,7 @@ msgid "Automatic"
 msgstr "Automatisk"
 
 #: jellyfin_mpv_shim/mpvtk_browser/downloads.py:51
-#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1355
+#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1288
 msgid "Episodes"
 msgstr ""
 
@@ -1298,7 +1322,7 @@ msgid "Season %s"
 msgstr ""
 
 #: jellyfin_mpv_shim/mpvtk_browser/downloads.py:52
-#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1351
+#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1284
 msgid "Specials"
 msgstr ""
 
@@ -1323,7 +1347,7 @@ msgid "Failed"
 msgstr "Misslyckat"
 
 #: jellyfin_mpv_shim/mpvtk_browser/downloads.py:185
-#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1105
+#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1038
 msgid "Playlist"
 msgstr ""
 
@@ -1335,30 +1359,30 @@ msgstr ""
 msgid "Movies & Videos"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/home_sections.py:103
+#: jellyfin_mpv_shim/mpvtk_browser/home_sections.py:104
 msgid "My Media"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/home_sections.py:104
-#: jellyfin_mpv_shim/mpvtk_browser/repository.py:352
+#: jellyfin_mpv_shim/mpvtk_browser/home_sections.py:105
+#: jellyfin_mpv_shim/mpvtk_browser/repository.py:350
 msgid "Continue Watching"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/home_sections.py:105
-#: jellyfin_mpv_shim/mpvtk_browser/repository.py:359
+#: jellyfin_mpv_shim/mpvtk_browser/home_sections.py:106
+#: jellyfin_mpv_shim/mpvtk_browser/repository.py:357
 msgid "Continue Listening"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/home_sections.py:106
-#: jellyfin_mpv_shim/mpvtk_browser/repository.py:366
+#: jellyfin_mpv_shim/mpvtk_browser/home_sections.py:107
+#: jellyfin_mpv_shim/mpvtk_browser/repository.py:364
 msgid "Next Up"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/home_sections.py:107
+#: jellyfin_mpv_shim/mpvtk_browser/home_sections.py:108
 msgid "Recently Added"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/home_sections.py:108
+#: jellyfin_mpv_shim/mpvtk_browser/home_sections.py:109
 msgid "Live TV"
 msgstr ""
 
@@ -1611,52 +1635,52 @@ msgstr ""
 "Kunde inte lägga till server.\n"
 "Var snäll och kolla din uppkoppling."
 
-#: jellyfin_mpv_shim/mpvtk_browser/repository.py:390
+#: jellyfin_mpv_shim/mpvtk_browser/repository.py:386
 msgid "On Now"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/repository.py:411
+#: jellyfin_mpv_shim/mpvtk_browser/repository.py:407
 msgid "Latest %s"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1119
+#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1052
 msgid "Downloaded"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1138
+#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1071
 msgid "Movies"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1143
+#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1076
 msgid "Videos"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1147
+#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1080
 msgid "TV Shows"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1151
+#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1084
 msgid "Playlists"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1168
-#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1441
+#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1101
+#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1374
 msgid "Series"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1212
+#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1145
 msgid "Downloaded Movies"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1216
+#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1149
 msgid "Downloaded Videos"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1220
+#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1153
 msgid "Downloaded Shows"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1353
+#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1286
 msgid "Season %d"
 msgstr ""
 

--- a/jellyfin_mpv_shim/messages/sw/LC_MESSAGES/base.po
+++ b/jellyfin_mpv_shim/messages/sw/LC_MESSAGES/base.po
@@ -5,7 +5,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2026-07-25 17:21-0400\n"
+"POT-Creation-Date: 2026-07-26 12:03-0400\n"
 "PO-Revision-Date: 2026-06-28 10:04+0000\n"
 "Last-Translator: Ricky Kimani <rkmacharia@outlook.com>\n"
 "Language-Team: Swahili <https://translate.jellyfin.org/projects/jellyfin/"
@@ -242,7 +242,7 @@ msgid "Select Subtitle Track"
 msgstr ""
 
 #: jellyfin_mpv_shim/menu.py:341
-#: jellyfin_mpv_shim/mpvtk_browser/home_sections.py:102
+#: jellyfin_mpv_shim/mpvtk_browser/home_sections.py:103
 #: jellyfin_mpv_shim/osc_bridge.py:81 jellyfin_mpv_shim/osc_bridge.py:82
 #: jellyfin_mpv_shim/osc_bridge.py:104 jellyfin_mpv_shim/osc_bridge.py:140
 msgid "None"
@@ -393,7 +393,7 @@ msgstr ""
 msgid "Enable thumbnail previews"
 msgstr ""
 
-#: jellyfin_mpv_shim/menu.py:609 jellyfin_mpv_shim/mpvtk_browser/config.py:186
+#: jellyfin_mpv_shim/menu.py:609 jellyfin_mpv_shim/mpvtk_browser/config.py:195
 #: jellyfin_mpv_shim/mpvtk_browser/hud.py:375
 msgid "Night Mode (Auto Volume Adj)"
 msgstr ""
@@ -658,298 +658,322 @@ msgstr ""
 msgid "Or switch to another user"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/cast.py:317
+#: jellyfin_mpv_shim/mpvtk_browser/cast.py:314
 msgid "Ready to cast"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/cast.py:318
+#: jellyfin_mpv_shim/mpvtk_browser/cast.py:315
 msgid "Select your media in Jellyfin and play it here."
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:74
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:83
 msgid "Interface"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:83
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:92
 msgid "Playback"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:88
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:97
 msgid "Audio"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:92
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:101
 msgid "Subtitles & Languages"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:97
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:106
 msgid "Transcoding"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:102
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:111
 msgid "Video Enhancement"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:104
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:113
 msgid "Skip Intro / Credits"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:107
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:116
 msgid "Library Browser"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:109
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:118
 msgid "Downloads"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:128
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:137
 msgid "Jellyfin UI"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:129
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:138
 msgid "MPV UI with thumbnails"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:130
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:139
 msgid "MPV built-in default"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:133
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:142
 msgid "Follow display"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:134
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:143
 msgid "100% (no scaling)"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:135
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:144
 msgid "125%"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:136
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:145
 msgid "150%"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:137
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:146
 msgid "200%"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:140
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:149
 msgid "Automatic (recommended)"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:141
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:150
 msgid "Vulkan"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:142
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:151
 msgid "Direct3D 11 (Windows only)"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:143
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:152
 msgid "OpenGL (compatibility)"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:146
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:155
 msgid "Default (auto)"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:147
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:156
 msgid "Force Stereo"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:148
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:157
 msgid "Optical Surround"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:149
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:158
 msgid "HDMI Passthrough"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:152
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:161
 msgid "Unset"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:153
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:162
 msgid "Dubbed (shows only)"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:154
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:163
 msgid "Subbed (shows only)"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:155
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:164
 msgid "Dubbed (all)"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:156
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:165
 msgid "Subbed (all)"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:157
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:166
 msgid "Custom (set in config)"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:162
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:171
 msgid "Download Folder"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:163
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:172
 msgid "Prefer Downloaded Copy"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:164
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:173
 msgid "Automatically Download Upcoming Episodes"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:165
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:174
 msgid "Include Next Up"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:166
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:175
 msgid "Next Up Entries to Consider"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:167
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:176
 msgid "Episodes to Keep Ahead (0 = off)"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:168
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:177
 msgid "Storage Limit for Automatic Downloads (GB)"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:169
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:178
 msgid "Delete Automatic Downloads Once Watched"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:170
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:179
 msgid "Delete Unwatched After (days, 0 = never)"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:171
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:180
 msgid "Check Every (minutes)"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:172
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:181
 msgid "Close to Tray (keep running)"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:173
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:182
 msgid "Keep Running in Background"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:174
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:183
 msgid "Remember Window Size"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:175
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:184
 msgid "Player Controls Style"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:176
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:185
 msgid "Show What You're Watching in Discord"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:177
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:186
 msgid "Interface Scale"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:178
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:187
 msgid "Cast-target mode (no library browsing)"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:179
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:188
 msgid "Casting Opens the Library Browser"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:180
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:189
 msgid "Fullscreen Library Browser"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:181
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:190
 msgid "Always Bind Arrow Keys to Player Controls"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:182
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:191
 msgid "Player Controls Activation Key"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:183
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:192
 msgid "Audio Output Mode"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:184
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:193
 msgid "Audio Output Device"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:185
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:194
 msgid "Take the Device Exclusively"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:187
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:196
 msgid "Enable Video Playback Profiles"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:188
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:197
 msgid "Profile Group"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:189
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:198
 msgid "Remember Last Used Profile"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:190
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:199
 msgid "Graphics API for Shaders"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:191
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:200
 msgid "Pass Through AC3"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:192
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:201
 msgid "Pass Through DTS"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:193
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:202
 msgid "Pass Through E-AC3"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:194
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:203
 msgid "Pass Through DTS-HD"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:195
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:204
 msgid "Pass Through TrueHD"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:196
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:205
 msgid "Re-encode Others to AC3"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:202
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:213
 msgid ""
-"MPV keybinds are used by default. Press ENTER to drive the player controls "
-"by keyboard."
+"With \"Start Minimized\" and \"Fullscreen\" this is the classic cast-target "
+"setup: the app waits out of the way, plays fullscreen when something casts "
+"to it, and goes back to waiting when the video ends or you press Q."
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:204
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:227
+msgid ""
+"Off means command-line mode: no window, no system tray and no settings "
+"screen, so the only way back is editing conf.json by hand. It is not how you "
+"get MPV's own on-screen controls — \"Player Controls Style\" under Interface "
+"does that."
+msgstr ""
+
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:234
+msgid ""
+"Show only what is cast to this machine — the library, including this "
+"settings screen, can't be reached from here. Without a system tray icon the "
+"only way back is editing conf.json. For the classic cast-target setup you "
+"want the Interface settings instead; this is for a shared TV nobody should "
+"be able to browse from."
+msgstr ""
+
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:240
+msgid ""
+"Requires restart to change. MPV keybinds are used by default. Press ENTER to "
+"drive the player controls by keyboard."
+msgstr ""
+
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:242
 msgid ""
 "Pixels one wheel notch scrolls. The scrollbar glides while the content snaps "
 "to the nearest row, so a trackpad or trackball no longer overshoots. Raise "
 "it to scroll faster, lower it for finer control."
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:209
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:247
 msgid ""
 "Make each wheel notch jump exactly one row (or one home-screen section) "
 "instead of gliding. Turn this on if you prefer the older stepped scrolling."
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:217
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:255
 msgid "Discord Rich Presence. Takes effect after a restart."
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:219
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:257
 msgid ""
 "Leave this to Default unless setting up passthrough. Note some audio servers "
 "like Pipewire don't like passthrough and will need to be disabled for a card "
@@ -957,57 +981,57 @@ msgid ""
 "silence otherwise, but results may vary."
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:225
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:263
 msgid ""
 "Stop anything else using the device while playing. Needed for passthrough on "
 "some systems, and it means other applications will be silent."
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:228
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:266
 msgid ""
 "Page the library and music tile grids instead of scrolling: each page is one "
 "screenful with First / Previous / Next / Last controls and a page number you "
 "can type into. Easier than precise scrolling on a trackpad."
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:232
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:270
 msgid ""
 "Takes effect after a restart. \"Follow display\" uses the scale your desktop "
 "reports, which is 100% on X11."
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:234
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:272
 msgid ""
 "\"Default\" changes nothing and lets MPV (and your own mpv.conf) decide. "
 "Pick a mode only if you are sending audio to a receiver."
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:237
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:275
 msgid ""
 "Audio your receiver can't be sent directly is encoded to AC3, which is the "
 "only way surround fits down an optical cable. Turn this off if the encoder "
 "causes audio delay — those tracks become stereo instead."
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:242
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:280
 msgid ""
 "\"hq\" offers heavier profiles. Pick it if you have a fast graphics card."
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:244
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:282
 msgid ""
 "Leave on Automatic unless video breaks when a profile is loaded. This only "
 "applies while a profile is active, and OpenGL can cost you HDR output."
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:248
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:286
 msgid ""
 "Evens out loud effects and quiet dialogue. This turns passthrough off while "
 "it is enabled, because the volume has to be adjusted before your receiver "
 "gets the audio."
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:330
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:368
 msgid "Advanced"
 msgstr ""
 
@@ -1185,7 +1209,7 @@ msgid "Automatic"
 msgstr ""
 
 #: jellyfin_mpv_shim/mpvtk_browser/downloads.py:51
-#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1355
+#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1288
 msgid "Episodes"
 msgstr ""
 
@@ -1194,7 +1218,7 @@ msgid "Season %s"
 msgstr ""
 
 #: jellyfin_mpv_shim/mpvtk_browser/downloads.py:52
-#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1351
+#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1284
 msgid "Specials"
 msgstr ""
 
@@ -1215,7 +1239,7 @@ msgid "Failed"
 msgstr ""
 
 #: jellyfin_mpv_shim/mpvtk_browser/downloads.py:185
-#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1105
+#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1038
 msgid "Playlist"
 msgstr ""
 
@@ -1227,30 +1251,30 @@ msgstr ""
 msgid "Movies & Videos"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/home_sections.py:103
+#: jellyfin_mpv_shim/mpvtk_browser/home_sections.py:104
 msgid "My Media"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/home_sections.py:104
-#: jellyfin_mpv_shim/mpvtk_browser/repository.py:352
+#: jellyfin_mpv_shim/mpvtk_browser/home_sections.py:105
+#: jellyfin_mpv_shim/mpvtk_browser/repository.py:350
 msgid "Continue Watching"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/home_sections.py:105
-#: jellyfin_mpv_shim/mpvtk_browser/repository.py:359
+#: jellyfin_mpv_shim/mpvtk_browser/home_sections.py:106
+#: jellyfin_mpv_shim/mpvtk_browser/repository.py:357
 msgid "Continue Listening"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/home_sections.py:106
-#: jellyfin_mpv_shim/mpvtk_browser/repository.py:366
+#: jellyfin_mpv_shim/mpvtk_browser/home_sections.py:107
+#: jellyfin_mpv_shim/mpvtk_browser/repository.py:364
 msgid "Next Up"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/home_sections.py:107
+#: jellyfin_mpv_shim/mpvtk_browser/home_sections.py:108
 msgid "Recently Added"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/home_sections.py:108
+#: jellyfin_mpv_shim/mpvtk_browser/home_sections.py:109
 msgid "Live TV"
 msgstr ""
 
@@ -1455,52 +1479,52 @@ msgstr ""
 msgid "Could not load this page."
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/repository.py:390
+#: jellyfin_mpv_shim/mpvtk_browser/repository.py:386
 msgid "On Now"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/repository.py:411
+#: jellyfin_mpv_shim/mpvtk_browser/repository.py:407
 msgid "Latest %s"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1119
+#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1052
 msgid "Downloaded"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1138
+#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1071
 msgid "Movies"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1143
+#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1076
 msgid "Videos"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1147
+#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1080
 msgid "TV Shows"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1151
+#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1084
 msgid "Playlists"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1168
-#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1441
+#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1101
+#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1374
 msgid "Series"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1212
+#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1145
 msgid "Downloaded Movies"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1216
+#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1149
 msgid "Downloaded Videos"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1220
+#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1153
 msgid "Downloaded Shows"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1353
+#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1286
 msgid "Season %d"
 msgstr ""
 

--- a/jellyfin_mpv_shim/messages/ta/LC_MESSAGES/base.po
+++ b/jellyfin_mpv_shim/messages/ta/LC_MESSAGES/base.po
@@ -5,7 +5,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2026-07-25 17:21-0400\n"
+"POT-Creation-Date: 2026-07-26 12:03-0400\n"
 "PO-Revision-Date: 2025-06-26 13:51+0000\n"
 "Last-Translator: Oatavandi <oatavandi@gmail.com>\n"
 "Language-Team: Tamil <https://translate.jellyfin.org/projects/jellyfin/"
@@ -252,7 +252,7 @@ msgid "Select Subtitle Track"
 msgstr "வசனத் தடத்தைத் தேர்ந்தெடுக்கவும்"
 
 #: jellyfin_mpv_shim/menu.py:341
-#: jellyfin_mpv_shim/mpvtk_browser/home_sections.py:102
+#: jellyfin_mpv_shim/mpvtk_browser/home_sections.py:103
 #: jellyfin_mpv_shim/osc_bridge.py:81 jellyfin_mpv_shim/osc_bridge.py:82
 #: jellyfin_mpv_shim/osc_bridge.py:104 jellyfin_mpv_shim/osc_bridge.py:140
 msgid "None"
@@ -403,7 +403,7 @@ msgstr "கிரெடிட்களைத் தவிர்க்கச் �
 msgid "Enable thumbnail previews"
 msgstr "படங்களின் முன்னோட்டங்களை கான்பி"
 
-#: jellyfin_mpv_shim/menu.py:609 jellyfin_mpv_shim/mpvtk_browser/config.py:186
+#: jellyfin_mpv_shim/menu.py:609 jellyfin_mpv_shim/mpvtk_browser/config.py:195
 #: jellyfin_mpv_shim/mpvtk_browser/hud.py:375
 msgid "Night Mode (Auto Volume Adj)"
 msgstr ""
@@ -702,310 +702,334 @@ msgstr ""
 msgid "Or switch to another user"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/cast.py:317
+#: jellyfin_mpv_shim/mpvtk_browser/cast.py:314
 msgid "Ready to cast"
 msgstr "நடிக்கத் தயார்"
 
-#: jellyfin_mpv_shim/mpvtk_browser/cast.py:318
+#: jellyfin_mpv_shim/mpvtk_browser/cast.py:315
 #, fuzzy
 #| msgid "Select your media in Jellyfin and play it here"
 msgid "Select your media in Jellyfin and play it here."
 msgstr "ஜெல்லிஃபினில் உங்கள் மீடியாவைத் தேர்ந்தெடுத்து இங்கே விளையாடுங்கள்"
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:74
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:83
 msgid "Interface"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:83
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:92
 msgid "Playback"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:88
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:97
 msgid "Audio"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:92
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:101
 msgid "Subtitles & Languages"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:97
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:106
 #, fuzzy
 #| msgid " (Transcode)"
 msgid "Transcoding"
 msgstr " (டிரான்ஸ்கோட்)"
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:102
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:111
 msgid "Video Enhancement"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:104
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:113
 #, fuzzy
 #| msgid "Seek to Skip Credits"
 msgid "Skip Intro / Credits"
 msgstr "கிரெடிட்களைத் தவிர்க்க முயற்சிக்கவும்"
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:107
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:116
 msgid "Library Browser"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:109
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:118
 msgid "Downloads"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:128
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:137
 msgid "Jellyfin UI"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:129
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:138
 msgid "MPV UI with thumbnails"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:130
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:139
 msgid "MPV built-in default"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:133
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:142
 msgid "Follow display"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:134
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:143
 msgid "100% (no scaling)"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:135
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:144
 msgid "125%"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:136
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:145
 msgid "150%"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:137
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:146
 msgid "200%"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:140
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:149
 msgid "Automatic (recommended)"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:141
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:150
 msgid "Vulkan"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:142
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:151
 msgid "Direct3D 11 (Windows only)"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:143
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:152
 msgid "OpenGL (compatibility)"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:146
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:155
 msgid "Default (auto)"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:147
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:156
 msgid "Force Stereo"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:148
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:157
 msgid "Optical Surround"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:149
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:158
 msgid "HDMI Passthrough"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:152
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:161
 msgid "Unset"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:153
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:162
 msgid "Dubbed (shows only)"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:154
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:163
 msgid "Subbed (shows only)"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:155
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:164
 msgid "Dubbed (all)"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:156
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:165
 msgid "Subbed (all)"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:157
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:166
 msgid "Custom (set in config)"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:162
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:171
 msgid "Download Folder"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:163
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:172
 msgid "Prefer Downloaded Copy"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:164
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:173
 msgid "Automatically Download Upcoming Episodes"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:165
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:174
 msgid "Include Next Up"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:166
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:175
 msgid "Next Up Entries to Consider"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:167
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:176
 msgid "Episodes to Keep Ahead (0 = off)"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:168
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:177
 msgid "Storage Limit for Automatic Downloads (GB)"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:169
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:178
 #, fuzzy
 #| msgid "Remove Server"
 msgid "Delete Automatic Downloads Once Watched"
 msgstr "சேவையகத்தை அகற்று"
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:170
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:179
 msgid "Delete Unwatched After (days, 0 = never)"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:171
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:180
 msgid "Check Every (minutes)"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:172
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:181
 msgid "Close to Tray (keep running)"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:173
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:182
 msgid "Keep Running in Background"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:174
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:183
 msgid "Remember Window Size"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:175
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:184
 msgid "Player Controls Style"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:176
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:185
 msgid "Show What You're Watching in Discord"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:177
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:186
 msgid "Interface Scale"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:178
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:187
 msgid "Cast-target mode (no library browsing)"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:179
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:188
 msgid "Casting Opens the Library Browser"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:180
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:189
 msgid "Fullscreen Library Browser"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:181
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:190
 msgid "Always Bind Arrow Keys to Player Controls"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:182
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:191
 msgid "Player Controls Activation Key"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:183
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:192
 msgid "Audio Output Mode"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:184
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:193
 msgid "Audio Output Device"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:185
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:194
 msgid "Take the Device Exclusively"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:187
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:196
 #, fuzzy
 #| msgid "Video Playback Profiles"
 msgid "Enable Video Playback Profiles"
 msgstr "வீடியோ பின்னணி சுயவிவரங்கள்"
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:188
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:197
 #, fuzzy
 #| msgid "New Group"
 msgid "Profile Group"
 msgstr "புதிய குழு"
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:189
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:198
 msgid "Remember Last Used Profile"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:190
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:199
 msgid "Graphics API for Shaders"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:191
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:200
 msgid "Pass Through AC3"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:192
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:201
 msgid "Pass Through DTS"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:193
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:202
 msgid "Pass Through E-AC3"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:194
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:203
 msgid "Pass Through DTS-HD"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:195
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:204
 msgid "Pass Through TrueHD"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:196
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:205
 msgid "Re-encode Others to AC3"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:202
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:213
 msgid ""
-"MPV keybinds are used by default. Press ENTER to drive the player controls "
-"by keyboard."
+"With \"Start Minimized\" and \"Fullscreen\" this is the classic cast-target "
+"setup: the app waits out of the way, plays fullscreen when something casts "
+"to it, and goes back to waiting when the video ends or you press Q."
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:204
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:227
+msgid ""
+"Off means command-line mode: no window, no system tray and no settings "
+"screen, so the only way back is editing conf.json by hand. It is not how you "
+"get MPV's own on-screen controls — \"Player Controls Style\" under Interface "
+"does that."
+msgstr ""
+
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:234
+msgid ""
+"Show only what is cast to this machine — the library, including this "
+"settings screen, can't be reached from here. Without a system tray icon the "
+"only way back is editing conf.json. For the classic cast-target setup you "
+"want the Interface settings instead; this is for a shared TV nobody should "
+"be able to browse from."
+msgstr ""
+
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:240
+msgid ""
+"Requires restart to change. MPV keybinds are used by default. Press ENTER to "
+"drive the player controls by keyboard."
+msgstr ""
+
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:242
 msgid ""
 "Pixels one wheel notch scrolls. The scrollbar glides while the content snaps "
 "to the nearest row, so a trackpad or trackball no longer overshoots. Raise "
 "it to scroll faster, lower it for finer control."
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:209
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:247
 msgid ""
 "Make each wheel notch jump exactly one row (or one home-screen section) "
 "instead of gliding. Turn this on if you prefer the older stepped scrolling."
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:217
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:255
 msgid "Discord Rich Presence. Takes effect after a restart."
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:219
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:257
 msgid ""
 "Leave this to Default unless setting up passthrough. Note some audio servers "
 "like Pipewire don't like passthrough and will need to be disabled for a card "
@@ -1013,57 +1037,57 @@ msgid ""
 "silence otherwise, but results may vary."
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:225
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:263
 msgid ""
 "Stop anything else using the device while playing. Needed for passthrough on "
 "some systems, and it means other applications will be silent."
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:228
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:266
 msgid ""
 "Page the library and music tile grids instead of scrolling: each page is one "
 "screenful with First / Previous / Next / Last controls and a page number you "
 "can type into. Easier than precise scrolling on a trackpad."
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:232
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:270
 msgid ""
 "Takes effect after a restart. \"Follow display\" uses the scale your desktop "
 "reports, which is 100% on X11."
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:234
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:272
 msgid ""
 "\"Default\" changes nothing and lets MPV (and your own mpv.conf) decide. "
 "Pick a mode only if you are sending audio to a receiver."
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:237
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:275
 msgid ""
 "Audio your receiver can't be sent directly is encoded to AC3, which is the "
 "only way surround fits down an optical cable. Turn this off if the encoder "
 "causes audio delay — those tracks become stereo instead."
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:242
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:280
 msgid ""
 "\"hq\" offers heavier profiles. Pick it if you have a fast graphics card."
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:244
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:282
 msgid ""
 "Leave on Automatic unless video breaks when a profile is loaded. This only "
 "applies while a profile is active, and OpenGL can cost you HDR output."
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:248
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:286
 msgid ""
 "Evens out loud effects and quiet dialogue. This turns passthrough off while "
 "it is enabled, because the volume has to be adjusted before your receiver "
 "gets the audio."
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:330
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:368
 msgid "Advanced"
 msgstr ""
 
@@ -1289,7 +1313,7 @@ msgid "Automatic"
 msgstr "தானியங்கி"
 
 #: jellyfin_mpv_shim/mpvtk_browser/downloads.py:51
-#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1355
+#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1288
 msgid "Episodes"
 msgstr ""
 
@@ -1298,7 +1322,7 @@ msgid "Season %s"
 msgstr ""
 
 #: jellyfin_mpv_shim/mpvtk_browser/downloads.py:52
-#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1351
+#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1284
 msgid "Specials"
 msgstr ""
 
@@ -1323,7 +1347,7 @@ msgid "Failed"
 msgstr "தோல்வி"
 
 #: jellyfin_mpv_shim/mpvtk_browser/downloads.py:185
-#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1105
+#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1038
 msgid "Playlist"
 msgstr ""
 
@@ -1335,30 +1359,30 @@ msgstr ""
 msgid "Movies & Videos"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/home_sections.py:103
+#: jellyfin_mpv_shim/mpvtk_browser/home_sections.py:104
 msgid "My Media"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/home_sections.py:104
-#: jellyfin_mpv_shim/mpvtk_browser/repository.py:352
+#: jellyfin_mpv_shim/mpvtk_browser/home_sections.py:105
+#: jellyfin_mpv_shim/mpvtk_browser/repository.py:350
 msgid "Continue Watching"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/home_sections.py:105
-#: jellyfin_mpv_shim/mpvtk_browser/repository.py:359
+#: jellyfin_mpv_shim/mpvtk_browser/home_sections.py:106
+#: jellyfin_mpv_shim/mpvtk_browser/repository.py:357
 msgid "Continue Listening"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/home_sections.py:106
-#: jellyfin_mpv_shim/mpvtk_browser/repository.py:366
+#: jellyfin_mpv_shim/mpvtk_browser/home_sections.py:107
+#: jellyfin_mpv_shim/mpvtk_browser/repository.py:364
 msgid "Next Up"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/home_sections.py:107
+#: jellyfin_mpv_shim/mpvtk_browser/home_sections.py:108
 msgid "Recently Added"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/home_sections.py:108
+#: jellyfin_mpv_shim/mpvtk_browser/home_sections.py:109
 msgid "Live TV"
 msgstr ""
 
@@ -1611,52 +1635,52 @@ msgstr ""
 "சேவையகத்தைச் சேர்க்க முடியவில்லை.\n"
 "உங்கள் இணைப்பு தகவலை சரிபார்க்கவும்."
 
-#: jellyfin_mpv_shim/mpvtk_browser/repository.py:390
+#: jellyfin_mpv_shim/mpvtk_browser/repository.py:386
 msgid "On Now"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/repository.py:411
+#: jellyfin_mpv_shim/mpvtk_browser/repository.py:407
 msgid "Latest %s"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1119
+#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1052
 msgid "Downloaded"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1138
+#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1071
 msgid "Movies"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1143
+#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1076
 msgid "Videos"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1147
+#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1080
 msgid "TV Shows"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1151
+#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1084
 msgid "Playlists"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1168
-#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1441
+#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1101
+#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1374
 msgid "Series"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1212
+#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1145
 msgid "Downloaded Movies"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1216
+#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1149
 msgid "Downloaded Videos"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1220
+#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1153
 msgid "Downloaded Shows"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1353
+#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1286
 msgid "Season %d"
 msgstr ""
 

--- a/jellyfin_mpv_shim/messages/th/LC_MESSAGES/base.po
+++ b/jellyfin_mpv_shim/messages/th/LC_MESSAGES/base.po
@@ -5,7 +5,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2026-07-25 17:21-0400\n"
+"POT-Creation-Date: 2026-07-26 12:03-0400\n"
 "PO-Revision-Date: 2026-05-04 02:27+0000\n"
 "Last-Translator: Bunyapat Thaibkhom <topstenbyp@gmail.com>\n"
 "Language-Team: Thai <https://translate.jellyfin.org/projects/jellyfin/"
@@ -253,7 +253,7 @@ msgid "Select Subtitle Track"
 msgstr "เลือกซับไตเติ้ล"
 
 #: jellyfin_mpv_shim/menu.py:341
-#: jellyfin_mpv_shim/mpvtk_browser/home_sections.py:102
+#: jellyfin_mpv_shim/mpvtk_browser/home_sections.py:103
 #: jellyfin_mpv_shim/osc_bridge.py:81 jellyfin_mpv_shim/osc_bridge.py:82
 #: jellyfin_mpv_shim/osc_bridge.py:104 jellyfin_mpv_shim/osc_bridge.py:140
 msgid "None"
@@ -404,7 +404,7 @@ msgstr "ถามก่อนข้ามเครดิต"
 msgid "Enable thumbnail previews"
 msgstr "เปิดใช้งานการแสดงตัวอย่างภาพขนาดย่อ"
 
-#: jellyfin_mpv_shim/menu.py:609 jellyfin_mpv_shim/mpvtk_browser/config.py:186
+#: jellyfin_mpv_shim/menu.py:609 jellyfin_mpv_shim/mpvtk_browser/config.py:195
 #: jellyfin_mpv_shim/mpvtk_browser/hud.py:375
 msgid "Night Mode (Auto Volume Adj)"
 msgstr ""
@@ -703,310 +703,334 @@ msgstr ""
 msgid "Or switch to another user"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/cast.py:317
+#: jellyfin_mpv_shim/mpvtk_browser/cast.py:314
 msgid "Ready to cast"
 msgstr "พร้อมสำหรับการแคสต์"
 
-#: jellyfin_mpv_shim/mpvtk_browser/cast.py:318
+#: jellyfin_mpv_shim/mpvtk_browser/cast.py:315
 #, fuzzy
 #| msgid "Select your media in Jellyfin and play it here"
 msgid "Select your media in Jellyfin and play it here."
 msgstr "เลือกสื่อใน Jellyfin และเล่นที่นี่"
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:74
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:83
 msgid "Interface"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:83
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:92
 msgid "Playback"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:88
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:97
 msgid "Audio"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:92
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:101
 msgid "Subtitles & Languages"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:97
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:106
 #, fuzzy
 #| msgid " (Transcode)"
 msgid "Transcoding"
 msgstr " (Transcode)"
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:102
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:111
 msgid "Video Enhancement"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:104
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:113
 #, fuzzy
 #| msgid "Seek to Skip Credits"
 msgid "Skip Intro / Credits"
 msgstr "เลื่อนเพื่อข้ามเครดิต"
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:107
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:116
 msgid "Library Browser"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:109
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:118
 msgid "Downloads"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:128
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:137
 msgid "Jellyfin UI"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:129
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:138
 msgid "MPV UI with thumbnails"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:130
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:139
 msgid "MPV built-in default"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:133
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:142
 msgid "Follow display"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:134
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:143
 msgid "100% (no scaling)"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:135
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:144
 msgid "125%"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:136
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:145
 msgid "150%"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:137
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:146
 msgid "200%"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:140
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:149
 msgid "Automatic (recommended)"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:141
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:150
 msgid "Vulkan"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:142
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:151
 msgid "Direct3D 11 (Windows only)"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:143
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:152
 msgid "OpenGL (compatibility)"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:146
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:155
 msgid "Default (auto)"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:147
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:156
 msgid "Force Stereo"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:148
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:157
 msgid "Optical Surround"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:149
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:158
 msgid "HDMI Passthrough"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:152
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:161
 msgid "Unset"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:153
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:162
 msgid "Dubbed (shows only)"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:154
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:163
 msgid "Subbed (shows only)"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:155
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:164
 msgid "Dubbed (all)"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:156
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:165
 msgid "Subbed (all)"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:157
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:166
 msgid "Custom (set in config)"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:162
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:171
 msgid "Download Folder"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:163
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:172
 msgid "Prefer Downloaded Copy"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:164
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:173
 msgid "Automatically Download Upcoming Episodes"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:165
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:174
 msgid "Include Next Up"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:166
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:175
 msgid "Next Up Entries to Consider"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:167
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:176
 msgid "Episodes to Keep Ahead (0 = off)"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:168
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:177
 msgid "Storage Limit for Automatic Downloads (GB)"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:169
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:178
 #, fuzzy
 #| msgid "Remove Server"
 msgid "Delete Automatic Downloads Once Watched"
 msgstr "ลบเซิร์ฟเวอร์"
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:170
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:179
 msgid "Delete Unwatched After (days, 0 = never)"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:171
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:180
 msgid "Check Every (minutes)"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:172
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:181
 msgid "Close to Tray (keep running)"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:173
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:182
 msgid "Keep Running in Background"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:174
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:183
 msgid "Remember Window Size"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:175
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:184
 msgid "Player Controls Style"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:176
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:185
 msgid "Show What You're Watching in Discord"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:177
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:186
 msgid "Interface Scale"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:178
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:187
 msgid "Cast-target mode (no library browsing)"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:179
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:188
 msgid "Casting Opens the Library Browser"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:180
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:189
 msgid "Fullscreen Library Browser"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:181
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:190
 msgid "Always Bind Arrow Keys to Player Controls"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:182
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:191
 msgid "Player Controls Activation Key"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:183
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:192
 msgid "Audio Output Mode"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:184
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:193
 msgid "Audio Output Device"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:185
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:194
 msgid "Take the Device Exclusively"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:187
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:196
 #, fuzzy
 #| msgid "Video Playback Profiles"
 msgid "Enable Video Playback Profiles"
 msgstr "โปรไฟล์การเล่นวิดีโอ"
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:188
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:197
 #, fuzzy
 #| msgid "New Group"
 msgid "Profile Group"
 msgstr "สร้างกลุ่มใหม่"
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:189
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:198
 msgid "Remember Last Used Profile"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:190
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:199
 msgid "Graphics API for Shaders"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:191
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:200
 msgid "Pass Through AC3"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:192
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:201
 msgid "Pass Through DTS"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:193
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:202
 msgid "Pass Through E-AC3"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:194
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:203
 msgid "Pass Through DTS-HD"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:195
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:204
 msgid "Pass Through TrueHD"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:196
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:205
 msgid "Re-encode Others to AC3"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:202
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:213
 msgid ""
-"MPV keybinds are used by default. Press ENTER to drive the player controls "
-"by keyboard."
+"With \"Start Minimized\" and \"Fullscreen\" this is the classic cast-target "
+"setup: the app waits out of the way, plays fullscreen when something casts "
+"to it, and goes back to waiting when the video ends or you press Q."
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:204
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:227
+msgid ""
+"Off means command-line mode: no window, no system tray and no settings "
+"screen, so the only way back is editing conf.json by hand. It is not how you "
+"get MPV's own on-screen controls — \"Player Controls Style\" under Interface "
+"does that."
+msgstr ""
+
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:234
+msgid ""
+"Show only what is cast to this machine — the library, including this "
+"settings screen, can't be reached from here. Without a system tray icon the "
+"only way back is editing conf.json. For the classic cast-target setup you "
+"want the Interface settings instead; this is for a shared TV nobody should "
+"be able to browse from."
+msgstr ""
+
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:240
+msgid ""
+"Requires restart to change. MPV keybinds are used by default. Press ENTER to "
+"drive the player controls by keyboard."
+msgstr ""
+
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:242
 msgid ""
 "Pixels one wheel notch scrolls. The scrollbar glides while the content snaps "
 "to the nearest row, so a trackpad or trackball no longer overshoots. Raise "
 "it to scroll faster, lower it for finer control."
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:209
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:247
 msgid ""
 "Make each wheel notch jump exactly one row (or one home-screen section) "
 "instead of gliding. Turn this on if you prefer the older stepped scrolling."
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:217
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:255
 msgid "Discord Rich Presence. Takes effect after a restart."
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:219
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:257
 msgid ""
 "Leave this to Default unless setting up passthrough. Note some audio servers "
 "like Pipewire don't like passthrough and will need to be disabled for a card "
@@ -1014,57 +1038,57 @@ msgid ""
 "silence otherwise, but results may vary."
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:225
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:263
 msgid ""
 "Stop anything else using the device while playing. Needed for passthrough on "
 "some systems, and it means other applications will be silent."
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:228
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:266
 msgid ""
 "Page the library and music tile grids instead of scrolling: each page is one "
 "screenful with First / Previous / Next / Last controls and a page number you "
 "can type into. Easier than precise scrolling on a trackpad."
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:232
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:270
 msgid ""
 "Takes effect after a restart. \"Follow display\" uses the scale your desktop "
 "reports, which is 100% on X11."
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:234
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:272
 msgid ""
 "\"Default\" changes nothing and lets MPV (and your own mpv.conf) decide. "
 "Pick a mode only if you are sending audio to a receiver."
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:237
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:275
 msgid ""
 "Audio your receiver can't be sent directly is encoded to AC3, which is the "
 "only way surround fits down an optical cable. Turn this off if the encoder "
 "causes audio delay — those tracks become stereo instead."
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:242
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:280
 msgid ""
 "\"hq\" offers heavier profiles. Pick it if you have a fast graphics card."
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:244
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:282
 msgid ""
 "Leave on Automatic unless video breaks when a profile is loaded. This only "
 "applies while a profile is active, and OpenGL can cost you HDR output."
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:248
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:286
 msgid ""
 "Evens out loud effects and quiet dialogue. This turns passthrough off while "
 "it is enabled, because the volume has to be adjusted before your receiver "
 "gets the audio."
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:330
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:368
 msgid "Advanced"
 msgstr ""
 
@@ -1290,7 +1314,7 @@ msgid "Automatic"
 msgstr "อัตโนมัติ"
 
 #: jellyfin_mpv_shim/mpvtk_browser/downloads.py:51
-#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1355
+#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1288
 msgid "Episodes"
 msgstr ""
 
@@ -1299,7 +1323,7 @@ msgid "Season %s"
 msgstr ""
 
 #: jellyfin_mpv_shim/mpvtk_browser/downloads.py:52
-#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1351
+#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1284
 msgid "Specials"
 msgstr ""
 
@@ -1324,7 +1348,7 @@ msgid "Failed"
 msgstr "ล้มเหลว"
 
 #: jellyfin_mpv_shim/mpvtk_browser/downloads.py:185
-#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1105
+#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1038
 msgid "Playlist"
 msgstr ""
 
@@ -1336,30 +1360,30 @@ msgstr ""
 msgid "Movies & Videos"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/home_sections.py:103
+#: jellyfin_mpv_shim/mpvtk_browser/home_sections.py:104
 msgid "My Media"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/home_sections.py:104
-#: jellyfin_mpv_shim/mpvtk_browser/repository.py:352
+#: jellyfin_mpv_shim/mpvtk_browser/home_sections.py:105
+#: jellyfin_mpv_shim/mpvtk_browser/repository.py:350
 msgid "Continue Watching"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/home_sections.py:105
-#: jellyfin_mpv_shim/mpvtk_browser/repository.py:359
+#: jellyfin_mpv_shim/mpvtk_browser/home_sections.py:106
+#: jellyfin_mpv_shim/mpvtk_browser/repository.py:357
 msgid "Continue Listening"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/home_sections.py:106
-#: jellyfin_mpv_shim/mpvtk_browser/repository.py:366
+#: jellyfin_mpv_shim/mpvtk_browser/home_sections.py:107
+#: jellyfin_mpv_shim/mpvtk_browser/repository.py:364
 msgid "Next Up"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/home_sections.py:107
+#: jellyfin_mpv_shim/mpvtk_browser/home_sections.py:108
 msgid "Recently Added"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/home_sections.py:108
+#: jellyfin_mpv_shim/mpvtk_browser/home_sections.py:109
 msgid "Live TV"
 msgstr ""
 
@@ -1611,52 +1635,52 @@ msgstr ""
 "ไม่สามารถเพิ่มเซิร์ฟเวอร์ได้\n"
 "โปรดตรวจสอบข้อมูลการเชื่อมต่อของคุณ"
 
-#: jellyfin_mpv_shim/mpvtk_browser/repository.py:390
+#: jellyfin_mpv_shim/mpvtk_browser/repository.py:386
 msgid "On Now"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/repository.py:411
+#: jellyfin_mpv_shim/mpvtk_browser/repository.py:407
 msgid "Latest %s"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1119
+#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1052
 msgid "Downloaded"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1138
+#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1071
 msgid "Movies"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1143
+#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1076
 msgid "Videos"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1147
+#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1080
 msgid "TV Shows"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1151
+#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1084
 msgid "Playlists"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1168
-#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1441
+#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1101
+#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1374
 msgid "Series"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1212
+#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1145
 msgid "Downloaded Movies"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1216
+#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1149
 msgid "Downloaded Videos"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1220
+#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1153
 msgid "Downloaded Shows"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1353
+#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1286
 msgid "Season %d"
 msgstr ""
 

--- a/jellyfin_mpv_shim/messages/tr/LC_MESSAGES/base.po
+++ b/jellyfin_mpv_shim/messages/tr/LC_MESSAGES/base.po
@@ -5,7 +5,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2026-07-25 17:21-0400\n"
+"POT-Creation-Date: 2026-07-26 12:03-0400\n"
 "PO-Revision-Date: 2026-06-18 18:32+0000\n"
 "Last-Translator: queeup <queeup@zoho.com>\n"
 "Language-Team: Turkish <https://translate.jellyfin.org/projects/jellyfin/"
@@ -252,7 +252,7 @@ msgid "Select Subtitle Track"
 msgstr "Altyazı Dosyasını Seç"
 
 #: jellyfin_mpv_shim/menu.py:341
-#: jellyfin_mpv_shim/mpvtk_browser/home_sections.py:102
+#: jellyfin_mpv_shim/mpvtk_browser/home_sections.py:103
 #: jellyfin_mpv_shim/osc_bridge.py:81 jellyfin_mpv_shim/osc_bridge.py:82
 #: jellyfin_mpv_shim/osc_bridge.py:104 jellyfin_mpv_shim/osc_bridge.py:140
 msgid "None"
@@ -403,7 +403,7 @@ msgstr "Jeneriği Atlamak için Sor"
 msgid "Enable thumbnail previews"
 msgstr "Küçük resim önizlemelerini etkinleştirin"
 
-#: jellyfin_mpv_shim/menu.py:609 jellyfin_mpv_shim/mpvtk_browser/config.py:186
+#: jellyfin_mpv_shim/menu.py:609 jellyfin_mpv_shim/mpvtk_browser/config.py:195
 #: jellyfin_mpv_shim/mpvtk_browser/hud.py:375
 msgid "Night Mode (Auto Volume Adj)"
 msgstr ""
@@ -702,310 +702,334 @@ msgstr ""
 msgid "Or switch to another user"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/cast.py:317
+#: jellyfin_mpv_shim/mpvtk_browser/cast.py:314
 msgid "Ready to cast"
 msgstr "Yayınlamaya hazır"
 
-#: jellyfin_mpv_shim/mpvtk_browser/cast.py:318
+#: jellyfin_mpv_shim/mpvtk_browser/cast.py:315
 #, fuzzy
 #| msgid "Select your media in Jellyfin and play it here"
 msgid "Select your media in Jellyfin and play it here."
 msgstr "Dosyayı Jellyfinden seçip burada oynat"
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:74
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:83
 msgid "Interface"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:83
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:92
 msgid "Playback"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:88
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:97
 msgid "Audio"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:92
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:101
 msgid "Subtitles & Languages"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:97
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:106
 #, fuzzy
 #| msgid " (Transcode)"
 msgid "Transcoding"
 msgstr " (Kod dönüştürme)"
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:102
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:111
 msgid "Video Enhancement"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:104
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:113
 #, fuzzy
 #| msgid "Seek to Skip Credits"
 msgid "Skip Intro / Credits"
 msgstr "Jeneriği Atlamak için Ara"
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:107
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:116
 msgid "Library Browser"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:109
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:118
 msgid "Downloads"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:128
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:137
 msgid "Jellyfin UI"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:129
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:138
 msgid "MPV UI with thumbnails"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:130
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:139
 msgid "MPV built-in default"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:133
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:142
 msgid "Follow display"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:134
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:143
 msgid "100% (no scaling)"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:135
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:144
 msgid "125%"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:136
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:145
 msgid "150%"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:137
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:146
 msgid "200%"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:140
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:149
 msgid "Automatic (recommended)"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:141
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:150
 msgid "Vulkan"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:142
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:151
 msgid "Direct3D 11 (Windows only)"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:143
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:152
 msgid "OpenGL (compatibility)"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:146
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:155
 msgid "Default (auto)"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:147
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:156
 msgid "Force Stereo"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:148
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:157
 msgid "Optical Surround"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:149
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:158
 msgid "HDMI Passthrough"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:152
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:161
 msgid "Unset"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:153
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:162
 msgid "Dubbed (shows only)"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:154
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:163
 msgid "Subbed (shows only)"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:155
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:164
 msgid "Dubbed (all)"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:156
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:165
 msgid "Subbed (all)"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:157
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:166
 msgid "Custom (set in config)"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:162
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:171
 msgid "Download Folder"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:163
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:172
 msgid "Prefer Downloaded Copy"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:164
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:173
 msgid "Automatically Download Upcoming Episodes"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:165
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:174
 msgid "Include Next Up"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:166
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:175
 msgid "Next Up Entries to Consider"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:167
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:176
 msgid "Episodes to Keep Ahead (0 = off)"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:168
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:177
 msgid "Storage Limit for Automatic Downloads (GB)"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:169
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:178
 #, fuzzy
 #| msgid "Remove Server"
 msgid "Delete Automatic Downloads Once Watched"
 msgstr "Sunucuyu Kaldır"
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:170
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:179
 msgid "Delete Unwatched After (days, 0 = never)"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:171
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:180
 msgid "Check Every (minutes)"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:172
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:181
 msgid "Close to Tray (keep running)"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:173
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:182
 msgid "Keep Running in Background"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:174
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:183
 msgid "Remember Window Size"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:175
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:184
 msgid "Player Controls Style"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:176
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:185
 msgid "Show What You're Watching in Discord"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:177
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:186
 msgid "Interface Scale"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:178
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:187
 msgid "Cast-target mode (no library browsing)"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:179
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:188
 msgid "Casting Opens the Library Browser"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:180
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:189
 msgid "Fullscreen Library Browser"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:181
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:190
 msgid "Always Bind Arrow Keys to Player Controls"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:182
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:191
 msgid "Player Controls Activation Key"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:183
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:192
 msgid "Audio Output Mode"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:184
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:193
 msgid "Audio Output Device"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:185
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:194
 msgid "Take the Device Exclusively"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:187
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:196
 #, fuzzy
 #| msgid "Video Playback Profiles"
 msgid "Enable Video Playback Profiles"
 msgstr "Video Oynatma Profilleri"
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:188
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:197
 #, fuzzy
 #| msgid "New Group"
 msgid "Profile Group"
 msgstr "Yeni Grup"
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:189
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:198
 msgid "Remember Last Used Profile"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:190
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:199
 msgid "Graphics API for Shaders"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:191
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:200
 msgid "Pass Through AC3"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:192
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:201
 msgid "Pass Through DTS"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:193
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:202
 msgid "Pass Through E-AC3"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:194
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:203
 msgid "Pass Through DTS-HD"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:195
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:204
 msgid "Pass Through TrueHD"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:196
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:205
 msgid "Re-encode Others to AC3"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:202
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:213
 msgid ""
-"MPV keybinds are used by default. Press ENTER to drive the player controls "
-"by keyboard."
+"With \"Start Minimized\" and \"Fullscreen\" this is the classic cast-target "
+"setup: the app waits out of the way, plays fullscreen when something casts "
+"to it, and goes back to waiting when the video ends or you press Q."
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:204
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:227
+msgid ""
+"Off means command-line mode: no window, no system tray and no settings "
+"screen, so the only way back is editing conf.json by hand. It is not how you "
+"get MPV's own on-screen controls — \"Player Controls Style\" under Interface "
+"does that."
+msgstr ""
+
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:234
+msgid ""
+"Show only what is cast to this machine — the library, including this "
+"settings screen, can't be reached from here. Without a system tray icon the "
+"only way back is editing conf.json. For the classic cast-target setup you "
+"want the Interface settings instead; this is for a shared TV nobody should "
+"be able to browse from."
+msgstr ""
+
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:240
+msgid ""
+"Requires restart to change. MPV keybinds are used by default. Press ENTER to "
+"drive the player controls by keyboard."
+msgstr ""
+
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:242
 msgid ""
 "Pixels one wheel notch scrolls. The scrollbar glides while the content snaps "
 "to the nearest row, so a trackpad or trackball no longer overshoots. Raise "
 "it to scroll faster, lower it for finer control."
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:209
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:247
 msgid ""
 "Make each wheel notch jump exactly one row (or one home-screen section) "
 "instead of gliding. Turn this on if you prefer the older stepped scrolling."
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:217
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:255
 msgid "Discord Rich Presence. Takes effect after a restart."
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:219
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:257
 msgid ""
 "Leave this to Default unless setting up passthrough. Note some audio servers "
 "like Pipewire don't like passthrough and will need to be disabled for a card "
@@ -1013,57 +1037,57 @@ msgid ""
 "silence otherwise, but results may vary."
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:225
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:263
 msgid ""
 "Stop anything else using the device while playing. Needed for passthrough on "
 "some systems, and it means other applications will be silent."
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:228
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:266
 msgid ""
 "Page the library and music tile grids instead of scrolling: each page is one "
 "screenful with First / Previous / Next / Last controls and a page number you "
 "can type into. Easier than precise scrolling on a trackpad."
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:232
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:270
 msgid ""
 "Takes effect after a restart. \"Follow display\" uses the scale your desktop "
 "reports, which is 100% on X11."
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:234
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:272
 msgid ""
 "\"Default\" changes nothing and lets MPV (and your own mpv.conf) decide. "
 "Pick a mode only if you are sending audio to a receiver."
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:237
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:275
 msgid ""
 "Audio your receiver can't be sent directly is encoded to AC3, which is the "
 "only way surround fits down an optical cable. Turn this off if the encoder "
 "causes audio delay — those tracks become stereo instead."
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:242
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:280
 msgid ""
 "\"hq\" offers heavier profiles. Pick it if you have a fast graphics card."
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:244
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:282
 msgid ""
 "Leave on Automatic unless video breaks when a profile is loaded. This only "
 "applies while a profile is active, and OpenGL can cost you HDR output."
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:248
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:286
 msgid ""
 "Evens out loud effects and quiet dialogue. This turns passthrough off while "
 "it is enabled, because the volume has to be adjusted before your receiver "
 "gets the audio."
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:330
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:368
 msgid "Advanced"
 msgstr ""
 
@@ -1289,7 +1313,7 @@ msgid "Automatic"
 msgstr "Otomatik"
 
 #: jellyfin_mpv_shim/mpvtk_browser/downloads.py:51
-#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1355
+#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1288
 msgid "Episodes"
 msgstr ""
 
@@ -1298,7 +1322,7 @@ msgid "Season %s"
 msgstr ""
 
 #: jellyfin_mpv_shim/mpvtk_browser/downloads.py:52
-#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1351
+#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1284
 msgid "Specials"
 msgstr ""
 
@@ -1323,7 +1347,7 @@ msgid "Failed"
 msgstr "Hata"
 
 #: jellyfin_mpv_shim/mpvtk_browser/downloads.py:185
-#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1105
+#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1038
 msgid "Playlist"
 msgstr ""
 
@@ -1335,30 +1359,30 @@ msgstr ""
 msgid "Movies & Videos"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/home_sections.py:103
+#: jellyfin_mpv_shim/mpvtk_browser/home_sections.py:104
 msgid "My Media"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/home_sections.py:104
-#: jellyfin_mpv_shim/mpvtk_browser/repository.py:352
+#: jellyfin_mpv_shim/mpvtk_browser/home_sections.py:105
+#: jellyfin_mpv_shim/mpvtk_browser/repository.py:350
 msgid "Continue Watching"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/home_sections.py:105
-#: jellyfin_mpv_shim/mpvtk_browser/repository.py:359
+#: jellyfin_mpv_shim/mpvtk_browser/home_sections.py:106
+#: jellyfin_mpv_shim/mpvtk_browser/repository.py:357
 msgid "Continue Listening"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/home_sections.py:106
-#: jellyfin_mpv_shim/mpvtk_browser/repository.py:366
+#: jellyfin_mpv_shim/mpvtk_browser/home_sections.py:107
+#: jellyfin_mpv_shim/mpvtk_browser/repository.py:364
 msgid "Next Up"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/home_sections.py:107
+#: jellyfin_mpv_shim/mpvtk_browser/home_sections.py:108
 msgid "Recently Added"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/home_sections.py:108
+#: jellyfin_mpv_shim/mpvtk_browser/home_sections.py:109
 msgid "Live TV"
 msgstr ""
 
@@ -1611,52 +1635,52 @@ msgstr ""
 "Sunucu eklenemedi.\n"
 "Lütfen bağlantınızı kontrol ediniz."
 
-#: jellyfin_mpv_shim/mpvtk_browser/repository.py:390
+#: jellyfin_mpv_shim/mpvtk_browser/repository.py:386
 msgid "On Now"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/repository.py:411
+#: jellyfin_mpv_shim/mpvtk_browser/repository.py:407
 msgid "Latest %s"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1119
+#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1052
 msgid "Downloaded"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1138
+#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1071
 msgid "Movies"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1143
+#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1076
 msgid "Videos"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1147
+#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1080
 msgid "TV Shows"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1151
+#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1084
 msgid "Playlists"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1168
-#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1441
+#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1101
+#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1374
 msgid "Series"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1212
+#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1145
 msgid "Downloaded Movies"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1216
+#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1149
 msgid "Downloaded Videos"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1220
+#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1153
 msgid "Downloaded Shows"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1353
+#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1286
 msgid "Season %d"
 msgstr ""
 

--- a/jellyfin_mpv_shim/messages/ug/LC_MESSAGES/base.po
+++ b/jellyfin_mpv_shim/messages/ug/LC_MESSAGES/base.po
@@ -5,7 +5,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2026-07-25 17:21-0400\n"
+"POT-Creation-Date: 2026-07-26 12:03-0400\n"
 "PO-Revision-Date: 2022-10-07 21:34+0000\n"
 "Last-Translator: YusanTayir <208060627@qq.com>\n"
 "Language-Team: Uyghur <https://translate.jellyfin.org/projects/jellyfin/"
@@ -244,7 +244,7 @@ msgid "Select Subtitle Track"
 msgstr ""
 
 #: jellyfin_mpv_shim/menu.py:341
-#: jellyfin_mpv_shim/mpvtk_browser/home_sections.py:102
+#: jellyfin_mpv_shim/mpvtk_browser/home_sections.py:103
 #: jellyfin_mpv_shim/osc_bridge.py:81 jellyfin_mpv_shim/osc_bridge.py:82
 #: jellyfin_mpv_shim/osc_bridge.py:104 jellyfin_mpv_shim/osc_bridge.py:140
 msgid "None"
@@ -395,7 +395,7 @@ msgstr ""
 msgid "Enable thumbnail previews"
 msgstr ""
 
-#: jellyfin_mpv_shim/menu.py:609 jellyfin_mpv_shim/mpvtk_browser/config.py:186
+#: jellyfin_mpv_shim/menu.py:609 jellyfin_mpv_shim/mpvtk_browser/config.py:195
 #: jellyfin_mpv_shim/mpvtk_browser/hud.py:375
 msgid "Night Mode (Auto Volume Adj)"
 msgstr ""
@@ -672,298 +672,322 @@ msgstr ""
 msgid "Or switch to another user"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/cast.py:317
+#: jellyfin_mpv_shim/mpvtk_browser/cast.py:314
 msgid "Ready to cast"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/cast.py:318
+#: jellyfin_mpv_shim/mpvtk_browser/cast.py:315
 msgid "Select your media in Jellyfin and play it here."
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:74
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:83
 msgid "Interface"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:83
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:92
 msgid "Playback"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:88
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:97
 msgid "Audio"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:92
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:101
 msgid "Subtitles & Languages"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:97
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:106
 msgid "Transcoding"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:102
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:111
 msgid "Video Enhancement"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:104
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:113
 msgid "Skip Intro / Credits"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:107
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:116
 msgid "Library Browser"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:109
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:118
 msgid "Downloads"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:128
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:137
 msgid "Jellyfin UI"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:129
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:138
 msgid "MPV UI with thumbnails"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:130
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:139
 msgid "MPV built-in default"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:133
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:142
 msgid "Follow display"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:134
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:143
 msgid "100% (no scaling)"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:135
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:144
 msgid "125%"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:136
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:145
 msgid "150%"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:137
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:146
 msgid "200%"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:140
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:149
 msgid "Automatic (recommended)"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:141
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:150
 msgid "Vulkan"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:142
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:151
 msgid "Direct3D 11 (Windows only)"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:143
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:152
 msgid "OpenGL (compatibility)"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:146
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:155
 msgid "Default (auto)"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:147
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:156
 msgid "Force Stereo"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:148
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:157
 msgid "Optical Surround"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:149
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:158
 msgid "HDMI Passthrough"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:152
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:161
 msgid "Unset"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:153
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:162
 msgid "Dubbed (shows only)"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:154
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:163
 msgid "Subbed (shows only)"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:155
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:164
 msgid "Dubbed (all)"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:156
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:165
 msgid "Subbed (all)"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:157
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:166
 msgid "Custom (set in config)"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:162
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:171
 msgid "Download Folder"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:163
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:172
 msgid "Prefer Downloaded Copy"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:164
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:173
 msgid "Automatically Download Upcoming Episodes"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:165
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:174
 msgid "Include Next Up"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:166
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:175
 msgid "Next Up Entries to Consider"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:167
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:176
 msgid "Episodes to Keep Ahead (0 = off)"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:168
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:177
 msgid "Storage Limit for Automatic Downloads (GB)"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:169
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:178
 msgid "Delete Automatic Downloads Once Watched"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:170
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:179
 msgid "Delete Unwatched After (days, 0 = never)"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:171
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:180
 msgid "Check Every (minutes)"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:172
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:181
 msgid "Close to Tray (keep running)"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:173
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:182
 msgid "Keep Running in Background"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:174
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:183
 msgid "Remember Window Size"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:175
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:184
 msgid "Player Controls Style"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:176
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:185
 msgid "Show What You're Watching in Discord"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:177
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:186
 msgid "Interface Scale"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:178
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:187
 msgid "Cast-target mode (no library browsing)"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:179
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:188
 msgid "Casting Opens the Library Browser"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:180
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:189
 msgid "Fullscreen Library Browser"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:181
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:190
 msgid "Always Bind Arrow Keys to Player Controls"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:182
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:191
 msgid "Player Controls Activation Key"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:183
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:192
 msgid "Audio Output Mode"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:184
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:193
 msgid "Audio Output Device"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:185
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:194
 msgid "Take the Device Exclusively"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:187
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:196
 msgid "Enable Video Playback Profiles"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:188
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:197
 msgid "Profile Group"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:189
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:198
 msgid "Remember Last Used Profile"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:190
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:199
 msgid "Graphics API for Shaders"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:191
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:200
 msgid "Pass Through AC3"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:192
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:201
 msgid "Pass Through DTS"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:193
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:202
 msgid "Pass Through E-AC3"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:194
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:203
 msgid "Pass Through DTS-HD"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:195
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:204
 msgid "Pass Through TrueHD"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:196
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:205
 msgid "Re-encode Others to AC3"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:202
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:213
 msgid ""
-"MPV keybinds are used by default. Press ENTER to drive the player controls "
-"by keyboard."
+"With \"Start Minimized\" and \"Fullscreen\" this is the classic cast-target "
+"setup: the app waits out of the way, plays fullscreen when something casts "
+"to it, and goes back to waiting when the video ends or you press Q."
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:204
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:227
+msgid ""
+"Off means command-line mode: no window, no system tray and no settings "
+"screen, so the only way back is editing conf.json by hand. It is not how you "
+"get MPV's own on-screen controls — \"Player Controls Style\" under Interface "
+"does that."
+msgstr ""
+
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:234
+msgid ""
+"Show only what is cast to this machine — the library, including this "
+"settings screen, can't be reached from here. Without a system tray icon the "
+"only way back is editing conf.json. For the classic cast-target setup you "
+"want the Interface settings instead; this is for a shared TV nobody should "
+"be able to browse from."
+msgstr ""
+
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:240
+msgid ""
+"Requires restart to change. MPV keybinds are used by default. Press ENTER to "
+"drive the player controls by keyboard."
+msgstr ""
+
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:242
 msgid ""
 "Pixels one wheel notch scrolls. The scrollbar glides while the content snaps "
 "to the nearest row, so a trackpad or trackball no longer overshoots. Raise "
 "it to scroll faster, lower it for finer control."
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:209
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:247
 msgid ""
 "Make each wheel notch jump exactly one row (or one home-screen section) "
 "instead of gliding. Turn this on if you prefer the older stepped scrolling."
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:217
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:255
 msgid "Discord Rich Presence. Takes effect after a restart."
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:219
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:257
 msgid ""
 "Leave this to Default unless setting up passthrough. Note some audio servers "
 "like Pipewire don't like passthrough and will need to be disabled for a card "
@@ -971,57 +995,57 @@ msgid ""
 "silence otherwise, but results may vary."
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:225
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:263
 msgid ""
 "Stop anything else using the device while playing. Needed for passthrough on "
 "some systems, and it means other applications will be silent."
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:228
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:266
 msgid ""
 "Page the library and music tile grids instead of scrolling: each page is one "
 "screenful with First / Previous / Next / Last controls and a page number you "
 "can type into. Easier than precise scrolling on a trackpad."
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:232
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:270
 msgid ""
 "Takes effect after a restart. \"Follow display\" uses the scale your desktop "
 "reports, which is 100% on X11."
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:234
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:272
 msgid ""
 "\"Default\" changes nothing and lets MPV (and your own mpv.conf) decide. "
 "Pick a mode only if you are sending audio to a receiver."
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:237
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:275
 msgid ""
 "Audio your receiver can't be sent directly is encoded to AC3, which is the "
 "only way surround fits down an optical cable. Turn this off if the encoder "
 "causes audio delay — those tracks become stereo instead."
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:242
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:280
 msgid ""
 "\"hq\" offers heavier profiles. Pick it if you have a fast graphics card."
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:244
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:282
 msgid ""
 "Leave on Automatic unless video breaks when a profile is loaded. This only "
 "applies while a profile is active, and OpenGL can cost you HDR output."
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:248
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:286
 msgid ""
 "Evens out loud effects and quiet dialogue. This turns passthrough off while "
 "it is enabled, because the volume has to be adjusted before your receiver "
 "gets the audio."
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:330
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:368
 msgid "Advanced"
 msgstr ""
 
@@ -1201,7 +1225,7 @@ msgid "Automatic"
 msgstr ""
 
 #: jellyfin_mpv_shim/mpvtk_browser/downloads.py:51
-#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1355
+#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1288
 msgid "Episodes"
 msgstr ""
 
@@ -1210,7 +1234,7 @@ msgid "Season %s"
 msgstr ""
 
 #: jellyfin_mpv_shim/mpvtk_browser/downloads.py:52
-#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1351
+#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1284
 msgid "Specials"
 msgstr ""
 
@@ -1231,7 +1255,7 @@ msgid "Failed"
 msgstr ""
 
 #: jellyfin_mpv_shim/mpvtk_browser/downloads.py:185
-#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1105
+#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1038
 msgid "Playlist"
 msgstr ""
 
@@ -1243,30 +1267,30 @@ msgstr ""
 msgid "Movies & Videos"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/home_sections.py:103
+#: jellyfin_mpv_shim/mpvtk_browser/home_sections.py:104
 msgid "My Media"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/home_sections.py:104
-#: jellyfin_mpv_shim/mpvtk_browser/repository.py:352
+#: jellyfin_mpv_shim/mpvtk_browser/home_sections.py:105
+#: jellyfin_mpv_shim/mpvtk_browser/repository.py:350
 msgid "Continue Watching"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/home_sections.py:105
-#: jellyfin_mpv_shim/mpvtk_browser/repository.py:359
+#: jellyfin_mpv_shim/mpvtk_browser/home_sections.py:106
+#: jellyfin_mpv_shim/mpvtk_browser/repository.py:357
 msgid "Continue Listening"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/home_sections.py:106
-#: jellyfin_mpv_shim/mpvtk_browser/repository.py:366
+#: jellyfin_mpv_shim/mpvtk_browser/home_sections.py:107
+#: jellyfin_mpv_shim/mpvtk_browser/repository.py:364
 msgid "Next Up"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/home_sections.py:107
+#: jellyfin_mpv_shim/mpvtk_browser/home_sections.py:108
 msgid "Recently Added"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/home_sections.py:108
+#: jellyfin_mpv_shim/mpvtk_browser/home_sections.py:109
 msgid "Live TV"
 msgstr ""
 
@@ -1481,52 +1505,52 @@ msgstr ""
 msgid "Could not load this page."
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/repository.py:390
+#: jellyfin_mpv_shim/mpvtk_browser/repository.py:386
 msgid "On Now"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/repository.py:411
+#: jellyfin_mpv_shim/mpvtk_browser/repository.py:407
 msgid "Latest %s"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1119
+#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1052
 msgid "Downloaded"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1138
+#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1071
 msgid "Movies"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1143
+#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1076
 msgid "Videos"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1147
+#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1080
 msgid "TV Shows"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1151
+#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1084
 msgid "Playlists"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1168
-#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1441
+#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1101
+#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1374
 msgid "Series"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1212
+#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1145
 msgid "Downloaded Movies"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1216
+#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1149
 msgid "Downloaded Videos"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1220
+#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1153
 msgid "Downloaded Shows"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1353
+#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1286
 msgid "Season %d"
 msgstr ""
 

--- a/jellyfin_mpv_shim/messages/uk/LC_MESSAGES/base.po
+++ b/jellyfin_mpv_shim/messages/uk/LC_MESSAGES/base.po
@@ -5,7 +5,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2026-07-25 17:21-0400\n"
+"POT-Creation-Date: 2026-07-26 12:03-0400\n"
 "PO-Revision-Date: 2026-05-18 17:22+0000\n"
 "Last-Translator: serzh-photograf <serzh.photograf@gmail.com>\n"
 "Language-Team: Ukrainian <https://translate.jellyfin.org/projects/jellyfin/"
@@ -253,7 +253,7 @@ msgid "Select Subtitle Track"
 msgstr "Вибрати доріжку субтитрів"
 
 #: jellyfin_mpv_shim/menu.py:341
-#: jellyfin_mpv_shim/mpvtk_browser/home_sections.py:102
+#: jellyfin_mpv_shim/mpvtk_browser/home_sections.py:103
 #: jellyfin_mpv_shim/osc_bridge.py:81 jellyfin_mpv_shim/osc_bridge.py:82
 #: jellyfin_mpv_shim/osc_bridge.py:104 jellyfin_mpv_shim/osc_bridge.py:140
 msgid "None"
@@ -404,7 +404,7 @@ msgstr "Запитати, перш ніж пропускати титри"
 msgid "Enable thumbnail previews"
 msgstr "Увімкнути попередній перегляд мініатюр"
 
-#: jellyfin_mpv_shim/menu.py:609 jellyfin_mpv_shim/mpvtk_browser/config.py:186
+#: jellyfin_mpv_shim/menu.py:609 jellyfin_mpv_shim/mpvtk_browser/config.py:195
 #: jellyfin_mpv_shim/mpvtk_browser/hud.py:375
 msgid "Night Mode (Auto Volume Adj)"
 msgstr ""
@@ -703,310 +703,334 @@ msgstr ""
 msgid "Or switch to another user"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/cast.py:317
+#: jellyfin_mpv_shim/mpvtk_browser/cast.py:314
 msgid "Ready to cast"
 msgstr "Готово до передавання"
 
-#: jellyfin_mpv_shim/mpvtk_browser/cast.py:318
+#: jellyfin_mpv_shim/mpvtk_browser/cast.py:315
 #, fuzzy
 #| msgid "Select your media in Jellyfin and play it here"
 msgid "Select your media in Jellyfin and play it here."
 msgstr "Оберіть медіадані та відтворіть їх тут"
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:74
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:83
 msgid "Interface"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:83
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:92
 msgid "Playback"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:88
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:97
 msgid "Audio"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:92
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:101
 msgid "Subtitles & Languages"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:97
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:106
 #, fuzzy
 #| msgid " (Transcode)"
 msgid "Transcoding"
 msgstr " (Перекодування)"
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:102
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:111
 msgid "Video Enhancement"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:104
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:113
 #, fuzzy
 #| msgid "Seek to Skip Credits"
 msgid "Skip Intro / Credits"
 msgstr "Пропустити титри"
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:107
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:116
 msgid "Library Browser"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:109
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:118
 msgid "Downloads"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:128
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:137
 msgid "Jellyfin UI"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:129
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:138
 msgid "MPV UI with thumbnails"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:130
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:139
 msgid "MPV built-in default"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:133
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:142
 msgid "Follow display"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:134
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:143
 msgid "100% (no scaling)"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:135
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:144
 msgid "125%"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:136
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:145
 msgid "150%"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:137
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:146
 msgid "200%"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:140
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:149
 msgid "Automatic (recommended)"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:141
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:150
 msgid "Vulkan"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:142
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:151
 msgid "Direct3D 11 (Windows only)"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:143
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:152
 msgid "OpenGL (compatibility)"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:146
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:155
 msgid "Default (auto)"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:147
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:156
 msgid "Force Stereo"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:148
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:157
 msgid "Optical Surround"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:149
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:158
 msgid "HDMI Passthrough"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:152
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:161
 msgid "Unset"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:153
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:162
 msgid "Dubbed (shows only)"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:154
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:163
 msgid "Subbed (shows only)"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:155
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:164
 msgid "Dubbed (all)"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:156
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:165
 msgid "Subbed (all)"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:157
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:166
 msgid "Custom (set in config)"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:162
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:171
 msgid "Download Folder"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:163
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:172
 msgid "Prefer Downloaded Copy"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:164
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:173
 msgid "Automatically Download Upcoming Episodes"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:165
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:174
 msgid "Include Next Up"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:166
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:175
 msgid "Next Up Entries to Consider"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:167
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:176
 msgid "Episodes to Keep Ahead (0 = off)"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:168
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:177
 msgid "Storage Limit for Automatic Downloads (GB)"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:169
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:178
 #, fuzzy
 #| msgid "Remove Server"
 msgid "Delete Automatic Downloads Once Watched"
 msgstr "Видалити сервер"
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:170
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:179
 msgid "Delete Unwatched After (days, 0 = never)"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:171
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:180
 msgid "Check Every (minutes)"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:172
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:181
 msgid "Close to Tray (keep running)"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:173
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:182
 msgid "Keep Running in Background"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:174
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:183
 msgid "Remember Window Size"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:175
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:184
 msgid "Player Controls Style"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:176
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:185
 msgid "Show What You're Watching in Discord"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:177
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:186
 msgid "Interface Scale"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:178
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:187
 msgid "Cast-target mode (no library browsing)"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:179
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:188
 msgid "Casting Opens the Library Browser"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:180
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:189
 msgid "Fullscreen Library Browser"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:181
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:190
 msgid "Always Bind Arrow Keys to Player Controls"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:182
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:191
 msgid "Player Controls Activation Key"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:183
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:192
 msgid "Audio Output Mode"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:184
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:193
 msgid "Audio Output Device"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:185
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:194
 msgid "Take the Device Exclusively"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:187
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:196
 #, fuzzy
 #| msgid "Video Playback Profiles"
 msgid "Enable Video Playback Profiles"
 msgstr "Профілі відтворення відео"
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:188
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:197
 #, fuzzy
 #| msgid "New Group"
 msgid "Profile Group"
 msgstr "Нова група"
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:189
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:198
 msgid "Remember Last Used Profile"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:190
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:199
 msgid "Graphics API for Shaders"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:191
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:200
 msgid "Pass Through AC3"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:192
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:201
 msgid "Pass Through DTS"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:193
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:202
 msgid "Pass Through E-AC3"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:194
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:203
 msgid "Pass Through DTS-HD"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:195
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:204
 msgid "Pass Through TrueHD"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:196
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:205
 msgid "Re-encode Others to AC3"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:202
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:213
 msgid ""
-"MPV keybinds are used by default. Press ENTER to drive the player controls "
-"by keyboard."
+"With \"Start Minimized\" and \"Fullscreen\" this is the classic cast-target "
+"setup: the app waits out of the way, plays fullscreen when something casts "
+"to it, and goes back to waiting when the video ends or you press Q."
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:204
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:227
+msgid ""
+"Off means command-line mode: no window, no system tray and no settings "
+"screen, so the only way back is editing conf.json by hand. It is not how you "
+"get MPV's own on-screen controls — \"Player Controls Style\" under Interface "
+"does that."
+msgstr ""
+
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:234
+msgid ""
+"Show only what is cast to this machine — the library, including this "
+"settings screen, can't be reached from here. Without a system tray icon the "
+"only way back is editing conf.json. For the classic cast-target setup you "
+"want the Interface settings instead; this is for a shared TV nobody should "
+"be able to browse from."
+msgstr ""
+
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:240
+msgid ""
+"Requires restart to change. MPV keybinds are used by default. Press ENTER to "
+"drive the player controls by keyboard."
+msgstr ""
+
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:242
 msgid ""
 "Pixels one wheel notch scrolls. The scrollbar glides while the content snaps "
 "to the nearest row, so a trackpad or trackball no longer overshoots. Raise "
 "it to scroll faster, lower it for finer control."
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:209
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:247
 msgid ""
 "Make each wheel notch jump exactly one row (or one home-screen section) "
 "instead of gliding. Turn this on if you prefer the older stepped scrolling."
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:217
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:255
 msgid "Discord Rich Presence. Takes effect after a restart."
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:219
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:257
 msgid ""
 "Leave this to Default unless setting up passthrough. Note some audio servers "
 "like Pipewire don't like passthrough and will need to be disabled for a card "
@@ -1014,57 +1038,57 @@ msgid ""
 "silence otherwise, but results may vary."
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:225
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:263
 msgid ""
 "Stop anything else using the device while playing. Needed for passthrough on "
 "some systems, and it means other applications will be silent."
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:228
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:266
 msgid ""
 "Page the library and music tile grids instead of scrolling: each page is one "
 "screenful with First / Previous / Next / Last controls and a page number you "
 "can type into. Easier than precise scrolling on a trackpad."
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:232
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:270
 msgid ""
 "Takes effect after a restart. \"Follow display\" uses the scale your desktop "
 "reports, which is 100% on X11."
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:234
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:272
 msgid ""
 "\"Default\" changes nothing and lets MPV (and your own mpv.conf) decide. "
 "Pick a mode only if you are sending audio to a receiver."
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:237
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:275
 msgid ""
 "Audio your receiver can't be sent directly is encoded to AC3, which is the "
 "only way surround fits down an optical cable. Turn this off if the encoder "
 "causes audio delay — those tracks become stereo instead."
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:242
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:280
 msgid ""
 "\"hq\" offers heavier profiles. Pick it if you have a fast graphics card."
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:244
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:282
 msgid ""
 "Leave on Automatic unless video breaks when a profile is loaded. This only "
 "applies while a profile is active, and OpenGL can cost you HDR output."
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:248
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:286
 msgid ""
 "Evens out loud effects and quiet dialogue. This turns passthrough off while "
 "it is enabled, because the volume has to be adjusted before your receiver "
 "gets the audio."
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:330
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:368
 msgid "Advanced"
 msgstr ""
 
@@ -1290,7 +1314,7 @@ msgid "Automatic"
 msgstr "Автоматично"
 
 #: jellyfin_mpv_shim/mpvtk_browser/downloads.py:51
-#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1355
+#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1288
 msgid "Episodes"
 msgstr ""
 
@@ -1299,7 +1323,7 @@ msgid "Season %s"
 msgstr ""
 
 #: jellyfin_mpv_shim/mpvtk_browser/downloads.py:52
-#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1351
+#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1284
 msgid "Specials"
 msgstr ""
 
@@ -1324,7 +1348,7 @@ msgid "Failed"
 msgstr "Невдало"
 
 #: jellyfin_mpv_shim/mpvtk_browser/downloads.py:185
-#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1105
+#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1038
 msgid "Playlist"
 msgstr ""
 
@@ -1336,30 +1360,30 @@ msgstr ""
 msgid "Movies & Videos"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/home_sections.py:103
+#: jellyfin_mpv_shim/mpvtk_browser/home_sections.py:104
 msgid "My Media"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/home_sections.py:104
-#: jellyfin_mpv_shim/mpvtk_browser/repository.py:352
+#: jellyfin_mpv_shim/mpvtk_browser/home_sections.py:105
+#: jellyfin_mpv_shim/mpvtk_browser/repository.py:350
 msgid "Continue Watching"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/home_sections.py:105
-#: jellyfin_mpv_shim/mpvtk_browser/repository.py:359
+#: jellyfin_mpv_shim/mpvtk_browser/home_sections.py:106
+#: jellyfin_mpv_shim/mpvtk_browser/repository.py:357
 msgid "Continue Listening"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/home_sections.py:106
-#: jellyfin_mpv_shim/mpvtk_browser/repository.py:366
+#: jellyfin_mpv_shim/mpvtk_browser/home_sections.py:107
+#: jellyfin_mpv_shim/mpvtk_browser/repository.py:364
 msgid "Next Up"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/home_sections.py:107
+#: jellyfin_mpv_shim/mpvtk_browser/home_sections.py:108
 msgid "Recently Added"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/home_sections.py:108
+#: jellyfin_mpv_shim/mpvtk_browser/home_sections.py:109
 msgid "Live TV"
 msgstr ""
 
@@ -1612,52 +1636,52 @@ msgstr ""
 "Не вдалося додати сервер.\n"
 "Перевірте дані для підключення."
 
-#: jellyfin_mpv_shim/mpvtk_browser/repository.py:390
+#: jellyfin_mpv_shim/mpvtk_browser/repository.py:386
 msgid "On Now"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/repository.py:411
+#: jellyfin_mpv_shim/mpvtk_browser/repository.py:407
 msgid "Latest %s"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1119
+#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1052
 msgid "Downloaded"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1138
+#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1071
 msgid "Movies"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1143
+#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1076
 msgid "Videos"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1147
+#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1080
 msgid "TV Shows"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1151
+#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1084
 msgid "Playlists"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1168
-#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1441
+#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1101
+#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1374
 msgid "Series"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1212
+#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1145
 msgid "Downloaded Movies"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1216
+#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1149
 msgid "Downloaded Videos"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1220
+#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1153
 msgid "Downloaded Shows"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1353
+#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1286
 msgid "Season %d"
 msgstr ""
 

--- a/jellyfin_mpv_shim/messages/uz/LC_MESSAGES/base.po
+++ b/jellyfin_mpv_shim/messages/uz/LC_MESSAGES/base.po
@@ -5,7 +5,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2026-07-25 17:21-0400\n"
+"POT-Creation-Date: 2026-07-26 12:03-0400\n"
 "PO-Revision-Date: 2026-06-21 14:18+0000\n"
 "Last-Translator: someone522 <eldorerkin99@gmail.com>\n"
 "Language-Team: Uzbek <https://translate.jellyfin.org/projects/jellyfin/"
@@ -247,7 +247,7 @@ msgid "Select Subtitle Track"
 msgstr ""
 
 #: jellyfin_mpv_shim/menu.py:341
-#: jellyfin_mpv_shim/mpvtk_browser/home_sections.py:102
+#: jellyfin_mpv_shim/mpvtk_browser/home_sections.py:103
 #: jellyfin_mpv_shim/osc_bridge.py:81 jellyfin_mpv_shim/osc_bridge.py:82
 #: jellyfin_mpv_shim/osc_bridge.py:104 jellyfin_mpv_shim/osc_bridge.py:140
 msgid "None"
@@ -398,7 +398,7 @@ msgstr ""
 msgid "Enable thumbnail previews"
 msgstr ""
 
-#: jellyfin_mpv_shim/menu.py:609 jellyfin_mpv_shim/mpvtk_browser/config.py:186
+#: jellyfin_mpv_shim/menu.py:609 jellyfin_mpv_shim/mpvtk_browser/config.py:195
 #: jellyfin_mpv_shim/mpvtk_browser/hud.py:375
 msgid "Night Mode (Auto Volume Adj)"
 msgstr ""
@@ -675,300 +675,324 @@ msgstr ""
 msgid "Or switch to another user"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/cast.py:317
+#: jellyfin_mpv_shim/mpvtk_browser/cast.py:314
 msgid "Ready to cast"
 msgstr "Translyatsiya qilishga tayyor"
 
-#: jellyfin_mpv_shim/mpvtk_browser/cast.py:318
+#: jellyfin_mpv_shim/mpvtk_browser/cast.py:315
 #, fuzzy
 #| msgid "Select your media in Jellyfin and play it here"
 msgid "Select your media in Jellyfin and play it here."
 msgstr "Mediyangizni Jellyfinda tanlang va shu yerda ijro qiling"
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:74
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:83
 msgid "Interface"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:83
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:92
 msgid "Playback"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:88
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:97
 msgid "Audio"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:92
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:101
 msgid "Subtitles & Languages"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:97
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:106
 msgid "Transcoding"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:102
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:111
 msgid "Video Enhancement"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:104
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:113
 msgid "Skip Intro / Credits"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:107
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:116
 msgid "Library Browser"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:109
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:118
 msgid "Downloads"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:128
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:137
 msgid "Jellyfin UI"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:129
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:138
 msgid "MPV UI with thumbnails"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:130
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:139
 msgid "MPV built-in default"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:133
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:142
 msgid "Follow display"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:134
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:143
 msgid "100% (no scaling)"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:135
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:144
 msgid "125%"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:136
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:145
 msgid "150%"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:137
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:146
 msgid "200%"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:140
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:149
 msgid "Automatic (recommended)"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:141
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:150
 msgid "Vulkan"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:142
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:151
 msgid "Direct3D 11 (Windows only)"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:143
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:152
 msgid "OpenGL (compatibility)"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:146
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:155
 msgid "Default (auto)"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:147
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:156
 msgid "Force Stereo"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:148
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:157
 msgid "Optical Surround"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:149
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:158
 msgid "HDMI Passthrough"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:152
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:161
 msgid "Unset"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:153
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:162
 msgid "Dubbed (shows only)"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:154
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:163
 msgid "Subbed (shows only)"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:155
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:164
 msgid "Dubbed (all)"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:156
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:165
 msgid "Subbed (all)"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:157
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:166
 msgid "Custom (set in config)"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:162
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:171
 msgid "Download Folder"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:163
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:172
 msgid "Prefer Downloaded Copy"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:164
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:173
 msgid "Automatically Download Upcoming Episodes"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:165
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:174
 msgid "Include Next Up"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:166
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:175
 msgid "Next Up Entries to Consider"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:167
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:176
 msgid "Episodes to Keep Ahead (0 = off)"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:168
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:177
 msgid "Storage Limit for Automatic Downloads (GB)"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:169
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:178
 msgid "Delete Automatic Downloads Once Watched"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:170
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:179
 msgid "Delete Unwatched After (days, 0 = never)"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:171
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:180
 msgid "Check Every (minutes)"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:172
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:181
 msgid "Close to Tray (keep running)"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:173
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:182
 msgid "Keep Running in Background"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:174
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:183
 msgid "Remember Window Size"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:175
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:184
 msgid "Player Controls Style"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:176
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:185
 msgid "Show What You're Watching in Discord"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:177
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:186
 msgid "Interface Scale"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:178
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:187
 msgid "Cast-target mode (no library browsing)"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:179
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:188
 msgid "Casting Opens the Library Browser"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:180
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:189
 msgid "Fullscreen Library Browser"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:181
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:190
 msgid "Always Bind Arrow Keys to Player Controls"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:182
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:191
 msgid "Player Controls Activation Key"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:183
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:192
 msgid "Audio Output Mode"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:184
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:193
 msgid "Audio Output Device"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:185
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:194
 msgid "Take the Device Exclusively"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:187
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:196
 msgid "Enable Video Playback Profiles"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:188
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:197
 msgid "Profile Group"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:189
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:198
 msgid "Remember Last Used Profile"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:190
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:199
 msgid "Graphics API for Shaders"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:191
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:200
 msgid "Pass Through AC3"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:192
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:201
 msgid "Pass Through DTS"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:193
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:202
 msgid "Pass Through E-AC3"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:194
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:203
 msgid "Pass Through DTS-HD"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:195
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:204
 msgid "Pass Through TrueHD"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:196
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:205
 msgid "Re-encode Others to AC3"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:202
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:213
 msgid ""
-"MPV keybinds are used by default. Press ENTER to drive the player controls "
-"by keyboard."
+"With \"Start Minimized\" and \"Fullscreen\" this is the classic cast-target "
+"setup: the app waits out of the way, plays fullscreen when something casts "
+"to it, and goes back to waiting when the video ends or you press Q."
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:204
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:227
+msgid ""
+"Off means command-line mode: no window, no system tray and no settings "
+"screen, so the only way back is editing conf.json by hand. It is not how you "
+"get MPV's own on-screen controls — \"Player Controls Style\" under Interface "
+"does that."
+msgstr ""
+
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:234
+msgid ""
+"Show only what is cast to this machine — the library, including this "
+"settings screen, can't be reached from here. Without a system tray icon the "
+"only way back is editing conf.json. For the classic cast-target setup you "
+"want the Interface settings instead; this is for a shared TV nobody should "
+"be able to browse from."
+msgstr ""
+
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:240
+msgid ""
+"Requires restart to change. MPV keybinds are used by default. Press ENTER to "
+"drive the player controls by keyboard."
+msgstr ""
+
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:242
 msgid ""
 "Pixels one wheel notch scrolls. The scrollbar glides while the content snaps "
 "to the nearest row, so a trackpad or trackball no longer overshoots. Raise "
 "it to scroll faster, lower it for finer control."
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:209
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:247
 msgid ""
 "Make each wheel notch jump exactly one row (or one home-screen section) "
 "instead of gliding. Turn this on if you prefer the older stepped scrolling."
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:217
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:255
 msgid "Discord Rich Presence. Takes effect after a restart."
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:219
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:257
 msgid ""
 "Leave this to Default unless setting up passthrough. Note some audio servers "
 "like Pipewire don't like passthrough and will need to be disabled for a card "
@@ -976,57 +1000,57 @@ msgid ""
 "silence otherwise, but results may vary."
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:225
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:263
 msgid ""
 "Stop anything else using the device while playing. Needed for passthrough on "
 "some systems, and it means other applications will be silent."
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:228
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:266
 msgid ""
 "Page the library and music tile grids instead of scrolling: each page is one "
 "screenful with First / Previous / Next / Last controls and a page number you "
 "can type into. Easier than precise scrolling on a trackpad."
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:232
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:270
 msgid ""
 "Takes effect after a restart. \"Follow display\" uses the scale your desktop "
 "reports, which is 100% on X11."
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:234
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:272
 msgid ""
 "\"Default\" changes nothing and lets MPV (and your own mpv.conf) decide. "
 "Pick a mode only if you are sending audio to a receiver."
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:237
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:275
 msgid ""
 "Audio your receiver can't be sent directly is encoded to AC3, which is the "
 "only way surround fits down an optical cable. Turn this off if the encoder "
 "causes audio delay — those tracks become stereo instead."
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:242
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:280
 msgid ""
 "\"hq\" offers heavier profiles. Pick it if you have a fast graphics card."
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:244
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:282
 msgid ""
 "Leave on Automatic unless video breaks when a profile is loaded. This only "
 "applies while a profile is active, and OpenGL can cost you HDR output."
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:248
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:286
 msgid ""
 "Evens out loud effects and quiet dialogue. This turns passthrough off while "
 "it is enabled, because the volume has to be adjusted before your receiver "
 "gets the audio."
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:330
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:368
 msgid "Advanced"
 msgstr ""
 
@@ -1206,7 +1230,7 @@ msgid "Automatic"
 msgstr ""
 
 #: jellyfin_mpv_shim/mpvtk_browser/downloads.py:51
-#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1355
+#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1288
 msgid "Episodes"
 msgstr ""
 
@@ -1215,7 +1239,7 @@ msgid "Season %s"
 msgstr ""
 
 #: jellyfin_mpv_shim/mpvtk_browser/downloads.py:52
-#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1351
+#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1284
 msgid "Specials"
 msgstr ""
 
@@ -1236,7 +1260,7 @@ msgid "Failed"
 msgstr ""
 
 #: jellyfin_mpv_shim/mpvtk_browser/downloads.py:185
-#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1105
+#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1038
 msgid "Playlist"
 msgstr ""
 
@@ -1248,30 +1272,30 @@ msgstr ""
 msgid "Movies & Videos"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/home_sections.py:103
+#: jellyfin_mpv_shim/mpvtk_browser/home_sections.py:104
 msgid "My Media"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/home_sections.py:104
-#: jellyfin_mpv_shim/mpvtk_browser/repository.py:352
+#: jellyfin_mpv_shim/mpvtk_browser/home_sections.py:105
+#: jellyfin_mpv_shim/mpvtk_browser/repository.py:350
 msgid "Continue Watching"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/home_sections.py:105
-#: jellyfin_mpv_shim/mpvtk_browser/repository.py:359
+#: jellyfin_mpv_shim/mpvtk_browser/home_sections.py:106
+#: jellyfin_mpv_shim/mpvtk_browser/repository.py:357
 msgid "Continue Listening"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/home_sections.py:106
-#: jellyfin_mpv_shim/mpvtk_browser/repository.py:366
+#: jellyfin_mpv_shim/mpvtk_browser/home_sections.py:107
+#: jellyfin_mpv_shim/mpvtk_browser/repository.py:364
 msgid "Next Up"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/home_sections.py:107
+#: jellyfin_mpv_shim/mpvtk_browser/home_sections.py:108
 msgid "Recently Added"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/home_sections.py:108
+#: jellyfin_mpv_shim/mpvtk_browser/home_sections.py:109
 msgid "Live TV"
 msgstr ""
 
@@ -1486,52 +1510,52 @@ msgstr ""
 msgid "Could not load this page."
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/repository.py:390
+#: jellyfin_mpv_shim/mpvtk_browser/repository.py:386
 msgid "On Now"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/repository.py:411
+#: jellyfin_mpv_shim/mpvtk_browser/repository.py:407
 msgid "Latest %s"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1119
+#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1052
 msgid "Downloaded"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1138
+#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1071
 msgid "Movies"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1143
+#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1076
 msgid "Videos"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1147
+#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1080
 msgid "TV Shows"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1151
+#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1084
 msgid "Playlists"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1168
-#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1441
+#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1101
+#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1374
 msgid "Series"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1212
+#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1145
 msgid "Downloaded Movies"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1216
+#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1149
 msgid "Downloaded Videos"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1220
+#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1153
 msgid "Downloaded Shows"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1353
+#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1286
 msgid "Season %d"
 msgstr ""
 

--- a/jellyfin_mpv_shim/messages/vi/LC_MESSAGES/base.po
+++ b/jellyfin_mpv_shim/messages/vi/LC_MESSAGES/base.po
@@ -5,7 +5,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2026-07-25 17:21-0400\n"
+"POT-Creation-Date: 2026-07-26 12:03-0400\n"
 "PO-Revision-Date: 2026-01-11 07:07+0000\n"
 "Last-Translator: CaRotNamAnh_2k11 <namanhcarot@gmail.com>\n"
 "Language-Team: Vietnamese <https://translate.jellyfin.org/projects/jellyfin/"
@@ -252,7 +252,7 @@ msgid "Select Subtitle Track"
 msgstr "Chọn bản nhạc phụ đề"
 
 #: jellyfin_mpv_shim/menu.py:341
-#: jellyfin_mpv_shim/mpvtk_browser/home_sections.py:102
+#: jellyfin_mpv_shim/mpvtk_browser/home_sections.py:103
 #: jellyfin_mpv_shim/osc_bridge.py:81 jellyfin_mpv_shim/osc_bridge.py:82
 #: jellyfin_mpv_shim/osc_bridge.py:104 jellyfin_mpv_shim/osc_bridge.py:140
 msgid "None"
@@ -403,7 +403,7 @@ msgstr "Hỏi để bỏ qua đoạn giới thiệu"
 msgid "Enable thumbnail previews"
 msgstr "Bật hình nhỏ xem trước"
 
-#: jellyfin_mpv_shim/menu.py:609 jellyfin_mpv_shim/mpvtk_browser/config.py:186
+#: jellyfin_mpv_shim/menu.py:609 jellyfin_mpv_shim/mpvtk_browser/config.py:195
 #: jellyfin_mpv_shim/mpvtk_browser/hud.py:375
 msgid "Night Mode (Auto Volume Adj)"
 msgstr ""
@@ -702,310 +702,334 @@ msgstr ""
 msgid "Or switch to another user"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/cast.py:317
+#: jellyfin_mpv_shim/mpvtk_browser/cast.py:314
 msgid "Ready to cast"
 msgstr "Sẵn sàng truyền"
 
-#: jellyfin_mpv_shim/mpvtk_browser/cast.py:318
+#: jellyfin_mpv_shim/mpvtk_browser/cast.py:315
 #, fuzzy
 #| msgid "Select your media in Jellyfin and play it here"
 msgid "Select your media in Jellyfin and play it here."
 msgstr "Chọn phương tiện của bạn trong Jellyfin và phát nó ở đây"
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:74
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:83
 msgid "Interface"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:83
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:92
 msgid "Playback"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:88
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:97
 msgid "Audio"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:92
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:101
 msgid "Subtitles & Languages"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:97
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:106
 #, fuzzy
 #| msgid " (Transcode)"
 msgid "Transcoding"
 msgstr " (Chuyển mã)"
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:102
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:111
 msgid "Video Enhancement"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:104
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:113
 #, fuzzy
 #| msgid "Seek to Skip Credits"
 msgid "Skip Intro / Credits"
 msgstr "Đi tới để bỏ qua đoạn giới thiệu"
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:107
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:116
 msgid "Library Browser"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:109
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:118
 msgid "Downloads"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:128
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:137
 msgid "Jellyfin UI"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:129
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:138
 msgid "MPV UI with thumbnails"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:130
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:139
 msgid "MPV built-in default"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:133
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:142
 msgid "Follow display"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:134
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:143
 msgid "100% (no scaling)"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:135
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:144
 msgid "125%"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:136
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:145
 msgid "150%"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:137
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:146
 msgid "200%"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:140
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:149
 msgid "Automatic (recommended)"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:141
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:150
 msgid "Vulkan"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:142
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:151
 msgid "Direct3D 11 (Windows only)"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:143
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:152
 msgid "OpenGL (compatibility)"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:146
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:155
 msgid "Default (auto)"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:147
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:156
 msgid "Force Stereo"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:148
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:157
 msgid "Optical Surround"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:149
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:158
 msgid "HDMI Passthrough"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:152
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:161
 msgid "Unset"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:153
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:162
 msgid "Dubbed (shows only)"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:154
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:163
 msgid "Subbed (shows only)"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:155
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:164
 msgid "Dubbed (all)"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:156
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:165
 msgid "Subbed (all)"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:157
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:166
 msgid "Custom (set in config)"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:162
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:171
 msgid "Download Folder"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:163
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:172
 msgid "Prefer Downloaded Copy"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:164
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:173
 msgid "Automatically Download Upcoming Episodes"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:165
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:174
 msgid "Include Next Up"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:166
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:175
 msgid "Next Up Entries to Consider"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:167
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:176
 msgid "Episodes to Keep Ahead (0 = off)"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:168
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:177
 msgid "Storage Limit for Automatic Downloads (GB)"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:169
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:178
 #, fuzzy
 #| msgid "Remove Server"
 msgid "Delete Automatic Downloads Once Watched"
 msgstr "Xóa máy chủ"
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:170
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:179
 msgid "Delete Unwatched After (days, 0 = never)"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:171
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:180
 msgid "Check Every (minutes)"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:172
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:181
 msgid "Close to Tray (keep running)"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:173
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:182
 msgid "Keep Running in Background"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:174
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:183
 msgid "Remember Window Size"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:175
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:184
 msgid "Player Controls Style"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:176
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:185
 msgid "Show What You're Watching in Discord"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:177
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:186
 msgid "Interface Scale"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:178
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:187
 msgid "Cast-target mode (no library browsing)"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:179
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:188
 msgid "Casting Opens the Library Browser"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:180
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:189
 msgid "Fullscreen Library Browser"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:181
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:190
 msgid "Always Bind Arrow Keys to Player Controls"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:182
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:191
 msgid "Player Controls Activation Key"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:183
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:192
 msgid "Audio Output Mode"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:184
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:193
 msgid "Audio Output Device"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:185
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:194
 msgid "Take the Device Exclusively"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:187
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:196
 #, fuzzy
 #| msgid "Video Playback Profiles"
 msgid "Enable Video Playback Profiles"
 msgstr "Cấu hình phát lại video"
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:188
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:197
 #, fuzzy
 #| msgid "New Group"
 msgid "Profile Group"
 msgstr "Nhóm Mới"
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:189
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:198
 msgid "Remember Last Used Profile"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:190
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:199
 msgid "Graphics API for Shaders"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:191
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:200
 msgid "Pass Through AC3"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:192
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:201
 msgid "Pass Through DTS"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:193
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:202
 msgid "Pass Through E-AC3"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:194
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:203
 msgid "Pass Through DTS-HD"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:195
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:204
 msgid "Pass Through TrueHD"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:196
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:205
 msgid "Re-encode Others to AC3"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:202
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:213
 msgid ""
-"MPV keybinds are used by default. Press ENTER to drive the player controls "
-"by keyboard."
+"With \"Start Minimized\" and \"Fullscreen\" this is the classic cast-target "
+"setup: the app waits out of the way, plays fullscreen when something casts "
+"to it, and goes back to waiting when the video ends or you press Q."
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:204
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:227
+msgid ""
+"Off means command-line mode: no window, no system tray and no settings "
+"screen, so the only way back is editing conf.json by hand. It is not how you "
+"get MPV's own on-screen controls — \"Player Controls Style\" under Interface "
+"does that."
+msgstr ""
+
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:234
+msgid ""
+"Show only what is cast to this machine — the library, including this "
+"settings screen, can't be reached from here. Without a system tray icon the "
+"only way back is editing conf.json. For the classic cast-target setup you "
+"want the Interface settings instead; this is for a shared TV nobody should "
+"be able to browse from."
+msgstr ""
+
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:240
+msgid ""
+"Requires restart to change. MPV keybinds are used by default. Press ENTER to "
+"drive the player controls by keyboard."
+msgstr ""
+
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:242
 msgid ""
 "Pixels one wheel notch scrolls. The scrollbar glides while the content snaps "
 "to the nearest row, so a trackpad or trackball no longer overshoots. Raise "
 "it to scroll faster, lower it for finer control."
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:209
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:247
 msgid ""
 "Make each wheel notch jump exactly one row (or one home-screen section) "
 "instead of gliding. Turn this on if you prefer the older stepped scrolling."
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:217
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:255
 msgid "Discord Rich Presence. Takes effect after a restart."
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:219
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:257
 msgid ""
 "Leave this to Default unless setting up passthrough. Note some audio servers "
 "like Pipewire don't like passthrough and will need to be disabled for a card "
@@ -1013,57 +1037,57 @@ msgid ""
 "silence otherwise, but results may vary."
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:225
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:263
 msgid ""
 "Stop anything else using the device while playing. Needed for passthrough on "
 "some systems, and it means other applications will be silent."
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:228
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:266
 msgid ""
 "Page the library and music tile grids instead of scrolling: each page is one "
 "screenful with First / Previous / Next / Last controls and a page number you "
 "can type into. Easier than precise scrolling on a trackpad."
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:232
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:270
 msgid ""
 "Takes effect after a restart. \"Follow display\" uses the scale your desktop "
 "reports, which is 100% on X11."
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:234
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:272
 msgid ""
 "\"Default\" changes nothing and lets MPV (and your own mpv.conf) decide. "
 "Pick a mode only if you are sending audio to a receiver."
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:237
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:275
 msgid ""
 "Audio your receiver can't be sent directly is encoded to AC3, which is the "
 "only way surround fits down an optical cable. Turn this off if the encoder "
 "causes audio delay — those tracks become stereo instead."
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:242
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:280
 msgid ""
 "\"hq\" offers heavier profiles. Pick it if you have a fast graphics card."
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:244
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:282
 msgid ""
 "Leave on Automatic unless video breaks when a profile is loaded. This only "
 "applies while a profile is active, and OpenGL can cost you HDR output."
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:248
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:286
 msgid ""
 "Evens out loud effects and quiet dialogue. This turns passthrough off while "
 "it is enabled, because the volume has to be adjusted before your receiver "
 "gets the audio."
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:330
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:368
 msgid "Advanced"
 msgstr ""
 
@@ -1289,7 +1313,7 @@ msgid "Automatic"
 msgstr "Tự động"
 
 #: jellyfin_mpv_shim/mpvtk_browser/downloads.py:51
-#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1355
+#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1288
 msgid "Episodes"
 msgstr ""
 
@@ -1298,7 +1322,7 @@ msgid "Season %s"
 msgstr ""
 
 #: jellyfin_mpv_shim/mpvtk_browser/downloads.py:52
-#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1351
+#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1284
 msgid "Specials"
 msgstr ""
 
@@ -1323,7 +1347,7 @@ msgid "Failed"
 msgstr "Thất bại"
 
 #: jellyfin_mpv_shim/mpvtk_browser/downloads.py:185
-#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1105
+#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1038
 msgid "Playlist"
 msgstr ""
 
@@ -1335,30 +1359,30 @@ msgstr ""
 msgid "Movies & Videos"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/home_sections.py:103
+#: jellyfin_mpv_shim/mpvtk_browser/home_sections.py:104
 msgid "My Media"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/home_sections.py:104
-#: jellyfin_mpv_shim/mpvtk_browser/repository.py:352
+#: jellyfin_mpv_shim/mpvtk_browser/home_sections.py:105
+#: jellyfin_mpv_shim/mpvtk_browser/repository.py:350
 msgid "Continue Watching"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/home_sections.py:105
-#: jellyfin_mpv_shim/mpvtk_browser/repository.py:359
+#: jellyfin_mpv_shim/mpvtk_browser/home_sections.py:106
+#: jellyfin_mpv_shim/mpvtk_browser/repository.py:357
 msgid "Continue Listening"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/home_sections.py:106
-#: jellyfin_mpv_shim/mpvtk_browser/repository.py:366
+#: jellyfin_mpv_shim/mpvtk_browser/home_sections.py:107
+#: jellyfin_mpv_shim/mpvtk_browser/repository.py:364
 msgid "Next Up"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/home_sections.py:107
+#: jellyfin_mpv_shim/mpvtk_browser/home_sections.py:108
 msgid "Recently Added"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/home_sections.py:108
+#: jellyfin_mpv_shim/mpvtk_browser/home_sections.py:109
 msgid "Live TV"
 msgstr ""
 
@@ -1611,52 +1635,52 @@ msgstr ""
 "Không thể thêm máy chủ.\n"
 "Vui lòng kiểm tra thông tin kết nối của bạn."
 
-#: jellyfin_mpv_shim/mpvtk_browser/repository.py:390
+#: jellyfin_mpv_shim/mpvtk_browser/repository.py:386
 msgid "On Now"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/repository.py:411
+#: jellyfin_mpv_shim/mpvtk_browser/repository.py:407
 msgid "Latest %s"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1119
+#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1052
 msgid "Downloaded"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1138
+#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1071
 msgid "Movies"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1143
+#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1076
 msgid "Videos"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1147
+#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1080
 msgid "TV Shows"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1151
+#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1084
 msgid "Playlists"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1168
-#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1441
+#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1101
+#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1374
 msgid "Series"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1212
+#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1145
 msgid "Downloaded Movies"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1216
+#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1149
 msgid "Downloaded Videos"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1220
+#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1153
 msgid "Downloaded Shows"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1353
+#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1286
 msgid "Season %d"
 msgstr ""
 

--- a/jellyfin_mpv_shim/messages/zh_Hans/LC_MESSAGES/base.po
+++ b/jellyfin_mpv_shim/messages/zh_Hans/LC_MESSAGES/base.po
@@ -5,7 +5,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2026-07-25 17:21-0400\n"
+"POT-Creation-Date: 2026-07-26 12:03-0400\n"
 "PO-Revision-Date: 2026-04-16 08:45+0000\n"
 "Last-Translator: wabisabi926 <liwenliang926@163.com>\n"
 "Language-Team: Chinese (Simplified Han script) <https://"
@@ -252,7 +252,7 @@ msgid "Select Subtitle Track"
 msgstr "选择字幕音轨"
 
 #: jellyfin_mpv_shim/menu.py:341
-#: jellyfin_mpv_shim/mpvtk_browser/home_sections.py:102
+#: jellyfin_mpv_shim/mpvtk_browser/home_sections.py:103
 #: jellyfin_mpv_shim/osc_bridge.py:81 jellyfin_mpv_shim/osc_bridge.py:82
 #: jellyfin_mpv_shim/osc_bridge.py:104 jellyfin_mpv_shim/osc_bridge.py:140
 msgid "None"
@@ -403,7 +403,7 @@ msgstr "询问是否跳过片头"
 msgid "Enable thumbnail previews"
 msgstr "启用缩略图预览"
 
-#: jellyfin_mpv_shim/menu.py:609 jellyfin_mpv_shim/mpvtk_browser/config.py:186
+#: jellyfin_mpv_shim/menu.py:609 jellyfin_mpv_shim/mpvtk_browser/config.py:195
 #: jellyfin_mpv_shim/mpvtk_browser/hud.py:375
 msgid "Night Mode (Auto Volume Adj)"
 msgstr ""
@@ -702,310 +702,334 @@ msgstr ""
 msgid "Or switch to another user"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/cast.py:317
+#: jellyfin_mpv_shim/mpvtk_browser/cast.py:314
 msgid "Ready to cast"
 msgstr "准备投屏"
 
-#: jellyfin_mpv_shim/mpvtk_browser/cast.py:318
+#: jellyfin_mpv_shim/mpvtk_browser/cast.py:315
 #, fuzzy
 #| msgid "Select your media in Jellyfin and play it here"
 msgid "Select your media in Jellyfin and play it here."
 msgstr "在 Jellyfin 中选择您的媒体并在此处播放"
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:74
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:83
 msgid "Interface"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:83
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:92
 msgid "Playback"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:88
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:97
 msgid "Audio"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:92
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:101
 msgid "Subtitles & Languages"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:97
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:106
 #, fuzzy
 #| msgid " (Transcode)"
 msgid "Transcoding"
 msgstr " (转码)"
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:102
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:111
 msgid "Video Enhancement"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:104
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:113
 #, fuzzy
 #| msgid "Seek to Skip Credits"
 msgid "Skip Intro / Credits"
 msgstr "跳过片头"
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:107
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:116
 msgid "Library Browser"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:109
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:118
 msgid "Downloads"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:128
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:137
 msgid "Jellyfin UI"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:129
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:138
 msgid "MPV UI with thumbnails"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:130
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:139
 msgid "MPV built-in default"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:133
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:142
 msgid "Follow display"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:134
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:143
 msgid "100% (no scaling)"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:135
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:144
 msgid "125%"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:136
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:145
 msgid "150%"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:137
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:146
 msgid "200%"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:140
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:149
 msgid "Automatic (recommended)"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:141
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:150
 msgid "Vulkan"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:142
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:151
 msgid "Direct3D 11 (Windows only)"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:143
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:152
 msgid "OpenGL (compatibility)"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:146
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:155
 msgid "Default (auto)"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:147
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:156
 msgid "Force Stereo"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:148
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:157
 msgid "Optical Surround"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:149
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:158
 msgid "HDMI Passthrough"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:152
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:161
 msgid "Unset"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:153
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:162
 msgid "Dubbed (shows only)"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:154
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:163
 msgid "Subbed (shows only)"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:155
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:164
 msgid "Dubbed (all)"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:156
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:165
 msgid "Subbed (all)"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:157
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:166
 msgid "Custom (set in config)"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:162
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:171
 msgid "Download Folder"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:163
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:172
 msgid "Prefer Downloaded Copy"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:164
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:173
 msgid "Automatically Download Upcoming Episodes"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:165
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:174
 msgid "Include Next Up"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:166
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:175
 msgid "Next Up Entries to Consider"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:167
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:176
 msgid "Episodes to Keep Ahead (0 = off)"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:168
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:177
 msgid "Storage Limit for Automatic Downloads (GB)"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:169
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:178
 #, fuzzy
 #| msgid "Remove Server"
 msgid "Delete Automatic Downloads Once Watched"
 msgstr "移除服务器"
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:170
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:179
 msgid "Delete Unwatched After (days, 0 = never)"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:171
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:180
 msgid "Check Every (minutes)"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:172
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:181
 msgid "Close to Tray (keep running)"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:173
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:182
 msgid "Keep Running in Background"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:174
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:183
 msgid "Remember Window Size"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:175
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:184
 msgid "Player Controls Style"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:176
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:185
 msgid "Show What You're Watching in Discord"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:177
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:186
 msgid "Interface Scale"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:178
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:187
 msgid "Cast-target mode (no library browsing)"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:179
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:188
 msgid "Casting Opens the Library Browser"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:180
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:189
 msgid "Fullscreen Library Browser"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:181
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:190
 msgid "Always Bind Arrow Keys to Player Controls"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:182
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:191
 msgid "Player Controls Activation Key"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:183
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:192
 msgid "Audio Output Mode"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:184
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:193
 msgid "Audio Output Device"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:185
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:194
 msgid "Take the Device Exclusively"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:187
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:196
 #, fuzzy
 #| msgid "Video Playback Profiles"
 msgid "Enable Video Playback Profiles"
 msgstr "视频播放预设"
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:188
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:197
 #, fuzzy
 #| msgid "New Group"
 msgid "Profile Group"
 msgstr "创建新组"
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:189
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:198
 msgid "Remember Last Used Profile"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:190
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:199
 msgid "Graphics API for Shaders"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:191
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:200
 msgid "Pass Through AC3"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:192
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:201
 msgid "Pass Through DTS"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:193
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:202
 msgid "Pass Through E-AC3"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:194
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:203
 msgid "Pass Through DTS-HD"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:195
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:204
 msgid "Pass Through TrueHD"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:196
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:205
 msgid "Re-encode Others to AC3"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:202
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:213
 msgid ""
-"MPV keybinds are used by default. Press ENTER to drive the player controls "
-"by keyboard."
+"With \"Start Minimized\" and \"Fullscreen\" this is the classic cast-target "
+"setup: the app waits out of the way, plays fullscreen when something casts "
+"to it, and goes back to waiting when the video ends or you press Q."
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:204
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:227
+msgid ""
+"Off means command-line mode: no window, no system tray and no settings "
+"screen, so the only way back is editing conf.json by hand. It is not how you "
+"get MPV's own on-screen controls — \"Player Controls Style\" under Interface "
+"does that."
+msgstr ""
+
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:234
+msgid ""
+"Show only what is cast to this machine — the library, including this "
+"settings screen, can't be reached from here. Without a system tray icon the "
+"only way back is editing conf.json. For the classic cast-target setup you "
+"want the Interface settings instead; this is for a shared TV nobody should "
+"be able to browse from."
+msgstr ""
+
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:240
+msgid ""
+"Requires restart to change. MPV keybinds are used by default. Press ENTER to "
+"drive the player controls by keyboard."
+msgstr ""
+
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:242
 msgid ""
 "Pixels one wheel notch scrolls. The scrollbar glides while the content snaps "
 "to the nearest row, so a trackpad or trackball no longer overshoots. Raise "
 "it to scroll faster, lower it for finer control."
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:209
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:247
 msgid ""
 "Make each wheel notch jump exactly one row (or one home-screen section) "
 "instead of gliding. Turn this on if you prefer the older stepped scrolling."
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:217
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:255
 msgid "Discord Rich Presence. Takes effect after a restart."
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:219
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:257
 msgid ""
 "Leave this to Default unless setting up passthrough. Note some audio servers "
 "like Pipewire don't like passthrough and will need to be disabled for a card "
@@ -1013,57 +1037,57 @@ msgid ""
 "silence otherwise, but results may vary."
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:225
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:263
 msgid ""
 "Stop anything else using the device while playing. Needed for passthrough on "
 "some systems, and it means other applications will be silent."
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:228
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:266
 msgid ""
 "Page the library and music tile grids instead of scrolling: each page is one "
 "screenful with First / Previous / Next / Last controls and a page number you "
 "can type into. Easier than precise scrolling on a trackpad."
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:232
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:270
 msgid ""
 "Takes effect after a restart. \"Follow display\" uses the scale your desktop "
 "reports, which is 100% on X11."
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:234
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:272
 msgid ""
 "\"Default\" changes nothing and lets MPV (and your own mpv.conf) decide. "
 "Pick a mode only if you are sending audio to a receiver."
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:237
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:275
 msgid ""
 "Audio your receiver can't be sent directly is encoded to AC3, which is the "
 "only way surround fits down an optical cable. Turn this off if the encoder "
 "causes audio delay — those tracks become stereo instead."
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:242
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:280
 msgid ""
 "\"hq\" offers heavier profiles. Pick it if you have a fast graphics card."
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:244
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:282
 msgid ""
 "Leave on Automatic unless video breaks when a profile is loaded. This only "
 "applies while a profile is active, and OpenGL can cost you HDR output."
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:248
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:286
 msgid ""
 "Evens out loud effects and quiet dialogue. This turns passthrough off while "
 "it is enabled, because the volume has to be adjusted before your receiver "
 "gets the audio."
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:330
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:368
 msgid "Advanced"
 msgstr ""
 
@@ -1289,7 +1313,7 @@ msgid "Automatic"
 msgstr "自动"
 
 #: jellyfin_mpv_shim/mpvtk_browser/downloads.py:51
-#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1355
+#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1288
 msgid "Episodes"
 msgstr ""
 
@@ -1298,7 +1322,7 @@ msgid "Season %s"
 msgstr ""
 
 #: jellyfin_mpv_shim/mpvtk_browser/downloads.py:52
-#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1351
+#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1284
 msgid "Specials"
 msgstr ""
 
@@ -1323,7 +1347,7 @@ msgid "Failed"
 msgstr "连接失败"
 
 #: jellyfin_mpv_shim/mpvtk_browser/downloads.py:185
-#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1105
+#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1038
 msgid "Playlist"
 msgstr ""
 
@@ -1335,30 +1359,30 @@ msgstr ""
 msgid "Movies & Videos"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/home_sections.py:103
+#: jellyfin_mpv_shim/mpvtk_browser/home_sections.py:104
 msgid "My Media"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/home_sections.py:104
-#: jellyfin_mpv_shim/mpvtk_browser/repository.py:352
+#: jellyfin_mpv_shim/mpvtk_browser/home_sections.py:105
+#: jellyfin_mpv_shim/mpvtk_browser/repository.py:350
 msgid "Continue Watching"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/home_sections.py:105
-#: jellyfin_mpv_shim/mpvtk_browser/repository.py:359
+#: jellyfin_mpv_shim/mpvtk_browser/home_sections.py:106
+#: jellyfin_mpv_shim/mpvtk_browser/repository.py:357
 msgid "Continue Listening"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/home_sections.py:106
-#: jellyfin_mpv_shim/mpvtk_browser/repository.py:366
+#: jellyfin_mpv_shim/mpvtk_browser/home_sections.py:107
+#: jellyfin_mpv_shim/mpvtk_browser/repository.py:364
 msgid "Next Up"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/home_sections.py:107
+#: jellyfin_mpv_shim/mpvtk_browser/home_sections.py:108
 msgid "Recently Added"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/home_sections.py:108
+#: jellyfin_mpv_shim/mpvtk_browser/home_sections.py:109
 msgid "Live TV"
 msgstr ""
 
@@ -1611,52 +1635,52 @@ msgstr ""
 "无法添加服务器。\n"
 "请检查您的连接信息。"
 
-#: jellyfin_mpv_shim/mpvtk_browser/repository.py:390
+#: jellyfin_mpv_shim/mpvtk_browser/repository.py:386
 msgid "On Now"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/repository.py:411
+#: jellyfin_mpv_shim/mpvtk_browser/repository.py:407
 msgid "Latest %s"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1119
+#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1052
 msgid "Downloaded"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1138
+#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1071
 msgid "Movies"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1143
+#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1076
 msgid "Videos"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1147
+#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1080
 msgid "TV Shows"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1151
+#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1084
 msgid "Playlists"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1168
-#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1441
+#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1101
+#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1374
 msgid "Series"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1212
+#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1145
 msgid "Downloaded Movies"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1216
+#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1149
 msgid "Downloaded Videos"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1220
+#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1153
 msgid "Downloaded Shows"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1353
+#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1286
 msgid "Season %d"
 msgstr ""
 

--- a/jellyfin_mpv_shim/messages/zh_Hant/LC_MESSAGES/base.po
+++ b/jellyfin_mpv_shim/messages/zh_Hant/LC_MESSAGES/base.po
@@ -5,7 +5,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2026-07-25 17:21-0400\n"
+"POT-Creation-Date: 2026-07-26 12:03-0400\n"
 "PO-Revision-Date: 2026-01-25 04:25+0000\n"
 "Last-Translator: ldmheaye <lhydeema@outlook.com>\n"
 "Language-Team: Chinese (Traditional Han script) <https://"
@@ -252,7 +252,7 @@ msgid "Select Subtitle Track"
 msgstr "選擇字幕軌"
 
 #: jellyfin_mpv_shim/menu.py:341
-#: jellyfin_mpv_shim/mpvtk_browser/home_sections.py:102
+#: jellyfin_mpv_shim/mpvtk_browser/home_sections.py:103
 #: jellyfin_mpv_shim/osc_bridge.py:81 jellyfin_mpv_shim/osc_bridge.py:82
 #: jellyfin_mpv_shim/osc_bridge.py:104 jellyfin_mpv_shim/osc_bridge.py:140
 msgid "None"
@@ -403,7 +403,7 @@ msgstr "詢問跳過片尾"
 msgid "Enable thumbnail previews"
 msgstr "啟用縮圖預覽"
 
-#: jellyfin_mpv_shim/menu.py:609 jellyfin_mpv_shim/mpvtk_browser/config.py:186
+#: jellyfin_mpv_shim/menu.py:609 jellyfin_mpv_shim/mpvtk_browser/config.py:195
 #: jellyfin_mpv_shim/mpvtk_browser/hud.py:375
 msgid "Night Mode (Auto Volume Adj)"
 msgstr ""
@@ -702,310 +702,334 @@ msgstr ""
 msgid "Or switch to another user"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/cast.py:317
+#: jellyfin_mpv_shim/mpvtk_browser/cast.py:314
 msgid "Ready to cast"
 msgstr "準備投放"
 
-#: jellyfin_mpv_shim/mpvtk_browser/cast.py:318
+#: jellyfin_mpv_shim/mpvtk_browser/cast.py:315
 #, fuzzy
 #| msgid "Select your media in Jellyfin and play it here"
 msgid "Select your media in Jellyfin and play it here."
 msgstr "在Jellyfin中選擇您的媒體並在此處播放"
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:74
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:83
 msgid "Interface"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:83
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:92
 msgid "Playback"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:88
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:97
 msgid "Audio"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:92
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:101
 msgid "Subtitles & Languages"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:97
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:106
 #, fuzzy
 #| msgid " (Transcode)"
 msgid "Transcoding"
 msgstr " (轉碼)"
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:102
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:111
 msgid "Video Enhancement"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:104
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:113
 #, fuzzy
 #| msgid "Seek to Skip Credits"
 msgid "Skip Intro / Credits"
 msgstr "略過工作人員名單"
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:107
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:116
 msgid "Library Browser"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:109
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:118
 msgid "Downloads"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:128
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:137
 msgid "Jellyfin UI"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:129
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:138
 msgid "MPV UI with thumbnails"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:130
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:139
 msgid "MPV built-in default"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:133
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:142
 msgid "Follow display"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:134
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:143
 msgid "100% (no scaling)"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:135
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:144
 msgid "125%"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:136
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:145
 msgid "150%"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:137
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:146
 msgid "200%"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:140
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:149
 msgid "Automatic (recommended)"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:141
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:150
 msgid "Vulkan"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:142
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:151
 msgid "Direct3D 11 (Windows only)"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:143
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:152
 msgid "OpenGL (compatibility)"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:146
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:155
 msgid "Default (auto)"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:147
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:156
 msgid "Force Stereo"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:148
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:157
 msgid "Optical Surround"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:149
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:158
 msgid "HDMI Passthrough"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:152
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:161
 msgid "Unset"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:153
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:162
 msgid "Dubbed (shows only)"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:154
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:163
 msgid "Subbed (shows only)"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:155
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:164
 msgid "Dubbed (all)"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:156
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:165
 msgid "Subbed (all)"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:157
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:166
 msgid "Custom (set in config)"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:162
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:171
 msgid "Download Folder"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:163
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:172
 msgid "Prefer Downloaded Copy"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:164
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:173
 msgid "Automatically Download Upcoming Episodes"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:165
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:174
 msgid "Include Next Up"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:166
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:175
 msgid "Next Up Entries to Consider"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:167
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:176
 msgid "Episodes to Keep Ahead (0 = off)"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:168
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:177
 msgid "Storage Limit for Automatic Downloads (GB)"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:169
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:178
 #, fuzzy
 #| msgid "Remove Server"
 msgid "Delete Automatic Downloads Once Watched"
 msgstr "刪除伺服器"
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:170
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:179
 msgid "Delete Unwatched After (days, 0 = never)"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:171
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:180
 msgid "Check Every (minutes)"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:172
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:181
 msgid "Close to Tray (keep running)"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:173
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:182
 msgid "Keep Running in Background"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:174
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:183
 msgid "Remember Window Size"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:175
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:184
 msgid "Player Controls Style"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:176
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:185
 msgid "Show What You're Watching in Discord"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:177
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:186
 msgid "Interface Scale"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:178
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:187
 msgid "Cast-target mode (no library browsing)"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:179
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:188
 msgid "Casting Opens the Library Browser"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:180
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:189
 msgid "Fullscreen Library Browser"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:181
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:190
 msgid "Always Bind Arrow Keys to Player Controls"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:182
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:191
 msgid "Player Controls Activation Key"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:183
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:192
 msgid "Audio Output Mode"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:184
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:193
 msgid "Audio Output Device"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:185
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:194
 msgid "Take the Device Exclusively"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:187
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:196
 #, fuzzy
 #| msgid "Video Playback Profiles"
 msgid "Enable Video Playback Profiles"
 msgstr "影片播放設定檔"
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:188
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:197
 #, fuzzy
 #| msgid "New Group"
 msgid "Profile Group"
 msgstr "新的群組"
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:189
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:198
 msgid "Remember Last Used Profile"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:190
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:199
 msgid "Graphics API for Shaders"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:191
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:200
 msgid "Pass Through AC3"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:192
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:201
 msgid "Pass Through DTS"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:193
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:202
 msgid "Pass Through E-AC3"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:194
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:203
 msgid "Pass Through DTS-HD"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:195
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:204
 msgid "Pass Through TrueHD"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:196
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:205
 msgid "Re-encode Others to AC3"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:202
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:213
 msgid ""
-"MPV keybinds are used by default. Press ENTER to drive the player controls "
-"by keyboard."
+"With \"Start Minimized\" and \"Fullscreen\" this is the classic cast-target "
+"setup: the app waits out of the way, plays fullscreen when something casts "
+"to it, and goes back to waiting when the video ends or you press Q."
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:204
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:227
+msgid ""
+"Off means command-line mode: no window, no system tray and no settings "
+"screen, so the only way back is editing conf.json by hand. It is not how you "
+"get MPV's own on-screen controls — \"Player Controls Style\" under Interface "
+"does that."
+msgstr ""
+
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:234
+msgid ""
+"Show only what is cast to this machine — the library, including this "
+"settings screen, can't be reached from here. Without a system tray icon the "
+"only way back is editing conf.json. For the classic cast-target setup you "
+"want the Interface settings instead; this is for a shared TV nobody should "
+"be able to browse from."
+msgstr ""
+
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:240
+msgid ""
+"Requires restart to change. MPV keybinds are used by default. Press ENTER to "
+"drive the player controls by keyboard."
+msgstr ""
+
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:242
 msgid ""
 "Pixels one wheel notch scrolls. The scrollbar glides while the content snaps "
 "to the nearest row, so a trackpad or trackball no longer overshoots. Raise "
 "it to scroll faster, lower it for finer control."
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:209
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:247
 msgid ""
 "Make each wheel notch jump exactly one row (or one home-screen section) "
 "instead of gliding. Turn this on if you prefer the older stepped scrolling."
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:217
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:255
 msgid "Discord Rich Presence. Takes effect after a restart."
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:219
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:257
 msgid ""
 "Leave this to Default unless setting up passthrough. Note some audio servers "
 "like Pipewire don't like passthrough and will need to be disabled for a card "
@@ -1013,57 +1037,57 @@ msgid ""
 "silence otherwise, but results may vary."
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:225
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:263
 msgid ""
 "Stop anything else using the device while playing. Needed for passthrough on "
 "some systems, and it means other applications will be silent."
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:228
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:266
 msgid ""
 "Page the library and music tile grids instead of scrolling: each page is one "
 "screenful with First / Previous / Next / Last controls and a page number you "
 "can type into. Easier than precise scrolling on a trackpad."
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:232
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:270
 msgid ""
 "Takes effect after a restart. \"Follow display\" uses the scale your desktop "
 "reports, which is 100% on X11."
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:234
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:272
 msgid ""
 "\"Default\" changes nothing and lets MPV (and your own mpv.conf) decide. "
 "Pick a mode only if you are sending audio to a receiver."
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:237
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:275
 msgid ""
 "Audio your receiver can't be sent directly is encoded to AC3, which is the "
 "only way surround fits down an optical cable. Turn this off if the encoder "
 "causes audio delay — those tracks become stereo instead."
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:242
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:280
 msgid ""
 "\"hq\" offers heavier profiles. Pick it if you have a fast graphics card."
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:244
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:282
 msgid ""
 "Leave on Automatic unless video breaks when a profile is loaded. This only "
 "applies while a profile is active, and OpenGL can cost you HDR output."
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:248
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:286
 msgid ""
 "Evens out loud effects and quiet dialogue. This turns passthrough off while "
 "it is enabled, because the volume has to be adjusted before your receiver "
 "gets the audio."
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:330
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:368
 msgid "Advanced"
 msgstr ""
 
@@ -1289,7 +1313,7 @@ msgid "Automatic"
 msgstr "自動"
 
 #: jellyfin_mpv_shim/mpvtk_browser/downloads.py:51
-#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1355
+#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1288
 msgid "Episodes"
 msgstr ""
 
@@ -1298,7 +1322,7 @@ msgid "Season %s"
 msgstr ""
 
 #: jellyfin_mpv_shim/mpvtk_browser/downloads.py:52
-#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1351
+#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1284
 msgid "Specials"
 msgstr ""
 
@@ -1323,7 +1347,7 @@ msgid "Failed"
 msgstr "連接失敗"
 
 #: jellyfin_mpv_shim/mpvtk_browser/downloads.py:185
-#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1105
+#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1038
 msgid "Playlist"
 msgstr ""
 
@@ -1335,30 +1359,30 @@ msgstr ""
 msgid "Movies & Videos"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/home_sections.py:103
+#: jellyfin_mpv_shim/mpvtk_browser/home_sections.py:104
 msgid "My Media"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/home_sections.py:104
-#: jellyfin_mpv_shim/mpvtk_browser/repository.py:352
+#: jellyfin_mpv_shim/mpvtk_browser/home_sections.py:105
+#: jellyfin_mpv_shim/mpvtk_browser/repository.py:350
 msgid "Continue Watching"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/home_sections.py:105
-#: jellyfin_mpv_shim/mpvtk_browser/repository.py:359
+#: jellyfin_mpv_shim/mpvtk_browser/home_sections.py:106
+#: jellyfin_mpv_shim/mpvtk_browser/repository.py:357
 msgid "Continue Listening"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/home_sections.py:106
-#: jellyfin_mpv_shim/mpvtk_browser/repository.py:366
+#: jellyfin_mpv_shim/mpvtk_browser/home_sections.py:107
+#: jellyfin_mpv_shim/mpvtk_browser/repository.py:364
 msgid "Next Up"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/home_sections.py:107
+#: jellyfin_mpv_shim/mpvtk_browser/home_sections.py:108
 msgid "Recently Added"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/home_sections.py:108
+#: jellyfin_mpv_shim/mpvtk_browser/home_sections.py:109
 msgid "Live TV"
 msgstr ""
 
@@ -1611,52 +1635,52 @@ msgstr ""
 "無法添加伺服器。\n"
 "請檢查您的連接資訊。"
 
-#: jellyfin_mpv_shim/mpvtk_browser/repository.py:390
+#: jellyfin_mpv_shim/mpvtk_browser/repository.py:386
 msgid "On Now"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/repository.py:411
+#: jellyfin_mpv_shim/mpvtk_browser/repository.py:407
 msgid "Latest %s"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1119
+#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1052
 msgid "Downloaded"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1138
+#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1071
 msgid "Movies"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1143
+#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1076
 msgid "Videos"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1147
+#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1080
 msgid "TV Shows"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1151
+#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1084
 msgid "Playlists"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1168
-#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1441
+#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1101
+#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1374
 msgid "Series"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1212
+#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1145
 msgid "Downloaded Movies"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1216
+#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1149
 msgid "Downloaded Videos"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1220
+#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1153
 msgid "Downloaded Shows"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1353
+#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1286
 msgid "Season %d"
 msgstr ""
 

--- a/jellyfin_mpv_shim/messages/zh_Hant_HK/LC_MESSAGES/base.po
+++ b/jellyfin_mpv_shim/messages/zh_Hant_HK/LC_MESSAGES/base.po
@@ -5,7 +5,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2026-07-25 17:21-0400\n"
+"POT-Creation-Date: 2026-07-26 12:03-0400\n"
 "PO-Revision-Date: 2026-07-06 08:24+0000\n"
 "Last-Translator: Lofuuzi <lather0519@gmail.com>\n"
 "Language-Team: Chinese (Traditional Han script, Hong Kong) <https://"
@@ -246,7 +246,7 @@ msgid "Select Subtitle Track"
 msgstr "揀邊條字幕"
 
 #: jellyfin_mpv_shim/menu.py:341
-#: jellyfin_mpv_shim/mpvtk_browser/home_sections.py:102
+#: jellyfin_mpv_shim/mpvtk_browser/home_sections.py:103
 #: jellyfin_mpv_shim/osc_bridge.py:81 jellyfin_mpv_shim/osc_bridge.py:82
 #: jellyfin_mpv_shim/osc_bridge.py:104 jellyfin_mpv_shim/osc_bridge.py:140
 msgid "None"
@@ -397,7 +397,7 @@ msgstr "跳過片尾前問我"
 msgid "Enable thumbnail previews"
 msgstr "啟用預覽圖"
 
-#: jellyfin_mpv_shim/menu.py:609 jellyfin_mpv_shim/mpvtk_browser/config.py:186
+#: jellyfin_mpv_shim/menu.py:609 jellyfin_mpv_shim/mpvtk_browser/config.py:195
 #: jellyfin_mpv_shim/mpvtk_browser/hud.py:375
 msgid "Night Mode (Auto Volume Adj)"
 msgstr ""
@@ -682,310 +682,334 @@ msgstr ""
 msgid "Or switch to another user"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/cast.py:317
+#: jellyfin_mpv_shim/mpvtk_browser/cast.py:314
 msgid "Ready to cast"
 msgstr "準備好投放"
 
-#: jellyfin_mpv_shim/mpvtk_browser/cast.py:318
+#: jellyfin_mpv_shim/mpvtk_browser/cast.py:315
 #, fuzzy
 #| msgid "Select your media in Jellyfin and play it here"
 msgid "Select your media in Jellyfin and play it here."
 msgstr "請響 Jellyfin 度揀片同喺度播放"
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:74
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:83
 msgid "Interface"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:83
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:92
 msgid "Playback"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:88
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:97
 msgid "Audio"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:92
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:101
 msgid "Subtitles & Languages"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:97
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:106
 #, fuzzy
 #| msgid " (Transcode)"
 msgid "Transcoding"
 msgstr " (轉碼)"
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:102
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:111
 msgid "Video Enhancement"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:104
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:113
 #, fuzzy
 #| msgid "Seek to Skip Credits"
 msgid "Skip Intro / Credits"
 msgstr "快進嚟跳過片尾"
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:107
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:116
 msgid "Library Browser"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:109
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:118
 msgid "Downloads"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:128
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:137
 msgid "Jellyfin UI"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:129
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:138
 msgid "MPV UI with thumbnails"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:130
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:139
 msgid "MPV built-in default"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:133
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:142
 msgid "Follow display"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:134
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:143
 msgid "100% (no scaling)"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:135
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:144
 msgid "125%"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:136
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:145
 msgid "150%"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:137
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:146
 msgid "200%"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:140
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:149
 msgid "Automatic (recommended)"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:141
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:150
 msgid "Vulkan"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:142
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:151
 msgid "Direct3D 11 (Windows only)"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:143
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:152
 msgid "OpenGL (compatibility)"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:146
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:155
 msgid "Default (auto)"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:147
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:156
 msgid "Force Stereo"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:148
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:157
 msgid "Optical Surround"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:149
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:158
 msgid "HDMI Passthrough"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:152
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:161
 msgid "Unset"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:153
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:162
 msgid "Dubbed (shows only)"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:154
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:163
 msgid "Subbed (shows only)"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:155
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:164
 msgid "Dubbed (all)"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:156
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:165
 msgid "Subbed (all)"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:157
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:166
 msgid "Custom (set in config)"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:162
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:171
 msgid "Download Folder"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:163
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:172
 msgid "Prefer Downloaded Copy"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:164
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:173
 msgid "Automatically Download Upcoming Episodes"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:165
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:174
 msgid "Include Next Up"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:166
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:175
 msgid "Next Up Entries to Consider"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:167
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:176
 msgid "Episodes to Keep Ahead (0 = off)"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:168
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:177
 msgid "Storage Limit for Automatic Downloads (GB)"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:169
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:178
 #, fuzzy
 #| msgid "Auto Play"
 msgid "Delete Automatic Downloads Once Watched"
 msgstr "自動播放"
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:170
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:179
 msgid "Delete Unwatched After (days, 0 = never)"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:171
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:180
 msgid "Check Every (minutes)"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:172
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:181
 msgid "Close to Tray (keep running)"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:173
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:182
 msgid "Keep Running in Background"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:174
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:183
 msgid "Remember Window Size"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:175
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:184
 msgid "Player Controls Style"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:176
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:185
 msgid "Show What You're Watching in Discord"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:177
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:186
 msgid "Interface Scale"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:178
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:187
 msgid "Cast-target mode (no library browsing)"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:179
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:188
 msgid "Casting Opens the Library Browser"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:180
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:189
 msgid "Fullscreen Library Browser"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:181
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:190
 msgid "Always Bind Arrow Keys to Player Controls"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:182
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:191
 msgid "Player Controls Activation Key"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:183
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:192
 msgid "Audio Output Mode"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:184
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:193
 msgid "Audio Output Device"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:185
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:194
 msgid "Take the Device Exclusively"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:187
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:196
 #, fuzzy
 #| msgid "Video Playback Profiles"
 msgid "Enable Video Playback Profiles"
 msgstr "影片播放設定檔"
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:188
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:197
 #, fuzzy
 #| msgid "New Group"
 msgid "Profile Group"
 msgstr "新群組"
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:189
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:198
 msgid "Remember Last Used Profile"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:190
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:199
 msgid "Graphics API for Shaders"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:191
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:200
 msgid "Pass Through AC3"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:192
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:201
 msgid "Pass Through DTS"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:193
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:202
 msgid "Pass Through E-AC3"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:194
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:203
 msgid "Pass Through DTS-HD"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:195
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:204
 msgid "Pass Through TrueHD"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:196
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:205
 msgid "Re-encode Others to AC3"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:202
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:213
 msgid ""
-"MPV keybinds are used by default. Press ENTER to drive the player controls "
-"by keyboard."
+"With \"Start Minimized\" and \"Fullscreen\" this is the classic cast-target "
+"setup: the app waits out of the way, plays fullscreen when something casts "
+"to it, and goes back to waiting when the video ends or you press Q."
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:204
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:227
+msgid ""
+"Off means command-line mode: no window, no system tray and no settings "
+"screen, so the only way back is editing conf.json by hand. It is not how you "
+"get MPV's own on-screen controls — \"Player Controls Style\" under Interface "
+"does that."
+msgstr ""
+
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:234
+msgid ""
+"Show only what is cast to this machine — the library, including this "
+"settings screen, can't be reached from here. Without a system tray icon the "
+"only way back is editing conf.json. For the classic cast-target setup you "
+"want the Interface settings instead; this is for a shared TV nobody should "
+"be able to browse from."
+msgstr ""
+
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:240
+msgid ""
+"Requires restart to change. MPV keybinds are used by default. Press ENTER to "
+"drive the player controls by keyboard."
+msgstr ""
+
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:242
 msgid ""
 "Pixels one wheel notch scrolls. The scrollbar glides while the content snaps "
 "to the nearest row, so a trackpad or trackball no longer overshoots. Raise "
 "it to scroll faster, lower it for finer control."
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:209
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:247
 msgid ""
 "Make each wheel notch jump exactly one row (or one home-screen section) "
 "instead of gliding. Turn this on if you prefer the older stepped scrolling."
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:217
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:255
 msgid "Discord Rich Presence. Takes effect after a restart."
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:219
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:257
 msgid ""
 "Leave this to Default unless setting up passthrough. Note some audio servers "
 "like Pipewire don't like passthrough and will need to be disabled for a card "
@@ -993,57 +1017,57 @@ msgid ""
 "silence otherwise, but results may vary."
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:225
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:263
 msgid ""
 "Stop anything else using the device while playing. Needed for passthrough on "
 "some systems, and it means other applications will be silent."
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:228
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:266
 msgid ""
 "Page the library and music tile grids instead of scrolling: each page is one "
 "screenful with First / Previous / Next / Last controls and a page number you "
 "can type into. Easier than precise scrolling on a trackpad."
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:232
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:270
 msgid ""
 "Takes effect after a restart. \"Follow display\" uses the scale your desktop "
 "reports, which is 100% on X11."
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:234
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:272
 msgid ""
 "\"Default\" changes nothing and lets MPV (and your own mpv.conf) decide. "
 "Pick a mode only if you are sending audio to a receiver."
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:237
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:275
 msgid ""
 "Audio your receiver can't be sent directly is encoded to AC3, which is the "
 "only way surround fits down an optical cable. Turn this off if the encoder "
 "causes audio delay — those tracks become stereo instead."
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:242
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:280
 msgid ""
 "\"hq\" offers heavier profiles. Pick it if you have a fast graphics card."
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:244
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:282
 msgid ""
 "Leave on Automatic unless video breaks when a profile is loaded. This only "
 "applies while a profile is active, and OpenGL can cost you HDR output."
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:248
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:286
 msgid ""
 "Evens out loud effects and quiet dialogue. This turns passthrough off while "
 "it is enabled, because the volume has to be adjusted before your receiver "
 "gets the audio."
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/config.py:330
+#: jellyfin_mpv_shim/mpvtk_browser/config.py:368
 msgid "Advanced"
 msgstr ""
 
@@ -1243,7 +1267,7 @@ msgid "Automatic"
 msgstr "全自動"
 
 #: jellyfin_mpv_shim/mpvtk_browser/downloads.py:51
-#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1355
+#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1288
 msgid "Episodes"
 msgstr ""
 
@@ -1252,7 +1276,7 @@ msgid "Season %s"
 msgstr ""
 
 #: jellyfin_mpv_shim/mpvtk_browser/downloads.py:52
-#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1351
+#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1284
 msgid "Specials"
 msgstr ""
 
@@ -1277,7 +1301,7 @@ msgid "Failed"
 msgstr "衰咗"
 
 #: jellyfin_mpv_shim/mpvtk_browser/downloads.py:185
-#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1105
+#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1038
 msgid "Playlist"
 msgstr ""
 
@@ -1289,30 +1313,30 @@ msgstr ""
 msgid "Movies & Videos"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/home_sections.py:103
+#: jellyfin_mpv_shim/mpvtk_browser/home_sections.py:104
 msgid "My Media"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/home_sections.py:104
-#: jellyfin_mpv_shim/mpvtk_browser/repository.py:352
+#: jellyfin_mpv_shim/mpvtk_browser/home_sections.py:105
+#: jellyfin_mpv_shim/mpvtk_browser/repository.py:350
 msgid "Continue Watching"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/home_sections.py:105
-#: jellyfin_mpv_shim/mpvtk_browser/repository.py:359
+#: jellyfin_mpv_shim/mpvtk_browser/home_sections.py:106
+#: jellyfin_mpv_shim/mpvtk_browser/repository.py:357
 msgid "Continue Listening"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/home_sections.py:106
-#: jellyfin_mpv_shim/mpvtk_browser/repository.py:366
+#: jellyfin_mpv_shim/mpvtk_browser/home_sections.py:107
+#: jellyfin_mpv_shim/mpvtk_browser/repository.py:364
 msgid "Next Up"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/home_sections.py:107
+#: jellyfin_mpv_shim/mpvtk_browser/home_sections.py:108
 msgid "Recently Added"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/home_sections.py:108
+#: jellyfin_mpv_shim/mpvtk_browser/home_sections.py:109
 msgid "Live TV"
 msgstr ""
 
@@ -1545,52 +1569,52 @@ msgstr ""
 msgid "Could not load this page."
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/repository.py:390
+#: jellyfin_mpv_shim/mpvtk_browser/repository.py:386
 msgid "On Now"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/repository.py:411
+#: jellyfin_mpv_shim/mpvtk_browser/repository.py:407
 msgid "Latest %s"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1119
+#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1052
 msgid "Downloaded"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1138
+#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1071
 msgid "Movies"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1143
+#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1076
 msgid "Videos"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1147
+#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1080
 msgid "TV Shows"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1151
+#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1084
 msgid "Playlists"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1168
-#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1441
+#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1101
+#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1374
 msgid "Series"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1212
+#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1145
 msgid "Downloaded Movies"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1216
+#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1149
 msgid "Downloaded Videos"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1220
+#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1153
 msgid "Downloaded Shows"
 msgstr ""
 
-#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1353
+#: jellyfin_mpv_shim/mpvtk_browser/repository.py:1286
 msgid "Season %d"
 msgstr ""
 

--- a/jellyfin_mpv_shim/mpvtk/layout.py
+++ b/jellyfin_mpv_shim/mpvtk/layout.py
@@ -243,6 +243,82 @@ def natural_size(el):
     return measure(el)
 
 
+def measure_h(el, avail_w):
+    """Natural height of ``el`` when the width it will get is known.
+
+    ``measure`` is *intrinsic*: with no width to wrap against, a
+    ``wrap=True`` Text with no explicit ``w`` measures one line tall. That
+    is the right answer to "how wide would this like to be" and the wrong
+    one for "how tall will this end up", and the gap is not cosmetic — a
+    scroll viewport takes its content height from a measure, so a column of
+    wrapped notes reported a content height short by however much the text
+    wrapped, and the scrollbar stopped before the last rows. The settings
+    form was unreachable below its notes.
+
+    ``_arrange_children`` stays the authority on the final geometry; this
+    agrees with it for the cases that decide a scroll extent (columns,
+    wrapped text, nesting) and approximates a Row's flex distribution
+    without re-running it.
+    """
+    if el.h is not None:
+        return _clamp_wh(el, 0.0, float(el.h), avail_w)[1]
+    return _clamp_wh(el, 0.0, _measure_h(el, avail_w), avail_w)[1]
+
+
+def _measure_h(el, avail_w):
+    if isinstance(el, Text) and el.wrap:
+        n = len(_wrap_lines(el, max(1.0, el.w if el.w is not None
+                                    else avail_w)))
+        if el.max_lines is not None:
+            n = min(n, el.max_lines)
+        return n * el.size * LINE_H
+    if isinstance(el, Stack):
+        return max([measure_h(c, avail_w) for c in el.children], default=0.0)
+    if isinstance(el, Box):
+        return _measure_box_h(el, avail_w)
+    # Scroll (its own viewport), Grid (rows measured against their tracks)
+    # and the leaf widgets have no width-dependent height.
+    return _measure(el)[1]
+
+
+def _measure_box_h(el, avail_w):
+    px, py = _pad2(el)
+    inner = max(0.0, avail_w - 2 * px)
+    kids = el.children
+    if not kids:
+        return 2 * py
+    if el.direction == "row":
+        # Widths come from the flex pass in _arrange_children. Reproducing
+        # its floors would be reproducing it; natural widths plus flex
+        # growth (and a proportional squeeze when they overflow) is close
+        # enough for a height, and a Row of wrapped text is rare — the
+        # notes that motivated this are column children.
+        widths = [float(c.w) if c.w is not None else measure(c)[0]
+                  for c in kids]
+        slack = inner - sum(widths) - el.gap * (len(kids) - 1)
+        flex_total = sum(c.flex for c in kids if c.flex > 0)
+        if slack > 0 and flex_total:
+            widths = [w + slack * c.flex / flex_total if c.flex > 0 else w
+                      for c, w in zip(kids, widths)]
+        elif slack < 0 and sum(widths) > 0:
+            k = max(0.0, inner) / sum(widths)
+            widths = [w * k for w in widths]
+        return max(measure_h(c, w)
+                   for c, w in zip(kids, widths)) + 2 * py
+    total = el.gap * (len(kids) - 1) + 2 * py
+    for c in kids:
+        # Same cross-axis rule _arrange_children applies: stretch fills the
+        # column, anything else takes its natural width capped at it.
+        if c.w is not None:
+            cw = float(c.w)
+        elif el.align == "stretch":
+            cw = inner
+        else:
+            cw = min(measure(c)[0], inner)
+        total += measure_h(c, cw)
+    return total
+
+
 def _measure(el):
     """Natural (width, height) of an element, ignoring flex."""
     if isinstance(el, Text):
@@ -707,6 +783,10 @@ def _arrange_overlay(ctx, el, x, y, w, h, sc, path):
     """Dialog and Float: positioned against the window, not the parent."""
     cw, ch = measure(el.child)
     cw, ch = _clamp_wh(el.child, cw, ch, ctx.root_w, ctx.root_h)
+    # Width first (a dialog is as wide as it wants to be), then the height
+    # that width implies -- otherwise wrapped body text sits outside the
+    # panel it is supposed to be inside.
+    ch = max(ch, measure_h(el.child, cw))
     if isinstance(el, Dialog):
         dx = (ctx.root_w - cw) / 2
         dy = max(0.0, (ctx.root_h - ch) / 2.5)
@@ -810,11 +890,16 @@ def _arrange_scroll(ctx, el, x, y, w, h, sc, path):
     if el.scrollbar and el.axis == "y":
         inner_w -= SCROLLBAR_W
         node["bar"] = True
-    cw, ch = measure(el.child)
     if el.axis == "x":
+        cw, ch = measure(el.child)
         cw, ch = max(cw, inner_w), inner_h
     else:
-        cw, ch = inner_w, max(ch, inner_h)
+        # measure_h, not measure: the child is about to be arranged at
+        # inner_w, and its wrapped text is only as tall as that width makes
+        # it. An intrinsic measure here reported a content height that
+        # stopped short of the content, and the scroll clamped to it.
+        cw = inner_w
+        ch = max(measure_h(el.child, inner_w), inner_h)
     node["cw"] = _round(cw)
     node["ch"] = _round(ch)
     if el.follow:

--- a/jellyfin_mpv_shim/mpvtk_browser/config.py
+++ b/jellyfin_mpv_shim/mpvtk_browser/config.py
@@ -71,9 +71,18 @@ BACKGROUND_DEPENDENT = ("start_minimized",)
 # Curated groups, mirroring the Tk browser's form. Anything not listed shows
 # under "Advanced".
 SECTIONS = [
+    # enable_gui and headless are deliberately *not* here. Both are one-way
+    # doors from the settings form's point of view: enable_gui doesn't
+    # disable "the Jellyfin UI", it drops the whole app to CLI mode -- no
+    # window, no tray, no settings -- and headless makes the cast screen the
+    # only page, so with no system tray installed there is nothing left to
+    # reach Settings from. Either way the way back is hand-editing conf.json,
+    # which is not a thing to leave one click away in the main list. They stay
+    # editable under Advanced, with notes saying what they cost. Someone who
+    # wants mpv's own controls wants osc_style, which is in this section.
     (_("Interface"), ["player_name", "browser_fullscreen",
-                      "headless", "display_mirror_summon",
-                      "enable_gui", "close_to_tray", "allow_background",
+                      "display_mirror_summon",
+                      "close_to_tray", "allow_background",
                       "start_minimized",
                       "remember_window_size",
                       "fullscreen", "ui_scale", "enable_osc", "osc_style",
@@ -196,10 +205,39 @@ LABEL_OVERRIDES = {
     "audio_optical_encode_ac3": _("Re-encode Others to AC3"),
 }
 
+# The classic MPV Shim behaviour is three ordinary settings and nothing said
+# so, which is how people ended up reaching for enable_gui (which does
+# something else entirely) to get it. Shown under whichever keep-running
+# toggle this machine has -- they are the same question, so the recipe reads
+# the same under either.
+CAST_TARGET_NOTE = _(
+    "With \"Start Minimized\" and \"Fullscreen\" this is the classic "
+    "cast-target setup: the app waits out of the way, plays fullscreen when "
+    "something casts to it, and goes back to waiting when the video ends or "
+    "you press Q.")
+
 # Explanatory line rendered under a setting, for the ones whose default
 # isn't self-explanatory from the label alone.
 NOTES = {
-    "osc_style": _("MPV keybinds are used by default. Press ENTER to drive "
+    "close_to_tray": CAST_TARGET_NOTE,
+    "allow_background": CAST_TARGET_NOTE,
+    # Advanced-only (see SECTIONS), and the note is why: it reads like "turn
+    # off the Jellyfin UI", and what it actually does is leave a Windows user
+    # with a process they can neither see nor quit.
+    "enable_gui": _("Off means command-line mode: no window, no system tray "
+                    "and no settings screen, so the only way back is editing "
+                    "conf.json by hand. It is not how you get MPV's own "
+                    "on-screen controls — \"Player Controls Style\" under "
+                    "Interface does that."),
+    # Advanced-only for the same reason as enable_gui: with no tray icon
+    # installed, the cast screen is the only page and Settings is gone.
+    "headless": _("Show only what is cast to this machine — the library, "
+                  "including this settings screen, can't be reached from "
+                  "here. Without a system tray icon the only way back is "
+                  "editing conf.json. For the classic cast-target setup you "
+                  "want the Interface settings instead; this is for a shared "
+                  "TV nobody should be able to browse from."),
+    "osc_style": _("Requires restart to change. MPV keybinds are used by default. Press ENTER to drive "
                    "the player controls by keyboard."),
     "scroll_wheel_pixels": _("Pixels one wheel notch scrolls. The scrollbar "
                              "glides while the content snaps to the nearest "

--- a/tests/snapshots/settings.jsonl
+++ b/tests/snapshots/settings.jsonl
@@ -22,234 +22,229 @@
 {"align": "center", "c": "e8e8e8", "h": 25.0, "id": "r.1.0.0.3.0", "size": 20, "t": "text", "text": "Downloads", "w": 99.4, "x": 436.4, "y": 82.0}
 {"click": true, "fill": "2e3138", "h": 45.0, "hover": {"fill": "4a4a4a"}, "id": "stab-logs", "radius": 6, "t": "rect", "w": 63.2, "x": 553.8, "y": 72.0}
 {"align": "center", "c": "e8e8e8", "h": 25.0, "id": "r.1.0.0.4.0", "size": 20, "t": "text", "text": "Logs", "w": 43.2, "x": 563.8, "y": 82.0}
-{"axis": "y", "bar": true, "ch": 3353.5, "cw": 1270.0, "h": 591.0, "id": "settings", "t": "scroll", "w": 1280.0, "x": 0.0, "y": 129.0}
+{"axis": "y", "bar": true, "ch": 3383.0, "cw": 1270.0, "h": 591.0, "id": "settings", "t": "scroll", "w": 1280.0, "x": 0.0, "y": 129.0}
 {"align": "left", "bold": true, "c": "eeeeee", "h": 25.0, "id": "r.1.1.0.0", "sc": "settings", "size": 20, "t": "text", "text": "Interface", "w": 1238.0, "x": 16.0, "y": 145.0}
 {"align": "left", "c": "9aa0a6", "h": 21.2, "id": "r.1.1.0.1.0", "sc": "settings", "size": 17, "t": "text", "text": "Player Name", "w": 340.0, "x": 16.0, "y": 186.4}
 {"h": 38.0, "id": "set-player_name", "ph": "", "sc": "settings", "size": 20, "t": "textbox", "text": "izzie-pc", "w": 340.0, "x": 368.0, "y": 178.0}
 {"click": true, "h": 25.0, "hover": {"c": "ffffff"}, "id": "set-browser_fullscreen", "sc": "settings", "t": "rect", "w": 1238.0, "x": 16.0, "y": 224.0}
 {"bc": "555555", "bw": 1, "fill": "2a2a2a", "h": 20.0, "id": "r.1.1.0.2.0", "radius": 5, "sc": "settings", "t": "rect", "w": 20.0, "x": 16.0, "y": 226.5}
 {"align": "left", "c": "eeeeee", "h": 25.0, "id": "r.1.1.0.2.1", "sc": "settings", "size": 20, "t": "text", "text": "Fullscreen Library Browser", "w": 245.4, "x": 46.0, "y": 224.0}
-{"click": true, "h": 25.0, "hover": {"c": "ffffff"}, "id": "set-headless", "sc": "settings", "t": "rect", "w": 1238.0, "x": 16.0, "y": 257.0}
+{"click": true, "h": 25.0, "hover": {"c": "ffffff"}, "id": "set-display_mirror_summon", "sc": "settings", "t": "rect", "w": 1238.0, "x": 16.0, "y": 257.0}
 {"bc": "555555", "bw": 1, "fill": "2a2a2a", "h": 20.0, "id": "r.1.1.0.3.0", "radius": 5, "sc": "settings", "t": "rect", "w": 20.0, "x": 16.0, "y": 259.5}
-{"align": "left", "c": "eeeeee", "h": 25.0, "id": "r.1.1.0.3.1", "sc": "settings", "size": 20, "t": "text", "text": "Cast-target mode (no library browsing)", "w": 355.6, "x": 46.0, "y": 257.0}
-{"click": true, "h": 25.0, "hover": {"c": "ffffff"}, "id": "set-display_mirror_summon", "sc": "settings", "t": "rect", "w": 1238.0, "x": 16.0, "y": 290.0}
+{"align": "left", "c": "eeeeee", "h": 25.0, "id": "r.1.1.0.3.1", "sc": "settings", "size": 20, "t": "text", "text": "Casting Opens the Library Browser", "w": 311.4, "x": 46.0, "y": 257.0}
+{"click": true, "h": 25.0, "hover": {"c": "ffffff"}, "id": "set-allow_background", "sc": "settings", "t": "rect", "w": 1238.0, "x": 16.0, "y": 290.0}
 {"bc": "555555", "bw": 1, "fill": "2a2a2a", "h": 20.0, "id": "r.1.1.0.4.0", "radius": 5, "sc": "settings", "t": "rect", "w": 20.0, "x": 16.0, "y": 292.5}
-{"align": "left", "c": "eeeeee", "h": 25.0, "id": "r.1.1.0.4.1", "sc": "settings", "size": 20, "t": "text", "text": "Casting Opens the Library Browser", "w": 311.4, "x": 46.0, "y": 290.0}
-{"click": true, "h": 25.0, "hover": {"c": "ffffff"}, "id": "set-enable_gui", "sc": "settings", "t": "rect", "w": 1238.0, "x": 16.0, "y": 323.0}
-{"fill": "00a4dc", "h": 20.0, "id": "r.1.1.0.5.0", "radius": 5, "sc": "settings", "t": "rect", "w": 20.0, "x": 16.0, "y": 325.5}
-{"align": "center", "c": "ffffff", "h": 18.8, "id": "r.1.1.0.5.0.0", "sc": "settings", "size": 15, "t": "text", "text": "\u2713", "w": 20.0, "x": 16.0, "y": 326.1}
-{"align": "left", "c": "eeeeee", "h": 25.0, "id": "r.1.1.0.5.1", "sc": "settings", "size": 20, "t": "text", "text": "Enable GUI", "w": 95.2, "x": 46.0, "y": 323.0}
-{"click": true, "h": 25.0, "hover": {"c": "ffffff"}, "id": "set-allow_background", "sc": "settings", "t": "rect", "w": 1238.0, "x": 16.0, "y": 356.0}
-{"bc": "555555", "bw": 1, "fill": "2a2a2a", "h": 20.0, "id": "r.1.1.0.6.0", "radius": 5, "sc": "settings", "t": "rect", "w": 20.0, "x": 16.0, "y": 358.5}
-{"align": "left", "c": "eeeeee", "h": 25.0, "id": "r.1.1.0.6.1", "sc": "settings", "size": 20, "t": "text", "text": "Keep Running in Background", "w": 254.4, "x": 46.0, "y": 356.0}
-{"click": true, "h": 25.0, "hover": {"c": "ffffff"}, "id": "set-remember_window_size", "sc": "settings", "t": "rect", "w": 1238.0, "x": 16.0, "y": 389.0}
-{"fill": "00a4dc", "h": 20.0, "id": "r.1.1.0.7.0", "radius": 5, "sc": "settings", "t": "rect", "w": 20.0, "x": 16.0, "y": 391.5}
-{"align": "center", "c": "ffffff", "h": 18.8, "id": "r.1.1.0.7.0.0", "sc": "settings", "size": 15, "t": "text", "text": "\u2713", "w": 20.0, "x": 16.0, "y": 392.1}
-{"align": "left", "c": "eeeeee", "h": 25.0, "id": "r.1.1.0.7.1", "sc": "settings", "size": 20, "t": "text", "text": "Remember Window Size", "w": 219.2, "x": 46.0, "y": 389.0}
-{"click": true, "h": 25.0, "hover": {"c": "ffffff"}, "id": "set-fullscreen", "sc": "settings", "t": "rect", "w": 1238.0, "x": 16.0, "y": 422.0}
-{"bc": "555555", "bw": 1, "fill": "2a2a2a", "h": 20.0, "id": "r.1.1.0.8.0", "radius": 5, "sc": "settings", "t": "rect", "w": 20.0, "x": 16.0, "y": 424.5}
-{"align": "left", "c": "eeeeee", "h": 25.0, "id": "r.1.1.0.8.1", "sc": "settings", "size": 20, "t": "text", "text": "Fullscreen", "w": 96.0, "x": 46.0, "y": 422.0}
-{"align": "left", "c": "9aa0a6", "h": 21.2, "id": "r.1.1.0.9.0", "sc": "settings", "size": 17, "t": "text", "text": "Interface Scale", "w": 340.0, "x": 16.0, "y": 463.4}
-{"force": true, "h": 38.0, "id": "set-ui_scale", "items": ["Follow display", "100% (no scaling)", "125%", "150%", "200%"], "sc": "settings", "sel": 0, "size": 20, "t": "dropdown", "w": 340.0, "x": 368.0, "y": 455.0}
-{"align": "left", "c": "9aa0a6", "h": 17.5, "id": "r.1.1.0.10", "sc": "settings", "size": 14, "t": "text", "text": "Takes effect after a restart. \"Follow display\" uses the scale your desktop reports, which is 100% on X11.", "w": 1238.0, "x": 16.0, "y": 501.0}
-{"click": true, "h": 25.0, "hover": {"c": "ffffff"}, "id": "set-enable_osc", "sc": "settings", "t": "rect", "w": 1238.0, "x": 16.0, "y": 526.5}
-{"fill": "00a4dc", "h": 20.0, "id": "r.1.1.0.11.0", "radius": 5, "sc": "settings", "t": "rect", "w": 20.0, "x": 16.0, "y": 529.0}
-{"align": "center", "c": "ffffff", "h": 18.8, "id": "r.1.1.0.11.0.0", "sc": "settings", "size": 15, "t": "text", "text": "\u2713", "w": 20.0, "x": 16.0, "y": 529.6}
-{"align": "left", "c": "eeeeee", "h": 25.0, "id": "r.1.1.0.11.1", "sc": "settings", "size": 20, "t": "text", "text": "Enable OSC", "w": 99.2, "x": 46.0, "y": 526.5}
-{"align": "left", "c": "9aa0a6", "h": 21.2, "id": "r.1.1.0.12.0", "sc": "settings", "size": 17, "t": "text", "text": "Player Controls Style", "w": 340.0, "x": 16.0, "y": 567.9}
-{"force": true, "h": 38.0, "id": "set-osc_style", "items": ["Jellyfin UI", "MPV UI with thumbnails", "MPV built-in default"], "sc": "settings", "sel": 0, "size": 20, "t": "dropdown", "w": 340.0, "x": 368.0, "y": 559.5}
-{"align": "left", "c": "9aa0a6", "h": 17.5, "id": "r.1.1.0.13", "sc": "settings", "size": 14, "t": "text", "text": "MPV keybinds are used by default. Press ENTER to drive the player controls by keyboard.", "w": 1238.0, "x": 16.0, "y": 605.5}
-{"click": true, "h": 25.0, "hover": {"c": "ffffff"}, "id": "set-hud_grab_keys", "sc": "settings", "t": "rect", "w": 1238.0, "x": 16.0, "y": 631.0}
-{"bc": "555555", "bw": 1, "fill": "2a2a2a", "h": 20.0, "id": "r.1.1.0.14.0", "radius": 5, "sc": "settings", "t": "rect", "w": 20.0, "x": 16.0, "y": 633.5}
-{"align": "left", "c": "eeeeee", "h": 25.0, "id": "r.1.1.0.14.1", "sc": "settings", "size": 20, "t": "text", "text": "Always Bind Arrow Keys to Player Controls", "w": 386.4, "x": 46.0, "y": 631.0}
-{"align": "left", "c": "9aa0a6", "h": 21.2, "id": "r.1.1.0.15.0", "sc": "settings", "size": 17, "t": "text", "text": "Player Controls Activation Key", "w": 340.0, "x": 16.0, "y": 672.4}
-{"h": 38.0, "id": "set-hud_wake_key", "ph": "", "sc": "settings", "size": 20, "t": "textbox", "text": "ENTER", "w": 340.0, "x": 368.0, "y": 664.0}
-{"click": true, "h": 25.0, "hover": {"c": "ffffff"}, "id": "set-raise_mpv", "sc": "settings", "t": "rect", "w": 1238.0, "x": 16.0, "y": 710.0}
-{"fill": "00a4dc", "h": 20.0, "id": "r.1.1.0.16.0", "radius": 5, "sc": "settings", "t": "rect", "w": 20.0, "x": 16.0, "y": 712.5}
-{"align": "center", "c": "ffffff", "h": 18.8, "id": "r.1.1.0.16.0.0", "sc": "settings", "size": 15, "t": "text", "text": "\u2713", "w": 20.0, "x": 16.0, "y": 713.1}
-{"align": "left", "c": "eeeeee", "h": 25.0, "id": "r.1.1.0.16.1", "sc": "settings", "size": 20, "t": "text", "text": "Raise MPV", "w": 94.6, "x": 46.0, "y": 710.0}
-{"click": true, "h": 25.0, "hover": {"c": "ffffff"}, "id": "set-discord_presence", "sc": "settings", "t": "rect", "w": 1238.0, "x": 16.0, "y": 743.0}
-{"bc": "555555", "bw": 1, "fill": "2a2a2a", "h": 20.0, "id": "r.1.1.0.17.0", "radius": 5, "sc": "settings", "t": "rect", "w": 20.0, "x": 16.0, "y": 745.5}
-{"align": "left", "c": "eeeeee", "h": 25.0, "id": "r.1.1.0.17.1", "sc": "settings", "size": 20, "t": "text", "text": "Show What You're Watching in Discord", "w": 351.4, "x": 46.0, "y": 743.0}
-{"align": "left", "c": "9aa0a6", "h": 17.5, "id": "r.1.1.0.18", "sc": "settings", "size": 14, "t": "text", "text": "Discord Rich Presence. Takes effect after a restart.", "w": 1238.0, "x": 16.0, "y": 776.0}
-{"click": true, "h": 25.0, "hover": {"c": "ffffff"}, "id": "set-check_updates", "sc": "settings", "t": "rect", "w": 1238.0, "x": 16.0, "y": 801.5}
-{"fill": "00a4dc", "h": 20.0, "id": "r.1.1.0.19.0", "radius": 5, "sc": "settings", "t": "rect", "w": 20.0, "x": 16.0, "y": 804.0}
-{"align": "center", "c": "ffffff", "h": 18.8, "id": "r.1.1.0.19.0.0", "sc": "settings", "size": 15, "t": "text", "text": "\u2713", "w": 20.0, "x": 16.0, "y": 804.6}
-{"align": "left", "c": "eeeeee", "h": 25.0, "id": "r.1.1.0.19.1", "sc": "settings", "size": 20, "t": "text", "text": "Check Updates", "w": 131.6, "x": 46.0, "y": 801.5}
-{"click": true, "h": 25.0, "hover": {"c": "ffffff"}, "id": "set-notify_updates", "sc": "settings", "t": "rect", "w": 1238.0, "x": 16.0, "y": 834.5}
-{"fill": "00a4dc", "h": 20.0, "id": "r.1.1.0.20.0", "radius": 5, "sc": "settings", "t": "rect", "w": 20.0, "x": 16.0, "y": 837.0}
-{"align": "center", "c": "ffffff", "h": 18.8, "id": "r.1.1.0.20.0.0", "sc": "settings", "size": 15, "t": "text", "text": "\u2713", "w": 20.0, "x": 16.0, "y": 837.6}
-{"align": "left", "c": "eeeeee", "h": 25.0, "id": "r.1.1.0.20.1", "sc": "settings", "size": 20, "t": "text", "text": "Notify Updates", "w": 130.4, "x": 46.0, "y": 834.5}
-{"align": "left", "bold": true, "c": "eeeeee", "h": 25.0, "id": "r.1.1.0.21", "sc": "settings", "size": 20, "t": "text", "text": "Playback", "w": 1238.0, "x": 16.0, "y": 867.5}
-{"click": true, "h": 25.0, "hover": {"c": "ffffff"}, "id": "set-auto_play", "sc": "settings", "t": "rect", "w": 1238.0, "x": 16.0, "y": 900.5}
-{"fill": "00a4dc", "h": 20.0, "id": "r.1.1.0.22.0", "radius": 5, "sc": "settings", "t": "rect", "w": 20.0, "x": 16.0, "y": 903.0}
-{"align": "center", "c": "ffffff", "h": 18.8, "id": "r.1.1.0.22.0.0", "sc": "settings", "size": 15, "t": "text", "text": "\u2713", "w": 20.0, "x": 16.0, "y": 903.6}
-{"align": "left", "c": "eeeeee", "h": 25.0, "id": "r.1.1.0.22.1", "sc": "settings", "size": 20, "t": "text", "text": "Auto Play", "w": 84.4, "x": 46.0, "y": 900.5}
-{"click": true, "h": 25.0, "hover": {"c": "ffffff"}, "id": "set-always_transcode", "sc": "settings", "t": "rect", "w": 1238.0, "x": 16.0, "y": 933.5}
-{"bc": "555555", "bw": 1, "fill": "2a2a2a", "h": 20.0, "id": "r.1.1.0.23.0", "radius": 5, "sc": "settings", "t": "rect", "w": 20.0, "x": 16.0, "y": 936.0}
-{"align": "left", "c": "eeeeee", "h": 25.0, "id": "r.1.1.0.23.1", "sc": "settings", "size": 20, "t": "text", "text": "Always Transcode", "w": 166.2, "x": 46.0, "y": 933.5}
-{"align": "left", "c": "9aa0a6", "h": 21.2, "id": "r.1.1.0.24.0", "sc": "settings", "size": 17, "t": "text", "text": "Local kbps", "w": 340.0, "x": 16.0, "y": 974.9}
-{"h": 38.0, "id": "set-local_kbps", "ph": "", "sc": "settings", "size": 20, "t": "textbox", "text": "2147483", "w": 340.0, "x": 368.0, "y": 966.5}
-{"align": "left", "c": "9aa0a6", "h": 21.2, "id": "r.1.1.0.25.0", "sc": "settings", "size": 17, "t": "text", "text": "Remote kbps", "w": 340.0, "x": 16.0, "y": 1020.9}
-{"h": 38.0, "id": "set-remote_kbps", "ph": "", "sc": "settings", "size": 20, "t": "textbox", "text": "10000", "w": 340.0, "x": 368.0, "y": 1012.5}
-{"click": true, "h": 25.0, "hover": {"c": "ffffff"}, "id": "set-direct_paths", "sc": "settings", "t": "rect", "w": 1238.0, "x": 16.0, "y": 1058.5}
-{"bc": "555555", "bw": 1, "fill": "2a2a2a", "h": 20.0, "id": "r.1.1.0.26.0", "radius": 5, "sc": "settings", "t": "rect", "w": 20.0, "x": 16.0, "y": 1061.0}
-{"align": "left", "c": "eeeeee", "h": 25.0, "id": "r.1.1.0.26.1", "sc": "settings", "size": 20, "t": "text", "text": "Direct Paths", "w": 108.8, "x": 46.0, "y": 1058.5}
-{"click": true, "h": 25.0, "hover": {"c": "ffffff"}, "id": "set-remote_direct_paths", "sc": "settings", "t": "rect", "w": 1238.0, "x": 16.0, "y": 1091.5}
-{"bc": "555555", "bw": 1, "fill": "2a2a2a", "h": 20.0, "id": "r.1.1.0.27.0", "radius": 5, "sc": "settings", "t": "rect", "w": 20.0, "x": 16.0, "y": 1094.0}
-{"align": "left", "c": "eeeeee", "h": 25.0, "id": "r.1.1.0.27.1", "sc": "settings", "size": 20, "t": "text", "text": "Remote Direct Paths", "w": 181.8, "x": 46.0, "y": 1091.5}
-{"align": "left", "c": "9aa0a6", "h": 21.2, "id": "r.1.1.0.28.0", "sc": "settings", "size": 17, "t": "text", "text": "Playback Timeout", "w": 340.0, "x": 16.0, "y": 1132.9}
-{"h": 38.0, "id": "set-playback_timeout", "ph": "", "sc": "settings", "size": 20, "t": "textbox", "text": "30", "w": 340.0, "x": 368.0, "y": 1124.5}
-{"align": "left", "bold": true, "c": "eeeeee", "h": 25.0, "id": "r.1.1.0.29", "sc": "settings", "size": 20, "t": "text", "text": "Audio", "w": 1238.0, "x": 16.0, "y": 1170.5}
-{"align": "left", "c": "9aa0a6", "h": 21.2, "id": "r.1.1.0.30.0", "sc": "settings", "size": 17, "t": "text", "text": "Audio Output Device", "w": 340.0, "x": 16.0, "y": 1211.9}
-{"h": 38.0, "id": "set-audio_device", "ph": "", "sc": "settings", "size": 20, "t": "textbox", "text": "", "w": 340.0, "x": 368.0, "y": 1203.5}
-{"align": "left", "c": "9aa0a6", "h": 17.5, "id": "r.1.1.0.31", "sc": "settings", "size": 14, "t": "text", "text": "Leave this to Default unless setting up passthrough. Note some audio servers like Pipewire don't like passthrough and will need to be disabled for a card before it'll let *any* audio through in", "w": 1238.0, "x": 16.0, "y": 1249.5}
-{"align": "left", "c": "9aa0a6", "h": 17.5, "id": "r.1.1.0.31.l1", "sc": "settings", "size": 14, "t": "text", "text": "passthrough mode. In my tests I got silence otherwise, but results may vary.", "w": 1238.0, "x": 16.0, "y": 1267.0}
-{"align": "left", "c": "9aa0a6", "h": 21.2, "id": "r.1.1.0.32.0", "sc": "settings", "size": 17, "t": "text", "text": "Audio Output Mode", "w": 340.0, "x": 16.0, "y": 1300.9}
-{"force": true, "h": 38.0, "id": "set-audio_mode", "items": ["Default (auto)", "Force Stereo", "Optical Surround", "HDMI Passthrough"], "sc": "settings", "sel": 0, "size": 20, "t": "dropdown", "w": 340.0, "x": 368.0, "y": 1292.5}
-{"align": "left", "c": "9aa0a6", "h": 17.5, "id": "r.1.1.0.33", "sc": "settings", "size": 14, "t": "text", "text": "\"Default\" changes nothing and lets MPV (and your own mpv.conf) decide. Pick a mode only if you are sending audio to a receiver.", "w": 1238.0, "x": 16.0, "y": 1338.5}
-{"click": true, "h": 25.0, "hover": {"c": "ffffff"}, "id": "set-audio_night_mode", "sc": "settings", "t": "rect", "w": 1238.0, "x": 16.0, "y": 1364.0}
-{"bc": "555555", "bw": 1, "fill": "2a2a2a", "h": 20.0, "id": "r.1.1.0.34.0", "radius": 5, "sc": "settings", "t": "rect", "w": 20.0, "x": 16.0, "y": 1366.5}
-{"align": "left", "c": "eeeeee", "h": 25.0, "id": "r.1.1.0.34.1", "sc": "settings", "size": 20, "t": "text", "text": "Night Mode (Auto Volume Adj)", "w": 267.6, "x": 46.0, "y": 1364.0}
-{"align": "left", "c": "9aa0a6", "h": 17.5, "id": "r.1.1.0.35", "sc": "settings", "size": 14, "t": "text", "text": "Evens out loud effects and quiet dialogue. This turns passthrough off while it is enabled, because the volume has to be adjusted before your receiver gets the audio.", "w": 1238.0, "x": 16.0, "y": 1397.0}
-{"align": "left", "bold": true, "c": "eeeeee", "h": 25.0, "id": "r.1.1.0.36", "sc": "settings", "size": 20, "t": "text", "text": "Subtitles & Languages", "w": 1238.0, "x": 16.0, "y": 1422.5}
-{"align": "left", "c": "9aa0a6", "h": 21.2, "id": "r.1.1.0.37.0", "sc": "settings", "size": 17, "t": "text", "text": "Subtitle Size", "w": 340.0, "x": 16.0, "y": 1463.9}
-{"h": 38.0, "id": "set-subtitle_size", "ph": "", "sc": "settings", "size": 20, "t": "textbox", "text": "100", "w": 340.0, "x": 368.0, "y": 1455.5}
-{"align": "left", "c": "9aa0a6", "h": 21.2, "id": "r.1.1.0.38.0", "sc": "settings", "size": 17, "t": "text", "text": "Subtitle Color", "w": 340.0, "x": 16.0, "y": 1509.9}
-{"h": 38.0, "id": "set-subtitle_color", "ph": "", "sc": "settings", "size": 20, "t": "textbox", "text": "#FFFFFFFF", "w": 340.0, "x": 368.0, "y": 1501.5}
-{"align": "left", "c": "9aa0a6", "h": 21.2, "id": "r.1.1.0.39.0", "sc": "settings", "size": 17, "t": "text", "text": "Subtitle Position", "w": 340.0, "x": 16.0, "y": 1555.9}
-{"force": true, "h": 38.0, "id": "set-subtitle_position", "items": ["top", "bottom", "middle"], "sc": "settings", "sel": 1, "size": 20, "t": "dropdown", "w": 340.0, "x": 368.0, "y": 1547.5}
-{"align": "left", "c": "9aa0a6", "h": 21.2, "id": "r.1.1.0.40.0", "sc": "settings", "size": 17, "t": "text", "text": "Language Preference", "w": 340.0, "x": 16.0, "y": 1601.9}
-{"force": true, "h": 38.0, "id": "set-language_preference", "items": ["Unset", "Dubbed (shows only)", "Subbed (shows only)", "Dubbed (all)", "Subbed (all)", "Custom (set in config)"], "sc": "settings", "sel": 5, "size": 20, "t": "dropdown", "w": 340.0, "x": 368.0, "y": 1593.5}
-{"align": "left", "c": "9aa0a6", "h": 21.2, "id": "r.1.1.0.41.0", "sc": "settings", "size": 17, "t": "text", "text": "Preferred Language", "w": 340.0, "x": 16.0, "y": 1647.9}
-{"h": 38.0, "id": "set-preferred_language", "ph": "", "sc": "settings", "size": 20, "t": "textbox", "text": "eng", "w": 340.0, "x": 368.0, "y": 1639.5}
-{"click": true, "h": 25.0, "hover": {"c": "ffffff"}, "id": "set-remember_audio_track", "sc": "settings", "t": "rect", "w": 1238.0, "x": 16.0, "y": 1685.5}
-{"fill": "00a4dc", "h": 20.0, "id": "r.1.1.0.42.0", "radius": 5, "sc": "settings", "t": "rect", "w": 20.0, "x": 16.0, "y": 1688.0}
-{"align": "center", "c": "ffffff", "h": 18.8, "id": "r.1.1.0.42.0.0", "sc": "settings", "size": 15, "t": "text", "text": "\u2713", "w": 20.0, "x": 16.0, "y": 1688.6}
-{"align": "left", "c": "eeeeee", "h": 25.0, "id": "r.1.1.0.42.1", "sc": "settings", "size": 20, "t": "text", "text": "Remember Audio Track", "w": 206.8, "x": 46.0, "y": 1685.5}
-{"click": true, "h": 25.0, "hover": {"c": "ffffff"}, "id": "set-remember_subtitle_track", "sc": "settings", "t": "rect", "w": 1238.0, "x": 16.0, "y": 1718.5}
-{"fill": "00a4dc", "h": 20.0, "id": "r.1.1.0.43.0", "radius": 5, "sc": "settings", "t": "rect", "w": 20.0, "x": 16.0, "y": 1721.0}
-{"align": "center", "c": "ffffff", "h": 18.8, "id": "r.1.1.0.43.0.0", "sc": "settings", "size": 15, "t": "text", "text": "\u2713", "w": 20.0, "x": 16.0, "y": 1721.6}
-{"align": "left", "c": "eeeeee", "h": 25.0, "id": "r.1.1.0.43.1", "sc": "settings", "size": 20, "t": "text", "text": "Remember Subtitle Track", "w": 227.2, "x": 46.0, "y": 1718.5}
-{"align": "left", "c": "9aa0a6", "h": 21.2, "id": "r.1.1.0.44.0", "sc": "settings", "size": 17, "t": "text", "text": "Lang Filter", "w": 340.0, "x": 16.0, "y": 1759.9}
-{"h": 38.0, "id": "set-lang_filter", "ph": "", "sc": "settings", "size": 20, "t": "textbox", "text": "und,eng,jpn,mis,mul,zxx", "w": 340.0, "x": 368.0, "y": 1751.5}
-{"click": true, "h": 25.0, "hover": {"c": "ffffff"}, "id": "set-lang_filter_sub", "sc": "settings", "t": "rect", "w": 1238.0, "x": 16.0, "y": 1797.5}
-{"bc": "555555", "bw": 1, "fill": "2a2a2a", "h": 20.0, "id": "r.1.1.0.45.0", "radius": 5, "sc": "settings", "t": "rect", "w": 20.0, "x": 16.0, "y": 1800.0}
-{"align": "left", "c": "eeeeee", "h": 25.0, "id": "r.1.1.0.45.1", "sc": "settings", "size": 20, "t": "text", "text": "Lang Filter Sub", "w": 136.4, "x": 46.0, "y": 1797.5}
-{"click": true, "h": 25.0, "hover": {"c": "ffffff"}, "id": "set-lang_filter_audio", "sc": "settings", "t": "rect", "w": 1238.0, "x": 16.0, "y": 1830.5}
-{"bc": "555555", "bw": 1, "fill": "2a2a2a", "h": 20.0, "id": "r.1.1.0.46.0", "radius": 5, "sc": "settings", "t": "rect", "w": 20.0, "x": 16.0, "y": 1833.0}
-{"align": "left", "c": "eeeeee", "h": 25.0, "id": "r.1.1.0.46.1", "sc": "settings", "size": 20, "t": "text", "text": "Lang Filter Audio", "w": 154.0, "x": 46.0, "y": 1830.5}
-{"align": "left", "bold": true, "c": "eeeeee", "h": 25.0, "id": "r.1.1.0.47", "sc": "settings", "size": 20, "t": "text", "text": "Transcoding", "w": 1238.0, "x": 16.0, "y": 1863.5}
-{"click": true, "h": 25.0, "hover": {"c": "ffffff"}, "id": "set-allow_transcode_to_h265", "sc": "settings", "t": "rect", "w": 1238.0, "x": 16.0, "y": 1896.5}
-{"bc": "555555", "bw": 1, "fill": "2a2a2a", "h": 20.0, "id": "r.1.1.0.48.0", "radius": 5, "sc": "settings", "t": "rect", "w": 20.0, "x": 16.0, "y": 1899.0}
-{"align": "left", "c": "eeeeee", "h": 25.0, "id": "r.1.1.0.48.1", "sc": "settings", "size": 20, "t": "text", "text": "Allow Transcode To H265", "w": 228.2, "x": 46.0, "y": 1896.5}
-{"click": true, "h": 25.0, "hover": {"c": "ffffff"}, "id": "set-prefer_transcode_to_h265", "sc": "settings", "t": "rect", "w": 1238.0, "x": 16.0, "y": 1929.5}
-{"bc": "555555", "bw": 1, "fill": "2a2a2a", "h": 20.0, "id": "r.1.1.0.49.0", "radius": 5, "sc": "settings", "t": "rect", "w": 20.0, "x": 16.0, "y": 1932.0}
-{"align": "left", "c": "eeeeee", "h": 25.0, "id": "r.1.1.0.49.1", "sc": "settings", "size": 20, "t": "text", "text": "Prefer Transcode To H265", "w": 228.8, "x": 46.0, "y": 1929.5}
-{"click": true, "h": 25.0, "hover": {"c": "ffffff"}, "id": "set-transcode_hevc", "sc": "settings", "t": "rect", "w": 1238.0, "x": 16.0, "y": 1962.5}
-{"bc": "555555", "bw": 1, "fill": "2a2a2a", "h": 20.0, "id": "r.1.1.0.50.0", "radius": 5, "sc": "settings", "t": "rect", "w": 20.0, "x": 16.0, "y": 1965.0}
-{"align": "left", "c": "eeeeee", "h": 25.0, "id": "r.1.1.0.50.1", "sc": "settings", "size": 20, "t": "text", "text": "Transcode HEVC", "w": 142.4, "x": 46.0, "y": 1962.5}
-{"click": true, "h": 25.0, "hover": {"c": "ffffff"}, "id": "set-transcode_av1", "sc": "settings", "t": "rect", "w": 1238.0, "x": 16.0, "y": 1995.5}
-{"bc": "555555", "bw": 1, "fill": "2a2a2a", "h": 20.0, "id": "r.1.1.0.51.0", "radius": 5, "sc": "settings", "t": "rect", "w": 20.0, "x": 16.0, "y": 1998.0}
-{"align": "left", "c": "eeeeee", "h": 25.0, "id": "r.1.1.0.51.1", "sc": "settings", "size": 20, "t": "text", "text": "Transcode AV1", "w": 131.6, "x": 46.0, "y": 1995.5}
-{"click": true, "h": 25.0, "hover": {"c": "ffffff"}, "id": "set-transcode_4k", "sc": "settings", "t": "rect", "w": 1238.0, "x": 16.0, "y": 2028.5}
-{"bc": "555555", "bw": 1, "fill": "2a2a2a", "h": 20.0, "id": "r.1.1.0.52.0", "radius": 5, "sc": "settings", "t": "rect", "w": 20.0, "x": 16.0, "y": 2031.0}
-{"align": "left", "c": "eeeeee", "h": 25.0, "id": "r.1.1.0.52.1", "sc": "settings", "size": 20, "t": "text", "text": "Transcode 4K", "w": 120.8, "x": 46.0, "y": 2028.5}
-{"click": true, "h": 25.0, "hover": {"c": "ffffff"}, "id": "set-transcode_hdr", "sc": "settings", "t": "rect", "w": 1238.0, "x": 16.0, "y": 2061.5}
-{"bc": "555555", "bw": 1, "fill": "2a2a2a", "h": 20.0, "id": "r.1.1.0.53.0", "radius": 5, "sc": "settings", "t": "rect", "w": 20.0, "x": 16.0, "y": 2064.0}
-{"align": "left", "c": "eeeeee", "h": 25.0, "id": "r.1.1.0.53.1", "sc": "settings", "size": 20, "t": "text", "text": "Transcode HDR", "w": 131.6, "x": 46.0, "y": 2061.5}
-{"click": true, "h": 25.0, "hover": {"c": "ffffff"}, "id": "set-transcode_hi10p", "sc": "settings", "t": "rect", "w": 1238.0, "x": 16.0, "y": 2094.5}
-{"bc": "555555", "bw": 1, "fill": "2a2a2a", "h": 20.0, "id": "r.1.1.0.54.0", "radius": 5, "sc": "settings", "t": "rect", "w": 20.0, "x": 16.0, "y": 2097.0}
-{"align": "left", "c": "eeeeee", "h": 25.0, "id": "r.1.1.0.54.1", "sc": "settings", "size": 20, "t": "text", "text": "Transcode Hi10P", "w": 149.2, "x": 46.0, "y": 2094.5}
-{"click": true, "h": 25.0, "hover": {"c": "ffffff"}, "id": "set-transcode_dolby_vision", "sc": "settings", "t": "rect", "w": 1238.0, "x": 16.0, "y": 2127.5}
-{"bc": "555555", "bw": 1, "fill": "2a2a2a", "h": 20.0, "id": "r.1.1.0.55.0", "radius": 5, "sc": "settings", "t": "rect", "w": 20.0, "x": 16.0, "y": 2130.0}
-{"align": "left", "c": "eeeeee", "h": 25.0, "id": "r.1.1.0.55.1", "sc": "settings", "size": 20, "t": "text", "text": "Transcode Dolby Vision", "w": 212.0, "x": 46.0, "y": 2127.5}
-{"align": "left", "c": "9aa0a6", "h": 21.2, "id": "r.1.1.0.56.0", "sc": "settings", "size": 17, "t": "text", "text": "Force Video Codec", "w": 340.0, "x": 16.0, "y": 2168.9}
-{"h": 38.0, "id": "set-force_video_codec", "ph": "", "sc": "settings", "size": 20, "t": "textbox", "text": "", "w": 340.0, "x": 368.0, "y": 2160.5}
-{"align": "left", "c": "9aa0a6", "h": 21.2, "id": "r.1.1.0.57.0", "sc": "settings", "size": 17, "t": "text", "text": "Force Audio Codec", "w": 340.0, "x": 16.0, "y": 2214.9}
-{"h": 38.0, "id": "set-force_audio_codec", "ph": "", "sc": "settings", "size": 20, "t": "textbox", "text": "", "w": 340.0, "x": 368.0, "y": 2206.5}
-{"align": "left", "bold": true, "c": "eeeeee", "h": 25.0, "id": "r.1.1.0.58", "sc": "settings", "size": 20, "t": "text", "text": "Video Enhancement", "w": 1238.0, "x": 16.0, "y": 2252.5}
-{"click": true, "h": 25.0, "hover": {"c": "ffffff"}, "id": "set-shader_pack_enable", "sc": "settings", "t": "rect", "w": 1238.0, "x": 16.0, "y": 2285.5}
-{"fill": "00a4dc", "h": 20.0, "id": "r.1.1.0.59.0", "radius": 5, "sc": "settings", "t": "rect", "w": 20.0, "x": 16.0, "y": 2288.0}
-{"align": "center", "c": "ffffff", "h": 18.8, "id": "r.1.1.0.59.0.0", "sc": "settings", "size": 15, "t": "text", "text": "\u2713", "w": 20.0, "x": 16.0, "y": 2288.6}
-{"align": "left", "c": "eeeeee", "h": 25.0, "id": "r.1.1.0.59.1", "sc": "settings", "size": 20, "t": "text", "text": "Enable Video Playback Profiles", "w": 281.6, "x": 46.0, "y": 2285.5}
-{"align": "left", "c": "9aa0a6", "h": 21.2, "id": "r.1.1.0.60.0", "sc": "settings", "size": 17, "t": "text", "text": "Profile Group", "w": 340.0, "x": 16.0, "y": 2326.9}
-{"force": true, "h": 38.0, "id": "set-shader_pack_subtype", "items": ["lq", "hq"], "sc": "settings", "sel": 0, "size": 20, "t": "dropdown", "w": 340.0, "x": 368.0, "y": 2318.5}
-{"align": "left", "c": "9aa0a6", "h": 17.5, "id": "r.1.1.0.61", "sc": "settings", "size": 14, "t": "text", "text": "\"hq\" offers heavier profiles. Pick it if you have a fast graphics card.", "w": 1238.0, "x": 16.0, "y": 2364.5}
-{"click": true, "h": 25.0, "hover": {"c": "ffffff"}, "id": "set-shader_pack_remember", "sc": "settings", "t": "rect", "w": 1238.0, "x": 16.0, "y": 2390.0}
-{"fill": "00a4dc", "h": 20.0, "id": "r.1.1.0.62.0", "radius": 5, "sc": "settings", "t": "rect", "w": 20.0, "x": 16.0, "y": 2392.5}
-{"align": "center", "c": "ffffff", "h": 18.8, "id": "r.1.1.0.62.0.0", "sc": "settings", "size": 15, "t": "text", "text": "\u2713", "w": 20.0, "x": 16.0, "y": 2393.1}
-{"align": "left", "c": "eeeeee", "h": 25.0, "id": "r.1.1.0.62.1", "sc": "settings", "size": 20, "t": "text", "text": "Remember Last Used Profile", "w": 254.8, "x": 46.0, "y": 2390.0}
-{"align": "left", "c": "9aa0a6", "h": 21.2, "id": "r.1.1.0.63.0", "sc": "settings", "size": 17, "t": "text", "text": "Graphics API for Shaders", "w": 340.0, "x": 16.0, "y": 2431.4}
-{"force": true, "h": 38.0, "id": "set-shader_pack_gpu_api", "items": ["Automatic (recommended)", "Vulkan", "Direct3D 11 (Windows only)", "OpenGL (compatibility)"], "sc": "settings", "sel": 0, "size": 20, "t": "dropdown", "w": 340.0, "x": 368.0, "y": 2423.0}
-{"align": "left", "c": "9aa0a6", "h": 17.5, "id": "r.1.1.0.64", "sc": "settings", "size": 14, "t": "text", "text": "Leave on Automatic unless video breaks when a profile is loaded. This only applies while a profile is active, and OpenGL can cost you HDR output.", "w": 1238.0, "x": 16.0, "y": 2469.0}
-{"align": "left", "bold": true, "c": "eeeeee", "h": 25.0, "id": "r.1.1.0.65", "sc": "settings", "size": 20, "t": "text", "text": "Skip Intro / Credits", "w": 1238.0, "x": 16.0, "y": 2494.5}
-{"click": true, "h": 25.0, "hover": {"c": "ffffff"}, "id": "set-skip_intro_enable", "sc": "settings", "t": "rect", "w": 1238.0, "x": 16.0, "y": 2527.5}
-{"fill": "00a4dc", "h": 20.0, "id": "r.1.1.0.66.0", "radius": 5, "sc": "settings", "t": "rect", "w": 20.0, "x": 16.0, "y": 2530.0}
-{"align": "center", "c": "ffffff", "h": 18.8, "id": "r.1.1.0.66.0.0", "sc": "settings", "size": 15, "t": "text", "text": "\u2713", "w": 20.0, "x": 16.0, "y": 2530.6}
-{"align": "left", "c": "eeeeee", "h": 25.0, "id": "r.1.1.0.66.1", "sc": "settings", "size": 20, "t": "text", "text": "Skip Intro Enable", "w": 154.0, "x": 46.0, "y": 2527.5}
-{"click": true, "h": 25.0, "hover": {"c": "ffffff"}, "id": "set-skip_intro_always", "sc": "settings", "t": "rect", "w": 1238.0, "x": 16.0, "y": 2560.5}
-{"bc": "555555", "bw": 1, "fill": "2a2a2a", "h": 20.0, "id": "r.1.1.0.67.0", "radius": 5, "sc": "settings", "t": "rect", "w": 20.0, "x": 16.0, "y": 2563.0}
-{"align": "left", "c": "eeeeee", "h": 25.0, "id": "r.1.1.0.67.1", "sc": "settings", "size": 20, "t": "text", "text": "Skip Intro Always", "w": 160.2, "x": 46.0, "y": 2560.5}
-{"click": true, "h": 25.0, "hover": {"c": "ffffff"}, "id": "set-skip_credits_enable", "sc": "settings", "t": "rect", "w": 1238.0, "x": 16.0, "y": 2593.5}
-{"fill": "00a4dc", "h": 20.0, "id": "r.1.1.0.68.0", "radius": 5, "sc": "settings", "t": "rect", "w": 20.0, "x": 16.0, "y": 2596.0}
-{"align": "center", "c": "ffffff", "h": 18.8, "id": "r.1.1.0.68.0.0", "sc": "settings", "size": 15, "t": "text", "text": "\u2713", "w": 20.0, "x": 16.0, "y": 2596.6}
-{"align": "left", "c": "eeeeee", "h": 25.0, "id": "r.1.1.0.68.1", "sc": "settings", "size": 20, "t": "text", "text": "Skip Credits Enable", "w": 175.6, "x": 46.0, "y": 2593.5}
-{"click": true, "h": 25.0, "hover": {"c": "ffffff"}, "id": "set-skip_credits_always", "sc": "settings", "t": "rect", "w": 1238.0, "x": 16.0, "y": 2626.5}
-{"bc": "555555", "bw": 1, "fill": "2a2a2a", "h": 20.0, "id": "r.1.1.0.69.0", "radius": 5, "sc": "settings", "t": "rect", "w": 20.0, "x": 16.0, "y": 2629.0}
-{"align": "left", "c": "eeeeee", "h": 25.0, "id": "r.1.1.0.69.1", "sc": "settings", "size": 20, "t": "text", "text": "Skip Credits Always", "w": 181.8, "x": 46.0, "y": 2626.5}
-{"click": true, "h": 25.0, "hover": {"c": "ffffff"}, "id": "set-skip_intro_on_seek", "sc": "settings", "t": "rect", "w": 1238.0, "x": 16.0, "y": 2659.5}
-{"fill": "00a4dc", "h": 20.0, "id": "r.1.1.0.70.0", "radius": 5, "sc": "settings", "t": "rect", "w": 20.0, "x": 16.0, "y": 2662.0}
-{"align": "center", "c": "ffffff", "h": 18.8, "id": "r.1.1.0.70.0.0", "sc": "settings", "size": 15, "t": "text", "text": "\u2713", "w": 20.0, "x": 16.0, "y": 2662.6}
-{"align": "left", "c": "eeeeee", "h": 25.0, "id": "r.1.1.0.70.1", "sc": "settings", "size": 20, "t": "text", "text": "Skip Intro On Seek", "w": 164.0, "x": 46.0, "y": 2659.5}
-{"align": "left", "bold": true, "c": "eeeeee", "h": 25.0, "id": "r.1.1.0.71", "sc": "settings", "size": 20, "t": "text", "text": "Library Browser", "w": 1238.0, "x": 16.0, "y": 2692.5}
-{"align": "left", "c": "9aa0a6", "h": 21.2, "id": "r.1.1.0.72.0", "sc": "settings", "size": 17, "t": "text", "text": "Library Image Cache Mb", "w": 340.0, "x": 16.0, "y": 2733.9}
-{"h": 38.0, "id": "set-library_image_cache_mb", "ph": "", "sc": "settings", "size": 20, "t": "textbox", "text": "256", "w": 340.0, "x": 368.0, "y": 2725.5}
-{"align": "left", "c": "9aa0a6", "h": 21.2, "id": "r.1.1.0.73.0", "sc": "settings", "size": 17, "t": "text", "text": "Scroll Wheel Pixels", "w": 340.0, "x": 16.0, "y": 2779.9}
-{"h": 38.0, "id": "set-scroll_wheel_pixels", "ph": "", "sc": "settings", "size": 20, "t": "textbox", "text": "80", "w": 340.0, "x": 368.0, "y": 2771.5}
-{"align": "left", "c": "9aa0a6", "h": 17.5, "id": "r.1.1.0.74", "sc": "settings", "size": 14, "t": "text", "text": "Pixels one wheel notch scrolls. The scrollbar glides while the content snaps to the nearest row, so a trackpad or trackball no longer overshoots. Raise it to scroll faster, lower it for finer", "w": 1238.0, "x": 16.0, "y": 2817.5}
-{"align": "left", "c": "9aa0a6", "h": 17.5, "id": "r.1.1.0.74.l1", "sc": "settings", "size": 14, "t": "text", "text": "control.", "w": 1238.0, "x": 16.0, "y": 2835.0}
-{"click": true, "h": 25.0, "hover": {"c": "ffffff"}, "id": "set-snapped_scrolling", "sc": "settings", "t": "rect", "w": 1238.0, "x": 16.0, "y": 2860.5}
-{"bc": "555555", "bw": 1, "fill": "2a2a2a", "h": 20.0, "id": "r.1.1.0.75.0", "radius": 5, "sc": "settings", "t": "rect", "w": 20.0, "x": 16.0, "y": 2863.0}
-{"align": "left", "c": "eeeeee", "h": 25.0, "id": "r.1.1.0.75.1", "sc": "settings", "size": 20, "t": "text", "text": "Snapped Scrolling", "w": 162.8, "x": 46.0, "y": 2860.5}
-{"align": "left", "c": "9aa0a6", "h": 17.5, "id": "r.1.1.0.76", "sc": "settings", "size": 14, "t": "text", "text": "Make each wheel notch jump exactly one row (or one home-screen section) instead of gliding. Turn this on if you prefer the older stepped scrolling.", "w": 1238.0, "x": 16.0, "y": 2893.5}
-{"click": true, "h": 25.0, "hover": {"c": "ffffff"}, "id": "set-paginated", "sc": "settings", "t": "rect", "w": 1238.0, "x": 16.0, "y": 2919.0}
-{"bc": "555555", "bw": 1, "fill": "2a2a2a", "h": 20.0, "id": "r.1.1.0.77.0", "radius": 5, "sc": "settings", "t": "rect", "w": 20.0, "x": 16.0, "y": 2921.5}
-{"align": "left", "c": "eeeeee", "h": 25.0, "id": "r.1.1.0.77.1", "sc": "settings", "size": 20, "t": "text", "text": "Paginated", "w": 89.2, "x": 46.0, "y": 2919.0}
-{"align": "left", "c": "9aa0a6", "h": 17.5, "id": "r.1.1.0.78", "sc": "settings", "size": 14, "t": "text", "text": "Page the library and music tile grids instead of scrolling: each page is one screenful with First / Previous / Next / Last controls and a page number you can type into. Easier than precise", "w": 1238.0, "x": 16.0, "y": 2952.0}
-{"align": "left", "c": "9aa0a6", "h": 17.5, "id": "r.1.1.0.78.l1", "sc": "settings", "size": 14, "t": "text", "text": "scrolling on a trackpad.", "w": 1238.0, "x": 16.0, "y": 2969.5}
-{"align": "left", "bold": true, "c": "eeeeee", "h": 25.0, "id": "r.1.1.0.79", "sc": "settings", "size": 20, "t": "text", "text": "Downloads", "w": 1238.0, "x": 16.0, "y": 2995.0}
-{"align": "left", "c": "9aa0a6", "h": 21.2, "id": "r.1.1.0.80.0", "sc": "settings", "size": 17, "t": "text", "text": "Download Folder", "w": 340.0, "x": 16.0, "y": 3039.9}
-{"h": 38.0, "id": "set-sync_path", "ph": "", "sc": "settings", "size": 20, "t": "textbox", "text": "", "w": 250.0, "x": 368.0, "y": 3031.5}
-{"click": true, "fill": "333333", "h": 45.0, "hover": {"fill": "4a4a4a"}, "id": "set-sync-move", "radius": 6, "sc": "settings", "t": "rect", "w": 69.4, "x": 626.0, "y": 3028.0}
-{"align": "center", "c": "eeeeee", "h": 25.0, "id": "r.1.1.0.80.1.1.0", "sc": "settings", "size": 20, "t": "text", "text": "Move", "w": 49.4, "x": 636.0, "y": 3038.0}
-{"click": true, "h": 25.0, "hover": {"c": "ffffff"}, "id": "set-prefer_downloaded", "sc": "settings", "t": "rect", "w": 1238.0, "x": 16.0, "y": 3081.0}
-{"fill": "00a4dc", "h": 20.0, "id": "r.1.1.0.81.0", "radius": 5, "sc": "settings", "t": "rect", "w": 20.0, "x": 16.0, "y": 3083.5}
-{"align": "center", "c": "ffffff", "h": 18.8, "id": "r.1.1.0.81.0.0", "sc": "settings", "size": 15, "t": "text", "text": "\u2713", "w": 20.0, "x": 16.0, "y": 3084.1}
-{"align": "left", "c": "eeeeee", "h": 25.0, "id": "r.1.1.0.81.1", "sc": "settings", "size": 20, "t": "text", "text": "Prefer Downloaded Copy", "w": 218.2, "x": 46.0, "y": 3081.0}
-{"click": true, "h": 25.0, "hover": {"c": "ffffff"}, "id": "set-auto_download_enable", "sc": "settings", "t": "rect", "w": 1238.0, "x": 16.0, "y": 3114.0}
-{"bc": "555555", "bw": 1, "fill": "2a2a2a", "h": 20.0, "id": "r.1.1.0.82.0", "radius": 5, "sc": "settings", "t": "rect", "w": 20.0, "x": 16.0, "y": 3116.5}
-{"align": "left", "c": "eeeeee", "h": 25.0, "id": "r.1.1.0.82.1", "sc": "settings", "size": 20, "t": "text", "text": "Automatically Download Upcoming Episodes", "w": 404.2, "x": 46.0, "y": 3114.0}
-{"align": "left", "c": "9aa0a6", "h": 17.5, "id": "r.1.1.0.83", "sc": "settings", "size": 14, "t": "text", "text": "Applies to srv1, enable other servers in servers tab.", "w": 1238.0, "x": 16.0, "y": 3147.0}
-{"click": true, "h": 25.0, "hover": {"c": "ffffff"}, "id": "set-auto_download_next_up", "sc": "settings", "t": "rect", "w": 1238.0, "x": 16.0, "y": 3172.5}
-{"fill": "00a4dc", "h": 20.0, "id": "r.1.1.0.84.0", "radius": 5, "sc": "settings", "t": "rect", "w": 20.0, "x": 16.0, "y": 3175.0}
-{"align": "center", "c": "ffffff", "h": 18.8, "id": "r.1.1.0.84.0.0", "sc": "settings", "size": 15, "t": "text", "text": "\u2713", "w": 20.0, "x": 16.0, "y": 3175.6}
-{"align": "left", "c": "eeeeee", "h": 25.0, "id": "r.1.1.0.84.1", "sc": "settings", "size": 20, "t": "text", "text": "Include Next Up", "w": 140.4, "x": 46.0, "y": 3172.5}
-{"align": "left", "c": "9aa0a6", "h": 21.2, "id": "r.1.1.0.85.0", "sc": "settings", "size": 17, "t": "text", "text": "Next Up Entries to Consider", "w": 340.0, "x": 16.0, "y": 3213.9}
-{"h": 38.0, "id": "set-auto_download_next_up_limit", "ph": "", "sc": "settings", "size": 20, "t": "textbox", "text": "10", "w": 340.0, "x": 368.0, "y": 3205.5}
-{"align": "left", "c": "9aa0a6", "h": 21.2, "id": "r.1.1.0.86.0", "sc": "settings", "size": 17, "t": "text", "text": "Episodes to Keep Ahead (0 = off)", "w": 340.0, "x": 16.0, "y": 3259.9}
-{"h": 38.0, "id": "set-auto_download_lookahead", "ph": "", "sc": "settings", "size": 20, "t": "textbox", "text": "2", "w": 340.0, "x": 368.0, "y": 3251.5}
-{"align": "left", "c": "9aa0a6", "h": 21.2, "id": "r.1.1.0.87.0", "sc": "settings", "size": 17, "t": "text", "text": "Storage Limit for Automatic Downloads (GB)", "w": 340.0, "x": 16.0, "y": 3305.9}
-{"h": 38.0, "id": "set-auto_download_max_gb", "ph": "", "sc": "settings", "size": 20, "t": "textbox", "text": "20", "w": 340.0, "x": 368.0, "y": 3297.5}
-{"click": true, "h": 25.0, "hover": {"c": "ffffff"}, "id": "set-auto_download_delete_watched", "sc": "settings", "t": "rect", "w": 1238.0, "x": 16.0, "y": 3343.5}
-{"fill": "00a4dc", "h": 20.0, "id": "r.1.1.0.88.0", "radius": 5, "sc": "settings", "t": "rect", "w": 20.0, "x": 16.0, "y": 3346.0}
-{"align": "center", "c": "ffffff", "h": 18.8, "id": "r.1.1.0.88.0.0", "sc": "settings", "size": 15, "t": "text", "text": "\u2713", "w": 20.0, "x": 16.0, "y": 3346.6}
-{"align": "left", "c": "eeeeee", "h": 25.0, "id": "r.1.1.0.88.1", "sc": "settings", "size": 20, "t": "text", "text": "Delete Automatic Downloads Once Watched", "w": 392.6, "x": 46.0, "y": 3343.5}
-{"align": "left", "c": "9aa0a6", "h": 21.2, "id": "r.1.1.0.89.0", "sc": "settings", "size": 17, "t": "text", "text": "Delete Unwatched After (days, 0 = never)", "w": 340.0, "x": 16.0, "y": 3384.9}
-{"h": 38.0, "id": "set-auto_download_keep_days", "ph": "", "sc": "settings", "size": 20, "t": "textbox", "text": "30", "w": 340.0, "x": 368.0, "y": 3376.5}
-{"align": "left", "c": "9aa0a6", "h": 21.2, "id": "r.1.1.0.90.0", "sc": "settings", "size": 17, "t": "text", "text": "Check Every (minutes)", "w": 340.0, "x": 16.0, "y": 3430.9}
-{"h": 38.0, "id": "set-auto_download_interval_mins", "ph": "", "sc": "settings", "size": 20, "t": "textbox", "text": "60", "w": 340.0, "x": 368.0, "y": 3422.5}
-{"click": true, "h": 25.0, "hover": {"c": "ffffff"}, "id": "set-adv", "sc": "settings", "t": "rect", "w": 1238.0, "x": 16.0, "y": 3468.5}
-{"bc": "555555", "bw": 1, "fill": "2a2a2a", "h": 20.0, "id": "r.1.1.0.91.0", "radius": 5, "sc": "settings", "t": "rect", "w": 20.0, "x": 16.0, "y": 3471.0}
-{"align": "left", "c": "eeeeee", "h": 25.0, "id": "r.1.1.0.91.1", "sc": "settings", "size": 20, "t": "text", "text": "Show advanced settings", "w": 222.2, "x": 46.0, "y": 3468.5}
-{"align": "left", "c": "9aa0a6", "h": 17.5, "id": "r.1.1.0.92", "sc": "settings", "size": 14, "t": "text", "text": "Some changes take effect after restarting.", "w": 1238.0, "x": 16.0, "y": 3501.5}
+{"align": "left", "c": "eeeeee", "h": 25.0, "id": "r.1.1.0.4.1", "sc": "settings", "size": 20, "t": "text", "text": "Keep Running in Background", "w": 254.4, "x": 46.0, "y": 290.0}
+{"align": "left", "c": "9aa0a6", "h": 17.5, "id": "r.1.1.0.5", "sc": "settings", "size": 14, "t": "text", "text": "With \"Start Minimized\" and \"Fullscreen\" this is the classic cast-target setup: the app waits out of the way, plays fullscreen when something casts to it, and goes back to waiting when the", "w": 1238.0, "x": 16.0, "y": 323.0}
+{"align": "left", "c": "9aa0a6", "h": 17.5, "id": "r.1.1.0.5.l1", "sc": "settings", "size": 14, "t": "text", "text": "video ends or you press Q.", "w": 1238.0, "x": 16.0, "y": 340.5}
+{"click": true, "h": 25.0, "hover": {"c": "ffffff"}, "id": "set-remember_window_size", "sc": "settings", "t": "rect", "w": 1238.0, "x": 16.0, "y": 366.0}
+{"fill": "00a4dc", "h": 20.0, "id": "r.1.1.0.6.0", "radius": 5, "sc": "settings", "t": "rect", "w": 20.0, "x": 16.0, "y": 368.5}
+{"align": "center", "c": "ffffff", "h": 18.8, "id": "r.1.1.0.6.0.0", "sc": "settings", "size": 15, "t": "text", "text": "\u2713", "w": 20.0, "x": 16.0, "y": 369.1}
+{"align": "left", "c": "eeeeee", "h": 25.0, "id": "r.1.1.0.6.1", "sc": "settings", "size": 20, "t": "text", "text": "Remember Window Size", "w": 219.2, "x": 46.0, "y": 366.0}
+{"click": true, "h": 25.0, "hover": {"c": "ffffff"}, "id": "set-fullscreen", "sc": "settings", "t": "rect", "w": 1238.0, "x": 16.0, "y": 399.0}
+{"bc": "555555", "bw": 1, "fill": "2a2a2a", "h": 20.0, "id": "r.1.1.0.7.0", "radius": 5, "sc": "settings", "t": "rect", "w": 20.0, "x": 16.0, "y": 401.5}
+{"align": "left", "c": "eeeeee", "h": 25.0, "id": "r.1.1.0.7.1", "sc": "settings", "size": 20, "t": "text", "text": "Fullscreen", "w": 96.0, "x": 46.0, "y": 399.0}
+{"align": "left", "c": "9aa0a6", "h": 21.2, "id": "r.1.1.0.8.0", "sc": "settings", "size": 17, "t": "text", "text": "Interface Scale", "w": 340.0, "x": 16.0, "y": 440.4}
+{"force": true, "h": 38.0, "id": "set-ui_scale", "items": ["Follow display", "100% (no scaling)", "125%", "150%", "200%"], "sc": "settings", "sel": 0, "size": 20, "t": "dropdown", "w": 340.0, "x": 368.0, "y": 432.0}
+{"align": "left", "c": "9aa0a6", "h": 17.5, "id": "r.1.1.0.9", "sc": "settings", "size": 14, "t": "text", "text": "Takes effect after a restart. \"Follow display\" uses the scale your desktop reports, which is 100% on X11.", "w": 1238.0, "x": 16.0, "y": 478.0}
+{"click": true, "h": 25.0, "hover": {"c": "ffffff"}, "id": "set-enable_osc", "sc": "settings", "t": "rect", "w": 1238.0, "x": 16.0, "y": 503.5}
+{"fill": "00a4dc", "h": 20.0, "id": "r.1.1.0.10.0", "radius": 5, "sc": "settings", "t": "rect", "w": 20.0, "x": 16.0, "y": 506.0}
+{"align": "center", "c": "ffffff", "h": 18.8, "id": "r.1.1.0.10.0.0", "sc": "settings", "size": 15, "t": "text", "text": "\u2713", "w": 20.0, "x": 16.0, "y": 506.6}
+{"align": "left", "c": "eeeeee", "h": 25.0, "id": "r.1.1.0.10.1", "sc": "settings", "size": 20, "t": "text", "text": "Enable OSC", "w": 99.2, "x": 46.0, "y": 503.5}
+{"align": "left", "c": "9aa0a6", "h": 21.2, "id": "r.1.1.0.11.0", "sc": "settings", "size": 17, "t": "text", "text": "Player Controls Style", "w": 340.0, "x": 16.0, "y": 544.9}
+{"force": true, "h": 38.0, "id": "set-osc_style", "items": ["Jellyfin UI", "MPV UI with thumbnails", "MPV built-in default"], "sc": "settings", "sel": 0, "size": 20, "t": "dropdown", "w": 340.0, "x": 368.0, "y": 536.5}
+{"align": "left", "c": "9aa0a6", "h": 17.5, "id": "r.1.1.0.12", "sc": "settings", "size": 14, "t": "text", "text": "MPV keybinds are used by default. Press ENTER to drive the player controls by keyboard.", "w": 1238.0, "x": 16.0, "y": 582.5}
+{"click": true, "h": 25.0, "hover": {"c": "ffffff"}, "id": "set-hud_grab_keys", "sc": "settings", "t": "rect", "w": 1238.0, "x": 16.0, "y": 608.0}
+{"bc": "555555", "bw": 1, "fill": "2a2a2a", "h": 20.0, "id": "r.1.1.0.13.0", "radius": 5, "sc": "settings", "t": "rect", "w": 20.0, "x": 16.0, "y": 610.5}
+{"align": "left", "c": "eeeeee", "h": 25.0, "id": "r.1.1.0.13.1", "sc": "settings", "size": 20, "t": "text", "text": "Always Bind Arrow Keys to Player Controls", "w": 386.4, "x": 46.0, "y": 608.0}
+{"align": "left", "c": "9aa0a6", "h": 21.2, "id": "r.1.1.0.14.0", "sc": "settings", "size": 17, "t": "text", "text": "Player Controls Activation Key", "w": 340.0, "x": 16.0, "y": 649.4}
+{"h": 38.0, "id": "set-hud_wake_key", "ph": "", "sc": "settings", "size": 20, "t": "textbox", "text": "ENTER", "w": 340.0, "x": 368.0, "y": 641.0}
+{"click": true, "h": 25.0, "hover": {"c": "ffffff"}, "id": "set-raise_mpv", "sc": "settings", "t": "rect", "w": 1238.0, "x": 16.0, "y": 687.0}
+{"fill": "00a4dc", "h": 20.0, "id": "r.1.1.0.15.0", "radius": 5, "sc": "settings", "t": "rect", "w": 20.0, "x": 16.0, "y": 689.5}
+{"align": "center", "c": "ffffff", "h": 18.8, "id": "r.1.1.0.15.0.0", "sc": "settings", "size": 15, "t": "text", "text": "\u2713", "w": 20.0, "x": 16.0, "y": 690.1}
+{"align": "left", "c": "eeeeee", "h": 25.0, "id": "r.1.1.0.15.1", "sc": "settings", "size": 20, "t": "text", "text": "Raise MPV", "w": 94.6, "x": 46.0, "y": 687.0}
+{"click": true, "h": 25.0, "hover": {"c": "ffffff"}, "id": "set-discord_presence", "sc": "settings", "t": "rect", "w": 1238.0, "x": 16.0, "y": 720.0}
+{"bc": "555555", "bw": 1, "fill": "2a2a2a", "h": 20.0, "id": "r.1.1.0.16.0", "radius": 5, "sc": "settings", "t": "rect", "w": 20.0, "x": 16.0, "y": 722.5}
+{"align": "left", "c": "eeeeee", "h": 25.0, "id": "r.1.1.0.16.1", "sc": "settings", "size": 20, "t": "text", "text": "Show What You're Watching in Discord", "w": 351.4, "x": 46.0, "y": 720.0}
+{"align": "left", "c": "9aa0a6", "h": 17.5, "id": "r.1.1.0.17", "sc": "settings", "size": 14, "t": "text", "text": "Discord Rich Presence. Takes effect after a restart.", "w": 1238.0, "x": 16.0, "y": 753.0}
+{"click": true, "h": 25.0, "hover": {"c": "ffffff"}, "id": "set-check_updates", "sc": "settings", "t": "rect", "w": 1238.0, "x": 16.0, "y": 778.5}
+{"fill": "00a4dc", "h": 20.0, "id": "r.1.1.0.18.0", "radius": 5, "sc": "settings", "t": "rect", "w": 20.0, "x": 16.0, "y": 781.0}
+{"align": "center", "c": "ffffff", "h": 18.8, "id": "r.1.1.0.18.0.0", "sc": "settings", "size": 15, "t": "text", "text": "\u2713", "w": 20.0, "x": 16.0, "y": 781.6}
+{"align": "left", "c": "eeeeee", "h": 25.0, "id": "r.1.1.0.18.1", "sc": "settings", "size": 20, "t": "text", "text": "Check Updates", "w": 131.6, "x": 46.0, "y": 778.5}
+{"click": true, "h": 25.0, "hover": {"c": "ffffff"}, "id": "set-notify_updates", "sc": "settings", "t": "rect", "w": 1238.0, "x": 16.0, "y": 811.5}
+{"fill": "00a4dc", "h": 20.0, "id": "r.1.1.0.19.0", "radius": 5, "sc": "settings", "t": "rect", "w": 20.0, "x": 16.0, "y": 814.0}
+{"align": "center", "c": "ffffff", "h": 18.8, "id": "r.1.1.0.19.0.0", "sc": "settings", "size": 15, "t": "text", "text": "\u2713", "w": 20.0, "x": 16.0, "y": 814.6}
+{"align": "left", "c": "eeeeee", "h": 25.0, "id": "r.1.1.0.19.1", "sc": "settings", "size": 20, "t": "text", "text": "Notify Updates", "w": 130.4, "x": 46.0, "y": 811.5}
+{"align": "left", "bold": true, "c": "eeeeee", "h": 25.0, "id": "r.1.1.0.20", "sc": "settings", "size": 20, "t": "text", "text": "Playback", "w": 1238.0, "x": 16.0, "y": 844.5}
+{"click": true, "h": 25.0, "hover": {"c": "ffffff"}, "id": "set-auto_play", "sc": "settings", "t": "rect", "w": 1238.0, "x": 16.0, "y": 877.5}
+{"fill": "00a4dc", "h": 20.0, "id": "r.1.1.0.21.0", "radius": 5, "sc": "settings", "t": "rect", "w": 20.0, "x": 16.0, "y": 880.0}
+{"align": "center", "c": "ffffff", "h": 18.8, "id": "r.1.1.0.21.0.0", "sc": "settings", "size": 15, "t": "text", "text": "\u2713", "w": 20.0, "x": 16.0, "y": 880.6}
+{"align": "left", "c": "eeeeee", "h": 25.0, "id": "r.1.1.0.21.1", "sc": "settings", "size": 20, "t": "text", "text": "Auto Play", "w": 84.4, "x": 46.0, "y": 877.5}
+{"click": true, "h": 25.0, "hover": {"c": "ffffff"}, "id": "set-always_transcode", "sc": "settings", "t": "rect", "w": 1238.0, "x": 16.0, "y": 910.5}
+{"bc": "555555", "bw": 1, "fill": "2a2a2a", "h": 20.0, "id": "r.1.1.0.22.0", "radius": 5, "sc": "settings", "t": "rect", "w": 20.0, "x": 16.0, "y": 913.0}
+{"align": "left", "c": "eeeeee", "h": 25.0, "id": "r.1.1.0.22.1", "sc": "settings", "size": 20, "t": "text", "text": "Always Transcode", "w": 166.2, "x": 46.0, "y": 910.5}
+{"align": "left", "c": "9aa0a6", "h": 21.2, "id": "r.1.1.0.23.0", "sc": "settings", "size": 17, "t": "text", "text": "Local kbps", "w": 340.0, "x": 16.0, "y": 951.9}
+{"h": 38.0, "id": "set-local_kbps", "ph": "", "sc": "settings", "size": 20, "t": "textbox", "text": "2147483", "w": 340.0, "x": 368.0, "y": 943.5}
+{"align": "left", "c": "9aa0a6", "h": 21.2, "id": "r.1.1.0.24.0", "sc": "settings", "size": 17, "t": "text", "text": "Remote kbps", "w": 340.0, "x": 16.0, "y": 997.9}
+{"h": 38.0, "id": "set-remote_kbps", "ph": "", "sc": "settings", "size": 20, "t": "textbox", "text": "10000", "w": 340.0, "x": 368.0, "y": 989.5}
+{"click": true, "h": 25.0, "hover": {"c": "ffffff"}, "id": "set-direct_paths", "sc": "settings", "t": "rect", "w": 1238.0, "x": 16.0, "y": 1035.5}
+{"bc": "555555", "bw": 1, "fill": "2a2a2a", "h": 20.0, "id": "r.1.1.0.25.0", "radius": 5, "sc": "settings", "t": "rect", "w": 20.0, "x": 16.0, "y": 1038.0}
+{"align": "left", "c": "eeeeee", "h": 25.0, "id": "r.1.1.0.25.1", "sc": "settings", "size": 20, "t": "text", "text": "Direct Paths", "w": 108.8, "x": 46.0, "y": 1035.5}
+{"click": true, "h": 25.0, "hover": {"c": "ffffff"}, "id": "set-remote_direct_paths", "sc": "settings", "t": "rect", "w": 1238.0, "x": 16.0, "y": 1068.5}
+{"bc": "555555", "bw": 1, "fill": "2a2a2a", "h": 20.0, "id": "r.1.1.0.26.0", "radius": 5, "sc": "settings", "t": "rect", "w": 20.0, "x": 16.0, "y": 1071.0}
+{"align": "left", "c": "eeeeee", "h": 25.0, "id": "r.1.1.0.26.1", "sc": "settings", "size": 20, "t": "text", "text": "Remote Direct Paths", "w": 181.8, "x": 46.0, "y": 1068.5}
+{"align": "left", "c": "9aa0a6", "h": 21.2, "id": "r.1.1.0.27.0", "sc": "settings", "size": 17, "t": "text", "text": "Playback Timeout", "w": 340.0, "x": 16.0, "y": 1109.9}
+{"h": 38.0, "id": "set-playback_timeout", "ph": "", "sc": "settings", "size": 20, "t": "textbox", "text": "30", "w": 340.0, "x": 368.0, "y": 1101.5}
+{"align": "left", "bold": true, "c": "eeeeee", "h": 25.0, "id": "r.1.1.0.28", "sc": "settings", "size": 20, "t": "text", "text": "Audio", "w": 1238.0, "x": 16.0, "y": 1147.5}
+{"align": "left", "c": "9aa0a6", "h": 21.2, "id": "r.1.1.0.29.0", "sc": "settings", "size": 17, "t": "text", "text": "Audio Output Device", "w": 340.0, "x": 16.0, "y": 1188.9}
+{"h": 38.0, "id": "set-audio_device", "ph": "", "sc": "settings", "size": 20, "t": "textbox", "text": "", "w": 340.0, "x": 368.0, "y": 1180.5}
+{"align": "left", "c": "9aa0a6", "h": 17.5, "id": "r.1.1.0.30", "sc": "settings", "size": 14, "t": "text", "text": "Leave this to Default unless setting up passthrough. Note some audio servers like Pipewire don't like passthrough and will need to be disabled for a card before it'll let *any* audio through in", "w": 1238.0, "x": 16.0, "y": 1226.5}
+{"align": "left", "c": "9aa0a6", "h": 17.5, "id": "r.1.1.0.30.l1", "sc": "settings", "size": 14, "t": "text", "text": "passthrough mode. In my tests I got silence otherwise, but results may vary.", "w": 1238.0, "x": 16.0, "y": 1244.0}
+{"align": "left", "c": "9aa0a6", "h": 21.2, "id": "r.1.1.0.31.0", "sc": "settings", "size": 17, "t": "text", "text": "Audio Output Mode", "w": 340.0, "x": 16.0, "y": 1277.9}
+{"force": true, "h": 38.0, "id": "set-audio_mode", "items": ["Default (auto)", "Force Stereo", "Optical Surround", "HDMI Passthrough"], "sc": "settings", "sel": 0, "size": 20, "t": "dropdown", "w": 340.0, "x": 368.0, "y": 1269.5}
+{"align": "left", "c": "9aa0a6", "h": 17.5, "id": "r.1.1.0.32", "sc": "settings", "size": 14, "t": "text", "text": "\"Default\" changes nothing and lets MPV (and your own mpv.conf) decide. Pick a mode only if you are sending audio to a receiver.", "w": 1238.0, "x": 16.0, "y": 1315.5}
+{"click": true, "h": 25.0, "hover": {"c": "ffffff"}, "id": "set-audio_night_mode", "sc": "settings", "t": "rect", "w": 1238.0, "x": 16.0, "y": 1341.0}
+{"bc": "555555", "bw": 1, "fill": "2a2a2a", "h": 20.0, "id": "r.1.1.0.33.0", "radius": 5, "sc": "settings", "t": "rect", "w": 20.0, "x": 16.0, "y": 1343.5}
+{"align": "left", "c": "eeeeee", "h": 25.0, "id": "r.1.1.0.33.1", "sc": "settings", "size": 20, "t": "text", "text": "Night Mode (Auto Volume Adj)", "w": 267.6, "x": 46.0, "y": 1341.0}
+{"align": "left", "c": "9aa0a6", "h": 17.5, "id": "r.1.1.0.34", "sc": "settings", "size": 14, "t": "text", "text": "Evens out loud effects and quiet dialogue. This turns passthrough off while it is enabled, because the volume has to be adjusted before your receiver gets the audio.", "w": 1238.0, "x": 16.0, "y": 1374.0}
+{"align": "left", "bold": true, "c": "eeeeee", "h": 25.0, "id": "r.1.1.0.35", "sc": "settings", "size": 20, "t": "text", "text": "Subtitles & Languages", "w": 1238.0, "x": 16.0, "y": 1399.5}
+{"align": "left", "c": "9aa0a6", "h": 21.2, "id": "r.1.1.0.36.0", "sc": "settings", "size": 17, "t": "text", "text": "Subtitle Size", "w": 340.0, "x": 16.0, "y": 1440.9}
+{"h": 38.0, "id": "set-subtitle_size", "ph": "", "sc": "settings", "size": 20, "t": "textbox", "text": "100", "w": 340.0, "x": 368.0, "y": 1432.5}
+{"align": "left", "c": "9aa0a6", "h": 21.2, "id": "r.1.1.0.37.0", "sc": "settings", "size": 17, "t": "text", "text": "Subtitle Color", "w": 340.0, "x": 16.0, "y": 1486.9}
+{"h": 38.0, "id": "set-subtitle_color", "ph": "", "sc": "settings", "size": 20, "t": "textbox", "text": "#FFFFFFFF", "w": 340.0, "x": 368.0, "y": 1478.5}
+{"align": "left", "c": "9aa0a6", "h": 21.2, "id": "r.1.1.0.38.0", "sc": "settings", "size": 17, "t": "text", "text": "Subtitle Position", "w": 340.0, "x": 16.0, "y": 1532.9}
+{"force": true, "h": 38.0, "id": "set-subtitle_position", "items": ["top", "bottom", "middle"], "sc": "settings", "sel": 1, "size": 20, "t": "dropdown", "w": 340.0, "x": 368.0, "y": 1524.5}
+{"align": "left", "c": "9aa0a6", "h": 21.2, "id": "r.1.1.0.39.0", "sc": "settings", "size": 17, "t": "text", "text": "Language Preference", "w": 340.0, "x": 16.0, "y": 1578.9}
+{"force": true, "h": 38.0, "id": "set-language_preference", "items": ["Unset", "Dubbed (shows only)", "Subbed (shows only)", "Dubbed (all)", "Subbed (all)", "Custom (set in config)"], "sc": "settings", "sel": 5, "size": 20, "t": "dropdown", "w": 340.0, "x": 368.0, "y": 1570.5}
+{"align": "left", "c": "9aa0a6", "h": 21.2, "id": "r.1.1.0.40.0", "sc": "settings", "size": 17, "t": "text", "text": "Preferred Language", "w": 340.0, "x": 16.0, "y": 1624.9}
+{"h": 38.0, "id": "set-preferred_language", "ph": "", "sc": "settings", "size": 20, "t": "textbox", "text": "eng", "w": 340.0, "x": 368.0, "y": 1616.5}
+{"click": true, "h": 25.0, "hover": {"c": "ffffff"}, "id": "set-remember_audio_track", "sc": "settings", "t": "rect", "w": 1238.0, "x": 16.0, "y": 1662.5}
+{"fill": "00a4dc", "h": 20.0, "id": "r.1.1.0.41.0", "radius": 5, "sc": "settings", "t": "rect", "w": 20.0, "x": 16.0, "y": 1665.0}
+{"align": "center", "c": "ffffff", "h": 18.8, "id": "r.1.1.0.41.0.0", "sc": "settings", "size": 15, "t": "text", "text": "\u2713", "w": 20.0, "x": 16.0, "y": 1665.6}
+{"align": "left", "c": "eeeeee", "h": 25.0, "id": "r.1.1.0.41.1", "sc": "settings", "size": 20, "t": "text", "text": "Remember Audio Track", "w": 206.8, "x": 46.0, "y": 1662.5}
+{"click": true, "h": 25.0, "hover": {"c": "ffffff"}, "id": "set-remember_subtitle_track", "sc": "settings", "t": "rect", "w": 1238.0, "x": 16.0, "y": 1695.5}
+{"fill": "00a4dc", "h": 20.0, "id": "r.1.1.0.42.0", "radius": 5, "sc": "settings", "t": "rect", "w": 20.0, "x": 16.0, "y": 1698.0}
+{"align": "center", "c": "ffffff", "h": 18.8, "id": "r.1.1.0.42.0.0", "sc": "settings", "size": 15, "t": "text", "text": "\u2713", "w": 20.0, "x": 16.0, "y": 1698.6}
+{"align": "left", "c": "eeeeee", "h": 25.0, "id": "r.1.1.0.42.1", "sc": "settings", "size": 20, "t": "text", "text": "Remember Subtitle Track", "w": 227.2, "x": 46.0, "y": 1695.5}
+{"align": "left", "c": "9aa0a6", "h": 21.2, "id": "r.1.1.0.43.0", "sc": "settings", "size": 17, "t": "text", "text": "Lang Filter", "w": 340.0, "x": 16.0, "y": 1736.9}
+{"h": 38.0, "id": "set-lang_filter", "ph": "", "sc": "settings", "size": 20, "t": "textbox", "text": "und,eng,jpn,mis,mul,zxx", "w": 340.0, "x": 368.0, "y": 1728.5}
+{"click": true, "h": 25.0, "hover": {"c": "ffffff"}, "id": "set-lang_filter_sub", "sc": "settings", "t": "rect", "w": 1238.0, "x": 16.0, "y": 1774.5}
+{"bc": "555555", "bw": 1, "fill": "2a2a2a", "h": 20.0, "id": "r.1.1.0.44.0", "radius": 5, "sc": "settings", "t": "rect", "w": 20.0, "x": 16.0, "y": 1777.0}
+{"align": "left", "c": "eeeeee", "h": 25.0, "id": "r.1.1.0.44.1", "sc": "settings", "size": 20, "t": "text", "text": "Lang Filter Sub", "w": 136.4, "x": 46.0, "y": 1774.5}
+{"click": true, "h": 25.0, "hover": {"c": "ffffff"}, "id": "set-lang_filter_audio", "sc": "settings", "t": "rect", "w": 1238.0, "x": 16.0, "y": 1807.5}
+{"bc": "555555", "bw": 1, "fill": "2a2a2a", "h": 20.0, "id": "r.1.1.0.45.0", "radius": 5, "sc": "settings", "t": "rect", "w": 20.0, "x": 16.0, "y": 1810.0}
+{"align": "left", "c": "eeeeee", "h": 25.0, "id": "r.1.1.0.45.1", "sc": "settings", "size": 20, "t": "text", "text": "Lang Filter Audio", "w": 154.0, "x": 46.0, "y": 1807.5}
+{"align": "left", "bold": true, "c": "eeeeee", "h": 25.0, "id": "r.1.1.0.46", "sc": "settings", "size": 20, "t": "text", "text": "Transcoding", "w": 1238.0, "x": 16.0, "y": 1840.5}
+{"click": true, "h": 25.0, "hover": {"c": "ffffff"}, "id": "set-allow_transcode_to_h265", "sc": "settings", "t": "rect", "w": 1238.0, "x": 16.0, "y": 1873.5}
+{"bc": "555555", "bw": 1, "fill": "2a2a2a", "h": 20.0, "id": "r.1.1.0.47.0", "radius": 5, "sc": "settings", "t": "rect", "w": 20.0, "x": 16.0, "y": 1876.0}
+{"align": "left", "c": "eeeeee", "h": 25.0, "id": "r.1.1.0.47.1", "sc": "settings", "size": 20, "t": "text", "text": "Allow Transcode To H265", "w": 228.2, "x": 46.0, "y": 1873.5}
+{"click": true, "h": 25.0, "hover": {"c": "ffffff"}, "id": "set-prefer_transcode_to_h265", "sc": "settings", "t": "rect", "w": 1238.0, "x": 16.0, "y": 1906.5}
+{"bc": "555555", "bw": 1, "fill": "2a2a2a", "h": 20.0, "id": "r.1.1.0.48.0", "radius": 5, "sc": "settings", "t": "rect", "w": 20.0, "x": 16.0, "y": 1909.0}
+{"align": "left", "c": "eeeeee", "h": 25.0, "id": "r.1.1.0.48.1", "sc": "settings", "size": 20, "t": "text", "text": "Prefer Transcode To H265", "w": 228.8, "x": 46.0, "y": 1906.5}
+{"click": true, "h": 25.0, "hover": {"c": "ffffff"}, "id": "set-transcode_hevc", "sc": "settings", "t": "rect", "w": 1238.0, "x": 16.0, "y": 1939.5}
+{"bc": "555555", "bw": 1, "fill": "2a2a2a", "h": 20.0, "id": "r.1.1.0.49.0", "radius": 5, "sc": "settings", "t": "rect", "w": 20.0, "x": 16.0, "y": 1942.0}
+{"align": "left", "c": "eeeeee", "h": 25.0, "id": "r.1.1.0.49.1", "sc": "settings", "size": 20, "t": "text", "text": "Transcode HEVC", "w": 142.4, "x": 46.0, "y": 1939.5}
+{"click": true, "h": 25.0, "hover": {"c": "ffffff"}, "id": "set-transcode_av1", "sc": "settings", "t": "rect", "w": 1238.0, "x": 16.0, "y": 1972.5}
+{"bc": "555555", "bw": 1, "fill": "2a2a2a", "h": 20.0, "id": "r.1.1.0.50.0", "radius": 5, "sc": "settings", "t": "rect", "w": 20.0, "x": 16.0, "y": 1975.0}
+{"align": "left", "c": "eeeeee", "h": 25.0, "id": "r.1.1.0.50.1", "sc": "settings", "size": 20, "t": "text", "text": "Transcode AV1", "w": 131.6, "x": 46.0, "y": 1972.5}
+{"click": true, "h": 25.0, "hover": {"c": "ffffff"}, "id": "set-transcode_4k", "sc": "settings", "t": "rect", "w": 1238.0, "x": 16.0, "y": 2005.5}
+{"bc": "555555", "bw": 1, "fill": "2a2a2a", "h": 20.0, "id": "r.1.1.0.51.0", "radius": 5, "sc": "settings", "t": "rect", "w": 20.0, "x": 16.0, "y": 2008.0}
+{"align": "left", "c": "eeeeee", "h": 25.0, "id": "r.1.1.0.51.1", "sc": "settings", "size": 20, "t": "text", "text": "Transcode 4K", "w": 120.8, "x": 46.0, "y": 2005.5}
+{"click": true, "h": 25.0, "hover": {"c": "ffffff"}, "id": "set-transcode_hdr", "sc": "settings", "t": "rect", "w": 1238.0, "x": 16.0, "y": 2038.5}
+{"bc": "555555", "bw": 1, "fill": "2a2a2a", "h": 20.0, "id": "r.1.1.0.52.0", "radius": 5, "sc": "settings", "t": "rect", "w": 20.0, "x": 16.0, "y": 2041.0}
+{"align": "left", "c": "eeeeee", "h": 25.0, "id": "r.1.1.0.52.1", "sc": "settings", "size": 20, "t": "text", "text": "Transcode HDR", "w": 131.6, "x": 46.0, "y": 2038.5}
+{"click": true, "h": 25.0, "hover": {"c": "ffffff"}, "id": "set-transcode_hi10p", "sc": "settings", "t": "rect", "w": 1238.0, "x": 16.0, "y": 2071.5}
+{"bc": "555555", "bw": 1, "fill": "2a2a2a", "h": 20.0, "id": "r.1.1.0.53.0", "radius": 5, "sc": "settings", "t": "rect", "w": 20.0, "x": 16.0, "y": 2074.0}
+{"align": "left", "c": "eeeeee", "h": 25.0, "id": "r.1.1.0.53.1", "sc": "settings", "size": 20, "t": "text", "text": "Transcode Hi10P", "w": 149.2, "x": 46.0, "y": 2071.5}
+{"click": true, "h": 25.0, "hover": {"c": "ffffff"}, "id": "set-transcode_dolby_vision", "sc": "settings", "t": "rect", "w": 1238.0, "x": 16.0, "y": 2104.5}
+{"bc": "555555", "bw": 1, "fill": "2a2a2a", "h": 20.0, "id": "r.1.1.0.54.0", "radius": 5, "sc": "settings", "t": "rect", "w": 20.0, "x": 16.0, "y": 2107.0}
+{"align": "left", "c": "eeeeee", "h": 25.0, "id": "r.1.1.0.54.1", "sc": "settings", "size": 20, "t": "text", "text": "Transcode Dolby Vision", "w": 212.0, "x": 46.0, "y": 2104.5}
+{"align": "left", "c": "9aa0a6", "h": 21.2, "id": "r.1.1.0.55.0", "sc": "settings", "size": 17, "t": "text", "text": "Force Video Codec", "w": 340.0, "x": 16.0, "y": 2145.9}
+{"h": 38.0, "id": "set-force_video_codec", "ph": "", "sc": "settings", "size": 20, "t": "textbox", "text": "", "w": 340.0, "x": 368.0, "y": 2137.5}
+{"align": "left", "c": "9aa0a6", "h": 21.2, "id": "r.1.1.0.56.0", "sc": "settings", "size": 17, "t": "text", "text": "Force Audio Codec", "w": 340.0, "x": 16.0, "y": 2191.9}
+{"h": 38.0, "id": "set-force_audio_codec", "ph": "", "sc": "settings", "size": 20, "t": "textbox", "text": "", "w": 340.0, "x": 368.0, "y": 2183.5}
+{"align": "left", "bold": true, "c": "eeeeee", "h": 25.0, "id": "r.1.1.0.57", "sc": "settings", "size": 20, "t": "text", "text": "Video Enhancement", "w": 1238.0, "x": 16.0, "y": 2229.5}
+{"click": true, "h": 25.0, "hover": {"c": "ffffff"}, "id": "set-shader_pack_enable", "sc": "settings", "t": "rect", "w": 1238.0, "x": 16.0, "y": 2262.5}
+{"fill": "00a4dc", "h": 20.0, "id": "r.1.1.0.58.0", "radius": 5, "sc": "settings", "t": "rect", "w": 20.0, "x": 16.0, "y": 2265.0}
+{"align": "center", "c": "ffffff", "h": 18.8, "id": "r.1.1.0.58.0.0", "sc": "settings", "size": 15, "t": "text", "text": "\u2713", "w": 20.0, "x": 16.0, "y": 2265.6}
+{"align": "left", "c": "eeeeee", "h": 25.0, "id": "r.1.1.0.58.1", "sc": "settings", "size": 20, "t": "text", "text": "Enable Video Playback Profiles", "w": 281.6, "x": 46.0, "y": 2262.5}
+{"align": "left", "c": "9aa0a6", "h": 21.2, "id": "r.1.1.0.59.0", "sc": "settings", "size": 17, "t": "text", "text": "Profile Group", "w": 340.0, "x": 16.0, "y": 2303.9}
+{"force": true, "h": 38.0, "id": "set-shader_pack_subtype", "items": ["lq", "hq"], "sc": "settings", "sel": 0, "size": 20, "t": "dropdown", "w": 340.0, "x": 368.0, "y": 2295.5}
+{"align": "left", "c": "9aa0a6", "h": 17.5, "id": "r.1.1.0.60", "sc": "settings", "size": 14, "t": "text", "text": "\"hq\" offers heavier profiles. Pick it if you have a fast graphics card.", "w": 1238.0, "x": 16.0, "y": 2341.5}
+{"click": true, "h": 25.0, "hover": {"c": "ffffff"}, "id": "set-shader_pack_remember", "sc": "settings", "t": "rect", "w": 1238.0, "x": 16.0, "y": 2367.0}
+{"fill": "00a4dc", "h": 20.0, "id": "r.1.1.0.61.0", "radius": 5, "sc": "settings", "t": "rect", "w": 20.0, "x": 16.0, "y": 2369.5}
+{"align": "center", "c": "ffffff", "h": 18.8, "id": "r.1.1.0.61.0.0", "sc": "settings", "size": 15, "t": "text", "text": "\u2713", "w": 20.0, "x": 16.0, "y": 2370.1}
+{"align": "left", "c": "eeeeee", "h": 25.0, "id": "r.1.1.0.61.1", "sc": "settings", "size": 20, "t": "text", "text": "Remember Last Used Profile", "w": 254.8, "x": 46.0, "y": 2367.0}
+{"align": "left", "c": "9aa0a6", "h": 21.2, "id": "r.1.1.0.62.0", "sc": "settings", "size": 17, "t": "text", "text": "Graphics API for Shaders", "w": 340.0, "x": 16.0, "y": 2408.4}
+{"force": true, "h": 38.0, "id": "set-shader_pack_gpu_api", "items": ["Automatic (recommended)", "Vulkan", "Direct3D 11 (Windows only)", "OpenGL (compatibility)"], "sc": "settings", "sel": 0, "size": 20, "t": "dropdown", "w": 340.0, "x": 368.0, "y": 2400.0}
+{"align": "left", "c": "9aa0a6", "h": 17.5, "id": "r.1.1.0.63", "sc": "settings", "size": 14, "t": "text", "text": "Leave on Automatic unless video breaks when a profile is loaded. This only applies while a profile is active, and OpenGL can cost you HDR output.", "w": 1238.0, "x": 16.0, "y": 2446.0}
+{"align": "left", "bold": true, "c": "eeeeee", "h": 25.0, "id": "r.1.1.0.64", "sc": "settings", "size": 20, "t": "text", "text": "Skip Intro / Credits", "w": 1238.0, "x": 16.0, "y": 2471.5}
+{"click": true, "h": 25.0, "hover": {"c": "ffffff"}, "id": "set-skip_intro_enable", "sc": "settings", "t": "rect", "w": 1238.0, "x": 16.0, "y": 2504.5}
+{"fill": "00a4dc", "h": 20.0, "id": "r.1.1.0.65.0", "radius": 5, "sc": "settings", "t": "rect", "w": 20.0, "x": 16.0, "y": 2507.0}
+{"align": "center", "c": "ffffff", "h": 18.8, "id": "r.1.1.0.65.0.0", "sc": "settings", "size": 15, "t": "text", "text": "\u2713", "w": 20.0, "x": 16.0, "y": 2507.6}
+{"align": "left", "c": "eeeeee", "h": 25.0, "id": "r.1.1.0.65.1", "sc": "settings", "size": 20, "t": "text", "text": "Skip Intro Enable", "w": 154.0, "x": 46.0, "y": 2504.5}
+{"click": true, "h": 25.0, "hover": {"c": "ffffff"}, "id": "set-skip_intro_always", "sc": "settings", "t": "rect", "w": 1238.0, "x": 16.0, "y": 2537.5}
+{"bc": "555555", "bw": 1, "fill": "2a2a2a", "h": 20.0, "id": "r.1.1.0.66.0", "radius": 5, "sc": "settings", "t": "rect", "w": 20.0, "x": 16.0, "y": 2540.0}
+{"align": "left", "c": "eeeeee", "h": 25.0, "id": "r.1.1.0.66.1", "sc": "settings", "size": 20, "t": "text", "text": "Skip Intro Always", "w": 160.2, "x": 46.0, "y": 2537.5}
+{"click": true, "h": 25.0, "hover": {"c": "ffffff"}, "id": "set-skip_credits_enable", "sc": "settings", "t": "rect", "w": 1238.0, "x": 16.0, "y": 2570.5}
+{"fill": "00a4dc", "h": 20.0, "id": "r.1.1.0.67.0", "radius": 5, "sc": "settings", "t": "rect", "w": 20.0, "x": 16.0, "y": 2573.0}
+{"align": "center", "c": "ffffff", "h": 18.8, "id": "r.1.1.0.67.0.0", "sc": "settings", "size": 15, "t": "text", "text": "\u2713", "w": 20.0, "x": 16.0, "y": 2573.6}
+{"align": "left", "c": "eeeeee", "h": 25.0, "id": "r.1.1.0.67.1", "sc": "settings", "size": 20, "t": "text", "text": "Skip Credits Enable", "w": 175.6, "x": 46.0, "y": 2570.5}
+{"click": true, "h": 25.0, "hover": {"c": "ffffff"}, "id": "set-skip_credits_always", "sc": "settings", "t": "rect", "w": 1238.0, "x": 16.0, "y": 2603.5}
+{"bc": "555555", "bw": 1, "fill": "2a2a2a", "h": 20.0, "id": "r.1.1.0.68.0", "radius": 5, "sc": "settings", "t": "rect", "w": 20.0, "x": 16.0, "y": 2606.0}
+{"align": "left", "c": "eeeeee", "h": 25.0, "id": "r.1.1.0.68.1", "sc": "settings", "size": 20, "t": "text", "text": "Skip Credits Always", "w": 181.8, "x": 46.0, "y": 2603.5}
+{"click": true, "h": 25.0, "hover": {"c": "ffffff"}, "id": "set-skip_intro_on_seek", "sc": "settings", "t": "rect", "w": 1238.0, "x": 16.0, "y": 2636.5}
+{"fill": "00a4dc", "h": 20.0, "id": "r.1.1.0.69.0", "radius": 5, "sc": "settings", "t": "rect", "w": 20.0, "x": 16.0, "y": 2639.0}
+{"align": "center", "c": "ffffff", "h": 18.8, "id": "r.1.1.0.69.0.0", "sc": "settings", "size": 15, "t": "text", "text": "\u2713", "w": 20.0, "x": 16.0, "y": 2639.6}
+{"align": "left", "c": "eeeeee", "h": 25.0, "id": "r.1.1.0.69.1", "sc": "settings", "size": 20, "t": "text", "text": "Skip Intro On Seek", "w": 164.0, "x": 46.0, "y": 2636.5}
+{"align": "left", "bold": true, "c": "eeeeee", "h": 25.0, "id": "r.1.1.0.70", "sc": "settings", "size": 20, "t": "text", "text": "Library Browser", "w": 1238.0, "x": 16.0, "y": 2669.5}
+{"align": "left", "c": "9aa0a6", "h": 21.2, "id": "r.1.1.0.71.0", "sc": "settings", "size": 17, "t": "text", "text": "Library Image Cache Mb", "w": 340.0, "x": 16.0, "y": 2710.9}
+{"h": 38.0, "id": "set-library_image_cache_mb", "ph": "", "sc": "settings", "size": 20, "t": "textbox", "text": "256", "w": 340.0, "x": 368.0, "y": 2702.5}
+{"align": "left", "c": "9aa0a6", "h": 21.2, "id": "r.1.1.0.72.0", "sc": "settings", "size": 17, "t": "text", "text": "Scroll Wheel Pixels", "w": 340.0, "x": 16.0, "y": 2756.9}
+{"h": 38.0, "id": "set-scroll_wheel_pixels", "ph": "", "sc": "settings", "size": 20, "t": "textbox", "text": "80", "w": 340.0, "x": 368.0, "y": 2748.5}
+{"align": "left", "c": "9aa0a6", "h": 17.5, "id": "r.1.1.0.73", "sc": "settings", "size": 14, "t": "text", "text": "Pixels one wheel notch scrolls. The scrollbar glides while the content snaps to the nearest row, so a trackpad or trackball no longer overshoots. Raise it to scroll faster, lower it for finer", "w": 1238.0, "x": 16.0, "y": 2794.5}
+{"align": "left", "c": "9aa0a6", "h": 17.5, "id": "r.1.1.0.73.l1", "sc": "settings", "size": 14, "t": "text", "text": "control.", "w": 1238.0, "x": 16.0, "y": 2812.0}
+{"click": true, "h": 25.0, "hover": {"c": "ffffff"}, "id": "set-snapped_scrolling", "sc": "settings", "t": "rect", "w": 1238.0, "x": 16.0, "y": 2837.5}
+{"bc": "555555", "bw": 1, "fill": "2a2a2a", "h": 20.0, "id": "r.1.1.0.74.0", "radius": 5, "sc": "settings", "t": "rect", "w": 20.0, "x": 16.0, "y": 2840.0}
+{"align": "left", "c": "eeeeee", "h": 25.0, "id": "r.1.1.0.74.1", "sc": "settings", "size": 20, "t": "text", "text": "Snapped Scrolling", "w": 162.8, "x": 46.0, "y": 2837.5}
+{"align": "left", "c": "9aa0a6", "h": 17.5, "id": "r.1.1.0.75", "sc": "settings", "size": 14, "t": "text", "text": "Make each wheel notch jump exactly one row (or one home-screen section) instead of gliding. Turn this on if you prefer the older stepped scrolling.", "w": 1238.0, "x": 16.0, "y": 2870.5}
+{"click": true, "h": 25.0, "hover": {"c": "ffffff"}, "id": "set-paginated", "sc": "settings", "t": "rect", "w": 1238.0, "x": 16.0, "y": 2896.0}
+{"bc": "555555", "bw": 1, "fill": "2a2a2a", "h": 20.0, "id": "r.1.1.0.76.0", "radius": 5, "sc": "settings", "t": "rect", "w": 20.0, "x": 16.0, "y": 2898.5}
+{"align": "left", "c": "eeeeee", "h": 25.0, "id": "r.1.1.0.76.1", "sc": "settings", "size": 20, "t": "text", "text": "Paginated", "w": 89.2, "x": 46.0, "y": 2896.0}
+{"align": "left", "c": "9aa0a6", "h": 17.5, "id": "r.1.1.0.77", "sc": "settings", "size": 14, "t": "text", "text": "Page the library and music tile grids instead of scrolling: each page is one screenful with First / Previous / Next / Last controls and a page number you can type into. Easier than precise", "w": 1238.0, "x": 16.0, "y": 2929.0}
+{"align": "left", "c": "9aa0a6", "h": 17.5, "id": "r.1.1.0.77.l1", "sc": "settings", "size": 14, "t": "text", "text": "scrolling on a trackpad.", "w": 1238.0, "x": 16.0, "y": 2946.5}
+{"align": "left", "bold": true, "c": "eeeeee", "h": 25.0, "id": "r.1.1.0.78", "sc": "settings", "size": 20, "t": "text", "text": "Downloads", "w": 1238.0, "x": 16.0, "y": 2972.0}
+{"align": "left", "c": "9aa0a6", "h": 21.2, "id": "r.1.1.0.79.0", "sc": "settings", "size": 17, "t": "text", "text": "Download Folder", "w": 340.0, "x": 16.0, "y": 3016.9}
+{"h": 38.0, "id": "set-sync_path", "ph": "", "sc": "settings", "size": 20, "t": "textbox", "text": "", "w": 250.0, "x": 368.0, "y": 3008.5}
+{"click": true, "fill": "333333", "h": 45.0, "hover": {"fill": "4a4a4a"}, "id": "set-sync-move", "radius": 6, "sc": "settings", "t": "rect", "w": 69.4, "x": 626.0, "y": 3005.0}
+{"align": "center", "c": "eeeeee", "h": 25.0, "id": "r.1.1.0.79.1.1.0", "sc": "settings", "size": 20, "t": "text", "text": "Move", "w": 49.4, "x": 636.0, "y": 3015.0}
+{"click": true, "h": 25.0, "hover": {"c": "ffffff"}, "id": "set-prefer_downloaded", "sc": "settings", "t": "rect", "w": 1238.0, "x": 16.0, "y": 3058.0}
+{"fill": "00a4dc", "h": 20.0, "id": "r.1.1.0.80.0", "radius": 5, "sc": "settings", "t": "rect", "w": 20.0, "x": 16.0, "y": 3060.5}
+{"align": "center", "c": "ffffff", "h": 18.8, "id": "r.1.1.0.80.0.0", "sc": "settings", "size": 15, "t": "text", "text": "\u2713", "w": 20.0, "x": 16.0, "y": 3061.1}
+{"align": "left", "c": "eeeeee", "h": 25.0, "id": "r.1.1.0.80.1", "sc": "settings", "size": 20, "t": "text", "text": "Prefer Downloaded Copy", "w": 218.2, "x": 46.0, "y": 3058.0}
+{"click": true, "h": 25.0, "hover": {"c": "ffffff"}, "id": "set-auto_download_enable", "sc": "settings", "t": "rect", "w": 1238.0, "x": 16.0, "y": 3091.0}
+{"bc": "555555", "bw": 1, "fill": "2a2a2a", "h": 20.0, "id": "r.1.1.0.81.0", "radius": 5, "sc": "settings", "t": "rect", "w": 20.0, "x": 16.0, "y": 3093.5}
+{"align": "left", "c": "eeeeee", "h": 25.0, "id": "r.1.1.0.81.1", "sc": "settings", "size": 20, "t": "text", "text": "Automatically Download Upcoming Episodes", "w": 404.2, "x": 46.0, "y": 3091.0}
+{"align": "left", "c": "9aa0a6", "h": 17.5, "id": "r.1.1.0.82", "sc": "settings", "size": 14, "t": "text", "text": "Applies to srv1, enable other servers in servers tab.", "w": 1238.0, "x": 16.0, "y": 3124.0}
+{"click": true, "h": 25.0, "hover": {"c": "ffffff"}, "id": "set-auto_download_next_up", "sc": "settings", "t": "rect", "w": 1238.0, "x": 16.0, "y": 3149.5}
+{"fill": "00a4dc", "h": 20.0, "id": "r.1.1.0.83.0", "radius": 5, "sc": "settings", "t": "rect", "w": 20.0, "x": 16.0, "y": 3152.0}
+{"align": "center", "c": "ffffff", "h": 18.8, "id": "r.1.1.0.83.0.0", "sc": "settings", "size": 15, "t": "text", "text": "\u2713", "w": 20.0, "x": 16.0, "y": 3152.6}
+{"align": "left", "c": "eeeeee", "h": 25.0, "id": "r.1.1.0.83.1", "sc": "settings", "size": 20, "t": "text", "text": "Include Next Up", "w": 140.4, "x": 46.0, "y": 3149.5}
+{"align": "left", "c": "9aa0a6", "h": 21.2, "id": "r.1.1.0.84.0", "sc": "settings", "size": 17, "t": "text", "text": "Next Up Entries to Consider", "w": 340.0, "x": 16.0, "y": 3190.9}
+{"h": 38.0, "id": "set-auto_download_next_up_limit", "ph": "", "sc": "settings", "size": 20, "t": "textbox", "text": "10", "w": 340.0, "x": 368.0, "y": 3182.5}
+{"align": "left", "c": "9aa0a6", "h": 21.2, "id": "r.1.1.0.85.0", "sc": "settings", "size": 17, "t": "text", "text": "Episodes to Keep Ahead (0 = off)", "w": 340.0, "x": 16.0, "y": 3236.9}
+{"h": 38.0, "id": "set-auto_download_lookahead", "ph": "", "sc": "settings", "size": 20, "t": "textbox", "text": "2", "w": 340.0, "x": 368.0, "y": 3228.5}
+{"align": "left", "c": "9aa0a6", "h": 21.2, "id": "r.1.1.0.86.0", "sc": "settings", "size": 17, "t": "text", "text": "Storage Limit for Automatic Downloads (GB)", "w": 340.0, "x": 16.0, "y": 3282.9}
+{"h": 38.0, "id": "set-auto_download_max_gb", "ph": "", "sc": "settings", "size": 20, "t": "textbox", "text": "20", "w": 340.0, "x": 368.0, "y": 3274.5}
+{"click": true, "h": 25.0, "hover": {"c": "ffffff"}, "id": "set-auto_download_delete_watched", "sc": "settings", "t": "rect", "w": 1238.0, "x": 16.0, "y": 3320.5}
+{"fill": "00a4dc", "h": 20.0, "id": "r.1.1.0.87.0", "radius": 5, "sc": "settings", "t": "rect", "w": 20.0, "x": 16.0, "y": 3323.0}
+{"align": "center", "c": "ffffff", "h": 18.8, "id": "r.1.1.0.87.0.0", "sc": "settings", "size": 15, "t": "text", "text": "\u2713", "w": 20.0, "x": 16.0, "y": 3323.6}
+{"align": "left", "c": "eeeeee", "h": 25.0, "id": "r.1.1.0.87.1", "sc": "settings", "size": 20, "t": "text", "text": "Delete Automatic Downloads Once Watched", "w": 392.6, "x": 46.0, "y": 3320.5}
+{"align": "left", "c": "9aa0a6", "h": 21.2, "id": "r.1.1.0.88.0", "sc": "settings", "size": 17, "t": "text", "text": "Delete Unwatched After (days, 0 = never)", "w": 340.0, "x": 16.0, "y": 3361.9}
+{"h": 38.0, "id": "set-auto_download_keep_days", "ph": "", "sc": "settings", "size": 20, "t": "textbox", "text": "30", "w": 340.0, "x": 368.0, "y": 3353.5}
+{"align": "left", "c": "9aa0a6", "h": 21.2, "id": "r.1.1.0.89.0", "sc": "settings", "size": 17, "t": "text", "text": "Check Every (minutes)", "w": 340.0, "x": 16.0, "y": 3407.9}
+{"h": 38.0, "id": "set-auto_download_interval_mins", "ph": "", "sc": "settings", "size": 20, "t": "textbox", "text": "60", "w": 340.0, "x": 368.0, "y": 3399.5}
+{"click": true, "h": 25.0, "hover": {"c": "ffffff"}, "id": "set-adv", "sc": "settings", "t": "rect", "w": 1238.0, "x": 16.0, "y": 3445.5}
+{"bc": "555555", "bw": 1, "fill": "2a2a2a", "h": 20.0, "id": "r.1.1.0.90.0", "radius": 5, "sc": "settings", "t": "rect", "w": 20.0, "x": 16.0, "y": 3448.0}
+{"align": "left", "c": "eeeeee", "h": 25.0, "id": "r.1.1.0.90.1", "sc": "settings", "size": 20, "t": "text", "text": "Show advanced settings", "w": 222.2, "x": 46.0, "y": 3445.5}
+{"align": "left", "c": "9aa0a6", "h": 17.5, "id": "r.1.1.0.91", "sc": "settings", "size": 14, "t": "text", "text": "Some changes take effect after restarting.", "w": 1238.0, "x": 16.0, "y": 3478.5}

--- a/tests/test_background_setting.py
+++ b/tests/test_background_setting.py
@@ -188,10 +188,16 @@ class BackgroundNoteTest(unittest.TestCase):
         with mock.patch.object(settings, "allow_background", False):
             self.assertIsNone(self._note())
 
-    def test_it_is_not_a_static_note(self):
-        # A NOTES entry would render unconditionally and win over the dynamic
-        # one, which is the mistake this guards.
-        self.assertNotIn("allow_background", cfg.NOTES)
+    def test_the_static_note_does_not_displace_it(self):
+        # This used to ban a NOTES entry outright, because
+        # `notes.get(key) or self._dynamic_note(key)` meant a static line
+        # silently suppressed the dynamic one. The form renders both now
+        # (test_shell_settings.test_a_static_note_does_not_hide_the_dynamic_one),
+        # so allow_background carries the cast-target recipe as well -- but
+        # the way-out warning still has to survive alongside it.
+        self.assertIn("allow_background", cfg.NOTES)
+        with mock.patch.object(settings, "allow_background", True):
+            self.assertIn("jellyfin-mpv-shim stop", self._note())
 
 
 if __name__ == "__main__":

--- a/tests/test_mpvtk_layout.py
+++ b/tests/test_mpvtk_layout.py
@@ -276,6 +276,69 @@ class TestWrapMargin(unittest.TestCase):
             self.assertTrue(wrap_text("hello world", 18, False, w))
 
 
+class TestWrappedContentIsScrollable(unittest.TestCase):
+    """A scroll viewport clamps to the content height it is told, and it
+    used to be told an *intrinsic* measure -- one line per wrapped Text,
+    whatever the text actually did at the width it got. Every explanatory
+    note in the settings form cost real rows off the bottom of the scroll:
+    the "Show advanced settings" checkbox was drawn but could not be
+    reached.
+    """
+
+    NOTE = ("An explanatory note under a setting, long enough that it wraps "
+            "to several lines in any settings column narrow enough to be a "
+            "settings column, which is the whole point of this test.")
+
+    def _page(self, n=6, w=None):
+        rows = []
+        for i in range(n):
+            rows.append(Box(h=25, bg="222222", id="row-%d" % i))
+            rows.append(Text(self.NOTE, size=14, wrap=True, **(
+                {"w": w} if w else {})))
+        rows.append(Box(h=25, bg="222222", id="last"))
+        return VScroll(Column(rows, pad=16, gap=8, align="stretch"),
+                       id="sc", flex=1)
+
+    def _extent(self, tree, w=600, h=400):
+        nodes, _h = layout(tree, w, h)
+        sc = by_id(nodes, "sc")
+        bottom = max(n["y"] + n.get("h", 0) for n in nodes
+                     if n.get("sc") == "sc")
+        return sc["ch"], bottom - sc["y"]
+
+    def test_content_height_covers_the_wrapped_text(self):
+        ch, content = self._extent(self._page())
+        self.assertGreaterEqual(
+            ch, content,
+            "scroll extent stops %.0fpx short of its own content" %
+            (content - ch))
+
+    def test_it_is_not_just_padded_out(self):
+        """Guarding the above with a fudge factor would pass too. The extent
+        has to actually track the wrapping: more notes, more height."""
+        few, _c = self._extent(self._page(2))
+        many, _c = self._extent(self._page(8))
+        self.assertGreater(many - few, 6 * 14 * 1.2)
+
+    def test_a_narrower_window_scrolls_further(self):
+        wide, _c = self._extent(self._page(), w=1000)
+        narrow, _c = self._extent(self._page(), w=420)
+        self.assertGreater(narrow, wide)
+
+    def test_explicit_width_still_measured(self):
+        """wrap=True with an explicit w already measured correctly; the
+        width-aware path must not regress it."""
+        ch, content = self._extent(self._page(w=300))
+        self.assertGreaterEqual(ch, content)
+
+    def test_viewport_is_the_floor(self):
+        """Content shorter than the viewport must not make it scrollable."""
+        tree = VScroll(Column([Text("short", size=14, wrap=True)], pad=16),
+                       id="sc", flex=1)
+        nodes, _h = layout(tree, 600, 400)
+        self.assertEqual(by_id(nodes, "sc")["ch"], 400.0)
+
+
 class TestAssWrapStyle(unittest.TestCase):
     """The layout engine breaks text into lines; libass must not then
     apply its own smart wrapping on top. Two wrappers disagreeing by a

--- a/tests/test_shell_settings.py
+++ b/tests/test_shell_settings.py
@@ -94,6 +94,38 @@ class TestSettings(unittest.TestCase):
         # about reads as something they are missing.
         self.assertNotIn("pypresence", real.NOTES["discord_presence"])
 
+    def test_one_way_doors_are_advanced_only(self):
+        """enable_gui reads like "turn off the Jellyfin UI" and actually
+        drops the app to CLI mode; headless takes the library away, Settings
+        with it. Both leave conf.json as the way back on a machine with no
+        tray, so neither belongs one click deep in Interface."""
+        from jellyfin_mpv_shim.mpvtk_browser import config as real
+
+        groups = dict(real.sections())
+        for key in ("enable_gui", "headless"):
+            self.assertNotIn(key, groups["Interface"])
+            self.assertIn(key, groups.get("Advanced", []))
+            note = real.NOTES.get(key)
+            self.assertIsNotNone(note, "%s hides the way to undo it and says "
+                                       "nothing about it" % key)
+            self.assertIn("conf.json", note)
+
+    def test_cast_target_setup_is_spelled_out(self):
+        """The classic cast-only behaviour is three ordinary settings, and
+        nowhere in the app said which — which is how people reached for
+        enable_gui to get it. The note rides the keep-running toggle, so it
+        is visible whichever of the two this machine shows."""
+        from jellyfin_mpv_shim.mpvtk_browser import config as real
+
+        for key in ("close_to_tray", "allow_background"):
+            note = real.NOTES.get(key) or ""
+            for label in (real.label_for("start_minimized"),
+                          real.label_for("fullscreen")):
+                self.assertIn(label, note)
+        shown = dict(real.sections())["Interface"]
+        self.assertTrue({"close_to_tray", "allow_background"} & set(shown),
+                        "the recipe's anchor left the visible section")
+
     def test_discord_says_so_when_it_is_on_but_did_not_load(self):
         """Ticking the box with pypresence missing did nothing at all, and
         said nothing either: player.py reads the setting once at import and


### PR DESCRIPTION
Fix issue where Windows users could easily set "enable_gui" to false and then have no way back because they thought it disables the library browser but it really disables *all* user interfaces and drops to the command line UI mode.

Also fixes an issue where settings UI overflows the scroll height.