### PR TITLE
Send the Jellyfin token as a header, not a query string

### DIFF
--- a/jellyfin_mpv_shim/log_utils.py
+++ b/jellyfin_mpv_shim/log_utils.py
@@ -4,6 +4,9 @@ import re
 
 bad_patterns = (
     (re.compile("api_key=[a-f0-9]*"), "api_key=REDACTED"),
+    # ApiKey is the non-legacy spelling and is what we send now; the old one
+    # stays above because logs from an older build still reach us.
+    (re.compile("ApiKey=[a-f0-9]*"), "ApiKey=REDACTED"),
     (
         re.compile("'X-MediaBrowser-Token': '[a-f0-9]*'"),
         "'X-MediaBrowser-Token': 'REDACTED'",
@@ -17,7 +20,9 @@ bad_patterns = (
 # module unwraps it -- it becomes the %-formatting mapping rather than a
 # one-tuple -- so the formatter sees the values individually and a bare
 # token matches nothing. Redact those by key instead.
-sensitive_keys = ("x-mediabrowser-token", "accesstoken", "api_key",
+# Matched against str(key).lower(), so "ApiKey" needs its own lowercased
+# entry -- "api_key" does not cover it, and that is the spelling we send now.
+sensitive_keys = ("x-mediabrowser-token", "accesstoken", "api_key", "apikey",
                   "password", "authorization")
 
 sanitize_logs = False

--- a/jellyfin_mpv_shim/media.py
+++ b/jellyfin_mpv_shim/media.py
@@ -596,14 +596,22 @@ class Video(object):
             # cannot decode HEIC, and finding out at decode time gives a
             # black window rather than a fallback. Branching on the container
             # up front is the cheap version of that test.
+            # Both of these take the header like every other url below, and
+            # for the same reason -- this branch returns before the one that
+            # drops the token, so leaving them at the apiclient's default
+            # sent both, and a photo was the one thing still putting a token
+            # in a query string after all of the above.
+            keep_token = not self.auth_via_header
             container = (self.item.get("Container") or "").lower()
             path = (self.item.get("Path") or "").lower()
             if container in _SERVER_CONVERTED_IMAGES or any(
                     path.endswith("." + ext)
                     for ext in _SERVER_CONVERTED_IMAGES):
                 return self.client.jellyfin.artwork(
-                    self.item_id, "Primary", _PHOTO_MAX_WIDTH)
-            return self.client.jellyfin.download_url(self.item_id)
+                    self.item_id, "Primary", _PHOTO_MAX_WIDTH,
+                    include_apikey=keep_token)
+            return self.client.jellyfin.download_url(
+                self.item_id, include_apikey=keep_token)
 
         if self.trs_ovr:
             video_bitrate, force_transcode = self.trs_ovr

--- a/jellyfin_mpv_shim/media.py
+++ b/jellyfin_mpv_shim/media.py
@@ -122,6 +122,44 @@ class Video(object):
         self.intros: List[Intro] = []
         self.intro_tried = False
 
+    def foreign_subtitle_hosts(self):
+        """Hosts, other than our server, that mpv would fetch a subtitle from.
+
+        ``--http-header-fields`` is a **global** mpv option: it applies to
+        every HTTP request mpv makes, not just the stream. An external
+        subtitle whose Path is an absolute URI is handed to ``sub_add``
+        unchanged (see map_streams), so setting the header while one of
+        those is in play would send our access token to whoever hosts it.
+
+        Read off the item rather than the media source because this has to
+        be answerable *before* PlaybackInfo -- the header has to be decided
+        before the stream URL is built. IsExternalUrl is set by the server
+        exactly when a subtitle's Path is an absolute http(s) URI
+        (StreamInfo.cs:1264-1274), so the same test on Path is the honest
+        pre-check.
+        """
+        try:
+            base = urllib.parse.urlparse(
+                self.client.config.data.get("auth.server") or "")
+        except Exception:
+            return set()
+        mine = (base.scheme, base.hostname, base.port)
+        foreign = set()
+        for source in self.item.get("MediaSources") or []:
+            for stream in source.get("MediaStreams") or []:
+                if stream.get("Type") != "Subtitle":
+                    continue
+                path = stream.get("Path") or ""
+                if not path.lower().startswith(("http://", "https://")):
+                    continue
+                try:
+                    parts = urllib.parse.urlparse(path)
+                except Exception:
+                    continue
+                if (parts.scheme, parts.hostname, parts.port) != mine:
+                    foreign.add(parts.hostname)
+        return foreign
+
     def map_streams(self):
         self.subtitle_seq = {}
         self.subtitle_uid = {}

--- a/jellyfin_mpv_shim/media.py
+++ b/jellyfin_mpv_shim/media.py
@@ -101,6 +101,12 @@ class Video(object):
         #: it starts paused, it reports nothing, and the seek controls are
         #: meaningless. See get_playback_url for why it skips PlaybackInfo.
         self.is_photo = self.item.get("Type") == "Photo"
+        #: Set by the player before it asks for a URL: True once mpv has been
+        #: handed this server's Authorization header, in which case the URL
+        #: leaves the token out. A token in a URL is a token in logs, in
+        #: ``ps`` output and in every proxy in the path -- and it is a query
+        #: parameter whose accepted spelling has already changed twice.
+        self.auth_via_header = False
 
         self.subtitle_seq = {}
         self.subtitle_uid = {}
@@ -389,8 +395,15 @@ class Video(object):
             query_params = {
                 "static": "true",
                 "MediaSourceId": self.media_source["Id"],
-                "api_key": self.client.config.data["auth.token"],
             }
+            if not self.auth_via_header:
+                # Only when the player could not be given the Authorization
+                # header. ApiKey, not api_key: the server reads both in the
+                # same place, but api_key is gated on
+                # EnableLegacyAuthorization, off by default from Jellyfin v12
+                # (AuthorizationContext.GetAuthorizationInfoFromDictionary).
+                query_params["ApiKey"] = (
+                    self.client.config.data["auth.token"])
 
             if "LiveStreamId" in self.media_source:
                 query_params["LiveStreamId"] = self.media_source["LiveStreamId"]

--- a/jellyfin_mpv_shim/mpvtk_browser/app.py
+++ b/jellyfin_mpv_shim/mpvtk_browser/app.py
@@ -1682,6 +1682,27 @@ class MpvtkBrowser(DialogsMixin, LiveTvDialogsMixin, AuthMixin, SettingsMixin,
 
         self._start_daemon("_np_thread", "mpvtk-np-tick", tick)
 
+    def _publish_auth_origins(self):
+        """Tell the thumbnail store which token belongs to which server.
+
+        Images are fetched on the store's own session, so this is how they
+        authenticate by header rather than by query string. Called on every
+        source swap, which is also what revokes a signed-out server's token
+        -- the store replaces its map wholesale.
+        """
+        origins = {}
+        get = getattr(self.source, "auth_origins", None)
+        if get is not None:
+            try:
+                origins = get()
+            except Exception:
+                log.debug("could not publish auth origins", exc_info=True)
+        try:
+            self.thumbs.set_auth(origins)
+        except Exception:
+            log.debug("thumbnail store would not take auth origins",
+                      exc_info=True)
+
     def set_source(self, source, server_uuid=None, keep_place=False):
         """Swap in a live data source once servers connect (the browser opens
         immediately on a spinner and populates when the network settles).
@@ -1706,6 +1727,7 @@ class MpvtkBrowser(DialogsMixin, LiveTvDialogsMixin, AuthMixin, SettingsMixin,
         self.set_offline(isinstance(source, OfflineLibrarySource))
         self._locked = False
         self.source = source
+        self._publish_auth_origins()
         try:
             servers = source.servers()
         except Exception:

--- a/jellyfin_mpv_shim/mpvtk_browser/repository.py
+++ b/jellyfin_mpv_shim/mpvtk_browser/repository.py
@@ -11,6 +11,7 @@ same shapes work whether they came from the server or a local cache.
 import datetime
 import json
 import logging
+from urllib.parse import urlparse
 import os
 import random
 
@@ -231,6 +232,32 @@ class LibrarySource:
 
     def servers(self):
         return [{"uuid": uuid, "name": self._conns[uuid].name} for uuid in self._order]
+
+    def auth_origins(self):
+        """``{(scheme, host, port): authorization-header}`` for every server
+        this source is connected to.
+
+        For the thumbnail store, which fetches image URLs on its own session
+        and would otherwise have to carry the token in the query string. The
+        header is the apiclient's own -- the non-legacy MediaBrowser scheme
+        -- so there is one spelling of it in the app.
+        """
+        out = {}
+        for conn in self._conns.values():
+            try:
+                client = conn.client
+                base = client.config.data.get("auth.server") or ""
+                header = client.http._get_authenication_header()
+            except Exception:
+                log.debug("no auth header for a browse connection",
+                          exc_info=True)
+                continue
+            if not header or "Token=" not in header:
+                continue
+            parts = urlparse(base)
+            if parts.hostname:
+                out[(parts.scheme, parts.hostname, parts.port)] = header
+        return out
 
     def _conn(self, server_uuid) -> ServerConn:
         return self._conns[server_uuid]
@@ -1870,13 +1897,18 @@ class LibrarySource:
             # the bitmap under -- backdrop_url has always passed index=0 for
             # the same reason.
             index = 0
+        # include_apikey=False throughout: the thumbnail store sends the
+        # Authorization header instead (see auth_origins). Images are the
+        # highest-volume first-party traffic here, so a token in these query
+        # strings is a token in the access log of every one of them.
         if fill and height:
             # Crop to the exact tile aspect so wide library/banner art still
             # reads as a uniform poster instead of a letterboxed thumbnail.
             return api.image_url(item_id, image_type, index=index, tag=tag,
-                                 fill_width=int(width), fill_height=int(height))
+                                 fill_width=int(width), fill_height=int(height),
+                                 include_apikey=False)
         return api.image_url(item_id, image_type, index=index, tag=tag,
-                             max_width=int(width))
+                             max_width=int(width), include_apikey=False)
 
     def chapter_image_url(self, server_uuid, item_id, chapter_index, chapter,
                           width=320):

--- a/jellyfin_mpv_shim/mpvtk_browser/thumbnails.py
+++ b/jellyfin_mpv_shim/mpvtk_browser/thumbnails.py
@@ -19,6 +19,7 @@ not just an in-memory LRU.
 import hashlib
 import logging
 import os
+from urllib.parse import urlparse
 import queue
 import threading
 from collections import OrderedDict
@@ -124,6 +125,16 @@ class ThumbnailStore:
         )
         self._session.mount("http://", adapter)
         self._session.mount("https://", adapter)
+        # origin -> Authorization header, registered by the source when its
+        # connections are built. Images are by far the highest-volume
+        # first-party requests this app makes, and putting the token in the
+        # query string means an admin cannot put Jellyfin behind a proxy
+        # that rejects unauthenticated traffic -- every tile would 401.
+        #
+        # Keyed by origin rather than held as one header because a session
+        # can hold several servers at once, and a token is only ever sent to
+        # the server it came from.
+        self._auth: dict = {}
         self._pool = ThreadPoolExecutor(max_workers=workers,
                                         thread_name_prefix="thumb")
         self._results: "queue.Queue[tuple[str, Optional[Image.Image]]]" = \
@@ -319,6 +330,27 @@ class ThumbnailStore:
             measure_transparency(image)
         return image
 
+    def set_auth(self, origins):
+        """``{origin: authorization-header}`` for the servers now connected.
+
+        Replaced wholesale rather than merged: a server the user has just
+        signed out of must stop receiving its old token.
+        """
+        self._auth = dict(origins or {})
+
+    def _headers_for(self, url):
+        """The Authorization header for ``url``, or none.
+
+        Matched on scheme+host+port, so a token never travels to another
+        host -- nor over plain http to a server we reached by https.
+        """
+        try:
+            parts = urlparse(url)
+        except Exception:
+            return {}
+        header = self._auth.get((parts.scheme, parts.hostname, parts.port))
+        return {"Authorization": header} if header else {}
+
     def _load_remote(self, key, url):
         path = os.path.join(self.cache_dir, key + ".img")
         if os.path.exists(path):
@@ -329,7 +361,8 @@ class ThumbnailStore:
             except OSError:
                 pass
 
-        resp = self._session.get(url, timeout=(5, 20), verify=self.verify_ssl)
+        resp = self._session.get(url, timeout=(5, 20), verify=self.verify_ssl,
+                                 headers=self._headers_for(url))
         resp.raise_for_status()
         data = resp.content
         tmp = path + ".tmp"

--- a/jellyfin_mpv_shim/mpvtk_browser/tile_renderer.py
+++ b/jellyfin_mpv_shim/mpvtk_browser/tile_renderer.py
@@ -457,9 +457,55 @@ class TileRenderer:
         if t == "Season":
             return iid in self._downloaded_seasons
         return t == "Playlist" and iid in self._downloaded_playlists
+    #: Banner widths are rounded up to a multiple of this before they reach
+    #: the artwork cache.
+    #:
+    #: The cache keys on exact pixel dimensions, and the banner used to be a
+    #: *continuous* function of the window width -- so dragging a window edge
+    #: across 400px asked the server for up to 400 different backdrops, decoded
+    #: 400 bitmaps and kept them all resident until the LRU pushed them out.
+    #: That is issue #592, and it is why a resize both hammered the access log
+    #: and ballooned memory.
+    #:
+    #: jellyfin-web does the same thing for the same stated reason -- it rounds
+    #: the screen width down to a multiple of 100 "to improve cache hits"
+    #: (cardBuilder.js:126-129). 128 rather than 100 because these are pixels
+    #: in a cache key, not a CSS breakpoint: it makes at most nine distinct
+    #: banner widths between a small window and the 1100 cap.
+    #:
+    #: Rounding UP, not down, so the bitmap is never asked to upscale -- a
+    #: banner drawn slightly wider than requested is cropped by the compositor,
+    #: which is invisible; one drawn narrower is soft.
+    BANNER_STEP = 128
+
     def banner_box(self, width):
+        """The banner's LAID-OUT size: exactly the space it has.
+
+        Deliberately not quantised. The header spans the content width, so
+        rounding this up overhangs the scrollbar and rounding it down leaves
+        a gap beside content that does reach the edge. What gets quantised is
+        the *fetch* -- see ``_banner_fetch_w``.
+        """
         bw = min(width - 2 * chrome.CONTENT_PAD, 1100)
         return bw, int(bw * self.BANNER_RATIO)
+
+    def _banner_fetch_w(self, physical_w):
+        """Physical width to ask the server for, given the drawn width.
+
+        Rounded UP to a step so a resize stops minting a new request per
+        pixel (issue #592) -- the artwork cache keys on exact dimensions, so
+        a continuous width meant a continuous stream of misses. Up rather
+        than down because the fetched image is *cropped* into the banner by
+        compose_banner: larger than needed costs nothing, smaller would have
+        to be upscaled.
+
+        Only the fetch. The composed banner is still built at the exact drawn
+        size, because that one has to match the box it is drawn in.
+        """
+        step = self.BANNER_STEP
+        if physical_w <= 0:
+            return 0
+        return int(-(-physical_w // step) * step)
     def backdrop_node(self, item, box, node_id, title=None, meta=None,
                        context=None):
         """A backdrop banner for detail/series headers.
@@ -482,11 +528,16 @@ class TileRenderer:
             if title:
                 key += "|" + make_key(title, meta or "", context or "",
                                       pbox[0], pbox[1])
-            url = self.art.source.backdrop_url(self.art.server, item, width=pbox[0],
-                                           height=pbox[1], fill=True)
             # Request at the *source* aspect and crop to the banner below, so
-            # a shallow banner doesn't ask the server for a squashed image.
-            img = self._request_image(key, url, (pbox[0], pbox[0]))
+            # a shallow banner doesn't ask the server for a squashed image --
+            # and at a quantised width, so dragging the window edge does not
+            # ask for a new one every pixel.
+            fetch_w = self._banner_fetch_w(pbox[0])
+            fetch_key = make_key(owner_id, "Backdrop", tag, fetch_w, fetch_w)
+            url = self.art.source.backdrop_url(self.art.server, item,
+                                               width=fetch_w, height=fetch_w,
+                                               fill=True)
+            img = self._request_image(fetch_key, url, (fetch_w, fetch_w))
             if img is not None:
                 b = self.art.strips.bitmap(key, components.compose_banner(
                     img, pbox, title, meta, context), lsize=box)

--- a/jellyfin_mpv_shim/mpvtk_browser/tile_renderer.py
+++ b/jellyfin_mpv_shim/mpvtk_browser/tile_renderer.py
@@ -528,16 +528,26 @@ class TileRenderer:
             if title:
                 key += "|" + make_key(title, meta or "", context or "",
                                       pbox[0], pbox[1])
-            # Request at the *source* aspect and crop to the banner below, so
-            # a shallow banner doesn't ask the server for a squashed image --
-            # and at a quantised width, so dragging the window edge does not
-            # ask for a new one every pixel.
+            # Request at the BANNER's aspect, at a quantised width so that
+            # dragging the window edge does not ask for a new image every
+            # pixel.
+            #
+            # The height is not incidental. `fill=True` is fillWidth +
+            # fillHeight, i.e. the server *crops* to the shape asked for
+            # (it does not squash), and compose_banner's scale_to_cover
+            # then centre-crops to the same shape — so asking for the
+            # banner's own aspect is the identical picture for a third of
+            # the pixels. Asking for a square instead, as this briefly
+            # did, hands back the centre square of a 16:9 backdrop, which
+            # cover then blows up to the full width: every header zoomed
+            # ~1.8x, in the commit whose point was making banners cheaper.
             fetch_w = self._banner_fetch_w(pbox[0])
-            fetch_key = make_key(owner_id, "Backdrop", tag, fetch_w, fetch_w)
+            fetch_h = max(1, int(fetch_w * self.BANNER_RATIO))
+            fetch_key = make_key(owner_id, "Backdrop", tag, fetch_w, fetch_h)
             url = self.art.source.backdrop_url(self.art.server, item,
-                                               width=fetch_w, height=fetch_w,
+                                               width=fetch_w, height=fetch_h,
                                                fill=True)
-            img = self._request_image(fetch_key, url, (fetch_w, fetch_w))
+            img = self._request_image(fetch_key, url, (fetch_w, fetch_h))
             if img is not None:
                 b = self.art.strips.bitmap(key, components.compose_banner(
                     img, pbox, title, meta, context), lsize=box)

--- a/jellyfin_mpv_shim/player.py
+++ b/jellyfin_mpv_shim/player.py
@@ -1504,6 +1504,21 @@ class PlayerManager(AudioMixin, ReportingMixin, WindowMixin):
             # claiming success would strip a url that needs one.
             return False
         try:
+            foreign = video.foreign_subtitle_hosts()
+        except Exception:
+            log.debug("could not check for foreign subtitle hosts",
+                      exc_info=True)
+            foreign = {"unknown"}
+        if foreign:
+            # http-header-fields is GLOBAL: mpv would send this token to
+            # whoever hosts that subtitle. There is no per-URL header option,
+            # so the only safe answer is to not set it at all and let the
+            # stream URL carry its own token, which is where it was before.
+            log.info("Not sending the auth header to mpv: this item has a "
+                     "subtitle on %s, and the option is not per-URL.",
+                     ", ".join(sorted(str(h) for h in foreign)))
+            return False
+        try:
             self._player.http_header_fields = ["Authorization: " + header]
         except Exception:
             log.warning("mpv would not take http-header-fields; falling back "

--- a/jellyfin_mpv_shim/player.py
+++ b/jellyfin_mpv_shim/player.py
@@ -1490,7 +1490,34 @@ class PlayerManager(AudioMixin, ReportingMixin, WindowMixin):
         falls back to putting the token in the url. mpv has had
         ``http-header-fields`` for over a decade so this should not happen,
         but the cost of being wrong is that nothing plays at all.
+
+        **The clear at the top is load-bearing.** ``http-header-fields`` is
+        a global, persistent mpv option and mpv is not re-created between
+        queue items, so a header installed for one item is still installed
+        for the next — including a next item we deliberately *refuse* to
+        set it for. That refusal is this guard's entire purpose, and
+        without the clear it defeated itself: auto-advance from a normal
+        item to one whose subtitle lives on a third-party host, and mpv
+        sent the previous item's ``Authorization`` to that host while the
+        log said it had not. Clearing here rather than on each ``return
+        False`` is the point — every exit path past this line leaves mpv
+        holding nothing, including the ones nobody has written yet.
         """
+        if not self._mpv_alive:
+            # mpv is DOWN — idle-quit, a crash, a window the user closed —
+            # and _play_media re-creates it moments from now, in
+            # _ensure_mpv, which runs after this. Touching the dead handle
+            # from here is not an exception to catch: libmpv's property
+            # write on a destroyed handle takes the process with it, and
+            # the try/except below cannot see that coming. The re-opened
+            # mpv holds no header of ours in any case, so the honest
+            # answer is this method's documented fallback — let the url
+            # carry the token, and the next start install the header.
+            return False
+        try:
+            self._player.http_header_fields = []
+        except Exception:
+            log.debug("could not clear http-header-fields", exc_info=True)
         client = getattr(video, "client", None)
         if client is None:
             return False

--- a/jellyfin_mpv_shim/player.py
+++ b/jellyfin_mpv_shim/player.py
@@ -1461,6 +1461,9 @@ class PlayerManager(AudioMixin, ReportingMixin, WindowMixin):
         self._load_cancelled = False
         self._start_in_progress = True
         try:
+            # BEFORE the url is built: whether the header took decides
+            # whether the url has to carry the token itself.
+            video.auth_via_header = self._apply_auth_headers(video)
             url = video.get_playback_url()
             if not url:
                 log.error("PlayerManager::play no URL found")
@@ -1469,6 +1472,44 @@ class PlayerManager(AudioMixin, ReportingMixin, WindowMixin):
                              is_initial_play, apply_memory)
         finally:
             self._start_in_progress = False
+
+    def _apply_auth_headers(self, video):
+        """Hand mpv this server's Authorization header. True if it took.
+
+        Everything mpv fetches for this file goes through it -- the stream,
+        any external subtitle sidecar -- so one option covers them all, and
+        none of those URLs then needs a token in its query string.
+
+        ``Authorization: MediaBrowser Token="…"`` is the one header scheme
+        the server does not gate behind ``EnableLegacyAuthorization``
+        (``AuthorizationContext``); ``X-Emby-Token`` and friends are all
+        legacy. The apiclient already builds exactly this line for its own
+        requests, so it is borrowed rather than re-spelled here.
+
+        Returns False rather than raising on any failure, and the caller
+        falls back to putting the token in the url. mpv has had
+        ``http-header-fields`` for over a decade so this should not happen,
+        but the cost of being wrong is that nothing plays at all.
+        """
+        client = getattr(video, "client", None)
+        if client is None:
+            return False
+        try:
+            header = client.http._get_authenication_header()
+        except Exception:
+            log.debug("could not build an auth header", exc_info=True)
+            return False
+        if not header or "Token=" not in header:
+            # No token yet (an unauthenticated probe): nothing to send, and
+            # claiming success would strip a url that needs one.
+            return False
+        try:
+            self._player.http_header_fields = ["Authorization: " + header]
+        except Exception:
+            log.warning("mpv would not take http-header-fields; falling back "
+                        "to a token in the URL", exc_info=True)
+            return False
+        return True
 
     @synchronous("_lock")
     def _play_media(

--- a/jellyfin_mpv_shim/sync/manager.py
+++ b/jellyfin_mpv_shim/sync/manager.py
@@ -9,10 +9,10 @@ import json
 import logging
 import math
 import os
+from urllib.parse import urlparse
 import shutil
 import threading
 import time
-import urllib.parse
 
 import requests
 
@@ -39,6 +39,21 @@ class _Stopped(Exception):
 
 class _Cancelled(Exception):
     """Raised inside the worker when the active download is being deleted."""
+
+
+def _same_origin(url, server):
+    """Whether ``url`` is on the same host as ``server``.
+
+    Scheme and port count: an http URL is not the same origin as the https
+    server we authenticated to, and sending a bearer token over the first
+    would hand it to anyone on the path.
+    """
+    try:
+        a, b = urlparse(url), urlparse(server)
+    except Exception:
+        return False
+    return bool(a.hostname) and (a.scheme, a.hostname, a.port) == (
+        b.scheme, b.hostname, b.port)
 
 
 def _sub_format(codec):
@@ -1139,8 +1154,13 @@ class SyncManager:
         the downloaded original file and need no sidecar.
         """
         server = client.config.data.get("auth.server", "").rstrip("/")
-        token = client.config.data.get("auth.token", "")
         verify = not settings.ignore_ssl_cert
+        try:
+            headers = {"Authorization": client.http._get_authenication_header()}
+        except Exception:
+            log.debug("could not build an auth header for subtitles",
+                      exc_info=True)
+            headers = {}
         media_source_id = source.get("Id") or item_id
         subs_dir = os.path.join(item_dir, "subs")
         for stream in source.get("MediaStreams") or []:
@@ -1151,16 +1171,33 @@ class SyncManager:
                 continue
             fmt = _sub_format(stream.get("Codec"))
             delivery = stream.get("DeliveryUrl")
+            external = bool(stream.get("IsExternalUrl"))
             if delivery:
-                base = delivery if stream.get("IsExternalUrl") else (server + delivery)
-                sep = "&" if "?" in base else "?"
-                url = "%s%sapi_key=%s" % (base, sep, urllib.parse.quote(token))
+                url = delivery if external else (server + delivery)
             else:
                 url = client.jellyfin.subtitle_url(
-                    item_id, media_source_id, index, fmt)
+                    item_id, media_source_id, index, fmt,
+                    include_apikey=False)
+            # We issue this request ourselves, so the token goes in a header
+            # rather than the query string -- no token in logs, in ps output
+            # or in any proxy in the path.
+            #
+            # But only to our own server. IsExternalUrl does NOT mean "third
+            # party": it means the stream's Path was already an absolute
+            # http(s) URI, so the server handed that over instead of
+            # proxying it (StreamInfo.cs:1264-1274). That host is often the
+            # same one -- a plugin, a co-located file server -- and
+            # sometimes not, and the DTO does not say which. So the test is
+            # the origin, not the flag: same host as the server we are
+            # logged in to, send the header; anything else, send nothing.
+            #
+            # The old code attached api_key to these unconditionally, which
+            # handed our access token to whatever host the path named.
+            req_headers = headers if _same_origin(url, server) else {}
             try:
                 os.makedirs(subs_dir, exist_ok=True)
-                resp = requests.get(url, timeout=(10, 30), verify=verify)
+                resp = requests.get(url, timeout=(10, 30), verify=verify,
+                                    headers=req_headers)
                 resp.raise_for_status()
                 with open(os.path.join(subs_dir, "%s.%s" % (index, fmt)), "wb") as fh:
                     fh.write(resp.content)

--- a/jellyfin_mpv_shim/sync/manager.py
+++ b/jellyfin_mpv_shim/sync/manager.py
@@ -830,10 +830,11 @@ class SyncManager:
 
             media_path = os.path.join(item_dir, "media." + (row["ext"] or "mkv"))
             tmp = media_path + ".part"
-            url = client.jellyfin.download_url(item_id)
+            url = client.jellyfin.download_url(item_id, include_apikey=False)
             expected = row.get("size_bytes") or 0
             size, total = self._stream(url, media_path, item_id, row.get("name"),
-                                       expected, stopping=stopping)
+                                       expected, stopping=stopping,
+                                       headers=self._headers_for(client, url))
 
             # Never record a short/truncated response as complete: keep the
             # .part and leave the row pending so a later pass resumes it. Don't
@@ -927,8 +928,42 @@ class SyncManager:
                 self._cancelled.discard(item_id)
         self._notify_change()
 
+    def _headers_for(self, client, url):
+        """Credentials for ``url``, as a headers dict, or ``{}``.
+
+        The single way this module authenticates an outbound request. It is
+        one function rather than a line at each call site because the call
+        sites are the failure mode: the subtitle sidecar was converted to
+        the header and the other six requests in here were not, so an
+        offline download went on quietly fetching its media, artwork and
+        trickplay tiles with ``?ApiKey=`` in the url. Six of those seven
+        swallow their own exceptions, so against a proxy that requires the
+        header they do not fail loudly -- the download completes and the
+        artwork is simply absent. ``test_sync_auth_headers`` now enumerates
+        the call sites so a new one cannot repeat it.
+
+        Same-origin gated like everything else. Every url here is built by
+        the apiclient from ``auth.server``, so the test is true by
+        construction today; it is applied anyway because "true by
+        construction today" is exactly what stops being true when someone
+        threads a server-supplied path through one of these.
+        """
+        try:
+            server = client.config.data.get("auth.server", "") or ""
+            if not _same_origin(url, server):
+                return {}
+            return {"Authorization": client.http._get_authenication_header()}
+        except Exception:
+            # {} is this function's documented answer, and the whole body is
+            # inside the guard so a half-built client cannot take a download
+            # down with an AttributeError instead. The request that follows
+            # then fails as an honest 401 rather than a traceback on a
+            # background worker.
+            log.debug("could not build an auth header", exc_info=True)
+            return {}
+
     def _stream(self, url, dest, item_id, name, expected,
-                stopping=None):
+                stopping=None, headers=None):
         """Download `url` to `dest`.part, resuming a partial file where possible.
 
         Returns ``(downloaded, total)``. The caller promotes the .part to `dest`
@@ -946,7 +981,7 @@ class SyncManager:
             return expected, expected
         try:
             return self._stream_request(url, tmp, item_id, name, expected,
-                                        resume, stopping)
+                                        resume, stopping, headers)
         except requests.HTTPError as exc:
             resp = getattr(exc, "response", None)
             if resp is None or resp.status_code != 416:
@@ -963,12 +998,17 @@ class SyncManager:
             except OSError:
                 pass
             return self._stream_request(url, tmp, item_id, name, expected,
-                                        0, stopping)
+                                        0, stopping, headers)
 
     def _stream_request(self, url, tmp, item_id, name, expected,
-                        resume, stopping=None):
+                        resume, stopping=None, headers=None):
         verify = not settings.ignore_ssl_cert
-        headers = {"Range": "bytes=%d-" % resume} if resume else {}
+        # Range and Authorization both, not one or the other: this used to
+        # build the dict from scratch here, which is why the resume header
+        # arrived and the credentials did not.
+        headers = dict(headers or {})
+        if resume:
+            headers["Range"] = "bytes=%d-" % resume
         with requests.get(url, stream=True, headers=headers, verify=verify,
                           timeout=(10, 60)) as resp:
             if resume and resp.status_code == 200:
@@ -1027,9 +1067,11 @@ class SyncManager:
         tp_dir = os.path.join(item_dir, "trickplay", str(width))
         os.makedirs(tp_dir, exist_ok=True)
         for i in range(tiles):
-            url = api.trickplay_tile_url(item_id, width, i, source.get("Id"))
+            url = api.trickplay_tile_url(item_id, width, i, source.get("Id"),
+                                         include_apikey=False)
             try:
-                resp = requests.get(url, timeout=(10, 30), verify=verify)
+                resp = requests.get(url, timeout=(10, 30), verify=verify,
+                                    headers=self._headers_for(client, url))
                 resp.raise_for_status()
                 with open(os.path.join(tp_dir, "%d.jpg" % i), "wb") as fh:
                     fh.write(resp.content)
@@ -1055,12 +1097,15 @@ class SyncManager:
         os.makedirs(series_dir, exist_ok=True)
         jobs = []
         if not os.path.exists(poster):
-            jobs.append((poster, api.artwork(series_id, "Primary", 600)))
+            jobs.append((poster, api.artwork(series_id, "Primary", 600,
+                                             include_apikey=False)))
         if not os.path.exists(backdrop):
-            jobs.append((backdrop, api.artwork(series_id, "Backdrop", 1280)))
+            jobs.append((backdrop, api.artwork(series_id, "Backdrop", 1280,
+                                               include_apikey=False)))
         for path, url in jobs:
             try:
-                resp = requests.get(url, timeout=(10, 30), verify=verify)
+                resp = requests.get(url, timeout=(10, 30), verify=verify,
+                                    headers=self._headers_for(client, url))
                 resp.raise_for_status()
                 with open(path, "wb") as fh:
                     fh.write(resp.content)
@@ -1079,10 +1124,12 @@ class SyncManager:
         if os.path.exists(poster):
             return
         os.makedirs(pl_dir, exist_ok=True)
-        url = client.jellyfin.artwork(playlist_id, "Primary", 600)
+        url = client.jellyfin.artwork(playlist_id, "Primary", 600,
+                                      include_apikey=False)
         try:
             resp = requests.get(url, timeout=(10, 30),
-                                verify=not settings.ignore_ssl_cert)
+                                verify=not settings.ignore_ssl_cert,
+                                headers=self._headers_for(client, url))
             resp.raise_for_status()
             with open(poster, "wb") as fh:
                 fh.write(resp.content)
@@ -1116,9 +1163,11 @@ class SyncManager:
             return
         os.makedirs(season_dir, exist_ok=True)
         verify = not settings.ignore_ssl_cert
+        url = client.jellyfin.artwork(season_id, "Primary", 600,
+                                      include_apikey=False)
         try:
-            resp = requests.get(client.jellyfin.artwork(season_id, "Primary", 600),
-                                timeout=(10, 30), verify=verify)
+            resp = requests.get(url, timeout=(10, 30), verify=verify,
+                                headers=self._headers_for(client, url))
             resp.raise_for_status()
             with open(poster, "wb") as fh:
                 fh.write(resp.content)
@@ -1130,15 +1179,19 @@ class SyncManager:
         tags = item.get("ImageTags") or {}
         jobs = []
         if "Primary" in tags:
-            jobs.append(("poster.jpg", api.artwork(item["Id"], "Primary", 600)))
+            jobs.append(("poster.jpg", api.artwork(item["Id"], "Primary", 600,
+                                                   include_apikey=False)))
         if item.get("BackdropImageTags"):
-            jobs.append(("backdrop.jpg", api.artwork(item["Id"], "Backdrop", 1280)))
+            jobs.append(("backdrop.jpg", api.artwork(item["Id"], "Backdrop", 1280,
+                                                     include_apikey=False)))
         if "Thumb" in tags:
-            jobs.append(("thumb.jpg", api.artwork(item["Id"], "Thumb", 600)))
+            jobs.append(("thumb.jpg", api.artwork(item["Id"], "Thumb", 600,
+                                                  include_apikey=False)))
         verify = not settings.ignore_ssl_cert
         for name, url in jobs:
             try:
-                resp = requests.get(url, timeout=(10, 30), verify=verify)
+                resp = requests.get(url, timeout=(10, 30), verify=verify,
+                                    headers=self._headers_for(client, url))
                 resp.raise_for_status()
                 with open(os.path.join(item_dir, name), "wb") as fh:
                     fh.write(resp.content)
@@ -1155,12 +1208,6 @@ class SyncManager:
         """
         server = client.config.data.get("auth.server", "").rstrip("/")
         verify = not settings.ignore_ssl_cert
-        try:
-            headers = {"Authorization": client.http._get_authenication_header()}
-        except Exception:
-            log.debug("could not build an auth header for subtitles",
-                      exc_info=True)
-            headers = {}
         media_source_id = source.get("Id") or item_id
         subs_dir = os.path.join(item_dir, "subs")
         for stream in source.get("MediaStreams") or []:
@@ -1193,11 +1240,10 @@ class SyncManager:
             #
             # The old code attached api_key to these unconditionally, which
             # handed our access token to whatever host the path named.
-            req_headers = headers if _same_origin(url, server) else {}
             try:
                 os.makedirs(subs_dir, exist_ok=True)
                 resp = requests.get(url, timeout=(10, 30), verify=verify,
-                                    headers=req_headers)
+                                    headers=self._headers_for(client, url))
                 resp.raise_for_status()
                 with open(os.path.join(subs_dir, "%s.%s" % (index, fmt)), "wb") as fh:
                     fh.write(resp.content)

--- a/tests/test_browser_features.py
+++ b/tests/test_browser_features.py
@@ -353,7 +353,7 @@ class BackdropIndexTest(unittest.TestCase):
         class FakeApi:
             def image_url(self, item_id, image_type, index=None, tag=None,
                           max_width=None, fill_width=None, fill_height=None,
-                          quality=90):
+                          quality=90, include_apikey=True):
                 seen.update(item_id=item_id, image_type=image_type,
                             index=index, tag=tag)
                 return "url"

--- a/tests/test_photos.py
+++ b/tests/test_photos.py
@@ -222,6 +222,10 @@ class AuthHeaderTest(unittest.TestCase):
 
         pm = PlayerManager.__new__(PlayerManager)
         pm._player = type("P", (), {})()
+        # A live mpv: the method declines outright on a dead handle, because
+        # writing a property to a destroyed libmpv segfaults rather than
+        # raising (see the guard in _apply_auth_headers).
+        pm._mpv_alive = True
         return pm
 
     def _video(self, token="T0KEN", raises=False):
@@ -293,6 +297,74 @@ class AuthHeaderTest(unittest.TestCase):
         self.assertEqual(len(sent), 1)
         self.assertTrue(sent[0].startswith("Authorization: MediaBrowser "))
         self.assertIn('Token="T0KEN"', sent[0])
+
+    def test_a_refusal_leaves_mpv_holding_nothing(self):
+        """The guard's whole purpose, and what it silently failed to do.
+
+        ``http-header-fields`` is a global, persistent option and mpv is not
+        re-created between queue items, so the assertion that matters is not
+        "did we return False" but "what is mpv left holding". Play something
+        normally, auto-advance to an item whose subtitle is on a third-party
+        host, and the refusal used to log, fall back to a token in the URL
+        — and let mpv send the *previous* item's Authorization to that host
+        anyway. Nothing failed; the evidence was in someone else's log.
+        """
+        from jellyfin_mpv_shim.player import PlayerManager
+
+        pm = self._pm()
+        self.assertTrue(
+            PlayerManager._apply_auth_headers(pm, self._video()))
+        self.assertTrue(pm._player.http_header_fields, "no header to leak")
+        video = self._with_subs("https://opensubtitles.example/x.srt")
+        self.assertFalse(PlayerManager._apply_auth_headers(pm, video))
+        self.assertEqual(pm._player.http_header_fields, [],
+                         "mpv still holds the previous item's token")
+
+    def test_a_dead_mpv_is_not_touched_at_all(self):
+        """`play()` runs this BEFORE `_play_media`, and `_ensure_mpv` — the
+        re-open after an idle-quit or a crash — is inside `_play_media`. So
+        the handle here can be a destroyed one, and libmpv answers a
+        property write on one of those with a segfault, not an exception:
+        the try/except around it cannot help. The integration matrix's
+        idle-quit-and-reopen test crashed the interpreter on exactly this.
+        """
+        from jellyfin_mpv_shim.player import PlayerManager
+
+        pm = self._pm()
+        pm._mpv_alive = False
+        touched = []
+
+        class _Dead:
+            def __setattr__(self, name, value):
+                touched.append(name)
+
+        pm._player = _Dead()
+        self.assertFalse(
+            PlayerManager._apply_auth_headers(pm, self._video()),
+            "claimed a header a dead mpv never took")
+        self.assertEqual(touched, [], "wrote to a destroyed mpv handle")
+
+    def test_every_refusal_path_clears_it(self):
+        """Swept rather than spot-checked: the clear is at the top for
+        exactly this reason, so a refusal added later cannot reintroduce
+        the leak by forgetting to clear on its way out."""
+        from jellyfin_mpv_shim.player import PlayerManager
+
+        refusals = {
+            "no client": lambda: type("V", (), {"client": None})(),
+            "no token": lambda: self._video(token=""),
+            "header raises": lambda: self._video(raises=True),
+            "foreign subtitle host":
+                lambda: self._with_subs("https://elsewhere.example/x.srt"),
+        }
+        for why, make in refusals.items():
+            pm = self._pm()
+            PlayerManager._apply_auth_headers(pm, self._video())
+            self.assertFalse(
+                PlayerManager._apply_auth_headers(pm, make()),
+                "%s should have been refused" % why)
+            self.assertEqual(pm._player.http_header_fields, [],
+                             "a token survived the %r refusal" % why)
 
     def test_a_client_with_no_token_is_not_claimed_as_authenticated(self):
         """Claiming success would strip a token off a URL that needs one."""

--- a/tests/test_photos.py
+++ b/tests/test_photos.py
@@ -396,3 +396,78 @@ class SubtitleSidecarAuthTest(unittest.TestCase):
                       DeliveryUrl="https://example.com:8920/subs/2.srt")
         _url, headers = self._download(stream)[0]
         self.assertFalse(headers)
+
+
+class ThumbnailAuthTest(unittest.TestCase):
+    """Images are the highest-volume first-party traffic here, so a token in
+    their query strings is a token in the access log of every one of them --
+    and it means Jellyfin cannot sit behind a proxy that rejects
+    unauthenticated requests, because every tile would 401.
+    """
+
+    def _store(self, origins):
+        import tempfile
+        from jellyfin_mpv_shim.mpvtk_browser.thumbnails import ThumbnailStore
+
+        store = ThumbnailStore.__new__(ThumbnailStore)
+        store._auth = {}
+        store.set_auth(origins)
+        del tempfile
+        return store
+
+    HDR = 'MediaBrowser Client="c", Token="T0KEN"'
+
+    def test_our_own_server_gets_the_header(self):
+        store = self._store({("https", "example.com", None): self.HDR})
+        got = store._headers_for("https://example.com/Items/1/Images/Primary")
+        self.assertEqual(got, {"Authorization": self.HDR})
+
+    def test_another_host_gets_nothing(self):
+        store = self._store({("https", "example.com", None): self.HDR})
+        self.assertEqual(
+            store._headers_for("https://elsewhere.example/Items/1/Images/X"),
+            {})
+
+    def test_a_downgrade_to_http_gets_nothing(self):
+        store = self._store({("https", "example.com", None): self.HDR})
+        self.assertEqual(
+            store._headers_for("http://example.com/Items/1/Images/X"), {})
+
+    def test_a_second_server_gets_its_own_token(self):
+        """One store serves every connected server, and a token only ever
+        goes to the server it came from."""
+        other = 'MediaBrowser Client="c", Token="OTHER"'
+        store = self._store({("https", "a.example", None): self.HDR,
+                             ("https", "b.example", None): other})
+        self.assertEqual(store._headers_for("https://b.example/i")[
+            "Authorization"], other)
+
+    def test_signing_out_revokes_the_token(self):
+        """set_auth replaces wholesale rather than merging, so a server the
+        user has left stops receiving its old token."""
+        store = self._store({("https", "example.com", None): self.HDR})
+        store.set_auth({})
+        self.assertEqual(store._headers_for("https://example.com/i"), {})
+
+    def test_a_junk_url_is_not_an_exception(self):
+        store = self._store({("https", "example.com", None): self.HDR})
+        self.assertEqual(store._headers_for("not a url"), {})
+
+    def test_image_urls_no_longer_carry_the_token(self):
+        from jellyfin_mpv_shim.mpvtk_browser.repository import LibrarySource
+
+        seen = {}
+
+        class _Api:
+            def image_url(self, item_id, image_type="Primary", index=None,
+                          tag=None, max_width=None, fill_width=None,
+                          fill_height=None, quality=90, include_apikey=True):
+                seen["include_apikey"] = include_apikey
+                return "https://example.com/img"
+
+        src = LibrarySource.__new__(LibrarySource)
+        src._conns = {"srv": type("C", (), {"api": _Api()})()}
+        src.image_url("srv", "i1", "Primary", "t", 150, 225, fill=True)
+        self.assertIs(seen["include_apikey"], False)
+        src.image_url("srv", "i1", "Primary", "t", 150)
+        self.assertIs(seen["include_apikey"], False)

--- a/tests/test_photos.py
+++ b/tests/test_photos.py
@@ -242,6 +242,47 @@ class AuthHeaderTest(unittest.TestCase):
             "auth.server": "https://example.com"}})()
         return Video("v1", parent)
 
+    def _with_subs(self, *paths):
+        video = self._video()
+        video.item = dict(video.item, MediaSources=[{"MediaStreams": [
+            {"Type": "Subtitle", "Path": p} for p in paths]}])
+        return video
+
+    def test_a_foreign_subtitle_host_blocks_the_header_entirely(self):
+        """http-header-fields is GLOBAL -- it applies to every request mpv
+        makes, and an IsExternalUrl subtitle is handed to sub_add unchanged.
+        Setting it would send our token to whoever hosts that subtitle, and
+        mpv has no per-URL header option, so the only safe answer is to fall
+        back to a token in the stream URL."""
+        from jellyfin_mpv_shim.player import PlayerManager
+
+        video = self._with_subs("https://opensubtitles.example/x.srt")
+        self.assertFalse(
+            PlayerManager._apply_auth_headers(self._pm(), video))
+
+    def test_a_subtitle_on_our_own_server_does_not(self):
+        from jellyfin_mpv_shim.player import PlayerManager
+
+        video = self._with_subs("https://example.com/subs/2.srt")
+        self.assertTrue(PlayerManager._apply_auth_headers(self._pm(), video))
+
+    def test_a_local_subtitle_path_does_not(self):
+        """Most external subtitles are files on the server's disk; only an
+        absolute http(s) Path becomes a URL mpv fetches."""
+        from jellyfin_mpv_shim.player import PlayerManager
+
+        video = self._with_subs("/media/movie/movie.en.srt")
+        self.assertTrue(PlayerManager._apply_auth_headers(self._pm(), video))
+
+    def test_the_check_is_answerable_before_playbackinfo(self):
+        """It has to be: the header decides whether the stream URL carries a
+        token, so it is applied before the URL is built. media_source is
+        still None at that point."""
+        video = self._with_subs("https://elsewhere.example/x.srt")
+        self.assertIsNone(video.media_source)
+        self.assertEqual(video.foreign_subtitle_hosts(),
+                         {"elsewhere.example"})
+
     def test_the_header_is_the_non_legacy_scheme(self):
         from jellyfin_mpv_shim.player import PlayerManager
 

--- a/tests/test_photos.py
+++ b/tests/test_photos.py
@@ -28,18 +28,27 @@ class _Jellyfin:
     def __init__(self, item):
         self._item = item
         self.calls = []
+        self.apikeys = []
 
     def get_item(self, item_id):
         return dict(self._item, Id=item_id)
 
-    def download_url(self, item_id):
+    # Both mirror the apiclient's own signature, ApiKey spelling and
+    # include_apikey default. The default is the point: it is what made a
+    # photo url carry a token nobody passed, so a fixture that ignored the
+    # argument would have agreed the bug was fixed while it was not.
+    def download_url(self, item_id, include_apikey=True):
         self.calls.append(("download", item_id))
-        return "http://srv/Items/%s/Download?api_key=k" % item_id
+        self.apikeys.append(include_apikey)
+        return "http://srv/Items/%s/Download%s" % (
+            item_id, "?ApiKey=k" if include_apikey else "")
 
-    def artwork(self, item_id, art, max_width, ext="jpg", index=None):
+    def artwork(self, item_id, art, max_width, ext="jpg", index=None,
+                include_apikey=True):
         self.calls.append(("artwork", item_id, art, max_width))
-        return "http://srv/Items/%s/Images/%s?MaxWidth=%d" % (
-            item_id, art, max_width)
+        self.apikeys.append(include_apikey)
+        return "http://srv/Items/%s/Images/%s?MaxWidth=%d%s" % (
+            item_id, art, max_width, "&ApiKey=k" if include_apikey else "")
 
     def get_play_info(self, *a, **kw):        # must never be reached
         raise AssertionError("a photo asked PlaybackInfo for a media source")
@@ -106,6 +115,59 @@ class PhotoUrlTest(unittest.TestCase):
 
     def test_heic_is_in_the_converted_set(self):
         self.assertIn("heic", _SERVER_CONVERTED_IMAGES)
+
+
+class PhotoUrlAuthTest(unittest.TestCase):
+    """A photo obeys the auth header like every other playback url.
+
+    Driven through ``get_playback_url`` rather than ``_get_url_from_source``
+    on purpose: the photo branch returns *above* the one that drops the
+    token, so the tests that exercise the source url walk straight past it.
+    That is how both of these paths kept sending a token in the query
+    string after the header was installed for them -- mpv held the header
+    and the url held the token, and every assertion in the suite was about
+    one or the other.
+    """
+
+    def _url(self, header, **item):
+        item.setdefault("Type", PHOTO_TYPE)
+        parent = _Parent(item)
+        v = Video("ph1", parent)
+        v.auth_via_header = header
+        return v.get_playback_url(), parent.client.jellyfin
+
+    def test_a_downloaded_photo_drops_the_token(self):
+        url, jf = self._url(True, Container="jpg", Path="/pics/a.jpg")
+        self.assertNotIn("ApiKey", url)
+        self.assertNotIn("api_key", url)
+        self.assertEqual(jf.apikeys, [False])
+
+    def test_a_converted_photo_drops_it_too(self):
+        url, jf = self._url(True, Container="heic", Path="/pics/a.HEIC")
+        self.assertNotIn("ApiKey", url)
+        self.assertNotIn("api_key", url)
+        self.assertEqual(jf.apikeys, [False])
+
+    def test_a_downloaded_photo_keeps_it_without_the_header(self):
+        """The fallback has to still work: no header means the url is the
+        only thing carrying credentials, and a photo that 401s is a black
+        window."""
+        url, jf = self._url(False, Container="jpg", Path="/pics/a.jpg")
+        self.assertIn("ApiKey=", url)
+        self.assertEqual(jf.apikeys, [True])
+
+    def test_a_converted_photo_keeps_it_without_the_header(self):
+        url, jf = self._url(False, Container="heic", Path="/pics/a.HEIC")
+        self.assertIn("ApiKey=", url)
+        self.assertEqual(jf.apikeys, [True])
+
+    def test_the_default_is_still_to_send_one(self):
+        """``auth_via_header`` defaults to False, so a caller that never
+        went through ``play()`` is unchanged rather than unauthenticated."""
+        parent = _Parent({"Type": PHOTO_TYPE, "Container": "jpg"})
+        v = Video("ph1", parent)
+        self.assertFalse(v.auth_via_header)
+        self.assertIn("ApiKey=", v.get_playback_url())
 
 
 class PhotoTypeSetsTest(unittest.TestCase):

--- a/tests/test_photos.py
+++ b/tests/test_photos.py
@@ -206,3 +206,193 @@ class PhotoOpensTheAlbumTest(unittest.TestCase):
 
 if __name__ == "__main__":
     unittest.main()
+
+
+class AuthHeaderTest(unittest.TestCase):
+    """The token travels in a header, not a query string.
+
+    Only ``Authorization: MediaBrowser Token="…"`` is un-gated on the
+    server; X-Emby-Token and api_key both sit behind
+    EnableLegacyAuthorization, which is off from Jellyfin v12
+    (AuthorizationContext.GetAuthorizationInfoFromDictionary).
+    """
+
+    def _pm(self, applied=True):
+        from jellyfin_mpv_shim.player import PlayerManager
+
+        pm = PlayerManager.__new__(PlayerManager)
+        pm._player = type("P", (), {})()
+        return pm
+
+    def _video(self, token="T0KEN", raises=False):
+        item = {"Type": "Movie", "Name": "M"}
+        parent = _Parent(item)
+
+        class _HTTP:
+            def _get_authenication_header(self):
+                if raises:
+                    raise RuntimeError("nope")
+                if not token:
+                    return 'MediaBrowser Client="c"'
+                return 'MediaBrowser Client="c", Token="%s"' % token
+
+        parent.client.http = _HTTP()
+        parent.client.config = type("C", (), {"data": {
+            "auth.token": token or "",
+            "auth.server": "https://example.com"}})()
+        return Video("v1", parent)
+
+    def test_the_header_is_the_non_legacy_scheme(self):
+        from jellyfin_mpv_shim.player import PlayerManager
+
+        pm = self._pm()
+        video = self._video()
+        self.assertTrue(PlayerManager._apply_auth_headers(pm, video))
+        sent = pm._player.http_header_fields
+        self.assertEqual(len(sent), 1)
+        self.assertTrue(sent[0].startswith("Authorization: MediaBrowser "))
+        self.assertIn('Token="T0KEN"', sent[0])
+
+    def test_a_client_with_no_token_is_not_claimed_as_authenticated(self):
+        """Claiming success would strip a token off a URL that needs one."""
+        from jellyfin_mpv_shim.player import PlayerManager
+
+        self.assertFalse(
+            PlayerManager._apply_auth_headers(self._pm(), self._video(token="")))
+
+    def test_a_broken_header_falls_back_rather_than_raising(self):
+        """mpv has had http-header-fields for over a decade, so this should
+        not happen -- but the cost of being wrong is that nothing plays."""
+        from jellyfin_mpv_shim.player import PlayerManager
+
+        self.assertFalse(PlayerManager._apply_auth_headers(
+            self._pm(), self._video(raises=True)))
+
+    def test_mpv_refusing_the_option_falls_back(self):
+        from jellyfin_mpv_shim.player import PlayerManager
+
+        pm = self._pm()
+
+        class _P:
+            def __setattr__(self, name, value):
+                raise RuntimeError("no such option")
+
+        pm._player = _P()
+        self.assertFalse(PlayerManager._apply_auth_headers(pm, self._video()))
+
+    def test_the_url_drops_the_token_once_the_header_is_set(self):
+        video = self._video()
+        video.media_source = {"SupportsDirectStream": True, "Id": "src1",
+                              "Protocol": "Http", "SupportsDirectPlay": False}
+        video.auth_via_header = True
+        url = video._get_url_from_source()
+        self.assertNotIn("ApiKey", url)
+        self.assertNotIn("api_key", url)
+
+    def test_and_keeps_it_when_the_header_could_not_be_set(self):
+        video = self._video()
+        video.media_source = {"SupportsDirectStream": True, "Id": "src1",
+                              "Protocol": "Http", "SupportsDirectPlay": False}
+        video.auth_via_header = False
+        url = video._get_url_from_source()
+        self.assertIn("ApiKey=", url)
+        self.assertNotIn("api_key=", url)
+
+
+class SubtitleSidecarAuthTest(unittest.TestCase):
+    """The sidecar download is issued by us, so the token is a header --
+    except when the sidecar is somewhere else entirely."""
+
+    def _download(self, stream):
+        from jellyfin_mpv_shim.sync.manager import SyncManager
+        import jellyfin_mpv_shim.sync.manager as mod
+
+        seen = []
+
+        class _Resp:
+            content = b"sub"
+
+            def raise_for_status(self):
+                pass
+
+        def fake_get(url, **kw):
+            seen.append((url, kw.get("headers")))
+            return _Resp()
+
+        class _HTTP:
+            def _get_authenication_header(self):
+                return 'MediaBrowser Client="c", Token="T0KEN"'
+
+        client = type("C", (), {})()
+        client.config = type("Cfg", (), {"data": {
+            "auth.server": "https://example.com",
+            "auth.token": "T0KEN"}})()
+        client.http = _HTTP()
+        client.jellyfin = type("J", (), {
+            "subtitle_url": staticmethod(
+                lambda *a, **kw: "https://example.com/built")})()
+
+        real_get, mod.requests.get = mod.requests.get, fake_get
+        real_mk, mod.os.makedirs = mod.os.makedirs, lambda *a, **kw: None
+        real_open = mod.open if hasattr(mod, "open") else None
+        try:
+            import builtins
+            import io
+            real_builtin_open = builtins.open
+            builtins.open = lambda *a, **kw: io.BytesIO()
+            try:
+                SyncManager._download_subs(
+                    SyncManager.__new__(SyncManager), client, "i1",
+                    {"Id": "s1", "MediaStreams": [stream]}, "/tmp/x")
+            finally:
+                builtins.open = real_builtin_open
+        finally:
+            mod.requests.get = real_get
+            mod.os.makedirs = real_mk
+            del real_open
+        return seen
+
+    OURS = {"Type": "Subtitle", "IsExternal": True, "Index": 2,
+            "Codec": "srt", "DeliveryUrl": "/Videos/1/Subtitles/2/Stream.srt"}
+
+    def test_our_own_server_gets_the_header_and_a_clean_url(self):
+        seen = self._download(self.OURS)
+        self.assertEqual(len(seen), 1)
+        url, headers = seen[0]
+        self.assertNotIn("ApiKey", url)
+        self.assertNotIn("api_key", url)
+        self.assertIn('Token="T0KEN"', headers["Authorization"])
+
+    def test_a_foreign_host_gets_no_credentials_at_all(self):
+        """IsExternalUrl does NOT mean third-party -- it means the stream's
+        Path was already an absolute URI, so the server handed that over
+        instead of proxying it (StreamInfo.cs:1264-1274). It is often the
+        same host. So the test is the origin, not the flag."""
+        stream = dict(self.OURS, IsExternalUrl=True,
+                      DeliveryUrl="https://opensubtitles.example/x.srt")
+        url, headers = self._download(stream)[0]
+        self.assertEqual(url, "https://opensubtitles.example/x.srt")
+        self.assertFalse(headers)
+
+    def test_an_external_url_on_our_own_server_still_gets_the_header(self):
+        """The case that made the old flag-based rule wrong: a plugin or a
+        co-located path on the very server we are logged in to."""
+        stream = dict(self.OURS, IsExternalUrl=True,
+                      DeliveryUrl="https://example.com/plugin/subs/2.srt")
+        url, headers = self._download(stream)[0]
+        self.assertEqual(url, "https://example.com/plugin/subs/2.srt")
+        self.assertIn('Token="T0KEN"', headers["Authorization"])
+
+    def test_a_downgrade_to_http_is_not_the_same_origin(self):
+        """Sending a bearer token over plain http hands it to anyone on the
+        path, however familiar the hostname looks."""
+        stream = dict(self.OURS, IsExternalUrl=True,
+                      DeliveryUrl="http://example.com/subs/2.srt")
+        _url, headers = self._download(stream)[0]
+        self.assertFalse(headers)
+
+    def test_a_different_port_is_not_the_same_origin(self):
+        stream = dict(self.OURS, IsExternalUrl=True,
+                      DeliveryUrl="https://example.com:8920/subs/2.srt")
+        _url, headers = self._download(stream)[0]
+        self.assertFalse(headers)

--- a/tests/test_playlist_offline.py
+++ b/tests/test_playlist_offline.py
@@ -35,7 +35,15 @@ def make_row(item_id, **overrides):
 
 class FakeConfig:
     def __init__(self):
-        self.data = {"auth.server-id": "srv"}
+        # auth.server matches the host the artwork fakes below hand back, so
+        # _headers_for sees a same-origin url and actually attaches the
+        # header here rather than short-circuiting to {}.
+        self.data = {"auth.server-id": "srv", "auth.server": "http://s"}
+
+
+class FakeHttp:
+    def _get_authenication_header(self):
+        return 'MediaBrowser Client="test", Token="TESTTOKEN"'
 
 
 class FakeJellyfin:
@@ -54,6 +62,7 @@ class FakeClient:
     def __init__(self, jf):
         self.jellyfin = jf
         self.config = FakeConfig()
+        self.http = FakeHttp()
 
 
 def make_manager(root, jf):
@@ -441,8 +450,10 @@ class TestPlaylistArtDownload(TmpTest):
         self.addCleanup(lambda: setattr(mgr, "requests", real))
 
         jf = FakeJellyfin([])
-        jf.artwork = lambda item_id, kind, size: "http://s/%s/%s" % (item_id,
-                                                                    kind)
+        # include_apikey mirrors the apiclient signature; the sync manager
+        # passes False and sends the token as a header instead.
+        jf.artwork = (lambda item_id, kind, size, include_apikey=True:
+                      "http://s/%s/%s" % (item_id, kind))
         m = make_manager(self.tmp, jf)
         self.addCleanup(m.db.close)
         return m

--- a/tests/test_shell_library.py
+++ b/tests/test_shell_library.py
@@ -98,6 +98,59 @@ class TestBannerFetchIsQuantised(unittest.TestCase):
         self.assertEqual(TileRenderer._banner_fetch_w(self._r(), 0), 0)
         self.assertEqual(TileRenderer._banner_fetch_w(self._r(), -5), 0)
 
+    def _asked_for(self, width=1280):
+        """Drive the real backdrop_node and record what it asks the server
+        for. `thumbs=None` stops _request_image before any fetch, which is
+        all this needs — the URL is built first."""
+        from types import SimpleNamespace
+        from jellyfin_mpv_shim.mpvtk_browser.tile_renderer import TileRenderer
+
+        asked = {}
+
+        class _Source:
+            @staticmethod
+            def backdrop_spec(_item):
+                return ("m1", "tag9")
+
+            @staticmethod
+            def backdrop_url(_server, _item, width=None, height=None,
+                             fill=False):
+                asked.update(width=width, height=height, fill=fill)
+                return "http://srv/bd.jpg"
+
+        r = self._r()
+        r.art = SimpleNamespace(server="srv1", source=_Source(), thumbs=None)
+        r._posters, r._requested, r._img_retry = {}, set(), {}
+        box = TileRenderer.banner_box(r, width)
+        TileRenderer.backdrop_node(r, {"Id": "m1"}, box, "detail-bd")
+        return asked, box
+
+    def test_the_banner_is_fetched_at_the_banners_aspect(self):
+        """`fill=True` is fillWidth+fillHeight: the server CROPS to the shape
+        asked for. Asking for a square hands back the centre square of a
+        16:9 backdrop, and compose_banner's cover then blows that up to the
+        full width — every detail header zoomed ~1.8x, for 2.7x the pixels,
+        in the commit whose point was making banners cheaper.
+        """
+        from jellyfin_mpv_shim.mpvtk_browser.tile_renderer import TileRenderer
+
+        asked, _box = self._asked_for()
+        self.assertTrue(asked["fill"], "without fill the server squashes")
+        self.assertLess(asked["height"], asked["width"], "asked for a square")
+        r = self._r()
+        self.assertAlmostEqual(asked["height"] / asked["width"],
+                               TileRenderer.BANNER_RATIO, delta=0.01)
+
+    def test_the_fetched_height_still_covers_the_drawn_banner(self):
+        """The other half: a crop that came back shorter than the box would
+        have to be upscaled to cover it."""
+        for width in (700, 1024, 1280, 1600):
+            with self.subTest(width=width):
+                asked, box = self._asked_for(width)
+                from jellyfin_mpv_shim.mpvtk import scaling
+                self.assertGreaterEqual(asked["height"],
+                                        scaling.raster(*box)[1])
+
     def test_the_aspect_ratio_survives(self):
         from jellyfin_mpv_shim.mpvtk_browser.tile_renderer import TileRenderer
         r = self._r()

--- a/tests/test_shell_library.py
+++ b/tests/test_shell_library.py
@@ -24,6 +24,87 @@ from tests._shell_harness import (
 )
 
 
+class TestBannerFetchIsQuantised(unittest.TestCase):
+    """Issue #592: resizing the window re-requested the header image.
+
+    The artwork cache keys on exact pixel dimensions, so a banner width that
+    followed the window pixel-for-pixel meant a request and a decode per
+    pixel of drag, all resident until the LRU pushed them out.
+
+    The fix quantises the FETCH, not the layout. Quantising the layout is
+    what the first attempt did, and it overhung the scrollbar when the
+    rounded-up width exceeded the space available.
+    """
+
+    def _r(self):
+        from jellyfin_mpv_shim.mpvtk_browser.tile_renderer import TileRenderer
+        return TileRenderer.__new__(TileRenderer)
+
+    def _layout(self, lo, hi):
+        from jellyfin_mpv_shim.mpvtk_browser.tile_renderer import TileRenderer
+        r = self._r()
+        return [TileRenderer.banner_box(r, w)[0] for w in range(lo, hi)]
+
+    def _fetches(self, lo, hi):
+        from jellyfin_mpv_shim.mpvtk_browser.tile_renderer import TileRenderer
+        r = self._r()
+        return [TileRenderer._banner_fetch_w(r, w) for w in self._layout(lo, hi)]
+
+    def test_the_drawn_banner_never_exceeds_the_space_it_has(self):
+        """The regression the first attempt caused: a rounded-up layout
+        width paints over the scrollbar."""
+        from jellyfin_mpv_shim.mpvtk_browser.components import chrome
+        from jellyfin_mpv_shim.mpvtk_browser.tile_renderer import TileRenderer
+        r = self._r()
+        for w in (500, 700, 913, 1024, 1280, 1600):
+            with self.subTest(w=w):
+                got, _h = TileRenderer.banner_box(r, w)
+                self.assertLessEqual(got, w - 2 * chrome.CONTENT_PAD)
+
+    def test_and_leaves_no_gap_beside_full_width_content(self):
+        """Which is why the layout is not quantised at all: rounding down
+        would leave the header short of content that does reach the edge."""
+        from jellyfin_mpv_shim.mpvtk_browser.components import chrome
+        from jellyfin_mpv_shim.mpvtk_browser.tile_renderer import TileRenderer
+        r = self._r()
+        for w in (913, 1001, 1077):
+            with self.subTest(w=w):
+                got, _h = TileRenderer.banner_box(r, w)
+                self.assertEqual(got, w - 2 * chrome.CONTENT_PAD)
+
+    def test_a_long_drag_asks_for_only_a_handful_of_images(self):
+        self.assertLessEqual(len(set(self._fetches(400, 1600))), 10,
+                             "a resize still asks for an image per pixel")
+
+    def test_neighbouring_widths_share_a_fetch(self):
+        """The property that matters: moving the edge by one pixel almost
+        never costs a request."""
+        f = self._fetches(400, 1600)
+        changes = sum(1 for a, b in zip(f, f[1:]) if a != b)
+        self.assertLessEqual(changes, 10)
+
+    def test_the_fetch_is_never_smaller_than_the_drawn_banner(self):
+        """compose_banner crops the fetched image into the banner, so larger
+        costs nothing and smaller would have to be upscaled."""
+        from jellyfin_mpv_shim.mpvtk_browser.tile_renderer import TileRenderer
+        r = self._r()
+        for drawn in (300, 512, 513, 1000, 1084):
+            with self.subTest(drawn=drawn):
+                self.assertGreaterEqual(
+                    TileRenderer._banner_fetch_w(r, drawn), drawn)
+
+    def test_a_degenerate_width_does_not_go_negative(self):
+        from jellyfin_mpv_shim.mpvtk_browser.tile_renderer import TileRenderer
+        self.assertEqual(TileRenderer._banner_fetch_w(self._r(), 0), 0)
+        self.assertEqual(TileRenderer._banner_fetch_w(self._r(), -5), 0)
+
+    def test_the_aspect_ratio_survives(self):
+        from jellyfin_mpv_shim.mpvtk_browser.tile_renderer import TileRenderer
+        r = self._r()
+        w, h = TileRenderer.banner_box(r, 1280)
+        self.assertEqual(h, int(w * TileRenderer.BANNER_RATIO))
+
+
 class TestLibraryGridShape(unittest.TestCase):
     """A library grid is shaped by its own artwork, like jellyfin-web's.
 

--- a/tests/test_sync_auth_headers.py
+++ b/tests/test_sync_auth_headers.py
@@ -1,0 +1,263 @@
+"""Every outbound request the sync manager makes carries the auth header.
+
+This file exists because of *how* the header work went wrong, not because of
+which request was wrong. The subtitle sidecar was converted to
+``Authorization`` and the other six ``requests.get`` calls in the same module
+were left building urls with ``?ApiKey=``. Against a stock Jellyfin that is
+invisible -- it accepts either -- so the gap survived a review, a test suite
+and a hand test, and only surfaced against a proxy that requires the header.
+
+Six of those seven calls swallow their own exceptions
+(``except Exception: log.debug(...)``), so the failure was not even loud:
+the download completed and was marked done, with its artwork and trickplay
+tiles silently absent. That is the case the enumeration below is really for.
+
+So the important test here is not any single site -- it is
+``TestEveryCallSiteIsCovered``, which reads the module's AST and fails on a
+``requests.*`` call that does not pass ``headers=``. A new download helper
+gets this wrong by default; this makes "by default" fail.
+"""
+
+import ast
+import inspect
+import os
+import unittest
+from unittest import mock
+
+from jellyfin_mpv_shim.sync import manager as sync_manager
+from jellyfin_mpv_shim.sync.manager import SyncManager, _same_origin
+
+SERVER = "https://srv.example:8920"
+TOKEN_HEADER = 'MediaBrowser Client="Shim", DeviceId="d", Token="REALTOKEN"'
+
+
+class _Http:
+    def _get_authenication_header(self):
+        return TOKEN_HEADER
+
+
+class _Config:
+    def __init__(self, server=SERVER):
+        self.data = {"auth.server": server, "auth.token": "REALTOKEN"}
+
+
+class _Client:
+    """Just enough client for the header helper."""
+
+    def __init__(self, server=SERVER):
+        self.config = _Config(server)
+        self.http = _Http()
+
+
+class TestHeadersFor(unittest.TestCase):
+    """The one way this module authenticates an outbound request."""
+
+    def setUp(self):
+        self.mgr = SyncManager.__new__(SyncManager)
+        self.client = _Client()
+
+    def test_our_own_server_gets_the_header(self):
+        h = self.mgr._headers_for(self.client, SERVER + "/Items/x/Download")
+        self.assertEqual(h, {"Authorization": TOKEN_HEADER})
+
+    def test_another_host_gets_nothing(self):
+        h = self.mgr._headers_for(self.client, "https://elsewhere.example/x.srt")
+        self.assertEqual(h, {})
+
+    def test_a_downgrade_to_http_is_not_the_same_origin(self):
+        """Sending the token over http to the host we reached over https
+        hands it to anyone on the path."""
+        h = self.mgr._headers_for(self.client, "http://srv.example:8920/x")
+        self.assertEqual(h, {})
+
+    def test_a_different_port_is_not_the_same_origin(self):
+        h = self.mgr._headers_for(self.client, "https://srv.example:9999/x")
+        self.assertEqual(h, {})
+
+    def test_a_broken_client_falls_back_rather_than_raising(self):
+        class _Boom:
+            def _get_authenication_header(self):
+                raise RuntimeError("no")
+
+        self.client.http = _Boom()
+        h = self.mgr._headers_for(self.client, SERVER + "/Items/x/Download")
+        self.assertEqual(h, {})
+
+    def test_a_junk_url_is_not_an_exception(self):
+        self.assertEqual(self.mgr._headers_for(self.client, "::::"), {})
+
+
+class TestTheMediaDownloadCarriesIt(unittest.TestCase):
+    """The visible half: this one raises, so it 401'd out loud."""
+
+    def setUp(self):
+        # __new__, not __init__: the real one opens the catalog db and starts
+        # a worker thread, and none of that is what this is about. The two
+        # attributes the streaming loop reads are set by hand.
+        self.mgr = SyncManager.__new__(SyncManager)
+        self.mgr._cancelled = set()
+        self.mgr._stop = False
+        self.client = _Client()
+
+    def _run(self, tmp, resume=0):
+        seen = {}
+
+        class _Resp:
+            status_code = 200
+            headers = {"Content-Length": "4"}
+
+            def __enter__(self_):
+                return self_
+
+            def __exit__(self_, *a):
+                return False
+
+            def raise_for_status(self_):
+                pass
+
+            def iter_content(self_, n):
+                return [b"data"]
+
+        def fake_get(url, **kw):
+            seen["url"] = url
+            seen["headers"] = kw.get("headers")
+            return _Resp()
+
+        with mock.patch.object(sync_manager.requests, "get", fake_get):
+            self.mgr._stream_request(
+                SERVER + "/Items/x/Download", tmp, "x", "name", 4, resume,
+                lambda: False,
+                self.mgr._headers_for(self.client, SERVER + "/Items/x/Download"))
+        return seen
+
+    def test_the_stream_request_sends_the_header(self):
+        import tempfile
+
+        with tempfile.TemporaryDirectory() as d:
+            seen = self._run(os.path.join(d, "m.part"))
+        self.assertEqual(seen["headers"].get("Authorization"), TOKEN_HEADER)
+
+    def test_a_resume_keeps_both_range_and_authorization(self):
+        """The bug's exact shape: the dict was rebuilt from scratch here, so
+        the resume header arrived and the credentials did not."""
+        import tempfile
+
+        with tempfile.TemporaryDirectory() as d:
+            seen = self._run(os.path.join(d, "m.part"), resume=1024)
+        self.assertEqual(seen["headers"].get("Authorization"), TOKEN_HEADER)
+        self.assertEqual(seen["headers"].get("Range"), "bytes=1024-")
+
+
+class TestEveryCallSiteIsCovered(unittest.TestCase):
+    """The point of this file.
+
+    A missed call site is what happened, so the guard is over call sites
+    rather than over behaviour. Reading the AST rather than the text so a
+    reformat, a wrapped line or a renamed variable cannot make it pass by
+    accident.
+    """
+
+    def _calls(self):
+        src = inspect.getsource(sync_manager)
+        tree = ast.parse(src)
+        out = []
+        for node in ast.walk(tree):
+            if not isinstance(node, ast.Call):
+                continue
+            fn = node.func
+            # requests.get / requests.post / ...
+            if (isinstance(fn, ast.Attribute)
+                    and isinstance(fn.value, ast.Name)
+                    and fn.value.id == "requests"):
+                out.append((node.lineno, "requests." + fn.attr, node))
+        return out
+
+    def test_there_are_call_sites_to_check(self):
+        """If this module stops using requests directly, this whole file is
+        measuring nothing -- fail rather than pass vacuously."""
+        self.assertGreaterEqual(len(self._calls()), 5)
+
+    def test_every_request_passes_headers(self):
+        missing = [(ln, name) for ln, name, node in self._calls()
+                   if not any(kw.arg == "headers" for kw in node.keywords)]
+        self.assertEqual(
+            missing, [],
+            "sync/manager.py issues a request without headers= at "
+            + ", ".join("line %d (%s)" % m for m in missing)
+            + ". Every outbound request must authenticate through "
+              "SyncManager._headers_for; see its docstring.")
+
+    def test_headers_come_from_the_helper(self):
+        """Not just any headers= -- the one that same-origin gates. A literal
+        dict here would pass the check above while sending the token to
+        whatever host the url named."""
+        offenders = []
+        for ln, name, node in self._calls():
+            kw = next((k for k in node.keywords if k.arg == "headers"), None)
+            if kw is None:
+                continue
+            # allowed: self._headers_for(...), or a name bound from it
+            ok = (isinstance(kw.value, ast.Call)
+                  and isinstance(kw.value.func, ast.Attribute)
+                  and kw.value.func.attr == "_headers_for")
+            ok = ok or isinstance(kw.value, ast.Name)
+            if not ok:
+                offenders.append((ln, name))
+        self.assertEqual(offenders, [],
+                         "headers= not derived from _headers_for at "
+                         + str(offenders))
+
+
+class TestUrlsNoLongerCarryTheToken(unittest.TestCase):
+    """The other half: the header is only a win if the url stops carrying it.
+
+    Checked at the call site rather than by running each downloader, because
+    the downloaders are wrapped in bare excepts -- a wrong url here fails
+    silently, which is how this went unnoticed.
+    """
+
+    URL_BUILDERS = {"download_url", "artwork", "trickplay_tile_url",
+                    "subtitle_url", "image_url", "audio_url", "video_url"}
+
+    def test_no_url_builder_is_left_at_the_apikey_default(self):
+        src = inspect.getsource(sync_manager)
+        tree = ast.parse(src)
+        offenders = []
+        for node in ast.walk(tree):
+            if not isinstance(node, ast.Call):
+                continue
+            fn = node.func
+            if not (isinstance(fn, ast.Attribute)
+                    and fn.attr in self.URL_BUILDERS):
+                continue
+            kw = next((k for k in node.keywords
+                       if k.arg == "include_apikey"), None)
+            if kw is None or not (isinstance(kw.value, ast.Constant)
+                                  and kw.value.value is False):
+                offenders.append((node.lineno, fn.attr))
+        self.assertEqual(
+            offenders, [],
+            "url built with the apiclient's include_apikey=True default at "
+            + ", ".join("line %d (%s)" % o for o in offenders)
+            + ". The sync manager authenticates by header, so its urls must "
+              "pass include_apikey=False.")
+
+
+class TestSameOriginStillHolds(unittest.TestCase):
+    """_headers_for leans on this entirely."""
+
+    def test_matching(self):
+        self.assertTrue(_same_origin(SERVER + "/a/b", SERVER))
+
+    def test_scheme_port_and_host_all_count(self):
+        for other in ("http://srv.example:8920", "https://srv.example:1",
+                      "https://other.example:8920"):
+            with self.subTest(other=other):
+                self.assertFalse(_same_origin(other + "/a", SERVER))
+
+    def test_a_relative_url_is_not_our_server(self):
+        self.assertFalse(_same_origin("/Items/x/Download", SERVER))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_sync_manager.py
+++ b/tests/test_sync_manager.py
@@ -35,13 +35,29 @@ def _short_join_timeout(seconds=0.1):
 
 
 class FakeJellyfin:
-    def download_url(self, item_id):
+    # include_apikey mirrors the apiclient's own signature. The sync manager
+    # passes False and authenticates by header instead; a fake that did not
+    # take the argument would make every download here a TypeError.
+    def download_url(self, item_id, include_apikey=True):
         return "http://example/download/%s" % item_id
+
+
+class FakeHttp:
+    def _get_authenication_header(self):
+        return 'MediaBrowser Client="test", Token="TESTTOKEN"'
+
+
+class FakeConfig:
+    # Same origin as FakeJellyfin's urls, so _headers_for actually attaches
+    # the header in these tests rather than short-circuiting to {}.
+    data = {"auth.server": "http://example", "auth.token": "TESTTOKEN"}
 
 
 class FakeClient:
     def __init__(self):
         self.jellyfin = FakeJellyfin()
+        self.http = FakeHttp()
+        self.config = FakeConfig()
 
 
 class FakeResp:
@@ -134,8 +150,11 @@ class DownloadCommitTest(TmpTest):
         add_row(m, "a", size_bytes=100)
         item_dir = m._item_dir(m.db.get("a"))
 
+        # headers= is passed by _download so the media request carries the
+        # Authorization header; a fake without it makes the download a
+        # TypeError and the row lands in 'error'.
         def fake_stream(url, dest, item_id, name, expected,
-                        stopping=None):
+                        stopping=None, headers=None):
             os.makedirs(os.path.dirname(dest), exist_ok=True)
             with open(dest + ".part", "wb") as fh:
                 fh.write(b"x" * 100)
@@ -157,8 +176,11 @@ class DownloadCommitTest(TmpTest):
         add_row(m, "a", size_bytes=100)
         item_dir = m._item_dir(m.db.get("a"))
 
+        # headers= is passed by _download so the media request carries the
+        # Authorization header; a fake without it makes the download a
+        # TypeError and the row lands in 'error'.
         def fake_stream(url, dest, item_id, name, expected,
-                        stopping=None):
+                        stopping=None, headers=None):
             os.makedirs(os.path.dirname(dest), exist_ok=True)
             with open(dest + ".part", "wb") as fh:
                 fh.write(b"x" * 100)
@@ -175,8 +197,11 @@ class DownloadCommitTest(TmpTest):
         m = make_manager(self.tmp, self.addCleanup)
         add_row(m, "a", size_bytes=100)
 
+        # headers= is passed by _download so the media request carries the
+        # Authorization header; a fake without it makes the download a
+        # TypeError and the row lands in 'error'.
         def fake_stream(url, dest, item_id, name, expected,
-                        stopping=None):
+                        stopping=None, headers=None):
             os.makedirs(os.path.dirname(dest), exist_ok=True)
             with open(dest + ".part", "wb") as fh:
                 fh.write(b"x" * 100)


### PR DESCRIPTION
This PR gets rid of the legacy api_key and where possible ApiKey (discouraged) authentication and switches to headers across the board. This has the added benefit that URLs are never used for auth, so it's possible to use stricter nginx reverse proxy configs to protect Jellyfin.

Note that the client falls back to ApiKey in the unlikely event that first-party and third-party requests get mixed in an MPV window, because the auth headers mechanism is sent to *all* endpoints including external subtitles/audio tracks.

Also fixes an issue where image cropping on banners was broken.

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>
