### PR TITLE
Disable HDR colorspace hint before stopping video

### DIFF
--- a/jellyfin_mpv_shim/player.py
+++ b/jellyfin_mpv_shim/player.py
@@ -675,6 +675,10 @@ class PlayerManager(AudioMixin, ReportingMixin, WindowMixin):
         # A fresh mpv starts with stats.lua's overlay off — don't let a stale
         # flag make clear_stats() toggle it back on.
         self._stats_shown = False
+        # Likewise the colorspace hint: this mpv holds the user's own value,
+        # so the flag must not claim it is already parked — the browser taking
+        # the window back would then skip parking it (suspend_colorspace_hint).
+        self._colorspace_hint_suspended = False
         try:
             self.apply_audio_settings()
         except Exception:
@@ -1595,6 +1599,9 @@ class PlayerManager(AudioMixin, ReportingMixin, WindowMixin):
         self._showing_browse_bg = False   # real media replaces the backdrop
         # A start supersedes any browse background a previous one deferred.
         self._browse_bg_deferred = False
+        # Real media wants the user's colorspace hint back, HDR passthrough
+        # included; the browser parks it while it holds an idle window.
+        self.resume_colorspace_hint()
         self.menu.hide_menu()
 
         if self.trickplay:

--- a/jellyfin_mpv_shim/player_window.py
+++ b/jellyfin_mpv_shim/player_window.py
@@ -100,6 +100,8 @@ class WindowMixin:
         _geometry_armed: Optional[str]
         _showing_browse_bg: bool
         _browse_bg_deferred: bool
+        _colorspace_hint: Any
+        _colorspace_hint_suspended: bool
         fullscreen_disable: bool
 
         # Provided by siblings on the composed PlayerManager. Three, and the
@@ -113,6 +115,97 @@ class WindowMixin:
 
         # ReportingMixin.
         def upd_player_hide(self) -> None: ...
+
+    #: mpv's ``--target-colorspace-hint``, spelled once. Both backends expose
+    #: options as attributes with the dashes turned into underscores.
+    _COLORSPACE_HINT = "target_colorspace_hint"
+
+    def suspend_colorspace_hint(self):
+        """Let the window's colorspace follow the display while the UI owns it.
+
+        mpv only revisits the swapchain's colorspace *while a video frame
+        exists*. ``vo_gpu_next.c``::
+
+            if (target_hint && frame->current) {
+                ... set_colorspace_hint(p, &hint);
+            } else if (!target_hint) {
+                ... set_colorspace_hint(p, NULL);
+            }
+
+        ``target_hint`` is ``--target-colorspace-hint``, whose default of
+        ``auto`` resolves to *true* on d3d11 (that context implements
+        ``target_csp()``), so on Windows the first branch is the live one —
+        and with no file loaded, ``frame->current`` is NULL and neither branch
+        runs. The last hint set during playback is never withdrawn, and it is
+        real swapchain state: libplacebo's d3d11 backend acts on it with
+        ``SetColorSpace1`` plus a backbuffer format change.
+
+        That is issue #605. Play something, turn Windows HDR on mid-playback
+        (mpv re-hints the swapchain to PQ, correctly), stop, then turn HDR
+        back off: nothing re-hints, so mpv keeps encoding the library UI as PQ
+        while the display reads it as sRGB — raised blacks and clipped
+        highlights. It only bites us because we are one of the few things that
+        keeps an mpv window on screen with no file loaded; the UI *is* the
+        idle window. Cycling HDR without ever opening the player is fine,
+        which is what the report says, because the hint is never set at all.
+
+        Parking the option at ``no`` takes the second branch instead, and
+        ``pl_swapchain_colorspace_hint`` maps its NULL to sRGB — so the
+        swapchain returns to 8-bit sRGB and stays there, letting Windows do
+        the SDR-in-HDR conversion it does for every other desktop app. Which
+        is the honest answer anyway: the library UI is sRGB content, so
+        hinting the swapchain toward a video's colorspace while no video
+        exists is meaningless.
+
+        Only the browse window needs this. The OSD menu's ``force_window``
+        window is torn down when the menu closes, and that destroys the
+        swapchain along with the stale hint.
+
+        Never raises, and does nothing at all on an mpv without the option
+        (built without gpu-next, or too old) — the read is how we find out.
+        """
+        if getattr(self, "_colorspace_hint_suspended", False):
+            return
+        if not self._mpv_alive:
+            return
+        try:
+            saved = getattr(self._player, self._COLORSPACE_HINT)
+            setattr(self._player, self._COLORSPACE_HINT, "no")
+        except Exception:
+            wlog.debug("this mpv will not take %s", self._COLORSPACE_HINT,
+                       exc_info=True)
+            return
+        self._colorspace_hint = saved
+        self._colorspace_hint_suspended = True
+        wlog.info("colorspace hint parked at no (was %r) <- %s",
+                  saved, _caller())
+
+    def resume_colorspace_hint(self):
+        """Give the user's ``--target-colorspace-hint`` back before playback.
+
+        Called from ``_play_media`` rather than from ``browse_yield``, which
+        would read as the natural counterpart to ``set_browse_window``: yield
+        is a browser gateway hook, so it misses every other way playback
+        starts (a cast, the remote, the OSD menu). Playing HDR with the hint
+        still parked would be a worse bug than the one being worked around,
+        so the restore hangs off the one path all of them share.
+
+        The flag is cleared only once mpv has taken the value, so a write that
+        fails is retried by the next start rather than silently left parked.
+        """
+        if not getattr(self, "_colorspace_hint_suspended", False):
+            return
+        if not self._mpv_alive:
+            return
+        try:
+            setattr(self._player, self._COLORSPACE_HINT, self._colorspace_hint)
+        except Exception:
+            wlog.debug("could not restore %s", self._COLORSPACE_HINT,
+                       exc_info=True)
+            return
+        self._colorspace_hint_suspended = False
+        wlog.info("colorspace hint restored to %r <- %s",
+                  self._colorspace_hint, _caller())
 
     def _set_force_window(self, value):
         """Single authority for force_window.
@@ -331,6 +424,18 @@ class WindowMixin:
                     self._player.keepaspect = False
                 except Exception:
                     pass  # older mpv without the property; harmless
+                # An idle window's colorspace has to keep tracking the
+                # display, which mpv only does with the hint off (see
+                # suspend_colorspace_hint) — but only once nothing is
+                # playing. This method also runs with media still live: music
+                # keeps the browser up, and the library can be opened over a
+                # playing video. Parking the hint there would cost that video
+                # its HDR passthrough, which is worse than the bug being
+                # worked around. Same guard as the backdrop below, and the
+                # `_loading` half is there for the same reason — _video is
+                # not set until a start has already succeeded.
+                if self._video is None and not self._loading:
+                    self.suspend_colorspace_hint()
                 # Paint the window ourselves rather than decoding a file to
                 # hold it open. This also fixes audio: playing a song
                 # replaces whatever is loaded with a picture-less file, and

--- a/tests/test_colorspace_hint.py
+++ b/tests/test_colorspace_hint.py
@@ -1,0 +1,181 @@
+"""The idle window must not stay stuck in the display's old colorspace.
+
+Issue #605: play something, turn Windows HDR on mid-playback, stop, then turn
+HDR back off — and the library UI comes back washed out with clipped
+highlights. mpv only revisits the swapchain colorspace while a video frame
+exists (`vo_gpu_next.c`, `if (target_hint && frame->current)`), so the hint it
+set for the video is never withdrawn, and an app whose UI *is* the idle mpv
+window goes on encoding sRGB artwork as PQ.
+
+The workaround parks `--target-colorspace-hint` at `no` while the browser owns
+the window, which takes mpv's other branch and resets the swapchain to sRGB.
+What these pin is the half that could hurt: giving the user's own value back
+before anything plays. Leaving it parked would cost HDR passthrough, which is
+a worse bug than the one being worked around.
+"""
+
+import sys
+import unittest
+
+sys.argv = [sys.argv[0]]      # importing the shim reaches args.get_args()
+
+from jellyfin_mpv_shim.player import PlayerManager  # noqa: E402
+
+HINT = "target_colorspace_hint"
+
+
+class _Player:
+    """Fake mpv that records colorspace-hint writes."""
+
+    def __init__(self, hint="auto"):
+        object.__setattr__(self, "writes", [])
+        # object.__setattr__: the fake's own construction is not a write the
+        # code under test made. hint=None is an mpv without the option at all.
+        if hint is not None:
+            object.__setattr__(self, HINT, hint)
+
+    def __setattr__(self, name, value):
+        if name == HINT:
+            self.writes.append(value)
+        object.__setattr__(self, name, value)
+
+
+class _RefusingPlayer(_Player):
+    """An mpv that has the option but will not take a write — a disconnect
+    mid-transition, which must not be recorded as a successful park."""
+
+    def __setattr__(self, name, value):
+        if name == HINT:
+            self.writes.append(value)
+            raise BrokenPipeError("mpv went away")
+        object.__setattr__(self, name, value)
+
+
+class ColorspaceHintTest(unittest.TestCase):
+    def _pm(self, player):
+        pm = PlayerManager.__new__(PlayerManager)
+        pm._player = player
+        pm._mpv_alive = True
+        pm._colorspace_hint_suspended = False
+        return pm
+
+    def test_browsing_parks_the_hint(self):
+        pm = self._pm(_Player())
+        pm.suspend_colorspace_hint()
+        self.assertEqual(pm._player.writes, ["no"])
+
+    def test_playback_gets_the_user_value_back(self):
+        """The half that must never be skipped: a parked hint through a real
+        start would mean no HDR passthrough."""
+        pm = self._pm(_Player(hint="auto"))
+        pm.suspend_colorspace_hint()
+        pm.resume_colorspace_hint()
+        self.assertEqual(pm._player.writes, ["no", "auto"])
+
+    def test_a_deliberate_user_setting_survives(self):
+        """`yes` is someone's HDR setup, not a default to overwrite. The
+        restore is of what was read, not of mpv's default."""
+        pm = self._pm(_Player(hint=True))
+        pm.suspend_colorspace_hint()
+        pm.resume_colorspace_hint()
+        self.assertEqual(pm._player.writes, ["no", True])
+
+    def test_parking_twice_does_not_lose_the_saved_value(self):
+        """set_browse_window(True) runs repeatedly — every stop reaches it
+        twice — and the second one must not save "no" as the user's value."""
+        pm = self._pm(_Player(hint="auto"))
+        pm.suspend_colorspace_hint()
+        pm.suspend_colorspace_hint()
+        pm.resume_colorspace_hint()
+        self.assertEqual(pm._player.writes, ["no", "auto"])
+
+    def test_resume_without_a_park_writes_nothing(self):
+        """Every start calls resume; only the ones that follow a park have
+        anything to undo."""
+        pm = self._pm(_Player())
+        pm.resume_colorspace_hint()
+        self.assertEqual(pm._player.writes, [])
+
+    def test_an_mpv_without_the_option_is_left_alone(self):
+        """Built without gpu-next, or simply too old. The read is how we find
+        out, and finding out must not be fatal."""
+        pm = self._pm(_Player(hint=None))
+        pm.suspend_colorspace_hint()
+        pm.resume_colorspace_hint()
+        self.assertEqual(pm._player.writes, [])
+        self.assertFalse(pm._colorspace_hint_suspended)
+
+    def test_a_failed_park_is_not_recorded_as_parked(self):
+        pm = self._pm(_RefusingPlayer())
+        pm.suspend_colorspace_hint()
+        self.assertFalse(pm._colorspace_hint_suspended)
+
+    def test_a_failed_restore_is_retried_by_the_next_start(self):
+        """Clearing the flag on a write that did not land would leave the
+        hint parked for the rest of the session."""
+        pm = self._pm(_Player())
+        pm.suspend_colorspace_hint()
+        pm._player.__class__ = _RefusingPlayer
+        pm.resume_colorspace_hint()
+        self.assertTrue(pm._colorspace_hint_suspended)
+        pm._player.__class__ = _Player
+        pm.resume_colorspace_hint()
+        self.assertFalse(pm._colorspace_hint_suspended)
+        self.assertEqual(pm._player.writes[-1], "auto")
+
+    def test_a_dead_mpv_is_not_written_to(self):
+        pm = self._pm(_Player())
+        pm._mpv_alive = False
+        pm.suspend_colorspace_hint()
+        self.assertEqual(pm._player.writes, [])
+
+
+class BrowseWindowIntegrationTest(unittest.TestCase):
+    """Through the real `set_browse_window`, where the park actually happens."""
+
+    class _BrowsePlayer(_Player):
+        def __init__(self):
+            super().__init__()
+            self.fs = None
+            self.keepaspect = True
+            self.image_display_duration = 0
+            self.keep_open = False
+            self.commands = []
+
+        def command(self, *a):
+            self.commands.append(a)
+
+    def _pm(self, video=None, loading=False):
+        pm = PlayerManager.__new__(PlayerManager)
+        pm._player = self._BrowsePlayer()
+        pm._video = video
+        pm._showing_browse_bg = False
+        pm._mpv_alive = True
+        pm._loading = loading
+        pm._colorspace_hint_suspended = False
+        pm._set_force_window = lambda *a, **k: None
+        return pm
+
+    def test_taking_the_window_parks_the_hint(self):
+        pm = self._pm()
+        pm.set_browse_window(True)
+        self.assertEqual(pm._player.writes, ["no"])
+
+    def test_live_media_keeps_its_hint(self):
+        """This runs with media still playing too — music keeps the browser
+        up, and the library can be opened over a video. Parking the hint there
+        would cost that video its HDR passthrough."""
+        pm = self._pm(video=object())
+        pm.set_browse_window(True)
+        self.assertEqual(pm._player.writes, [])
+
+    def test_a_start_in_flight_is_left_alone(self):
+        """_video is not set until a start has succeeded, so mid-load it
+        looks like an idle window and is not one."""
+        pm = self._pm(loading=True)
+        pm.set_browse_window(True)
+        self.assertEqual(pm._player.writes, [])
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
HDR hints don't update when MPV doesn't have a video loaded. The fixes the issue by forcing MPV into sRGB when not playing content, such that if the user switches out of HDR mode after a video quits it doesn't break the video browser.

Fixes #605