### PR TITLE
mpvtk: a disabled control state, plus two small UI fixes (#613, #618)

### DIFF
--- a/jellyfin_mpv_shim/mpvtk/GUIDE.md
+++ b/jellyfin_mpv_shim/mpvtk/GUIDE.md
@@ -104,6 +104,19 @@ Floating: `Menu` (context menu at a point; `on_select`/`on_dismiss`),
 `on_dismiss`), `Float` (positioned toast/banner, no grab). All floating
 content draws above everything and occludes image overlays.
 
+**`disabled=True`** is a control that is on screen but cannot be used
+right now — a setting the current mode ignores. The node draws muted
+(`on_surface_faint` over the control's own surface, geometry unchanged
+so the form does not reflow) and is inert: no hover, no click, no
+spatial-nav focus. It still **absorbs** the pointer, so the press stops
+there instead of reaching whatever it sits over — `node_at` keeps
+returning it and each consumer drops it, which is not the same as making
+it invisible. `Dropdown`/`TextBox`/`Slider` are drawn by the renderer and
+mute themselves; `Button`/`Checkbox` are composites whose colours are
+baked into child nodes the renderer cannot recognise, so they mute in
+`widgets.py` and drop their handler. Always say *why* next to it: a
+disabled control with no explanation reads as a broken one.
+
 Every element takes `id=`, `w=`, `h=`, `flex=`, and size constraints
 `min_w`/`max_w`/`min_h`/`max_h` — int px, or a float in (0, 1] as a
 fraction of the available space (a Dialog child resolves fractions

--- a/jellyfin_mpv_shim/mpvtk/layout.py
+++ b/jellyfin_mpv_shim/mpvtk/layout.py
@@ -519,6 +519,8 @@ def _base(el, t, x, y, w, h, sc, path):
         node["tip"] = el.tip
     if getattr(el, "autofocus", False):
         node["af"] = True
+    if getattr(el, "disabled", False):
+        node["dis"] = True
     return node
 
 

--- a/jellyfin_mpv_shim/mpvtk/renderer.lua
+++ b/jellyfin_mpv_shim/mpvtk/renderer.lua
@@ -1066,6 +1066,9 @@ local function draw_textbox(ass, node, ex, ey, clip)
         bc = focused and state.accent or state.tok.outline,
         bw = focused and 2 or 1, clip = clip,
     })
+    -- see draw_dropdown: shape kept, contrast dropped
+    local ink = node.dis and state.tok.on_surface_faint
+        or state.tok.on_surface
     local pad = 10
     local inner = {
         x1 = math.max(ex + pad, clip and clip.x1 or 0),
@@ -1144,9 +1147,9 @@ local function draw_textbox(ass, node, ex, ey, clip)
         end
         draw_text(ass, tnode, x0, ey, inner,
             pre .. caret .. esc(b),
-            state.tok.on_surface, nil, true)
+            ink, nil, true)
     else
-        draw_text(ass, tnode, x0, ey, inner, disp, state.tok.on_surface)
+        draw_text(ass, tnode, x0, ey, inner, disp, ink)
     end
 end
 
@@ -1305,13 +1308,21 @@ local function draw_dropdown(ass, node, ex, ey, clip)
         fill = state.tok.control_sunken, radius = 6,
         bc = open and state.accent or state.tok.outline, bw = 1, clip = clip,
     })
+    -- Disabled: the control keeps its shape so the form does not reflow,
+    -- and loses its contrast. on_surface_faint for everything that was
+    -- ink, which is the token that already means "present but not the
+    -- thing you are reading".
+    local ink = node.dis and state.tok.on_surface_faint
+        or state.tok.on_surface
+    local dim = node.dis and state.tok.on_surface_faint
+        or state.tok.on_surface_muted
     local label = node.items[d.sel + 1] or ''
     local indent = 0
     local ipath = node.icons and node.icons[d.sel + 1]
     if ipath and ipath ~= '' then
         local isz = math.floor(node.size * 1.1)
         draw_icon_path(ass, ipath, ex + 8, ey + (node.h - isz) / 2,
-            isz, state.tok.on_surface_muted, clip)
+            isz, dim, clip)
         indent = isz + 6
     end
     local tnode = {
@@ -1320,14 +1331,14 @@ local function draw_dropdown(ass, node, ex, ey, clip)
     }
     -- the label must not spill under the arrow or past the control
     label = ellipsize(label, node.size, false, tnode.w)
-    draw_text(ass, tnode, ex + 10 + indent, ey, clip, label, state.tok.on_surface)
+    draw_text(ass, tnode, ex + 10 + indent, ey, clip, label, ink)
     -- arrow
     local ax = ex + node.w - 22
     local ay = ey + node.h / 2 - 2
     ass:new_event()
     ass:append(string.format(
         '{\\pos(0,0)\\an7\\bord0\\shad0\\1c%s\\1a&H00&%s}',
-        ass_color(state.tok.on_surface_muted), clip_tag(clip)))
+        ass_color(dim), clip_tag(clip)))
     ass:draw_start()
     ass:move_to(ax, ay)
     ass:line_to(ax + 12, ay)
@@ -1565,6 +1576,11 @@ local function draw_slider(ass, node, ex, ey, clip)
     -- not read on a picture can pin the seek bar without giving up its
     -- colour everywhere else. Defaults to the accent.
     local accent = (ov and state.tok.accent_on_video) or state.accent
+    if node.dis then
+        -- see draw_dropdown: a disabled bar keeps its geometry (so the
+        -- value it is stuck at stays readable) and loses its colour
+        accent = state.tok.on_surface_faint
+    end
     draw_rect(ass, tx1, ty - 3, tw, 6,
         { fill = ov and '3a3a3a' or state.tok.control_sunken,
           radius = 3, clip = clip })
@@ -1600,7 +1616,8 @@ local function draw_slider(ass, node, ex, ey, clip)
         end
     end
     draw_rect(ass, tx1 + tw * frac - 8, ty - 8, 16, 16,
-        { fill = ov and 'dddddd' or state.tok.on_surface,
+        { fill = node.dis and state.tok.on_surface_faint
+                 or (ov and 'dddddd' or state.tok.on_surface),
           radius = 8, clip = clip })
 end
 
@@ -2778,6 +2795,12 @@ local function on_mouse_move(x, y)
     if state.dd_open or active_menu() or state.tb_menu then
         node = nil
     end
+    -- A disabled control still ABSORBS the pointer (node_at returned it,
+    -- so nothing underneath lights up either) but takes no hover of its
+    -- own: no ring, no tooltip, no slider hover reporting.
+    if node and node.dis then
+        node = nil
+    end
     update_slider_hover(node)
     local id = node and node.id or nil
     if id ~= state.hover_id then
@@ -2953,6 +2976,12 @@ local function on_mouse_down()
             -- the lua OSC's click-anywhere behavior
             mp.commandv('cycle', 'pause')
         end
+        return
+    end
+    if node.dis then
+        -- Absorbed, not passed through: the press lands on the disabled
+        -- control and stops there rather than reaching whatever it sits
+        -- over. Focus was already dropped above.
         return
     end
     if node.t == 'textbox' then
@@ -3310,7 +3339,7 @@ local function nav_candidates()
     for _, node in ipairs(state.nodes) do
         if node.t ~= 'scroll' and node.t ~= 'layer' and
             node.t ~= 'menu' and node.t ~= 'occ' and
-            (not modal or node.mod) and
+            (not modal or node.mod) and not node.dis and
             (node.click or node.dbl or node.t == 'textbox' or
              node.t == 'dropdown' or node.t == 'slider') and
             visible(node) then

--- a/jellyfin_mpv_shim/mpvtk/widgets.py
+++ b/jellyfin_mpv_shim/mpvtk/widgets.py
@@ -29,7 +29,7 @@ class Element:
     def __init__(self, id=None, w=None, h=None, flex=0,
                  anchor=None, dx=0, dy=0, occlude=False, tip=None,
                  min_w=None, max_w=None, min_h=None, max_h=None,
-                 autofocus=False):
+                 autofocus=False, disabled=False):
         self.id = id
         self.w = w
         self.h = h
@@ -47,6 +47,16 @@ class Element:
         # first scene lands (renderer: phud want_focus). Inert outside
         # that flow — ordinary scenes never steal focus.
         self.autofocus = autofocus
+        # A control that is on screen but cannot be used right now: the
+        # renderer draws it muted and the pointer passes through it, so it
+        # takes no hover, no click and no spatial-nav focus (see
+        # renderer.lua's node_at / nav_candidates). Say WHY next to the
+        # control -- a disabled thing with no explanation reads as broken.
+        #
+        # Composite widgets (Button, Checkbox) additionally mute their own
+        # colours here, because those are baked into child nodes the
+        # renderer cannot recognise as parts of a control.
+        self.disabled = disabled
 
 
 class Box(Element):
@@ -312,6 +322,18 @@ class Button(Box):
         # applied later -- let alone one swapped at runtime.
         themed_fg = fg is None
         fg = fg or theme.ON_SURFACE
+        if kw.get("disabled"):
+            # A composite's colours are baked into child nodes, and the
+            # renderer cannot tell which of them belong to a control -- so
+            # unlike a dropdown or a slider, a disabled Button has to mute
+            # itself here. The handler goes with them: the renderer already
+            # refuses to dispatch it, and dropping it means the node is not
+            # even a spatial-nav candidate.
+            themed_fg = False
+            fg = theme.ON_SURFACE_FAINT
+            on_click = None
+            kw["hover"] = None
+            kw.setdefault("bg", None if flat else theme.CONTROL_SUNKEN)
         if flat:
             # transparent-at-rest, for controls over video/gradients
             # (playback HUD): round translucent accent wash + accent
@@ -433,26 +455,40 @@ class Checkbox(Row):
     """Labelled toggle — pure composite sugar over Row/Box/Text."""
 
     def __init__(self, label, checked, on_toggle=None, size=20, **kw):
+        # Muted here rather than in the renderer, and the handler dropped:
+        # see Button for why a composite cannot leave this to the draw side.
+        # The check itself still shows -- a disabled setting has a value, and
+        # hiding it would say the opposite of what it is.
+        off = bool(kw.get("disabled"))
         box = Box(
             w=20,
             h=20,
-            bg=theme.ACCENT if checked else theme.CONTROL_SUNKEN,
-            border=None if checked else theme.OUTLINE_STRONG,
+            bg=((theme.ACCENT if not off else theme.CONTROL_SUNKEN)
+                if checked else theme.CONTROL_SUNKEN),
+            border=(theme.OUTLINE_STRONG
+                    if (not checked or off) else None),
             radius=5,
             align="center",
             direction="row",
             children=(
-                [Text("✓", size=15, color=theme.ON_ACCENT, align="center",
-                      flex=1)]
+                [Text("✓", size=15, align="center", flex=1,
+                      color=(theme.ON_SURFACE_FAINT if off
+                             else theme.ON_ACCENT))]
                 if checked
                 else []
             ),
         )
         kw.setdefault("gap", 10)
         kw.setdefault("align", "center")
-        kw.setdefault("hover", {"c": theme.ON_SURFACE_STRONG})
+        if off:
+            kw["hover"] = None
+            on_toggle = None
+        else:
+            kw.setdefault("hover", {"c": theme.ON_SURFACE_STRONG})
         super().__init__(
-            [box, Text(label, size=size)], on_click=on_toggle, **kw
+            [box, Text(label, size=size,
+                       color=theme.ON_SURFACE_FAINT if off else None)],
+            on_click=on_toggle, **kw
         )
 
 

--- a/jellyfin_mpv_shim/mpvtk_browser/hud.py
+++ b/jellyfin_mpv_shim/mpvtk_browser/hud.py
@@ -478,6 +478,21 @@ def _toggle_tc(b):
     b.invalidate()
 
 
+def _toggle_hud_mute(b):
+    """Flip the icon on the click, not on the round trip.
+
+    The player now observes ``mute`` and pushes a snapshot (see
+    _on_volume_change), so this only covers the trip out to the action
+    thread and back — but that trip runs behind the player's lock, which a
+    playback start holds for its whole duration. Same optimism as the
+    favourite button below, and self-correcting: the next snapshot is the
+    truth whatever we guessed."""
+    st = b.hud.state or {}
+    st["muted"] = not st.get("muted")
+    b._ctl(lambda c: c.toggle_mute())
+    b.invalidate()
+
+
 def _toggle_hud_favorite(b):
     st = b.hud.state or {}
     st["favorite"] = not st.get("favorite")   # optimistic, like the np bar
@@ -651,7 +666,7 @@ def build_hud(b, size):
         right.append(tbtn(
             "volume_off" if muted else
             ("volume_up" if vol >= 50 else "volume_down"),
-            "hud-mute", lambda: b._ctl(lambda c: c.toggle_mute()),
+            "hud-mute", lambda: _toggle_hud_mute(b),
             tip=_("Mute")))
     if tiers["volbar"]:
         right.append(Slider(

--- a/jellyfin_mpv_shim/mpvtk_browser/pages/grid.py
+++ b/jellyfin_mpv_shim/mpvtk_browser/pages/grid.py
@@ -246,10 +246,20 @@ class GridPage(Page):
         labels = (bool(self._view("showTitle")),
                   bool(self._view("showYear")))
         if not labels[0]:
-            # No caption means no room for one: the strip reserves
-            # caption_h under every tile whether or not anything is drawn
-            # there, so leaving it would just be a band of background.
-            geom = dataclasses.replace(geom, caption_h=0)
+            # The strip reserves caption_h under every tile whether or not
+            # anything is drawn there, so the reservation has to follow what
+            # will actually be drawn -- too much is a band of background,
+            # too little puts a caption over the next row.
+            #
+            # Titles off, years on is ONE line (the year moves up into the
+            # title's place; see strips._paint_caption), so drop exactly the
+            # title line: its size plus the gap under it. Derived from the
+            # geometry rather than a constant, because a theme's cover size
+            # scales all of these together.
+            geom = dataclasses.replace(
+                geom,
+                caption_h=(max(0, geom.caption_h - geom.title_size - 7)
+                           if labels[1] else 0))
         if self._pages.enabled():
             return self._paged_grid(size, header, geom, image_type, labels)
         rows = header + tiles.grid_of(

--- a/jellyfin_mpv_shim/mpvtk_browser/strips.py
+++ b/jellyfin_mpv_shim/mpvtk_browser/strips.py
@@ -761,16 +761,21 @@ class StripStore:
         img.paste(glyph, (int(cx - size // 2), int(cy - size // 2)), glyph)
 
     def _paint_caption(self, dr, x, t, g):
+        # The second line follows the first rather than sitting at a fixed
+        # y: with "show titles" off and "show years" on there is no first
+        # line, and the year used to be dropped entirely (#613). Leaving it
+        # at the old offset instead would draw it a full line below the
+        # artwork with a band of nothing between.
+        y = g.tile_h + _px(6)
         if t.title:
             fnt = _font(g.title_size, text=t.title)
             title = self._ellipsize(dr, t.title, fnt, g.tile_w)
-            dr.text((x, g.tile_h + _px(6)), title, font=fnt,
-                    fill=theme.rgb(theme.TEXT_FG))
+            dr.text((x, y), title, font=fnt, fill=theme.rgb(theme.TEXT_FG))
+            y += g.title_size + _px(7)
         if t.subtitle:
             fnt = _font(g.sub_size, text=t.subtitle)
             sub = self._ellipsize(dr, t.subtitle, fnt, g.tile_w)
-            dr.text((x, g.tile_h + _px(6) + g.title_size + _px(7)), sub,
-                    font=fnt, fill=theme.rgb(theme.SUBTLE_FG))
+            dr.text((x, y), sub, font=fnt, fill=theme.rgb(theme.SUBTLE_FG))
 
     @staticmethod
     def _ellipsize(dr, text, font, max_w):

--- a/jellyfin_mpv_shim/mpvtk_browser/tile_renderer.py
+++ b/jellyfin_mpv_shim/mpvtk_browser/tile_renderer.py
@@ -733,7 +733,14 @@ class TileRenderer:
         title, subtitle = components.tile_lines(item, parent_item,
                                                 show_year=show_year)
         if not show_title:
-            title = subtitle = ""
+            title = ""
+            if not show_year:
+                # Both off means no caption at all, and the grid reserves no
+                # room for one -- so the second line has to go even where
+                # show_year does not govern it (an episode's "Show · S1E2",
+                # a listing's channel and time). Otherwise it draws into the
+                # row below.
+                subtitle = ""
         return Tile(
             key=item.get("Id", ""),
             title=title,

--- a/jellyfin_mpv_shim/player.py
+++ b/jellyfin_mpv_shim/player.py
@@ -794,6 +794,8 @@ class PlayerManager(AudioMixin, ReportingMixin, WindowMixin):
         self._observe("seeking", self._on_seeking)
         self._observe("pause", self._on_pause_change)
         self._observe("paused-for-cache", self._on_cache_pause)
+        self._observe("mute", self._on_volume_change)
+        self._observe("volume", self._on_volume_change)
         p.event_callback("file-loaded")(self._on_file_loaded)
         self._observe("current-tracks/audio/codec", self._on_audio_codec_change)
         p.event_callback("end-file")(self._on_end_file)
@@ -1097,6 +1099,29 @@ class PlayerManager(AudioMixin, ReportingMixin, WindowMixin):
             self.syncplay.on_buffer()
         else:
             self.syncplay.on_buffer_done()
+
+    def _on_volume_change(self, _name, _value):
+        """Volume or mute moved -- tell the UI now rather than on the tick.
+
+        The playback HUD's mute icon and volume bar read the playstate
+        snapshot, and nothing pushed one when either changed: the only
+        thing that did was the browser's own 1s ticker, so clicking mute
+        left the button showing the old icon for up to a second and a bit
+        while the audio had already stopped (#618). Pause never had this
+        because `pause` has been observed all along.
+
+        push_playstate() directly, not timeline_handle(): the timeline
+        thread also POSTs progress to the server, and a volume nudge is not
+        worth a request. The snapshot is local and cheap, and it is what the
+        bar actually reads.
+
+        Both properties share a handler because they answer the same
+        question for the UI ("what does the volume control look like?"), and
+        observing mpv rather than patching the state at our own button is
+        what makes mpv's OWN bindings -- `m`, the wheel, a script -- move it
+        too.
+        """
+        self.push_playstate()
 
     def _on_file_loaded(self, _event):
         # Mirrors _on_end_file's generation guard: a file-loaded from

--- a/tests/lua/test_renderer.lua
+++ b/tests/lua/test_renderer.lua
@@ -1093,6 +1093,58 @@ ok(slot_of("/chip") > slot_of("/strip2"),
    string.format("chip is slot %s, its row is slot %s",
                  tostring(slot_of("/chip")), tostring(slot_of("/strip2"))))
 
+-- ========================================================= disabled
+
+-- A disabled control is on screen and inert: no click, no spatial-nav
+-- focus. It still ABSORBS the pointer -- the press must stop there rather
+-- than reaching whatever it happens to sit over, which is why node_at
+-- keeps returning it and each consumer drops it instead.
+
+local function btn(id, row, extra)
+    local node = { id = id, t = "rect", x = 0, y = (row or 0) * 40,
+                   w = 200, h = 30, click = true }
+    for k, v in pairs(extra or {}) do node[k] = v end
+    return node
+end
+
+scene({ btn("live", 0), btn("dead", 1, { dis = true }) })
+fake.reset_events()
+click("dead")
+ok(last_event("click") == nil, "a disabled node does not fire its click")
+click("live")
+local fired = last_event("click")
+ok(fired ~= nil and fired.id == "live",
+   "an enabled node beside it still fires")
+
+-- Underneath, not beside: the disabled node covers the live one exactly.
+scene({ btn("under", 0), btn("over", 0, { dis = true }) })
+fake.reset_events()
+click("over")
+ok(last_event("click") == nil,
+   "a disabled node absorbs the click instead of passing it down")
+
+-- Spatial nav must skip it, or a remote lands focus on something that
+-- cannot be activated and the ring appears to get stuck.
+scene({ btn("first", 0), btn("skipme", 1, { dis = true }), btn("last", 2) })
+fake.send("mpvtk-debug", fake.token({ cmd = "nav", id = "first" }))
+fake.send("mpvtk-debug", fake.token({ cmd = "nav", dir = "down" }))
+fake.reset_events()
+fake.send("mpvtk-debug", fake.token({ cmd = "nav", action = "enter" }))
+local navd = last_event("click")
+ok(navd ~= nil and navd.id == "last",
+   "arrowing down steps over the disabled node",
+   navd and navd.id or "nothing activated")
+
+-- A disabled textbox takes no focus either, so typing cannot reach it.
+scene({ textbox("ro", "keep"), btn("elsewhere", 2) })
+scene({ { id = "ro", t = "textbox", x = 0, y = 0, w = 200, h = 30,
+          size = 18, text = "keep", dis = true }, btn("elsewhere", 2) })
+fake.reset_events()
+click("ro")
+type_text("Z")
+click("elsewhere")
+ok(last_event("commit") == nil, "a disabled textbox cannot be edited")
+
 -- ========================================================== teardown
 
 scene({})

--- a/tests/test_list_page.py
+++ b/tests/test_list_page.py
@@ -1210,22 +1210,55 @@ class ViewLabelsAndListTest(unittest.TestCase):
         nodes, _h, _t = self._scene(b)
         self.assertNotIn("1999", {n.get("text") for n in nodes})
 
+    def _tile_h(self, b):
+        nodes, _h = build_scene(b)
+        hit = [n for n in nodes
+               if re.match(r"^grid-\d+-", str(n.get("id", "")))
+               and n.get("t") == "rect"]
+        self.assertTrue(hit)
+        return hit[0]["h"]
+
     def test_showtitle_off_takes_the_caption_space_with_it(self):
         """The strip reserves caption_h under every tile whether or not
         anything is drawn there, so leaving it would be a band of
         background."""
-        b_on, _s = self._grid()
-        b_off, _s2 = self._grid(showTitle=False)
+        self.assertLess(self._tile_h(self._grid(showTitle=False,
+                                                showYear=False)[0]),
+                        self._tile_h(self._grid()[0]))
 
-        def tile_h(b):
-            nodes, _h = build_scene(b)
-            hit = [n for n in nodes
-                   if re.match(r"^grid-\d+-", str(n.get("id", "")))
-                   and n.get("t") == "rect"]
-            self.assertTrue(hit)
-            return hit[0]["h"]
+    def test_the_year_survives_the_title_being_switched_off(self):
+        """#613: turning titles off blanked the year with them, so "years
+        only" was unreachable even though both are separate checkboxes."""
+        b, _src = self._grid(showTitle=False)      # showYear defaults on
+        tile = b.tiles._tile({"Id": "g1", "Name": "Alpha", "Type": "Movie",
+                              "ProductionYear": 1999}, b.geom,
+                             labels=(False, True))
+        self.assertEqual(tile.title, "")
+        self.assertEqual(tile.subtitle, "1999")
 
-        self.assertLess(tile_h(b_off), tile_h(b_on))
+    def test_a_year_only_caption_is_one_line_tall(self):
+        """Between the two-line caption and no caption at all -- the year
+        moves up into the title's place rather than sitting a line below
+        the artwork with a band of nothing above it."""
+        both = self._tile_h(self._grid()[0])
+        year_only = self._tile_h(self._grid(showTitle=False)[0])
+        neither = self._tile_h(self._grid(showTitle=False,
+                                          showYear=False)[0])
+        self.assertLess(neither, year_only)
+        self.assertLess(year_only, both)
+
+    def test_both_off_blanks_a_line_show_year_does_not_govern(self):
+        """An episode's "Show · S1E2" ignores showYear by design, but with
+        both switched off the grid reserves NO caption space -- so it has to
+        go too, or it draws into the row below."""
+        b, _src = self._grid(showTitle=False, showYear=False)
+        ep = {"Id": "e1", "Name": "Pilot", "Type": "Episode",
+              "SeriesName": "Show", "ParentIndexNumber": 1,
+              "IndexNumber": 2}
+        self.assertEqual(b.tiles._tile(ep, b.geom, labels=(False, False))
+                         .subtitle, "")
+        self.assertEqual(b.tiles._tile(ep, b.geom, labels=(False, True))
+                         .subtitle, "Show · S1E2")
 
     def test_showyear_off_still_leaves_a_live_tv_line_alone(self):
         """Every other subtitle branch is a channel, an air time or an

--- a/tests/test_playstate_payload.py
+++ b/tests/test_playstate_payload.py
@@ -378,3 +378,46 @@ class TestReportingIsWiredIn(unittest.TestCase):
         self.assertEqual(out.returncode, 0, out.stderr)
         self.assertEqual(out.stdout.strip(), "",
                          "player_reporting captured the backend at import time")
+
+
+class TestVolumeAndMuteReachTheUI(unittest.TestCase):
+    """#618: the HUD's mute button took up to a second and a half to change.
+
+    Its icon reads the playstate snapshot, and nothing pushed one when the
+    volume or the mute flag moved -- the only thing that did was the
+    browser's 1s ticker. Pause never had the problem because ``pause`` has
+    been observed all along, which is why the two felt so different.
+    """
+
+    def test_both_properties_are_observed(self):
+        import inspect
+
+        src = inspect.getsource(PlayerManager._bind_mpv_handlers)
+        for prop in ("mute", "volume"):
+            self.assertIn('self._observe("%s"' % prop, src,
+                          "%s is not observed, so the UI only learns about "
+                          "it on the next tick" % prop)
+
+    def test_the_handler_pushes_a_snapshot(self):
+        got = []
+        pm = PlayerManager.__new__(PlayerManager)
+        pm.on_playstate = got.append
+        pm._video = _Video({"Name": "x"})
+        pm._player = _Player()
+        pm._hud_skip = None
+        pm.repeat_mode = "none"
+        PlayerManager._on_volume_change(pm, "mute", True)
+        self.assertTrue(got, "the observer pushed no playstate")
+        self.assertIn("muted", got[0])
+
+    def test_it_does_not_go_through_the_timeline_thread(self):
+        """timeline_handle() would also POST progress to the server, which
+        is not what a volume nudge is worth. Read the code, not the
+        docstring -- which says the same thing and would satisfy a naive
+        substring check on its own."""
+        import inspect
+
+        src = inspect.getsource(PlayerManager._on_volume_change)
+        body = src.split('"""')[2]
+        self.assertNotIn("timeline_handle", body)
+        self.assertIn("push_playstate", body)


### PR DESCRIPTION
Add disabled state for mpvtk controls.

Also fixes two minor issues:
- Fix mute/volume taking a while to update in HUD
- Allow showing year when toggling off title display in listing pages

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>