### PR TITLE
HUD scrim and auto-hide as settings, one action per segment type (#620, #575)

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -655,18 +655,32 @@ Other miscellaneous configuration options. You probably won't have to change the
 - `raise_mpv` - Windows only. Disable this if you are fine with MPV sometimes appearing behind other windows when playing.
 - `health_check_interval` - The number of seconds between each client health check. Null disables it. Default: `300`
 
-## Skip Intro Support
+## Media Segments (Skip Intro and friends)
 
-Intro and credits detection uses Jellyfin's MediaSegments API.
+Segment detection uses Jellyfin's MediaSegments API. There is one setting per
+segment type the server publishes, and each takes the same three values:
 
-- `skip_intro_always` - Always skip intros, without asking. Default: `false`
-- `skip_intro_enable` - Offer to skip intros. With the Jellyfin player UI
-  (`osc_style: mpvtk`) this shows a floating "Skip Intro" button during the
-  intro (even while the controls are hidden); with other UIs it shows the
-  classic seek-to-skip prompt. Default: `true`
-- `skip_credits_always` - Always skip credits, without asking. Default: `false`
-- `skip_credits_enable` - Offer to skip credits (same behavior as
-  `skip_intro_enable`). Default: `true`
+- `off` - ignore this kind of segment.
+- `ask` - offer to skip it. With the Jellyfin player UI (`osc_style: mpvtk`)
+  that is a floating "Skip …" button during the segment, shown even while the
+  controls are hidden; with other UIs it is the classic seek-to-skip prompt.
+- `always` - skip it silently, with a brief "Skipped …" message.
+
+Settings, and their defaults:
+
+- `segment_intro` - Intros. Default: `ask`
+- `segment_outro` - Credits. Default: `ask`
+- `segment_commercial` - Commercials. Default: `off`
+- `segment_preview` - Previews. Default: `off`
+- `segment_recap` - Recaps. Default: `off`
+
+The last three default to off, as they do in jellyfin-web: they are far less
+common, and a segment skipped out from under you is worse than one you have
+to skip yourself.
+
+**These replace `skip_intro_always`, `skip_intro_enable`, `skip_credits_always`
+and `skip_credits_enable`, and ARE migrated from them** — `always` wins over
+`enable`, so an install that skipped intros automatically still does.
 - `skip_intro_on_seek` - Seeking forward during an intro/credits window skips
   the whole segment. Applies to keyboard and remote seeks only; scrubbing or
   seeking from the Jellyfin player UI never triggers it (use its Skip button).

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -287,6 +287,35 @@ You can use the config file to enable and disable features.
   driving while they are hidden, and that takes keyboard control of controls
   already showing (mpv key name syntax). ENTER also toggles pause/play when
   it wakes them. Default: `ENTER`
+- `hud_scrim` - How the picture is shaded behind the player controls, so they
+  stay legible over any frame. One of `default`, `half`, `panel`, `none`.
+  Default: `default`
+  - `default` is a gradient rising from the bottom of the window (and a
+    smaller one from the top, under the title).
+  - `half` is the same gradient, half as tall. The controls end up nearer the
+    faded end of it, which is the trade.
+  - `panel` is a flat band exactly the height of each bar — a hard edge, and
+    nothing washed over the picture above it.
+  - `none` draws no shading at all and gives the controls' text and icons a
+    dark halo instead. Legibility has to come from somewhere; this is the
+    option that pays for it in the glyphs rather than in the picture.
+- `hud_autohide` - When the player controls hide. One of `hover`, `always`,
+  `paused`. Default: `hover`
+  - `hover` keeps them up only while the pointer is on them — paused or not.
+  - `always` runs the timer regardless, including while paused.
+  - `paused` runs the timer but never hides while playback is paused (what
+    earlier versions always did).
+- `hud_hide_secs` - Seconds of no input before the player controls hide.
+  Default: `4.0`
+  - `0` means "as soon as the pointer is not on them", and forces `hover`
+    mode — a zero delay means nothing without a pointer test, since mouse
+    motion is also what summons them. The timer never runs shorter than
+    0.5s, so the controls cannot blink out in the same frame they appear.
+- `hud_sub_margin` - Raise bottom subtitles clear of the controls while they
+  are showing. Default: `true`
+  - Already skipped for top- and middle-positioned subtitles. Turn it off if
+    the subtitles moving as the controls appear is more distracting than the
+    bar covering them.
 - `media_key_seek` - Use the media next/prev keys to seek instead of skip episodes. Default: `false`
 - `mouse_chapter_nav` - The mouse's back/forward buttons jump a chapter
   during playback. Off by default: they are easy to hit by accident on

--- a/jellyfin_mpv_shim/conf.py
+++ b/jellyfin_mpv_shim/conf.py
@@ -373,6 +373,19 @@ class Settings(SettingsBase):
     # "jellyfin" is a legacy alias for "mpvtk" (the lua OSC it used to
     # name was retired once the HUD reached parity).
     osc_style: str = "mpvtk"
+    # Playback HUD looks and lifecycle (osc_style "mpvtk"). The scrim
+    # is what makes the controls legible over any frame; "none" pays
+    # for that with a drop shadow on the text instead.
+    hud_scrim: str = "default"
+    # When the controls hide: "hover" (they stay while the pointer is
+    # on them, paused or not), "always" (the timer, regardless), or
+    # "paused" (the timer, but never while paused).
+    hud_autohide: str = "hover"
+    # Seconds of no input before they hide. 0 means "as soon as the
+    # pointer is not on them", and forces the hover mode.
+    hud_hide_secs: float = 4.0
+    # Raise bottom subtitles clear of the bar while it shows.
+    hud_sub_margin: bool = True
     # Scale factor for the whole in-player UI (tiles, text, chrome).
     # null follows the display: mpv's display-hidpi-scale, which is 1.0
     # on X11 and the compositor's factor on Wayland/macOS. Set a number

--- a/jellyfin_mpv_shim/conf.py
+++ b/jellyfin_mpv_shim/conf.py
@@ -8,7 +8,7 @@ import sys
 import getpass
 import threading
 from typing import List, Optional
-from .settings_base import SettingsBase, object_types
+from .settings_base import SettingsBase, adv_bool, object_types
 from .language_config import LanguageRule, parse_language_config
 
 # Register the structured-type parser. Done here (rather than in
@@ -22,7 +22,45 @@ config_path = None
 # Bump when a default changes in a way existing installs must pick up, and add
 # the corresponding step to Settings._migrate().
 #   1: transcode_dolby_vision defaults off (mpv plays Dolby Vision natively).
-CONFIG_VERSION = 1
+#   2: the four skip_intro/skip_credits booleans become one action per
+#      media segment type (segment_intro and friends).
+CONFIG_VERSION = 2
+
+# Media segment types the server publishes, and the setting that decides what
+# each one does. Jellyfin's enum also has "Unknown", which has no meaning to
+# act on. The values are SEGMENT_ACTIONS: leave it alone, offer a Skip
+# button, or skip it silently -- the three jellyfin-web offers.
+SEGMENT_SETTINGS = {
+    "Intro": "segment_intro",
+    "Outro": "segment_outro",
+    "Commercial": "segment_commercial",
+    "Preview": "segment_preview",
+    "Recap": "segment_recap",
+}
+SEGMENT_ACTIONS = ("off", "ask", "always")
+
+
+def segment_action(segment_type):
+    """What to do about a segment of this type: "off", "ask" or "always".
+
+    Unknown types -- a newer server, a hand-edited value -- are "off". A
+    segment the shim does not understand must not be skipped out from under
+    the viewer, and a Skip button for it would have nothing to say.
+    """
+    key = SEGMENT_SETTINGS.get(segment_type)
+    value = getattr(settings, key, None) if key else None
+    return value if value in SEGMENT_ACTIONS else "off"
+
+
+def any_segment_wanted():
+    """Whether any segment type is set to anything but "off" -- i.e.
+    whether it is worth asking the server for segments at all."""
+    return any(segment_action(t) != "off" for t in SEGMENT_SETTINGS)
+
+
+def wanted_segment_types():
+    """The segment types to request, newest-first order irrelevant."""
+    return [t for t in SEGMENT_SETTINGS if segment_action(t) != "off"]
 
 # Values `scroll_mode` accepts, most permissive first. The first entry is the
 # default AND the fallback: anything unrecognised (a hand-edited typo, a value
@@ -355,10 +393,14 @@ class Settings(SettingsBase):
     force_video_codec: Optional[str] = None
     force_audio_codec: Optional[str] = None
     health_check_interval: Optional[int] = 300
-    skip_intro_always: bool = False
-    skip_intro_enable: bool = True
-    skip_credits_always: bool = False
-    skip_credits_enable: bool = True
+    # One per media segment type the server knows (SEGMENT_SETTINGS below),
+    # each "off" / "ask" / "always". Replaces the four booleans that covered
+    # only intros and credits; migrated from them at CONFIG_VERSION 2.
+    segment_intro: str = "ask"
+    segment_outro: str = "ask"
+    segment_commercial: str = "off"
+    segment_preview: str = "off"
+    segment_recap: str = "off"
     # Seeking forward during an intro/credits window skips the whole
     # segment. Applies to keyboard/remote seeks; seeks made from the
     # jellyfin OSC's seekbar never trigger it (it has its own button).
@@ -411,7 +453,7 @@ class Settings(SettingsBase):
     tls_server_ca: Optional[str] = None
     language_config: Optional[List[LanguageRule]] = None
 
-    def _migrate(self):
+    def _migrate(self, data=None):
         """Apply one-time upgrades for configs written by older versions.
 
         Every key is written to disk on save (see SettingsBase.dict), so a
@@ -422,8 +464,40 @@ class Settings(SettingsBase):
         Only migrate a default whose old value is actively harmful; a setting
         the user may have deliberately chosen cannot be distinguished from an
         inherited default, so each step here silently overrides a real choice.
+        A step that RENAMES a setting is exempt from that caution -- carrying
+        a real choice across is the whole point -- and needs ``data``, the
+        raw config as read from disk, because the old key is no longer in the
+        schema and so never reaches an attribute.
         """
         changed = False
+        data = data or {}
+        if self.config_version < 2:
+            # The four booleans become one action per segment type. Read from
+            # the raw config rather than from self: the old keys are gone from
+            # the schema, so they never reach an attribute.
+            #
+            # adv_bool, not Python truthiness. The keys being read were
+            # declared `bool`, which in this schema means adv_bool -- and
+            # adv_bool says the STRINGS "false"/"no"/"0"/"off" are False
+            # while bool() says they are all True. A hand-edited or
+            # templated conf.json that quotes its booleans would otherwise
+            # migrate "skip_intro_always": "false" to `always`, i.e. start
+            # silently skipping intros for someone who had asked to be
+            # prompted -- and the source keys are dropped on the next save,
+            # so the evidence goes with them.
+            for prefix, key in (("skip_intro", "segment_intro"),
+                                ("skip_credits", "segment_outro")):
+                if adv_bool(data.get(prefix + "_always")):
+                    action = "always"
+                elif prefix + "_enable" in data:
+                    action = "ask" if adv_bool(data[prefix + "_enable"]) \
+                        else "off"
+                else:
+                    continue
+                if getattr(self, key) != action:
+                    log.info("Config migration: %s = %s (from %s_*)",
+                             key, action, prefix)
+                    setattr(self, key, action)
         if self.config_version < 1:
             # mpv plays Dolby Vision natively now, so the old default of
             # force-transcoding it to SDR just burns server CPU and throws
@@ -492,7 +566,7 @@ class Settings(SettingsBase):
                         )
 
                 log.info("Loaded settings from json: %s" % path)
-                migrated = self._migrate()
+                migrated = self._migrate(data)
                 if migrated or input_params < len(self.__fields__):
                     log.info("Saving back due to schema change.")
                     self.save()

--- a/jellyfin_mpv_shim/media.py
+++ b/jellyfin_mpv_shim/media.py
@@ -6,6 +6,7 @@ import pathlib
 from io import BytesIO
 from sys import platform
 
+from . import conf
 from .conf import settings
 from .language_config import apply as apply_language_config
 from .utils import is_local_domain, get_profile, get_seq
@@ -66,10 +67,38 @@ def build_video(item_id, parent, aid=None, sid=None, srcid=None,
 
 class Intro(object):
     def __init__(self, type, start, end):
-        self.type: str = type  # "Intro" or "Outro"
+        # A Jellyfin MediaSegmentType: Intro, Outro, Commercial, Preview or
+        # Recap. Named Intro for its first two.
+        self.type: str = type
         self.start: float = start
         self.end: float = end
         self.has_triggered: bool = False
+
+
+def segment_labels(segment_type):
+    """``(button, done, prompt)`` for a segment type.
+
+    Whole phrases per type rather than "Skip {0}" with a noun: gettext keys
+    on the English, and a language that inflects the verb with the object
+    cannot fix a sentence assembled after translation. This is also what
+    jellyfin-web does.
+
+    Built per call, not at import: ``_()`` resolves against whatever locale
+    is loaded, and at module scope that is whatever was loaded first.
+    """
+    table = {
+        "Outro": (_("Skip Credits"), _("Skipped Credits"),
+                  _("Seek to Skip Credits")),
+        "Commercial": (_("Skip Commercial"), _("Skipped Commercial"),
+                       _("Seek to Skip Commercial")),
+        "Preview": (_("Skip Preview"), _("Skipped Preview"),
+                    _("Seek to Skip Preview")),
+        "Recap": (_("Skip Recap"), _("Skipped Recap"),
+                  _("Seek to Skip Recap")),
+    }
+    return table.get(segment_type,
+                     (_("Skip Intro"), _("Skipped Intro"),
+                      _("Seek to Skip Intro")))
 
 
 class Video(object):
@@ -498,7 +527,8 @@ class Video(object):
         # provided by plugin
         try:
             skip_intro_data = self.client.jellyfin.get_media_segments(
-                media_source_id, include_segment_types=["Outro", "Intro"]
+                media_source_id,
+                include_segment_types=conf.wanted_segment_types(),
             )
             for intro in skip_intro_data["Items"]:
                 self.intros.append(
@@ -630,12 +660,7 @@ class Video(object):
         )
 
         self.media_source = self.get_best_media_source(self.srcid)
-        if (
-            settings.skip_intro_always
-            or settings.skip_intro_enable
-            or settings.skip_credits_always
-            or settings.skip_credits_enable
-        ):
+        if conf.any_segment_wanted():
             self.get_intro(self.media_source["Id"])
 
         self.map_streams()

--- a/jellyfin_mpv_shim/menu.py
+++ b/jellyfin_mpv_shim/menu.py
@@ -1,5 +1,6 @@
 from queue import LifoQueue
 from .bulk_subtitle import process_series
+from . import conf
 from .conf import settings
 from .utils import mpv_color_to_plex, get_sub_display_title
 from .video_profile import VideoProfileManager
@@ -442,6 +443,33 @@ class OSDMenu(object):
             self.playerManager.put_task(self.playerManager.apply_audio_settings)
         self.menu_list[self.menu_selection] = self.get_settings_toggle(name, key)
 
+    def settings_cycle_segment(self):
+        """Step a media-segment setting through off / ask / always.
+
+        A tri-state does not fit the bool toggle above, and three menu rows
+        per segment type (five of them) would not fit the menu.
+        """
+        _x, _x, key, name = self.menu_list[self.menu_selection]
+        actions = conf.SEGMENT_ACTIONS
+        try:
+            nxt = actions[(actions.index(getattr(settings, key)) + 1)
+                          % len(actions)]
+        except ValueError:
+            nxt = actions[0]
+        setattr(settings, key, nxt)
+        settings.save()
+        self.menu_list[self.menu_selection] = self.get_segment_cycle(name, key)
+
+    def get_segment_cycle(self, name: str, setting: str):
+        labels = {"off": _("No"), "ask": _("Ask"), "always": _("Always")}
+        value = getattr(settings, setting, "off")
+        return (
+            "{0}: {1}".format(name, labels.get(value, labels["off"])),
+            self.settings_cycle_segment,
+            setting,
+            name,
+        )
+
     def get_settings_toggle(self, name: str, setting: str):
         return (
             "{0}: {1}".format(name, getattr(settings, setting)),
@@ -594,14 +622,12 @@ class OSDMenu(object):
                 self.get_settings_toggle(
                     _("Discord Rich Presence"), "discord_presence"
                 ),
-                self.get_settings_toggle(_("Always Skip Intros"), "skip_intro_always"),
-                self.get_settings_toggle(_("Ask to Skip Intros"), "skip_intro_enable"),
-                self.get_settings_toggle(
-                    _("Always Skip Credits"), "skip_credits_always"
-                ),
-                self.get_settings_toggle(
-                    _("Ask to Skip Credits"), "skip_credits_enable"
-                ),
+                self.get_segment_cycle(_("Skip Intros"), "segment_intro"),
+                self.get_segment_cycle(_("Skip Credits"), "segment_outro"),
+                self.get_segment_cycle(_("Skip Commercials"),
+                                       "segment_commercial"),
+                self.get_segment_cycle(_("Skip Previews"), "segment_preview"),
+                self.get_segment_cycle(_("Skip Recaps"), "segment_recap"),
                 self.get_settings_toggle(
                     _("Enable thumbnail previews"), "thumbnail_enable"
                 ),

--- a/jellyfin_mpv_shim/messages/base.pot
+++ b/jellyfin_mpv_shim/messages/base.pot
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: jellyfin-mpv-shim\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2026-08-01 15:30-0400\n"
+"POT-Creation-Date: 2026-08-01 15:36-0400\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -108,6 +108,67 @@ msgstr ""
 
 #: jellyfin_mpv_shim/clients.py
 msgid "Could not start Quick Connect."
+msgstr ""
+
+#: jellyfin_mpv_shim/media.py jellyfin_mpv_shim/menu.py
+#: jellyfin_mpv_shim/mpvtk_browser/config.py
+msgid "Skip Credits"
+msgstr ""
+
+#: jellyfin_mpv_shim/media.py
+msgid "Skipped Credits"
+msgstr ""
+
+#: jellyfin_mpv_shim/media.py
+msgid "Seek to Skip Credits"
+msgstr ""
+
+#: jellyfin_mpv_shim/media.py
+msgid "Skip Commercial"
+msgstr ""
+
+#: jellyfin_mpv_shim/media.py
+msgid "Skipped Commercial"
+msgstr ""
+
+#: jellyfin_mpv_shim/media.py
+msgid "Seek to Skip Commercial"
+msgstr ""
+
+#: jellyfin_mpv_shim/media.py
+msgid "Skip Preview"
+msgstr ""
+
+#: jellyfin_mpv_shim/media.py
+msgid "Skipped Preview"
+msgstr ""
+
+#: jellyfin_mpv_shim/media.py
+msgid "Seek to Skip Preview"
+msgstr ""
+
+#: jellyfin_mpv_shim/media.py
+msgid "Skip Recap"
+msgstr ""
+
+#: jellyfin_mpv_shim/media.py
+msgid "Skipped Recap"
+msgstr ""
+
+#: jellyfin_mpv_shim/media.py
+msgid "Seek to Skip Recap"
+msgstr ""
+
+#: jellyfin_mpv_shim/media.py
+msgid "Skip Intro"
+msgstr ""
+
+#: jellyfin_mpv_shim/media.py
+msgid "Skipped Intro"
+msgstr ""
+
+#: jellyfin_mpv_shim/media.py
+msgid "Seek to Skip Intro"
 msgstr ""
 
 #: jellyfin_mpv_shim/media.py
@@ -276,6 +337,18 @@ msgid "Manual by Track Index (Less Reliable)"
 msgstr ""
 
 #: jellyfin_mpv_shim/menu.py
+msgid "No"
+msgstr ""
+
+#: jellyfin_mpv_shim/menu.py jellyfin_mpv_shim/mpvtk_browser/config.py
+msgid "Ask"
+msgstr ""
+
+#: jellyfin_mpv_shim/menu.py jellyfin_mpv_shim/mpvtk_browser/config.py
+msgid "Always"
+msgstr ""
+
+#: jellyfin_mpv_shim/menu.py
 msgid "Select Default Transcode Profile"
 msgstr ""
 
@@ -380,20 +453,20 @@ msgstr ""
 msgid "Discord Rich Presence"
 msgstr ""
 
-#: jellyfin_mpv_shim/menu.py
-msgid "Always Skip Intros"
+#: jellyfin_mpv_shim/menu.py jellyfin_mpv_shim/mpvtk_browser/config.py
+msgid "Skip Intros"
 msgstr ""
 
-#: jellyfin_mpv_shim/menu.py
-msgid "Ask to Skip Intros"
+#: jellyfin_mpv_shim/menu.py jellyfin_mpv_shim/mpvtk_browser/config.py
+msgid "Skip Commercials"
 msgstr ""
 
-#: jellyfin_mpv_shim/menu.py
-msgid "Always Skip Credits"
+#: jellyfin_mpv_shim/menu.py jellyfin_mpv_shim/mpvtk_browser/config.py
+msgid "Skip Previews"
 msgstr ""
 
-#: jellyfin_mpv_shim/menu.py
-msgid "Ask to Skip Credits"
+#: jellyfin_mpv_shim/menu.py jellyfin_mpv_shim/mpvtk_browser/config.py
+msgid "Skip Recaps"
 msgstr ""
 
 #: jellyfin_mpv_shim/menu.py
@@ -747,6 +820,10 @@ msgstr ""
 #: jellyfin_mpv_shim/mpvtk_browser/settings/downloads.py
 #: jellyfin_mpv_shim/mpvtk_browser/settings/__init__.py
 msgid "Downloads"
+msgstr ""
+
+#: jellyfin_mpv_shim/mpvtk_browser/config.py
+msgid "Never"
 msgstr ""
 
 #: jellyfin_mpv_shim/mpvtk_browser/config.py
@@ -3041,22 +3118,6 @@ msgid "Please wait, loading..."
 msgstr ""
 
 #: jellyfin_mpv_shim/player.py
-msgid "Skipped Credits"
-msgstr ""
-
-#: jellyfin_mpv_shim/player.py
-msgid "Skipped Intro"
-msgstr ""
-
-#: jellyfin_mpv_shim/player.py
-msgid "Seek to Skip Credits"
-msgstr ""
-
-#: jellyfin_mpv_shim/player.py
-msgid "Seek to Skip Intro"
-msgstr ""
-
-#: jellyfin_mpv_shim/player.py
 msgid ""
 "Your remote video is transcoding!\n"
 "Press c to adjust bandwidth settings if this is not needed."
@@ -3064,14 +3125,6 @@ msgstr ""
 
 #: jellyfin_mpv_shim/player.py
 msgid "Next episode is not downloaded."
-msgstr ""
-
-#: jellyfin_mpv_shim/player_reporting.py
-msgid "Skip Credits"
-msgstr ""
-
-#: jellyfin_mpv_shim/player_reporting.py
-msgid "Skip Intro"
 msgstr ""
 
 #: jellyfin_mpv_shim/player_reporting.py

--- a/jellyfin_mpv_shim/messages/base.pot
+++ b/jellyfin_mpv_shim/messages/base.pot
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: jellyfin-mpv-shim\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2026-08-01 15:14-0400\n"
+"POT-Creation-Date: 2026-08-01 15:30-0400\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -798,6 +798,34 @@ msgid "One row per notch"
 msgstr ""
 
 #: jellyfin_mpv_shim/mpvtk_browser/config.py
+msgid "Default"
+msgstr ""
+
+#: jellyfin_mpv_shim/mpvtk_browser/config.py
+msgid "Half height"
+msgstr ""
+
+#: jellyfin_mpv_shim/mpvtk_browser/config.py
+msgid "Panel behind the controls"
+msgstr ""
+
+#: jellyfin_mpv_shim/mpvtk_browser/config.py
+msgid "None (shadowed text)"
+msgstr ""
+
+#: jellyfin_mpv_shim/mpvtk_browser/config.py
+msgid "Hide unless hovered"
+msgstr ""
+
+#: jellyfin_mpv_shim/mpvtk_browser/config.py
+msgid "Always hide"
+msgstr ""
+
+#: jellyfin_mpv_shim/mpvtk_browser/config.py
+msgid "Never hide while paused"
+msgstr ""
+
+#: jellyfin_mpv_shim/mpvtk_browser/config.py
 msgid "Theme default"
 msgstr ""
 
@@ -963,6 +991,22 @@ msgid "Player Controls Activation Key"
 msgstr ""
 
 #: jellyfin_mpv_shim/mpvtk_browser/config.py
+msgid "Shading Behind the Player Controls"
+msgstr ""
+
+#: jellyfin_mpv_shim/mpvtk_browser/config.py
+msgid "When the Player Controls Hide"
+msgstr ""
+
+#: jellyfin_mpv_shim/mpvtk_browser/config.py
+msgid "Hide the Player Controls After (seconds)"
+msgstr ""
+
+#: jellyfin_mpv_shim/mpvtk_browser/config.py
+msgid "Raise Subtitles Above the Player Controls"
+msgstr ""
+
+#: jellyfin_mpv_shim/mpvtk_browser/config.py
 msgid "Mouse Back/Forward Buttons Skip Chapters"
 msgstr ""
 
@@ -1102,6 +1146,30 @@ msgstr ""
 msgid ""
 "Overrides the theme's cover size. Applies immediately, and is also on the "
 "View menu of any library."
+msgstr ""
+
+#: jellyfin_mpv_shim/mpvtk_browser/config.py
+msgid ""
+"The controls have to stay legible over any frame. \"None\" gives the text a "
+"drop shadow instead of shading the picture behind it."
+msgstr ""
+
+#: jellyfin_mpv_shim/mpvtk_browser/config.py
+msgid ""
+"\"Hide unless hovered\" keeps them up only while the pointer is on them, "
+"paused or not."
+msgstr ""
+
+#: jellyfin_mpv_shim/mpvtk_browser/config.py
+msgid ""
+"0 hides them as soon as the pointer is not on them, and forces \"Hide unless "
+"hovered\"."
+msgstr ""
+
+#: jellyfin_mpv_shim/mpvtk_browser/config.py
+msgid ""
+"Subtitles move up while the controls show so the bar does not cover them. "
+"Turn this off if the movement is more distracting than the overlap."
 msgstr ""
 
 #: jellyfin_mpv_shim/mpvtk_browser/config.py

--- a/jellyfin_mpv_shim/mpvtk/renderer.lua
+++ b/jellyfin_mpv_shim/mpvtk/renderer.lua
@@ -183,7 +183,10 @@ local state = {
     snap_timer = nil,
     -- playback-HUD lifecycle (see mpvtk-hud): attached-but-idle during
     -- video, summoned by nav keys / mouse motion, auto-hides
-    phud = { mode = false, shown = false, timer = nil, mx = -1, my = -1 },
+    phud = { mode = false, shown = false, timer = nil, mx = -1, my = -1,
+             -- auto-hide policy and the no-scrim text halo, pushed
+             -- with the engage (mpvtk-hud) so setting changes stick
+             hide_s = 4, hide_mode = 'hover', shadow = false },
     ready_sent = false,
     mouse = { x = -1, y = -1, hover = false },
     hover_id = nil,
@@ -686,6 +689,13 @@ local function draw_text(ass, node, ex, ey, clip, text, color, extra,
     if state.glow and node.bold and (node.size or 0) >= 22 then
         glow = string.format('\\bord2\\blur6\\3c%s\\3a&H30&',
                              ass_color(state.accent))
+    elseif state.phud.shown and state.phud.shadow then
+        -- The scrim is what normally makes HUD text legible over any
+        -- frame. With hud_scrim "none" there is nothing behind it, so the
+        -- glyphs carry their own dark halo instead. Scoped to a summoned
+        -- HUD, which is the only thing on screen while it is up -- no node
+        -- needs to declare anything.
+        glow = '\\bord1.4\\blur2\\3c&H000000&\\3a&H40&'
     end
     ass:append(string.format(
         '{\\q2\\an%d\\pos(%.1f,%.1f)\\fs%d\\bord0\\shad0' ..
@@ -704,9 +714,13 @@ local function draw_icon_path(ass, path, x, y, px, color, clip)
     local scale = px / 24 * 100
     ass:new_event()
     ass:append(string.format(
-        '{\\pos(%.1f,%.1f)\\an7\\bord0\\shad0\\1c%s\\1a&H00&' ..
+        '{\\pos(%.1f,%.1f)\\an7%s\\shad0\\1c%s\\1a&H00&' ..
         '\\fscx%.2f\\fscy%.2f%s\\p1}',
-        x, y, ass_color(color), scale, scale, clip_tag(clip)))
+        x, y,
+        -- see draw_text: with no scrim the glyph carries its own halo
+        (state.phud.shown and state.phud.shadow)
+            and '\\bord1.4\\blur2\\3c&H000000&\\3a&H40&' or '\\bord0',
+        ass_color(color), scale, scale, clip_tag(clip)))
     ass:append(path)
     ass:append('{\\p0}')
 end
@@ -4360,7 +4374,14 @@ end)
 -- tears it back down to idle. While idle, every other key keeps its
 -- mpv default (space pauses, q quits, …).
 
-local PHUD_HIDE_S = 4
+-- Default auto-hide delay, and the floor an explicit one is clamped
+-- to. Zero is a legal setting -- it means "gone the moment the
+-- pointer is not on the controls" -- but a literal zero would also
+-- blink them out in the same frame as the mouse motion that
+-- summoned them, so the timer never runs shorter than the floor.
+-- One table, not two locals: this chunk is at LuaJIT's 200-local ceiling
+-- (tests/test_renderer_lua.py reports the headroom).
+local PHUD_HIDE = { def = 4, min = 0.5 }
 -- How long the standalone Skip button stays up on its own after a
 -- segment starts. Independent of the HUD: it runs whether or not the
 -- bar is summoned, so the offer is on screen for the same window
@@ -4494,22 +4515,57 @@ local function phud_disarm()
 end
 
 -- Interactions the auto-hide must not interrupt; checked at expiry
--- (the timer re-arms instead of hiding). Paused playback also keeps
--- the HUD up — hiding the controls the moment someone pauses is the
--- opposite of what pausing means. nav_adjust is deliberately NOT
+-- (the timer re-arms instead of hiding). nav_adjust is deliberately NOT
 -- here: the bar wakes in adjust mode by default, and an actual scrub
 -- gesture pauses playback, which already holds the HUD open.
+--
+-- Two of these are the hud_autohide setting rather than a rule:
+--
+--   * The POINTER RESTING ON THE CONTROLS holds them up, in every mode but
+--     'always'. Reaching for a button and then reading its tooltip must not
+--     be a race against the timer, and it is what makes a short delay --
+--     down to none -- usable: the controls go when you are not using them
+--     rather than when you stop moving.
+--   * PAUSED playback held them up unconditionally, on the reasoning that
+--     hiding the controls the moment someone pauses is the opposite of what
+--     pausing means. It is also how you end up unable to look at the frame
+--     you paused to look at (#620), so it is now the 'paused' mode.
 local function phud_busy()
-    return state.dd_open ~= nil or state.modal ~= nil
+    if state.dd_open ~= nil or state.modal ~= nil
         or state.tb_menu ~= nil or state.slider_drag ~= nil
         or state.pressed ~= nil
-        or active_menu() ~= nil
-        or mp.get_property_native('pause', false)
+        or active_menu() ~= nil then
+        return true
+    end
+    if state.phud.hide_mode == 'paused'
+        and mp.get_property_native('pause', false) then
+        return true
+    end
+    if state.phud.hide_mode ~= 'always' then
+        -- Over either bar: the ids are the contract (hud.py gives the top
+        -- row and the transport column one for exactly this). Falling back
+        -- to "over any clickable node" would flicker in the gaps between
+        -- buttons, which is most of the bar's area.
+        local mx, my = state.mouse.x, state.mouse.y
+        for _, id in ipairs({ 'hud-bar', 'hud-topbar' }) do
+            local bar = state.byid[id]
+            if bar then
+                local bx, by = eff(bar)
+                if mx >= bx and mx <= bx + bar.w
+                    and my >= by and my <= by + bar.h then
+                    return true
+                end
+            end
+        end
+    end
+    return false
 end
 
 local function phud_arm()
     phud_disarm()
-    state.phud.timer = mp.add_timeout(PHUD_HIDE_S, function()
+    local delay = math.max(PHUD_HIDE.min,
+                           state.phud.hide_s or PHUD_HIDE.def)
+    state.phud.timer = mp.add_timeout(delay, function()
         state.phud.timer = nil
         if not (state.phud.mode and state.phud.shown) then return end
         if phud_busy() then
@@ -4654,6 +4710,15 @@ mp.register_script_message('mpvtk-hud', function(on, opts_json)
         local opts = opts_json and utils.parse_json(opts_json) or nil
         state.phud.grab = (opts and opts.grab) or false
         state.phud.wake_key = (opts and opts.key) or 'ENTER'
+        state.phud.hide_s = (opts and opts.hide) or 0
+        state.phud.hide_mode = (opts and opts.mode) or 'hover'
+        state.phud.shadow = (opts and opts.shadow) or false
+        if state.phud.hide_s <= 0 then
+            -- A zero delay only means anything as "gone the moment the
+            -- pointer leaves the controls"; with no pointer test it is a
+            -- HUD the mouse cannot summon at all.
+            state.phud.hide_mode = 'hover'
+        end
     end
     if want == state.phud.mode then return end
     if want then

--- a/jellyfin_mpv_shim/mpvtk_browser/config.py
+++ b/jellyfin_mpv_shim/mpvtk_browser/config.py
@@ -87,6 +87,8 @@ SECTIONS = [
                       "remember_window_size",
                       "fullscreen", "osc_style",
                       "hud_grab_keys", "hud_wake_key",
+                      "hud_scrim", "hud_autohide", "hud_hide_secs",
+                      "hud_sub_margin",
                       "mouse_chapter_nav", "raise_mpv",
                       "discord_presence",
                       "check_updates", "notify_updates"]),
@@ -163,6 +165,17 @@ LABELED_ENUMS = {
     # Every label points at the value it has always pointed at -- "Small" is
     # the base size, which reads oddly beside two smaller steps but is the
     # price of not silently re-pointing a string 86 locales have translated.
+    "hud_scrim": [
+        (_("Default"), "default"),
+        (_("Half height"), "half"),
+        (_("Panel behind the controls"), "panel"),
+        (_("None (shadowed text)"), "none"),
+    ],
+    "hud_autohide": [
+        (_("Hide unless hovered"), "hover"),
+        (_("Always hide"), "always"),
+        (_("Never hide while paused"), "paused"),
+    ],
     "poster_scale": [
         (_("Theme default"), None),
         (_("Extra Compact"), 0.75),
@@ -218,6 +231,10 @@ LABEL_OVERRIDES = {
     "browser_fullscreen": _("Fullscreen Library Browser"),
     "hud_grab_keys": _("Always Bind Arrow Keys to Player Controls"),
     "hud_wake_key": _("Player Controls Activation Key"),
+    "hud_scrim": _("Shading Behind the Player Controls"),
+    "hud_autohide": _("When the Player Controls Hide"),
+    "hud_hide_secs": _("Hide the Player Controls After (seconds)"),
+    "hud_sub_margin": _("Raise Subtitles Above the Player Controls"),
     "mouse_chapter_nav": _("Mouse Back/Forward Buttons Skip Chapters"),
     "audio_mode": _("Audio Output Mode"),
     "audio_device": _("Audio Output Device"),
@@ -316,6 +333,16 @@ NOTES = {
     "poster_scale": _("Overrides the theme's cover size. Applies "
                       "immediately, and is also on the View menu of any "
                       "library."),
+    "hud_scrim": _("The controls have to stay legible over any frame. "
+                   "\"None\" gives the text a drop shadow instead of "
+                   "shading the picture behind it."),
+    "hud_autohide": _("\"Hide unless hovered\" keeps them up only while "
+                      "the pointer is on them, paused or not."),
+    "hud_hide_secs": _("0 hides them as soon as the pointer is not on "
+                       "them, and forces \"Hide unless hovered\"."),
+    "hud_sub_margin": _("Subtitles move up while the controls show so the "
+                        "bar does not cover them. Turn this off if the "
+                        "movement is more distracting than the overlap."),
     "mouse_chapter_nav": _("During playback only — in the library those "
                            "buttons stay Back and Forward. Off by default "
                            "because they are easy to hit by accident on some "

--- a/jellyfin_mpv_shim/mpvtk_browser/config.py
+++ b/jellyfin_mpv_shim/mpvtk_browser/config.py
@@ -116,9 +116,9 @@ SECTIONS = [
                         "force_audio_codec"]),
     (_("Video Enhancement"), ["shader_pack_enable", "shader_pack_subtype",
                               "shader_pack_remember", "shader_pack_gpu_api"]),
-    (_("Skip Intro / Credits"), ["skip_intro_enable", "skip_intro_always",
-                                 "skip_credits_enable", "skip_credits_always",
-                                 "skip_intro_on_seek"]),
+    (_("Skip Intro / Credits"), ["segment_intro", "segment_outro",
+                                 "segment_commercial", "segment_preview",
+                                 "segment_recap", "skip_intro_on_seek"]),
     (_("Library Browser"), ["library_image_cache_mb", "scroll_wheel_pixels",
                             "scroll_mode", "paginated"]),
     (_("Downloads"), ["sync_path", "prefer_downloaded",
@@ -136,6 +136,13 @@ ENUMS = {
     "mpv_log_level": ["fatal", "error", "warn", "info", "debug"],
     "shader_pack_subtype": ["lq", "hq"],
 }
+
+#: Shared by the five media-segment settings below.
+_SEGMENT_ACTIONS = [
+    (_("Never"), "off"),
+    (_("Ask"), "ask"),
+    (_("Always"), "always"),
+]
 
 # Enums whose stored value isn't presentable: [(label, value), ...].
 LABELED_ENUMS = {
@@ -165,6 +172,13 @@ LABELED_ENUMS = {
     # Every label points at the value it has always pointed at -- "Small" is
     # the base size, which reads oddly beside two smaller steps but is the
     # price of not silently re-pointing a string 86 locales have translated.
+    # One list, five settings: the three things that can be done about a
+    # media segment (jellyfin-web offers the same three).
+    "segment_intro": _SEGMENT_ACTIONS,
+    "segment_outro": _SEGMENT_ACTIONS,
+    "segment_commercial": _SEGMENT_ACTIONS,
+    "segment_preview": _SEGMENT_ACTIONS,
+    "segment_recap": _SEGMENT_ACTIONS,
     "hud_scrim": [
         (_("Default"), "default"),
         (_("Half height"), "half"),
@@ -231,6 +245,11 @@ LABEL_OVERRIDES = {
     "browser_fullscreen": _("Fullscreen Library Browser"),
     "hud_grab_keys": _("Always Bind Arrow Keys to Player Controls"),
     "hud_wake_key": _("Player Controls Activation Key"),
+    "segment_intro": _("Skip Intros"),
+    "segment_outro": _("Skip Credits"),
+    "segment_commercial": _("Skip Commercials"),
+    "segment_preview": _("Skip Previews"),
+    "segment_recap": _("Skip Recaps"),
     "hud_scrim": _("Shading Behind the Player Controls"),
     "hud_autohide": _("When the Player Controls Hide"),
     "hud_hide_secs": _("Hide the Player Controls After (seconds)"),

--- a/jellyfin_mpv_shim/mpvtk_browser/gateway/hud.py
+++ b/jellyfin_mpv_shim/mpvtk_browser/gateway/hud.py
@@ -28,11 +28,22 @@ class HudMixin(GatewayCore):
         return playerManager.trickplay_meta
 
     def hud_key_opts(self):
-        """Keyboard policy for the idle HUD ({"grab", "key"}): by
-        default only hud_wake_key is taken over during playback so
-        mpv's own seek keys keep working."""
+        """Everything the renderer owns about the HUD, sent with the engage.
+
+        Keyboard policy ("grab"/"key"): by default only hud_wake_key is taken
+        over during playback so mpv's own seek keys keep working.
+
+        Auto-hide policy ("hide"/"mode") and the no-scrim text halo
+        ("shadow") ride the same message, because the renderer owns the
+        summon/hide lifecycle and draws the glyphs -- and because engage
+        re-sends them, which is what makes a settings change stick without a
+        restart.
+        """
         return {"grab": bool(settings.hud_grab_keys),
-                "key": settings.hud_wake_key or "ENTER"}
+                "key": settings.hud_wake_key or "ENTER",
+                "hide": max(0.0, float(settings.hud_hide_secs or 0)),
+                "mode": settings.hud_autohide or "hover",
+                "shadow": settings.hud_scrim == "none"}
 
     def hud_menu_state(self):
         """osc_bridge's menu/track state blob for the HUD's pickers
@@ -111,11 +122,13 @@ class HudMixin(GatewayCore):
     def hud_sub_margin(self, visible):
         """Raise bottom subtitles above the HUD's bar while it is
         summoned; restore on hide. Skipped for top/middle-positioned
-        subtitles (sub-pos < 50), like the lua OSC."""
+        subtitles (sub-pos < 50), like the lua OSC, and switchable off
+        entirely: subtitles jumping as the controls appear is distracting if
+        you are reading them (#620)."""
         from ...player import playerManager
         try:
             player = playerManager._player
-            if visible:
+            if visible and settings.hud_sub_margin:
                 sub_pos = player.sub_pos
                 if sub_pos is not None and sub_pos < 50:
                     return

--- a/jellyfin_mpv_shim/mpvtk_browser/hud.py
+++ b/jellyfin_mpv_shim/mpvtk_browser/hud.py
@@ -44,8 +44,33 @@ log = logging.getLogger("mpvtk_browser.hud")
 # the bar's height for the title/slider to sit on dark instead of the
 # ramp's transparent half. Capped by a window fraction so short
 # windows keep most of the picture clean.
-SCRIM_FRAC = 0.55
-SCRIM_MAX = 380
+#
+# Lowered from 0.55/380 after #620, where the shadow over the picture was
+# the first thing anyone mentioned. This is still ~2.2x the bar; what went
+# was the headroom above that, which was buying nothing.
+SCRIM_FRAC = 0.42
+SCRIM_MAX = 300
+# Top scrim, same relation to the header's height.
+TOP_SCRIM_FRAC = 0.20
+TOP_SCRIM_MAX = 130
+# "half": the same ramp, half as tall. The bar's own text ends up nearer
+# the fade than the solid end, which is the trade the option exists to
+# offer.
+#
+# BOTTOM ONLY. The top band is already the small one (TOP_SCRIM_FRAC is
+# less than half of SCRIM_FRAC), and halving it puts the title and the
+# top-row buttons in the fading half of a 65px ramp -- unreadable over a
+# bright frame, for a strip of picture nobody was looking at. What this
+# option is for is the wash over the *middle* of the picture, and that is
+# the bottom ramp's headroom.
+HALF_SCRIM = 0.5
+# "panel": a flat band exactly the height of the bar rather than a ramp --
+# a hard edge, and no wash over the picture above it. Opacity, 255 opaque.
+# Black rather than theme.SCRIM: the HUD is drawn over VIDEO and stays dark
+# whatever the theme does (see mpvtk.theme), which is why the gradients
+# above are a literal too.
+PANEL_BG = "000000"
+PANEL_ALPHA = 170
 
 # Bottom inset of the Skip Intro/Credits button, measured to its BOTTOM
 # edge so the two implementations line up whatever the label's measured
@@ -520,6 +545,45 @@ def _skip_float(b, size):
         anchor="se", dx=-_SKIP_RIGHT, dy=-_SKIP_BOTTOM)
 
 
+def _panel():
+    """Box styling for the two bars: a flat translucent band under the
+    "panel" scrim, and an invisible one otherwise.
+
+    Invisible rather than absent because the renderer needs the bars to
+    EXIST as scene nodes: it holds the auto-hide off while the pointer is
+    over them (phud_busy), and layout only emits a node for a container that
+    has a fill, a border or a click. Alpha 0 costs one ASS event that draws
+    nothing, and the node is not a hit target -- node_at ignores a rect with
+    no click, tip or hover of its own.
+    """
+    return {"bg": PANEL_BG,
+            "alpha": PANEL_ALPHA if settings.hud_scrim == "panel" else 0}
+
+
+def _scrim(h, w):
+    """The wash behind the controls, per ``hud_scrim``.
+
+    It is not decoration: white-on-white is what the controls hit without
+    it, over a frame nobody chose. So "none" is not simply the absence of
+    the others -- it moves the job onto the glyphs, which is the ``shadow``
+    flag the renderer draws them with (see gateway.hud_key_opts).
+    """
+    style = settings.hud_scrim
+    if style in ("none", "panel"):
+        return []          # panel paints as the bars' own background
+    scale = HALF_SCRIM if style == "half" else 1.0
+    return [
+        Gradient(color="000000", top=0, bottom=215, w=w,
+                 h=int(min(h * SCRIM_FRAC, SCRIM_MAX) * scale), anchor="sw"),
+        # top scrim: dense at the top, same relation to the header's height
+        # as the bottom one has to the bar's. Full height even under
+        # "half" -- see HALF_SCRIM.
+        Gradient(color="000000", top=170, bottom=0, w=w,
+                 h=int(min(h * TOP_SCRIM_FRAC, TOP_SCRIM_MAX)),
+                 anchor="nw"),
+    ]
+
+
 def build_hud(b, size):
     """The summoned HUD scene. ``b`` is the Browser (playstate snapshot,
     scrub state, controller plumbing); returns the full-window tree."""
@@ -692,8 +756,11 @@ def build_hud(b, size):
         # touch it directly: an unsized Row wrapper stretches to the
         # column width and flex=1 spreads the slider inside it
         Row([seek], align="center")]) + [transport]
+    # id: renderer.lua's phud_busy holds the auto-hide off while the pointer
+    # is over the controls, and these two rects are what "over the controls"
+    # means (hover mode). Also where the "panel" scrim paints.
     bar = Column(bar_rows, gap=sz(6), pad=(sz(24), sz(14)), w=w, anchor="s",
-                 align="stretch")
+                 align="stretch", id="hud-bar", **_panel())
 
     # Top header, like the lua OSC's: back (yield to the library),
     # title, SyncPlay drop-down — over its own top-down scrim.
@@ -726,18 +793,9 @@ def build_hud(b, size):
             tip=_("SyncPlay"),
             fg=theme.ACCENT if syncplay.get("enabled") else "eeeeee"))
     top = Row(top_items, gap=sz(10), pad=(sz(24), sz(10)), w=w,
-              anchor="n", align="center")
+              anchor="n", align="center", id="hud-topbar", **_panel())
 
-    children = [
-        Gradient(color="000000", top=0, bottom=215, w=w,
-                 h=min(int(h * SCRIM_FRAC), SCRIM_MAX), anchor="sw"),
-        # top scrim: dense at the top, ~2.2x the header height so the
-        # title sits on the solid half (same math as the bottom scrim)
-        Gradient(color="000000", top=170, bottom=0, w=w,
-                 h=min(int(h * 0.25), 160), anchor="nw"),
-        bar,
-        top,
-    ]
+    children = _scrim(h, w) + [bar, top]
 
     skip = _skip_float(b, size)
     if skip is not None:

--- a/jellyfin_mpv_shim/player.py
+++ b/jellyfin_mpv_shim/player.py
@@ -12,6 +12,7 @@ from typing import TYPE_CHECKING, Optional
 
 from . import conffile
 from .utils import synchronous, Timer
+from .media import segment_labels
 from .mpv_events import wait_property
 from .player_audio import AudioMixin
 from .player_reporting import ReportingMixin
@@ -19,6 +20,7 @@ from . import player_window
 from .player_window import WindowMixin, wlog
 from .mpv_options import build_mpv_options, mpv_scripts, resolve_osc_style
 from .session_reporter import SessionReporter
+from . import conf
 from .conf import settings
 from .menu import OSDMenu
 from .osc_bridge import OscBridge
@@ -1434,12 +1436,7 @@ class PlayerManager(AudioMixin, ReportingMixin, WindowMixin):
         prev_hud_skip = self._hud_skip
         try:
             if (
-                (
-                    settings.skip_intro_always
-                    or settings.skip_intro_enable
-                    or settings.skip_credits_always
-                    or settings.skip_credits_enable
-                )
+                conf.any_segment_wanted()
                 and not self.syncplay.is_enabled()
                 and self._video is not None
                 and self._player.playback_time is not None
@@ -1458,26 +1455,16 @@ class PlayerManager(AudioMixin, ReportingMixin, WindowMixin):
                 )
 
                 if intro is not None:
-                    should_prompt = (
-                        intro.type != "Outro" and settings.skip_intro_enable
-                    ) or (intro.type == "Outro" and settings.skip_credits_enable)
-                    should_skip = (not intro.has_triggered) and (
-                        (intro.type != "Outro" and settings.skip_intro_always)
-                        or (intro.type == "Outro" and settings.skip_credits_always)
-                    )
+                    action = conf.segment_action(intro.type)
+                    should_prompt = action == "ask"
+                    should_skip = (not intro.has_triggered
+                                   and action == "always")
 
                     if should_skip and ready_to_skip:
                         intro.has_triggered = True
                         self.skip_intro()
                         self._player.show_text(
-                            (
-                                _("Skipped Credits")
-                                if intro.type == "Outro"
-                                else _("Skipped Intro")
-                            ),
-                            3000,
-                            1,
-                        )
+                            segment_labels(intro.type)[1], 3000, 1)
                         self._last_intro_msg_time = time.time()
 
                     if hud_skip_button:
@@ -1491,14 +1478,7 @@ class PlayerManager(AudioMixin, ReportingMixin, WindowMixin):
                         and time.time() - self._last_intro_msg_time > 3
                     ):
                         self._player.show_text(
-                            (
-                                _("Seek to Skip Credits")
-                                if intro.type == "Outro"
-                                else _("Seek to Skip Intro")
-                            ),
-                            3000,
-                            1,
-                        )
+                            segment_labels(intro.type)[2], 3000, 1)
                         self._last_intro_msg_time = time.time()
                     self.is_in_intro = True
                 else:

--- a/jellyfin_mpv_shim/player_reporting.py
+++ b/jellyfin_mpv_shim/player_reporting.py
@@ -41,6 +41,7 @@ import time
 from typing import TYPE_CHECKING, Any, Optional
 
 from .i18n import _
+from .media import segment_labels
 from .utils import none_fallback, synchronous
 
 log = logging.getLogger("player")
@@ -154,11 +155,8 @@ class ReportingMixin:
                 # nothing, and a progress bar crawling across a photo reads
                 # as a video about to end.
                 "is_photo": item.get("Type") == "Photo",
-                "skip_label": (
-                    (_("Skip Credits") if skip.type == "Outro"
-                     else _("Skip Intro"))
-                    if skip is not None else None
-                ),
+                "skip_label": (segment_labels(skip.type)[0]
+                               if skip is not None else None),
                 # Which queue entry this is, so the browser's queue view
                 # can move its now-playing highlight without refetching.
                 "id": getattr(video, "item_id", None),

--- a/tests/lua/test_renderer.lua
+++ b/tests/lua/test_renderer.lua
@@ -1145,6 +1145,81 @@ type_text("Z")
 click("elsewhere")
 ok(last_event("commit") == nil, "a disabled textbox cannot be edited")
 
+-- =================================================== HUD auto-hide
+
+-- The controls' auto-hide is a policy (hud_autohide), and the pointer
+-- resting ON them holds it off in every mode but 'always'. Reaching for a
+-- button must not be a race against the timer.
+
+local function hud_engage(opts)
+    fake.send("mpvtk-hud", "no")
+    fake.send("mpvtk-hud", "yes", fake.token(opts or {}))
+    -- Pointer movement is what summons an idle HUD, and the first event
+    -- after engaging only records the position.
+    fake.observe("mouse-pos", { x = 600, y = 300, hover = true })
+    fake.observe("mouse-pos", { x = 600, y = 360, hover = true })
+    -- What hud.py pushes once summoned: two bars carrying the ids
+    -- phud_busy tests the pointer against.
+    scene({ { id = "hud-topbar", t = "rect", x = 0, y = 0, w = 1280, h = 60 },
+            { id = "hud-bar", t = "rect", x = 0, y = 640, w = 1280, h = 80 } })
+end
+
+local function hud_pointer(x, y)
+    fake.observe("mouse-pos", { x = x, y = y, hover = true })
+end
+
+local function hud_wait()
+    fake.advance(30)
+    fake.fire_timers()
+end
+
+local function hud_hidden()
+    local ev = last_event("hud")
+    return ev ~= nil and ev.active == false
+end
+
+hud_engage({ hide = 4, mode = "hover" })
+hud_pointer(600, 680)          -- onto the bar
+fake.reset_events()
+hud_wait()
+ok(not hud_hidden(), "the controls stay up while the pointer is on them")
+
+hud_pointer(600, 300)          -- back over the picture
+fake.reset_events()
+hud_wait()
+ok(hud_hidden(), "they hide once the pointer is off them")
+
+-- 'always' does not care where the pointer is.
+hud_engage({ hide = 4, mode = "always" })
+hud_pointer(600, 680)
+fake.reset_events()
+hud_wait()
+ok(hud_hidden(), "'always' hides them even under the pointer")
+
+-- A zero delay is only meaningful as "gone when not hovered", so it forces
+-- that mode however the mode was set.
+hud_engage({ hide = 0, mode = "always" })
+hud_pointer(600, 680)
+fake.reset_events()
+hud_wait()
+ok(not hud_hidden(),
+   "a zero delay still holds while the pointer is on the controls")
+
+-- Paused playback stopped being a rule and became a mode.
+fake.log.props["pause"] = true
+hud_engage({ hide = 4, mode = "paused" })
+hud_pointer(600, 300)
+fake.reset_events()
+hud_wait()
+ok(not hud_hidden(), "'paused' keeps them up on a paused film")
+
+hud_engage({ hide = 4, mode = "hover" })
+hud_pointer(600, 300)
+fake.reset_events()
+hud_wait()
+ok(hud_hidden(), "the default hides them on a paused film")
+fake.log.props["pause"] = nil
+
 -- ========================================================== teardown
 
 scene({})

--- a/tests/snapshots/settings.jsonl
+++ b/tests/snapshots/settings.jsonl
@@ -24,7 +24,7 @@
 {"align": "center", "c": "e8e8e8", "h": 25.0, "id": "r.1.0.0.4.0", "size": 20, "t": "text", "text": "Downloads", "w": 99.4, "x": 532.0, "y": 82.0}
 {"click": true, "fill": "2e3138", "h": 45.0, "hover": {"fill": "3a3e46"}, "id": "stab-logs", "radius": 6, "t": "rect", "w": 63.2, "x": 649.4, "y": 72.0}
 {"align": "center", "c": "e8e8e8", "h": 25.0, "id": "r.1.0.0.5.0", "size": 20, "t": "text", "text": "Logs", "w": 43.2, "x": 659.4, "y": 82.0}
-{"axis": "y", "bar": true, "ch": 3658.0, "cw": 1270.0, "h": 591.0, "id": "settings", "t": "scroll", "w": 1280.0, "x": 0.0, "y": 129.0}
+{"axis": "y", "bar": true, "ch": 3931.0, "cw": 1270.0, "h": 591.0, "id": "settings", "t": "scroll", "w": 1280.0, "x": 0.0, "y": 129.0}
 {"align": "left", "bold": true, "c": "e8e8e8", "h": 25.0, "id": "r.1.1.0.0", "sc": "settings", "size": 20, "t": "text", "text": "Interface", "w": 1238.0, "x": 16.0, "y": 145.0}
 {"align": "left", "c": "9aa0a6", "h": 21.2, "id": "r.1.1.0.1.0", "sc": "settings", "size": 17, "t": "text", "text": "Player Name", "w": 340.0, "x": 16.0, "y": 186.4}
 {"h": 38.0, "id": "set-player_name", "ph": "", "sc": "settings", "size": 20, "t": "textbox", "text": "izzie-pc", "w": 340.0, "x": 368.0, "y": 178.0}
@@ -55,206 +55,220 @@
 {"align": "left", "c": "e8e8e8", "h": 25.0, "id": "r.1.1.0.10.1", "sc": "settings", "size": 20, "t": "text", "text": "Always Bind Arrow Keys to Player Controls", "w": 386.4, "x": 46.0, "y": 521.0}
 {"align": "left", "c": "9aa0a6", "h": 21.2, "id": "r.1.1.0.11.0", "sc": "settings", "size": 17, "t": "text", "text": "Player Controls Activation Key", "w": 340.0, "x": 16.0, "y": 562.4}
 {"h": 38.0, "id": "set-hud_wake_key", "ph": "", "sc": "settings", "size": 20, "t": "textbox", "text": "ENTER", "w": 340.0, "x": 368.0, "y": 554.0}
-{"click": true, "h": 25.0, "hover": {"c": "747474"}, "id": "set-mouse_chapter_nav", "sc": "settings", "t": "rect", "w": 1238.0, "x": 16.0, "y": 600.0}
-{"bc": "3a3d42", "bw": 1, "fill": "2a2d33", "h": 20.0, "id": "r.1.1.0.12.0", "radius": 5, "sc": "settings", "t": "rect", "w": 20.0, "x": 16.0, "y": 602.5}
-{"align": "left", "c": "e8e8e8", "h": 25.0, "id": "r.1.1.0.12.1", "sc": "settings", "size": 20, "t": "text", "text": "Mouse Back/Forward Buttons Skip Chapters", "w": 397.2, "x": 46.0, "y": 600.0}
-{"align": "left", "c": "9aa0a6", "h": 17.5, "id": "r.1.1.0.13", "sc": "settings", "size": 14, "t": "text", "text": "During playback only \u2014 in the library those buttons stay Back and Forward. Off by default because they are easy to hit by accident on some mice. Takes effect after a restart.", "w": 1238.0, "x": 16.0, "y": 633.0}
-{"click": true, "h": 25.0, "hover": {"c": "747474"}, "id": "set-raise_mpv", "sc": "settings", "t": "rect", "w": 1238.0, "x": 16.0, "y": 658.5}
-{"fill": "00a4dc", "h": 20.0, "id": "r.1.1.0.14.0", "radius": 5, "sc": "settings", "t": "rect", "w": 20.0, "x": 16.0, "y": 661.0}
-{"align": "center", "c": "ffffff", "h": 18.8, "id": "r.1.1.0.14.0.0", "sc": "settings", "size": 15, "t": "text", "text": "\u2713", "w": 20.0, "x": 16.0, "y": 661.6}
-{"align": "left", "c": "e8e8e8", "h": 25.0, "id": "r.1.1.0.14.1", "sc": "settings", "size": 20, "t": "text", "text": "Raise MPV", "w": 94.6, "x": 46.0, "y": 658.5}
-{"click": true, "h": 25.0, "hover": {"c": "747474"}, "id": "set-discord_presence", "sc": "settings", "t": "rect", "w": 1238.0, "x": 16.0, "y": 691.5}
-{"bc": "3a3d42", "bw": 1, "fill": "2a2d33", "h": 20.0, "id": "r.1.1.0.15.0", "radius": 5, "sc": "settings", "t": "rect", "w": 20.0, "x": 16.0, "y": 694.0}
-{"align": "left", "c": "e8e8e8", "h": 25.0, "id": "r.1.1.0.15.1", "sc": "settings", "size": 20, "t": "text", "text": "Show What You're Watching in Discord", "w": 351.4, "x": 46.0, "y": 691.5}
-{"align": "left", "c": "9aa0a6", "h": 17.5, "id": "r.1.1.0.16", "sc": "settings", "size": 14, "t": "text", "text": "Discord Rich Presence. Takes effect after a restart.", "w": 1238.0, "x": 16.0, "y": 724.5}
-{"click": true, "h": 25.0, "hover": {"c": "747474"}, "id": "set-check_updates", "sc": "settings", "t": "rect", "w": 1238.0, "x": 16.0, "y": 750.0}
-{"fill": "00a4dc", "h": 20.0, "id": "r.1.1.0.17.0", "radius": 5, "sc": "settings", "t": "rect", "w": 20.0, "x": 16.0, "y": 752.5}
-{"align": "center", "c": "ffffff", "h": 18.8, "id": "r.1.1.0.17.0.0", "sc": "settings", "size": 15, "t": "text", "text": "\u2713", "w": 20.0, "x": 16.0, "y": 753.1}
-{"align": "left", "c": "e8e8e8", "h": 25.0, "id": "r.1.1.0.17.1", "sc": "settings", "size": 20, "t": "text", "text": "Check Updates", "w": 131.6, "x": 46.0, "y": 750.0}
-{"click": true, "h": 25.0, "hover": {"c": "747474"}, "id": "set-notify_updates", "sc": "settings", "t": "rect", "w": 1238.0, "x": 16.0, "y": 783.0}
-{"fill": "00a4dc", "h": 20.0, "id": "r.1.1.0.18.0", "radius": 5, "sc": "settings", "t": "rect", "w": 20.0, "x": 16.0, "y": 785.5}
-{"align": "center", "c": "ffffff", "h": 18.8, "id": "r.1.1.0.18.0.0", "sc": "settings", "size": 15, "t": "text", "text": "\u2713", "w": 20.0, "x": 16.0, "y": 786.1}
-{"align": "left", "c": "e8e8e8", "h": 25.0, "id": "r.1.1.0.18.1", "sc": "settings", "size": 20, "t": "text", "text": "Notify Updates", "w": 130.4, "x": 46.0, "y": 783.0}
-{"align": "left", "bold": true, "c": "e8e8e8", "h": 25.0, "id": "r.1.1.0.19", "sc": "settings", "size": 20, "t": "text", "text": "Theme", "w": 1238.0, "x": 16.0, "y": 816.0}
-{"align": "left", "c": "9aa0a6", "h": 21.2, "id": "r.1.1.0.20.0", "sc": "settings", "size": 17, "t": "text", "text": "Theme", "w": 340.0, "x": 16.0, "y": 857.4}
-{"force": true, "h": 38.0, "id": "set-theme", "items": ["Default", "Apple TV (Jellyfin)", "Blue Radiance (Jellyfin)", "Light (Jellyfin)", "Nebula", "Purple Haze (Jellyfin)", "Windows Media Center (Jellyfin)"], "sc": "settings", "sel": 0, "size": 20, "t": "dropdown", "w": 340.0, "x": 368.0, "y": 849.0}
-{"align": "left", "c": "9aa0a6", "h": 17.5, "id": "r.1.1.0.21", "sc": "settings", "size": 14, "t": "text", "text": "Palette, glow, cover style and default cover size. Colours change immediately; cover and heading sizes take effect after a restart.", "w": 1238.0, "x": 16.0, "y": 895.0}
-{"align": "left", "c": "9aa0a6", "h": 21.2, "id": "r.1.1.0.22.0", "sc": "settings", "size": 17, "t": "text", "text": "Cover Size", "w": 340.0, "x": 16.0, "y": 928.9}
-{"force": true, "h": 38.0, "id": "set-poster_scale", "items": ["Theme default", "Extra Compact", "Compact", "Small", "Medium", "Large", "Extra Large"], "sc": "settings", "sel": 0, "size": 20, "t": "dropdown", "w": 340.0, "x": 368.0, "y": 920.5}
-{"align": "left", "c": "9aa0a6", "h": 17.5, "id": "r.1.1.0.23", "sc": "settings", "size": 14, "t": "text", "text": "Overrides the theme's cover size. Applies immediately, and is also on the View menu of any library.", "w": 1238.0, "x": 16.0, "y": 966.5}
-{"align": "left", "c": "9aa0a6", "h": 21.2, "id": "r.1.1.0.24.0", "sc": "settings", "size": 17, "t": "text", "text": "Interface Scale", "w": 340.0, "x": 16.0, "y": 1000.4}
-{"force": true, "h": 38.0, "id": "set-ui_scale", "items": ["Follow display", "100% (no scaling)", "125%", "150%", "200%"], "sc": "settings", "sel": 0, "size": 20, "t": "dropdown", "w": 340.0, "x": 368.0, "y": 992.0}
-{"align": "left", "c": "9aa0a6", "h": 17.5, "id": "r.1.1.0.25", "sc": "settings", "size": 14, "t": "text", "text": "Takes effect after a restart. \"Follow display\" uses the scale your desktop reports, which is 100% on X11.", "w": 1238.0, "x": 16.0, "y": 1038.0}
-{"align": "left", "c": "9aa0a6", "h": 17.5, "id": "r.1.1.0.26", "sc": "settings", "size": 14, "t": "text", "text": "Cover size and interface scale require a restart.", "w": 1238.0, "x": 16.0, "y": 1063.5}
-{"align": "left", "bold": true, "c": "e8e8e8", "h": 25.0, "id": "r.1.1.0.27", "sc": "settings", "size": 20, "t": "text", "text": "Playback", "w": 1238.0, "x": 16.0, "y": 1089.0}
-{"click": true, "h": 25.0, "hover": {"c": "747474"}, "id": "set-auto_play", "sc": "settings", "t": "rect", "w": 1238.0, "x": 16.0, "y": 1122.0}
-{"fill": "00a4dc", "h": 20.0, "id": "r.1.1.0.28.0", "radius": 5, "sc": "settings", "t": "rect", "w": 20.0, "x": 16.0, "y": 1124.5}
-{"align": "center", "c": "ffffff", "h": 18.8, "id": "r.1.1.0.28.0.0", "sc": "settings", "size": 15, "t": "text", "text": "\u2713", "w": 20.0, "x": 16.0, "y": 1125.1}
-{"align": "left", "c": "e8e8e8", "h": 25.0, "id": "r.1.1.0.28.1", "sc": "settings", "size": 20, "t": "text", "text": "Auto Play", "w": 84.4, "x": 46.0, "y": 1122.0}
-{"click": true, "h": 25.0, "hover": {"c": "747474"}, "id": "set-always_transcode", "sc": "settings", "t": "rect", "w": 1238.0, "x": 16.0, "y": 1155.0}
-{"bc": "3a3d42", "bw": 1, "fill": "2a2d33", "h": 20.0, "id": "r.1.1.0.29.0", "radius": 5, "sc": "settings", "t": "rect", "w": 20.0, "x": 16.0, "y": 1157.5}
-{"align": "left", "c": "e8e8e8", "h": 25.0, "id": "r.1.1.0.29.1", "sc": "settings", "size": 20, "t": "text", "text": "Always Transcode", "w": 166.2, "x": 46.0, "y": 1155.0}
-{"align": "left", "c": "9aa0a6", "h": 21.2, "id": "r.1.1.0.30.0", "sc": "settings", "size": 17, "t": "text", "text": "Local kbps", "w": 340.0, "x": 16.0, "y": 1196.4}
-{"h": 38.0, "id": "set-local_kbps", "ph": "", "sc": "settings", "size": 20, "t": "textbox", "text": "2147483", "w": 340.0, "x": 368.0, "y": 1188.0}
-{"align": "left", "c": "9aa0a6", "h": 21.2, "id": "r.1.1.0.31.0", "sc": "settings", "size": 17, "t": "text", "text": "Remote kbps", "w": 340.0, "x": 16.0, "y": 1242.4}
-{"h": 38.0, "id": "set-remote_kbps", "ph": "", "sc": "settings", "size": 20, "t": "textbox", "text": "10000", "w": 340.0, "x": 368.0, "y": 1234.0}
-{"click": true, "h": 25.0, "hover": {"c": "747474"}, "id": "set-direct_paths", "sc": "settings", "t": "rect", "w": 1238.0, "x": 16.0, "y": 1280.0}
-{"bc": "3a3d42", "bw": 1, "fill": "2a2d33", "h": 20.0, "id": "r.1.1.0.32.0", "radius": 5, "sc": "settings", "t": "rect", "w": 20.0, "x": 16.0, "y": 1282.5}
-{"align": "left", "c": "e8e8e8", "h": 25.0, "id": "r.1.1.0.32.1", "sc": "settings", "size": 20, "t": "text", "text": "Direct Paths", "w": 108.8, "x": 46.0, "y": 1280.0}
-{"click": true, "h": 25.0, "hover": {"c": "747474"}, "id": "set-remote_direct_paths", "sc": "settings", "t": "rect", "w": 1238.0, "x": 16.0, "y": 1313.0}
-{"bc": "3a3d42", "bw": 1, "fill": "2a2d33", "h": 20.0, "id": "r.1.1.0.33.0", "radius": 5, "sc": "settings", "t": "rect", "w": 20.0, "x": 16.0, "y": 1315.5}
-{"align": "left", "c": "e8e8e8", "h": 25.0, "id": "r.1.1.0.33.1", "sc": "settings", "size": 20, "t": "text", "text": "Remote Direct Paths", "w": 181.8, "x": 46.0, "y": 1313.0}
-{"align": "left", "c": "9aa0a6", "h": 21.2, "id": "r.1.1.0.34.0", "sc": "settings", "size": 17, "t": "text", "text": "Playback Timeout", "w": 340.0, "x": 16.0, "y": 1354.4}
-{"h": 38.0, "id": "set-playback_timeout", "ph": "", "sc": "settings", "size": 20, "t": "textbox", "text": "30", "w": 340.0, "x": 368.0, "y": 1346.0}
-{"align": "left", "bold": true, "c": "e8e8e8", "h": 25.0, "id": "r.1.1.0.35", "sc": "settings", "size": 20, "t": "text", "text": "Audio", "w": 1238.0, "x": 16.0, "y": 1392.0}
-{"align": "left", "c": "9aa0a6", "h": 21.2, "id": "r.1.1.0.36.0", "sc": "settings", "size": 17, "t": "text", "text": "Audio Output Device", "w": 340.0, "x": 16.0, "y": 1433.4}
-{"h": 38.0, "id": "set-audio_device", "ph": "", "sc": "settings", "size": 20, "t": "textbox", "text": "", "w": 340.0, "x": 368.0, "y": 1425.0}
-{"align": "left", "c": "9aa0a6", "h": 17.5, "id": "r.1.1.0.37", "sc": "settings", "size": 14, "t": "text", "text": "Leave this to Default unless setting up passthrough. Note some audio servers like Pipewire don't like passthrough and will need to be disabled for a card before it'll let *any* audio through in", "w": 1238.0, "x": 16.0, "y": 1471.0}
-{"align": "left", "c": "9aa0a6", "h": 17.5, "id": "r.1.1.0.37.l1", "sc": "settings", "size": 14, "t": "text", "text": "passthrough mode. In my tests I got silence otherwise, but results may vary.", "w": 1238.0, "x": 16.0, "y": 1488.5}
-{"align": "left", "c": "9aa0a6", "h": 21.2, "id": "r.1.1.0.38.0", "sc": "settings", "size": 17, "t": "text", "text": "Audio Output Mode", "w": 340.0, "x": 16.0, "y": 1522.4}
-{"force": true, "h": 38.0, "id": "set-audio_mode", "items": ["Default (auto)", "Force Stereo", "Optical Surround", "HDMI Passthrough"], "sc": "settings", "sel": 0, "size": 20, "t": "dropdown", "w": 340.0, "x": 368.0, "y": 1514.0}
-{"align": "left", "c": "9aa0a6", "h": 17.5, "id": "r.1.1.0.39", "sc": "settings", "size": 14, "t": "text", "text": "\"Default\" changes nothing and lets MPV (and your own mpv.conf) decide. Pick a mode only if you are sending audio to a receiver.", "w": 1238.0, "x": 16.0, "y": 1560.0}
-{"click": true, "h": 25.0, "hover": {"c": "747474"}, "id": "set-audio_night_mode", "sc": "settings", "t": "rect", "w": 1238.0, "x": 16.0, "y": 1585.5}
-{"bc": "3a3d42", "bw": 1, "fill": "2a2d33", "h": 20.0, "id": "r.1.1.0.40.0", "radius": 5, "sc": "settings", "t": "rect", "w": 20.0, "x": 16.0, "y": 1588.0}
-{"align": "left", "c": "e8e8e8", "h": 25.0, "id": "r.1.1.0.40.1", "sc": "settings", "size": 20, "t": "text", "text": "Night Mode (Auto Volume Adj)", "w": 267.6, "x": 46.0, "y": 1585.5}
-{"align": "left", "c": "9aa0a6", "h": 17.5, "id": "r.1.1.0.41", "sc": "settings", "size": 14, "t": "text", "text": "Evens out loud effects and quiet dialogue. This turns passthrough off while it is enabled, because the volume has to be adjusted before your receiver gets the audio.", "w": 1238.0, "x": 16.0, "y": 1618.5}
-{"align": "left", "bold": true, "c": "e8e8e8", "h": 25.0, "id": "r.1.1.0.42", "sc": "settings", "size": 20, "t": "text", "text": "Subtitles & Languages", "w": 1238.0, "x": 16.0, "y": 1644.0}
-{"align": "left", "c": "9aa0a6", "h": 21.2, "id": "r.1.1.0.43.0", "sc": "settings", "size": 17, "t": "text", "text": "Subtitle Size", "w": 340.0, "x": 16.0, "y": 1685.4}
-{"h": 38.0, "id": "set-subtitle_size", "ph": "", "sc": "settings", "size": 20, "t": "textbox", "text": "100", "w": 340.0, "x": 368.0, "y": 1677.0}
-{"align": "left", "c": "9aa0a6", "h": 21.2, "id": "r.1.1.0.44.0", "sc": "settings", "size": 17, "t": "text", "text": "Subtitle Color", "w": 340.0, "x": 16.0, "y": 1731.4}
-{"h": 38.0, "id": "set-subtitle_color", "ph": "", "sc": "settings", "size": 20, "t": "textbox", "text": "#FFFFFFFF", "w": 340.0, "x": 368.0, "y": 1723.0}
-{"align": "left", "c": "9aa0a6", "h": 21.2, "id": "r.1.1.0.45.0", "sc": "settings", "size": 17, "t": "text", "text": "Subtitle Position", "w": 340.0, "x": 16.0, "y": 1777.4}
-{"force": true, "h": 38.0, "id": "set-subtitle_position", "items": ["top", "bottom", "middle"], "sc": "settings", "sel": 1, "size": 20, "t": "dropdown", "w": 340.0, "x": 368.0, "y": 1769.0}
-{"align": "left", "c": "9aa0a6", "h": 21.2, "id": "r.1.1.0.46.0", "sc": "settings", "size": 17, "t": "text", "text": "Language Preference", "w": 340.0, "x": 16.0, "y": 1823.4}
-{"force": true, "h": 38.0, "id": "set-language_preference", "items": ["Unset", "Dubbed (shows only)", "Subbed (shows only)", "Dubbed (all)", "Subbed (all)", "Custom (set in config)"], "sc": "settings", "sel": 5, "size": 20, "t": "dropdown", "w": 340.0, "x": 368.0, "y": 1815.0}
-{"align": "left", "c": "9aa0a6", "h": 21.2, "id": "r.1.1.0.47.0", "sc": "settings", "size": 17, "t": "text", "text": "Preferred Language", "w": 340.0, "x": 16.0, "y": 1869.4}
-{"h": 38.0, "id": "set-preferred_language", "ph": "", "sc": "settings", "size": 20, "t": "textbox", "text": "eng", "w": 340.0, "x": 368.0, "y": 1861.0}
-{"click": true, "h": 25.0, "hover": {"c": "747474"}, "id": "set-remember_audio_track", "sc": "settings", "t": "rect", "w": 1238.0, "x": 16.0, "y": 1907.0}
-{"fill": "00a4dc", "h": 20.0, "id": "r.1.1.0.48.0", "radius": 5, "sc": "settings", "t": "rect", "w": 20.0, "x": 16.0, "y": 1909.5}
-{"align": "center", "c": "ffffff", "h": 18.8, "id": "r.1.1.0.48.0.0", "sc": "settings", "size": 15, "t": "text", "text": "\u2713", "w": 20.0, "x": 16.0, "y": 1910.1}
-{"align": "left", "c": "e8e8e8", "h": 25.0, "id": "r.1.1.0.48.1", "sc": "settings", "size": 20, "t": "text", "text": "Remember Audio Track", "w": 206.8, "x": 46.0, "y": 1907.0}
-{"click": true, "h": 25.0, "hover": {"c": "747474"}, "id": "set-remember_subtitle_track", "sc": "settings", "t": "rect", "w": 1238.0, "x": 16.0, "y": 1940.0}
-{"fill": "00a4dc", "h": 20.0, "id": "r.1.1.0.49.0", "radius": 5, "sc": "settings", "t": "rect", "w": 20.0, "x": 16.0, "y": 1942.5}
-{"align": "center", "c": "ffffff", "h": 18.8, "id": "r.1.1.0.49.0.0", "sc": "settings", "size": 15, "t": "text", "text": "\u2713", "w": 20.0, "x": 16.0, "y": 1943.1}
-{"align": "left", "c": "e8e8e8", "h": 25.0, "id": "r.1.1.0.49.1", "sc": "settings", "size": 20, "t": "text", "text": "Remember Subtitle Track", "w": 227.2, "x": 46.0, "y": 1940.0}
-{"align": "left", "c": "9aa0a6", "h": 21.2, "id": "r.1.1.0.50.0", "sc": "settings", "size": 17, "t": "text", "text": "Lang Filter", "w": 340.0, "x": 16.0, "y": 1981.4}
-{"h": 38.0, "id": "set-lang_filter", "ph": "", "sc": "settings", "size": 20, "t": "textbox", "text": "und,eng,jpn,mis,mul,zxx", "w": 340.0, "x": 368.0, "y": 1973.0}
-{"click": true, "h": 25.0, "hover": {"c": "747474"}, "id": "set-lang_filter_sub", "sc": "settings", "t": "rect", "w": 1238.0, "x": 16.0, "y": 2019.0}
-{"bc": "3a3d42", "bw": 1, "fill": "2a2d33", "h": 20.0, "id": "r.1.1.0.51.0", "radius": 5, "sc": "settings", "t": "rect", "w": 20.0, "x": 16.0, "y": 2021.5}
-{"align": "left", "c": "e8e8e8", "h": 25.0, "id": "r.1.1.0.51.1", "sc": "settings", "size": 20, "t": "text", "text": "Lang Filter Sub", "w": 136.4, "x": 46.0, "y": 2019.0}
-{"click": true, "h": 25.0, "hover": {"c": "747474"}, "id": "set-lang_filter_audio", "sc": "settings", "t": "rect", "w": 1238.0, "x": 16.0, "y": 2052.0}
-{"bc": "3a3d42", "bw": 1, "fill": "2a2d33", "h": 20.0, "id": "r.1.1.0.52.0", "radius": 5, "sc": "settings", "t": "rect", "w": 20.0, "x": 16.0, "y": 2054.5}
-{"align": "left", "c": "e8e8e8", "h": 25.0, "id": "r.1.1.0.52.1", "sc": "settings", "size": 20, "t": "text", "text": "Lang Filter Audio", "w": 154.0, "x": 46.0, "y": 2052.0}
-{"align": "left", "bold": true, "c": "e8e8e8", "h": 25.0, "id": "r.1.1.0.53", "sc": "settings", "size": 20, "t": "text", "text": "Transcoding", "w": 1238.0, "x": 16.0, "y": 2085.0}
-{"click": true, "h": 25.0, "hover": {"c": "747474"}, "id": "set-allow_transcode_to_h265", "sc": "settings", "t": "rect", "w": 1238.0, "x": 16.0, "y": 2118.0}
-{"bc": "3a3d42", "bw": 1, "fill": "2a2d33", "h": 20.0, "id": "r.1.1.0.54.0", "radius": 5, "sc": "settings", "t": "rect", "w": 20.0, "x": 16.0, "y": 2120.5}
-{"align": "left", "c": "e8e8e8", "h": 25.0, "id": "r.1.1.0.54.1", "sc": "settings", "size": 20, "t": "text", "text": "Allow Transcode To H265", "w": 228.2, "x": 46.0, "y": 2118.0}
-{"click": true, "h": 25.0, "hover": {"c": "747474"}, "id": "set-prefer_transcode_to_h265", "sc": "settings", "t": "rect", "w": 1238.0, "x": 16.0, "y": 2151.0}
-{"bc": "3a3d42", "bw": 1, "fill": "2a2d33", "h": 20.0, "id": "r.1.1.0.55.0", "radius": 5, "sc": "settings", "t": "rect", "w": 20.0, "x": 16.0, "y": 2153.5}
-{"align": "left", "c": "e8e8e8", "h": 25.0, "id": "r.1.1.0.55.1", "sc": "settings", "size": 20, "t": "text", "text": "Prefer Transcode To H265", "w": 228.8, "x": 46.0, "y": 2151.0}
-{"click": true, "h": 25.0, "hover": {"c": "747474"}, "id": "set-transcode_hevc", "sc": "settings", "t": "rect", "w": 1238.0, "x": 16.0, "y": 2184.0}
-{"bc": "3a3d42", "bw": 1, "fill": "2a2d33", "h": 20.0, "id": "r.1.1.0.56.0", "radius": 5, "sc": "settings", "t": "rect", "w": 20.0, "x": 16.0, "y": 2186.5}
-{"align": "left", "c": "e8e8e8", "h": 25.0, "id": "r.1.1.0.56.1", "sc": "settings", "size": 20, "t": "text", "text": "Transcode HEVC", "w": 142.4, "x": 46.0, "y": 2184.0}
-{"click": true, "h": 25.0, "hover": {"c": "747474"}, "id": "set-transcode_av1", "sc": "settings", "t": "rect", "w": 1238.0, "x": 16.0, "y": 2217.0}
-{"bc": "3a3d42", "bw": 1, "fill": "2a2d33", "h": 20.0, "id": "r.1.1.0.57.0", "radius": 5, "sc": "settings", "t": "rect", "w": 20.0, "x": 16.0, "y": 2219.5}
-{"align": "left", "c": "e8e8e8", "h": 25.0, "id": "r.1.1.0.57.1", "sc": "settings", "size": 20, "t": "text", "text": "Transcode AV1", "w": 131.6, "x": 46.0, "y": 2217.0}
-{"click": true, "h": 25.0, "hover": {"c": "747474"}, "id": "set-transcode_4k", "sc": "settings", "t": "rect", "w": 1238.0, "x": 16.0, "y": 2250.0}
-{"bc": "3a3d42", "bw": 1, "fill": "2a2d33", "h": 20.0, "id": "r.1.1.0.58.0", "radius": 5, "sc": "settings", "t": "rect", "w": 20.0, "x": 16.0, "y": 2252.5}
-{"align": "left", "c": "e8e8e8", "h": 25.0, "id": "r.1.1.0.58.1", "sc": "settings", "size": 20, "t": "text", "text": "Transcode 4K", "w": 120.8, "x": 46.0, "y": 2250.0}
-{"click": true, "h": 25.0, "hover": {"c": "747474"}, "id": "set-transcode_hdr", "sc": "settings", "t": "rect", "w": 1238.0, "x": 16.0, "y": 2283.0}
-{"bc": "3a3d42", "bw": 1, "fill": "2a2d33", "h": 20.0, "id": "r.1.1.0.59.0", "radius": 5, "sc": "settings", "t": "rect", "w": 20.0, "x": 16.0, "y": 2285.5}
-{"align": "left", "c": "e8e8e8", "h": 25.0, "id": "r.1.1.0.59.1", "sc": "settings", "size": 20, "t": "text", "text": "Transcode HDR", "w": 131.6, "x": 46.0, "y": 2283.0}
-{"click": true, "h": 25.0, "hover": {"c": "747474"}, "id": "set-transcode_hi10p", "sc": "settings", "t": "rect", "w": 1238.0, "x": 16.0, "y": 2316.0}
-{"bc": "3a3d42", "bw": 1, "fill": "2a2d33", "h": 20.0, "id": "r.1.1.0.60.0", "radius": 5, "sc": "settings", "t": "rect", "w": 20.0, "x": 16.0, "y": 2318.5}
-{"align": "left", "c": "e8e8e8", "h": 25.0, "id": "r.1.1.0.60.1", "sc": "settings", "size": 20, "t": "text", "text": "Transcode Hi10P", "w": 149.2, "x": 46.0, "y": 2316.0}
-{"click": true, "h": 25.0, "hover": {"c": "747474"}, "id": "set-transcode_dolby_vision", "sc": "settings", "t": "rect", "w": 1238.0, "x": 16.0, "y": 2349.0}
-{"bc": "3a3d42", "bw": 1, "fill": "2a2d33", "h": 20.0, "id": "r.1.1.0.61.0", "radius": 5, "sc": "settings", "t": "rect", "w": 20.0, "x": 16.0, "y": 2351.5}
-{"align": "left", "c": "e8e8e8", "h": 25.0, "id": "r.1.1.0.61.1", "sc": "settings", "size": 20, "t": "text", "text": "Transcode Dolby Vision", "w": 212.0, "x": 46.0, "y": 2349.0}
-{"align": "left", "c": "9aa0a6", "h": 21.2, "id": "r.1.1.0.62.0", "sc": "settings", "size": 17, "t": "text", "text": "Force Video Codec", "w": 340.0, "x": 16.0, "y": 2390.4}
-{"h": 38.0, "id": "set-force_video_codec", "ph": "", "sc": "settings", "size": 20, "t": "textbox", "text": "", "w": 340.0, "x": 368.0, "y": 2382.0}
-{"align": "left", "c": "9aa0a6", "h": 21.2, "id": "r.1.1.0.63.0", "sc": "settings", "size": 17, "t": "text", "text": "Force Audio Codec", "w": 340.0, "x": 16.0, "y": 2436.4}
-{"h": 38.0, "id": "set-force_audio_codec", "ph": "", "sc": "settings", "size": 20, "t": "textbox", "text": "", "w": 340.0, "x": 368.0, "y": 2428.0}
-{"align": "left", "bold": true, "c": "e8e8e8", "h": 25.0, "id": "r.1.1.0.64", "sc": "settings", "size": 20, "t": "text", "text": "Video Enhancement", "w": 1238.0, "x": 16.0, "y": 2474.0}
-{"click": true, "h": 25.0, "hover": {"c": "747474"}, "id": "set-shader_pack_enable", "sc": "settings", "t": "rect", "w": 1238.0, "x": 16.0, "y": 2507.0}
-{"fill": "00a4dc", "h": 20.0, "id": "r.1.1.0.65.0", "radius": 5, "sc": "settings", "t": "rect", "w": 20.0, "x": 16.0, "y": 2509.5}
-{"align": "center", "c": "ffffff", "h": 18.8, "id": "r.1.1.0.65.0.0", "sc": "settings", "size": 15, "t": "text", "text": "\u2713", "w": 20.0, "x": 16.0, "y": 2510.1}
-{"align": "left", "c": "e8e8e8", "h": 25.0, "id": "r.1.1.0.65.1", "sc": "settings", "size": 20, "t": "text", "text": "Enable Video Playback Profiles", "w": 281.6, "x": 46.0, "y": 2507.0}
-{"align": "left", "c": "9aa0a6", "h": 21.2, "id": "r.1.1.0.66.0", "sc": "settings", "size": 17, "t": "text", "text": "Profile Group", "w": 340.0, "x": 16.0, "y": 2548.4}
-{"force": true, "h": 38.0, "id": "set-shader_pack_subtype", "items": ["lq", "hq"], "sc": "settings", "sel": 0, "size": 20, "t": "dropdown", "w": 340.0, "x": 368.0, "y": 2540.0}
-{"align": "left", "c": "9aa0a6", "h": 17.5, "id": "r.1.1.0.67", "sc": "settings", "size": 14, "t": "text", "text": "\"hq\" offers heavier profiles. Pick it if you have a fast graphics card.", "w": 1238.0, "x": 16.0, "y": 2586.0}
-{"click": true, "h": 25.0, "hover": {"c": "747474"}, "id": "set-shader_pack_remember", "sc": "settings", "t": "rect", "w": 1238.0, "x": 16.0, "y": 2611.5}
-{"fill": "00a4dc", "h": 20.0, "id": "r.1.1.0.68.0", "radius": 5, "sc": "settings", "t": "rect", "w": 20.0, "x": 16.0, "y": 2614.0}
-{"align": "center", "c": "ffffff", "h": 18.8, "id": "r.1.1.0.68.0.0", "sc": "settings", "size": 15, "t": "text", "text": "\u2713", "w": 20.0, "x": 16.0, "y": 2614.6}
-{"align": "left", "c": "e8e8e8", "h": 25.0, "id": "r.1.1.0.68.1", "sc": "settings", "size": 20, "t": "text", "text": "Remember Last Used Profile", "w": 254.8, "x": 46.0, "y": 2611.5}
-{"align": "left", "c": "9aa0a6", "h": 21.2, "id": "r.1.1.0.69.0", "sc": "settings", "size": 17, "t": "text", "text": "Graphics API for Shaders", "w": 340.0, "x": 16.0, "y": 2652.9}
-{"force": true, "h": 38.0, "id": "set-shader_pack_gpu_api", "items": ["Automatic (recommended)", "Vulkan", "Direct3D 11 (Windows only)", "OpenGL (compatibility)"], "sc": "settings", "sel": 0, "size": 20, "t": "dropdown", "w": 340.0, "x": 368.0, "y": 2644.5}
-{"align": "left", "c": "9aa0a6", "h": 17.5, "id": "r.1.1.0.70", "sc": "settings", "size": 14, "t": "text", "text": "Leave on Automatic unless video breaks when a profile is loaded. This only applies while a profile is active, and OpenGL can cost you HDR output.", "w": 1238.0, "x": 16.0, "y": 2690.5}
-{"align": "left", "bold": true, "c": "e8e8e8", "h": 25.0, "id": "r.1.1.0.71", "sc": "settings", "size": 20, "t": "text", "text": "Skip Intro / Credits", "w": 1238.0, "x": 16.0, "y": 2716.0}
-{"click": true, "h": 25.0, "hover": {"c": "747474"}, "id": "set-skip_intro_enable", "sc": "settings", "t": "rect", "w": 1238.0, "x": 16.0, "y": 2749.0}
-{"fill": "00a4dc", "h": 20.0, "id": "r.1.1.0.72.0", "radius": 5, "sc": "settings", "t": "rect", "w": 20.0, "x": 16.0, "y": 2751.5}
-{"align": "center", "c": "ffffff", "h": 18.8, "id": "r.1.1.0.72.0.0", "sc": "settings", "size": 15, "t": "text", "text": "\u2713", "w": 20.0, "x": 16.0, "y": 2752.1}
-{"align": "left", "c": "e8e8e8", "h": 25.0, "id": "r.1.1.0.72.1", "sc": "settings", "size": 20, "t": "text", "text": "Skip Intro Enable", "w": 154.0, "x": 46.0, "y": 2749.0}
-{"click": true, "h": 25.0, "hover": {"c": "747474"}, "id": "set-skip_intro_always", "sc": "settings", "t": "rect", "w": 1238.0, "x": 16.0, "y": 2782.0}
-{"bc": "3a3d42", "bw": 1, "fill": "2a2d33", "h": 20.0, "id": "r.1.1.0.73.0", "radius": 5, "sc": "settings", "t": "rect", "w": 20.0, "x": 16.0, "y": 2784.5}
-{"align": "left", "c": "e8e8e8", "h": 25.0, "id": "r.1.1.0.73.1", "sc": "settings", "size": 20, "t": "text", "text": "Skip Intro Always", "w": 160.2, "x": 46.0, "y": 2782.0}
-{"click": true, "h": 25.0, "hover": {"c": "747474"}, "id": "set-skip_credits_enable", "sc": "settings", "t": "rect", "w": 1238.0, "x": 16.0, "y": 2815.0}
-{"fill": "00a4dc", "h": 20.0, "id": "r.1.1.0.74.0", "radius": 5, "sc": "settings", "t": "rect", "w": 20.0, "x": 16.0, "y": 2817.5}
-{"align": "center", "c": "ffffff", "h": 18.8, "id": "r.1.1.0.74.0.0", "sc": "settings", "size": 15, "t": "text", "text": "\u2713", "w": 20.0, "x": 16.0, "y": 2818.1}
-{"align": "left", "c": "e8e8e8", "h": 25.0, "id": "r.1.1.0.74.1", "sc": "settings", "size": 20, "t": "text", "text": "Skip Credits Enable", "w": 175.6, "x": 46.0, "y": 2815.0}
-{"click": true, "h": 25.0, "hover": {"c": "747474"}, "id": "set-skip_credits_always", "sc": "settings", "t": "rect", "w": 1238.0, "x": 16.0, "y": 2848.0}
-{"bc": "3a3d42", "bw": 1, "fill": "2a2d33", "h": 20.0, "id": "r.1.1.0.75.0", "radius": 5, "sc": "settings", "t": "rect", "w": 20.0, "x": 16.0, "y": 2850.5}
-{"align": "left", "c": "e8e8e8", "h": 25.0, "id": "r.1.1.0.75.1", "sc": "settings", "size": 20, "t": "text", "text": "Skip Credits Always", "w": 181.8, "x": 46.0, "y": 2848.0}
-{"click": true, "h": 25.0, "hover": {"c": "747474"}, "id": "set-skip_intro_on_seek", "sc": "settings", "t": "rect", "w": 1238.0, "x": 16.0, "y": 2881.0}
-{"bc": "3a3d42", "bw": 1, "fill": "2a2d33", "h": 20.0, "id": "r.1.1.0.76.0", "radius": 5, "sc": "settings", "t": "rect", "w": 20.0, "x": 16.0, "y": 2883.5}
-{"align": "left", "c": "e8e8e8", "h": 25.0, "id": "r.1.1.0.76.1", "sc": "settings", "size": 20, "t": "text", "text": "Skip Intro On Seek", "w": 164.0, "x": 46.0, "y": 2881.0}
-{"align": "left", "bold": true, "c": "e8e8e8", "h": 25.0, "id": "r.1.1.0.77", "sc": "settings", "size": 20, "t": "text", "text": "Library Browser", "w": 1238.0, "x": 16.0, "y": 2914.0}
-{"align": "left", "c": "9aa0a6", "h": 21.2, "id": "r.1.1.0.78.0", "sc": "settings", "size": 17, "t": "text", "text": "Library Image Cache Mb", "w": 340.0, "x": 16.0, "y": 2955.4}
-{"h": 38.0, "id": "set-library_image_cache_mb", "ph": "", "sc": "settings", "size": 20, "t": "textbox", "text": "256", "w": 340.0, "x": 368.0, "y": 2947.0}
-{"align": "left", "c": "9aa0a6", "h": 21.2, "id": "r.1.1.0.79.0", "sc": "settings", "size": 17, "t": "text", "text": "Scroll Wheel Pixels", "w": 340.0, "x": 16.0, "y": 3001.4}
-{"h": 38.0, "id": "set-scroll_wheel_pixels", "ph": "", "sc": "settings", "size": 20, "t": "textbox", "text": "80", "w": 340.0, "x": 368.0, "y": 2993.0}
-{"align": "left", "c": "9aa0a6", "h": 17.5, "id": "r.1.1.0.80", "sc": "settings", "size": 14, "t": "text", "text": "Pixels one wheel notch scrolls. On a grid this is rounded so a whole number of notches spans one row, whichever scroll mode you are in \u2014 a trackpad or trackball never leaves you a sliver of a", "w": 1238.0, "x": 16.0, "y": 3039.0}
-{"align": "left", "c": "9aa0a6", "h": 17.5, "id": "r.1.1.0.80.l1", "sc": "settings", "size": 14, "t": "text", "text": "row off. Raise it to scroll faster, lower it for finer control.", "w": 1238.0, "x": 16.0, "y": 3056.5}
-{"align": "left", "c": "9aa0a6", "h": 21.2, "id": "r.1.1.0.81.0", "sc": "settings", "size": 17, "t": "text", "text": "Scroll Mode", "w": 340.0, "x": 16.0, "y": 3090.4}
-{"force": true, "h": 38.0, "id": "set-scroll_mode", "items": ["Continuous", "Aligned to rows", "One row per notch"], "sc": "settings", "sel": 0, "size": 20, "t": "dropdown", "w": 340.0, "x": 368.0, "y": 3082.0}
-{"align": "left", "c": "9aa0a6", "h": 17.5, "id": "r.1.1.0.82", "sc": "settings", "size": 14, "t": "text", "text": "\"Continuous\" scrolls by pixels and lands wherever the wheel puts it; it lines rows up by itself if the display cannot keep up. Pick \"Aligned to rows\" if scrolling still stutters \u2014 on a very large", "w": 1238.0, "x": 16.0, "y": 3128.0}
-{"align": "left", "c": "9aa0a6", "h": 17.5, "id": "r.1.1.0.82.l1", "sc": "settings", "size": 14, "t": "text", "text": "display, a slow or remote one, or with an external MPV. Pick \"One row per notch\" to move a whole row (or one home-screen section) at a time.", "w": 1238.0, "x": 16.0, "y": 3145.5}
-{"click": true, "h": 25.0, "hover": {"c": "747474"}, "id": "set-paginated", "sc": "settings", "t": "rect", "w": 1238.0, "x": 16.0, "y": 3171.0}
-{"bc": "3a3d42", "bw": 1, "fill": "2a2d33", "h": 20.0, "id": "r.1.1.0.83.0", "radius": 5, "sc": "settings", "t": "rect", "w": 20.0, "x": 16.0, "y": 3173.5}
-{"align": "left", "c": "e8e8e8", "h": 25.0, "id": "r.1.1.0.83.1", "sc": "settings", "size": 20, "t": "text", "text": "Paginated", "w": 89.2, "x": 46.0, "y": 3171.0}
-{"align": "left", "c": "9aa0a6", "h": 17.5, "id": "r.1.1.0.84", "sc": "settings", "size": 14, "t": "text", "text": "Page the library and music tile grids instead of scrolling: each page is one screenful with First / Previous / Next / Last controls and a page number you can type into. Easier than precise", "w": 1238.0, "x": 16.0, "y": 3204.0}
-{"align": "left", "c": "9aa0a6", "h": 17.5, "id": "r.1.1.0.84.l1", "sc": "settings", "size": 14, "t": "text", "text": "scrolling on a trackpad.", "w": 1238.0, "x": 16.0, "y": 3221.5}
-{"align": "left", "bold": true, "c": "e8e8e8", "h": 25.0, "id": "r.1.1.0.85", "sc": "settings", "size": 20, "t": "text", "text": "Downloads", "w": 1238.0, "x": 16.0, "y": 3247.0}
-{"align": "left", "c": "9aa0a6", "h": 21.2, "id": "r.1.1.0.86.0", "sc": "settings", "size": 17, "t": "text", "text": "Download Folder", "w": 340.0, "x": 16.0, "y": 3291.9}
-{"h": 38.0, "id": "set-sync_path", "ph": "", "sc": "settings", "size": 20, "t": "textbox", "text": "", "w": 250.0, "x": 368.0, "y": 3283.5}
-{"click": true, "fill": "2e3138", "h": 45.0, "hover": {"fill": "3a3e46"}, "id": "set-sync-move", "radius": 6, "sc": "settings", "t": "rect", "w": 69.4, "x": 626.0, "y": 3280.0}
-{"align": "center", "c": "e8e8e8", "h": 25.0, "id": "r.1.1.0.86.1.1.0", "sc": "settings", "size": 20, "t": "text", "text": "Move", "w": 49.4, "x": 636.0, "y": 3290.0}
-{"click": true, "h": 25.0, "hover": {"c": "747474"}, "id": "set-prefer_downloaded", "sc": "settings", "t": "rect", "w": 1238.0, "x": 16.0, "y": 3333.0}
-{"fill": "00a4dc", "h": 20.0, "id": "r.1.1.0.87.0", "radius": 5, "sc": "settings", "t": "rect", "w": 20.0, "x": 16.0, "y": 3335.5}
-{"align": "center", "c": "ffffff", "h": 18.8, "id": "r.1.1.0.87.0.0", "sc": "settings", "size": 15, "t": "text", "text": "\u2713", "w": 20.0, "x": 16.0, "y": 3336.1}
-{"align": "left", "c": "e8e8e8", "h": 25.0, "id": "r.1.1.0.87.1", "sc": "settings", "size": 20, "t": "text", "text": "Prefer Downloaded Copy", "w": 218.2, "x": 46.0, "y": 3333.0}
-{"click": true, "h": 25.0, "hover": {"c": "747474"}, "id": "set-auto_download_enable", "sc": "settings", "t": "rect", "w": 1238.0, "x": 16.0, "y": 3366.0}
-{"bc": "3a3d42", "bw": 1, "fill": "2a2d33", "h": 20.0, "id": "r.1.1.0.88.0", "radius": 5, "sc": "settings", "t": "rect", "w": 20.0, "x": 16.0, "y": 3368.5}
-{"align": "left", "c": "e8e8e8", "h": 25.0, "id": "r.1.1.0.88.1", "sc": "settings", "size": 20, "t": "text", "text": "Automatically Download Upcoming Episodes", "w": 404.2, "x": 46.0, "y": 3366.0}
-{"align": "left", "c": "9aa0a6", "h": 17.5, "id": "r.1.1.0.89", "sc": "settings", "size": 14, "t": "text", "text": "Applies to srv1, enable other servers in servers tab.", "w": 1238.0, "x": 16.0, "y": 3399.0}
-{"click": true, "h": 25.0, "hover": {"c": "747474"}, "id": "set-auto_download_next_up", "sc": "settings", "t": "rect", "w": 1238.0, "x": 16.0, "y": 3424.5}
-{"fill": "00a4dc", "h": 20.0, "id": "r.1.1.0.90.0", "radius": 5, "sc": "settings", "t": "rect", "w": 20.0, "x": 16.0, "y": 3427.0}
-{"align": "center", "c": "ffffff", "h": 18.8, "id": "r.1.1.0.90.0.0", "sc": "settings", "size": 15, "t": "text", "text": "\u2713", "w": 20.0, "x": 16.0, "y": 3427.6}
-{"align": "left", "c": "e8e8e8", "h": 25.0, "id": "r.1.1.0.90.1", "sc": "settings", "size": 20, "t": "text", "text": "Include Next Up", "w": 140.4, "x": 46.0, "y": 3424.5}
-{"align": "left", "c": "9aa0a6", "h": 21.2, "id": "r.1.1.0.91.0", "sc": "settings", "size": 17, "t": "text", "text": "Next Up Entries to Consider", "w": 340.0, "x": 16.0, "y": 3465.9}
-{"h": 38.0, "id": "set-auto_download_next_up_limit", "ph": "", "sc": "settings", "size": 20, "t": "textbox", "text": "10", "w": 340.0, "x": 368.0, "y": 3457.5}
-{"align": "left", "c": "9aa0a6", "h": 21.2, "id": "r.1.1.0.92.0", "sc": "settings", "size": 17, "t": "text", "text": "Episodes to Keep Ahead (0 = off)", "w": 340.0, "x": 16.0, "y": 3511.9}
-{"h": 38.0, "id": "set-auto_download_lookahead", "ph": "", "sc": "settings", "size": 20, "t": "textbox", "text": "2", "w": 340.0, "x": 368.0, "y": 3503.5}
-{"align": "left", "c": "9aa0a6", "h": 21.2, "id": "r.1.1.0.93.0", "sc": "settings", "size": 17, "t": "text", "text": "Storage Limit for Automatic Downloads (GB)", "w": 340.0, "x": 16.0, "y": 3557.9}
-{"h": 38.0, "id": "set-auto_download_max_gb", "ph": "", "sc": "settings", "size": 20, "t": "textbox", "text": "20", "w": 340.0, "x": 368.0, "y": 3549.5}
-{"click": true, "h": 25.0, "hover": {"c": "747474"}, "id": "set-auto_download_delete_watched", "sc": "settings", "t": "rect", "w": 1238.0, "x": 16.0, "y": 3595.5}
-{"fill": "00a4dc", "h": 20.0, "id": "r.1.1.0.94.0", "radius": 5, "sc": "settings", "t": "rect", "w": 20.0, "x": 16.0, "y": 3598.0}
-{"align": "center", "c": "ffffff", "h": 18.8, "id": "r.1.1.0.94.0.0", "sc": "settings", "size": 15, "t": "text", "text": "\u2713", "w": 20.0, "x": 16.0, "y": 3598.6}
-{"align": "left", "c": "e8e8e8", "h": 25.0, "id": "r.1.1.0.94.1", "sc": "settings", "size": 20, "t": "text", "text": "Delete Automatic Downloads Once Watched", "w": 392.6, "x": 46.0, "y": 3595.5}
-{"align": "left", "c": "9aa0a6", "h": 21.2, "id": "r.1.1.0.95.0", "sc": "settings", "size": 17, "t": "text", "text": "Delete Unwatched After (days, 0 = never)", "w": 340.0, "x": 16.0, "y": 3636.9}
-{"h": 38.0, "id": "set-auto_download_keep_days", "ph": "", "sc": "settings", "size": 20, "t": "textbox", "text": "30", "w": 340.0, "x": 368.0, "y": 3628.5}
-{"align": "left", "c": "9aa0a6", "h": 21.2, "id": "r.1.1.0.96.0", "sc": "settings", "size": 17, "t": "text", "text": "Check Every (minutes)", "w": 340.0, "x": 16.0, "y": 3682.9}
-{"h": 38.0, "id": "set-auto_download_interval_mins", "ph": "", "sc": "settings", "size": 20, "t": "textbox", "text": "60", "w": 340.0, "x": 368.0, "y": 3674.5}
-{"click": true, "h": 25.0, "hover": {"c": "747474"}, "id": "set-adv", "sc": "settings", "t": "rect", "w": 1238.0, "x": 16.0, "y": 3720.5}
-{"bc": "3a3d42", "bw": 1, "fill": "2a2d33", "h": 20.0, "id": "r.1.1.0.97.0", "radius": 5, "sc": "settings", "t": "rect", "w": 20.0, "x": 16.0, "y": 3723.0}
-{"align": "left", "c": "e8e8e8", "h": 25.0, "id": "r.1.1.0.97.1", "sc": "settings", "size": 20, "t": "text", "text": "Show advanced settings", "w": 222.2, "x": 46.0, "y": 3720.5}
-{"align": "left", "c": "9aa0a6", "h": 17.5, "id": "r.1.1.0.98", "sc": "settings", "size": 14, "t": "text", "text": "Some changes take effect after restarting.", "w": 1238.0, "x": 16.0, "y": 3753.5}
+{"align": "left", "c": "9aa0a6", "h": 21.2, "id": "r.1.1.0.12.0", "sc": "settings", "size": 17, "t": "text", "text": "Shading Behind the Player Controls", "w": 340.0, "x": 16.0, "y": 608.4}
+{"force": true, "h": 38.0, "id": "set-hud_scrim", "items": ["Default", "Half height", "Panel behind the controls", "None (shadowed text)"], "sc": "settings", "sel": 0, "size": 20, "t": "dropdown", "w": 340.0, "x": 368.0, "y": 600.0}
+{"align": "left", "c": "9aa0a6", "h": 17.5, "id": "r.1.1.0.13", "sc": "settings", "size": 14, "t": "text", "text": "The controls have to stay legible over any frame. \"None\" gives the text a drop shadow instead of shading the picture behind it.", "w": 1238.0, "x": 16.0, "y": 646.0}
+{"align": "left", "c": "9aa0a6", "h": 21.2, "id": "r.1.1.0.14.0", "sc": "settings", "size": 17, "t": "text", "text": "When the Player Controls Hide", "w": 340.0, "x": 16.0, "y": 679.9}
+{"force": true, "h": 38.0, "id": "set-hud_autohide", "items": ["Hide unless hovered", "Always hide", "Never hide while paused"], "sc": "settings", "sel": 0, "size": 20, "t": "dropdown", "w": 340.0, "x": 368.0, "y": 671.5}
+{"align": "left", "c": "9aa0a6", "h": 17.5, "id": "r.1.1.0.15", "sc": "settings", "size": 14, "t": "text", "text": "\"Hide unless hovered\" keeps them up only while the pointer is on them, paused or not.", "w": 1238.0, "x": 16.0, "y": 717.5}
+{"align": "left", "c": "9aa0a6", "h": 21.2, "id": "r.1.1.0.16.0", "sc": "settings", "size": 17, "t": "text", "text": "Hide the Player Controls After (seconds)", "w": 340.0, "x": 16.0, "y": 751.4}
+{"h": 38.0, "id": "set-hud_hide_secs", "ph": "", "sc": "settings", "size": 20, "t": "textbox", "text": "4.0", "w": 340.0, "x": 368.0, "y": 743.0}
+{"align": "left", "c": "9aa0a6", "h": 17.5, "id": "r.1.1.0.17", "sc": "settings", "size": 14, "t": "text", "text": "0 hides them as soon as the pointer is not on them, and forces \"Hide unless hovered\".", "w": 1238.0, "x": 16.0, "y": 789.0}
+{"click": true, "h": 25.0, "hover": {"c": "747474"}, "id": "set-hud_sub_margin", "sc": "settings", "t": "rect", "w": 1238.0, "x": 16.0, "y": 814.5}
+{"fill": "00a4dc", "h": 20.0, "id": "r.1.1.0.18.0", "radius": 5, "sc": "settings", "t": "rect", "w": 20.0, "x": 16.0, "y": 817.0}
+{"align": "center", "c": "ffffff", "h": 18.8, "id": "r.1.1.0.18.0.0", "sc": "settings", "size": 15, "t": "text", "text": "\u2713", "w": 20.0, "x": 16.0, "y": 817.6}
+{"align": "left", "c": "e8e8e8", "h": 25.0, "id": "r.1.1.0.18.1", "sc": "settings", "size": 20, "t": "text", "text": "Raise Subtitles Above the Player Controls", "w": 374.8, "x": 46.0, "y": 814.5}
+{"align": "left", "c": "9aa0a6", "h": 17.5, "id": "r.1.1.0.19", "sc": "settings", "size": 14, "t": "text", "text": "Subtitles move up while the controls show so the bar does not cover them. Turn this off if the movement is more distracting than the overlap.", "w": 1238.0, "x": 16.0, "y": 847.5}
+{"click": true, "h": 25.0, "hover": {"c": "747474"}, "id": "set-mouse_chapter_nav", "sc": "settings", "t": "rect", "w": 1238.0, "x": 16.0, "y": 873.0}
+{"bc": "3a3d42", "bw": 1, "fill": "2a2d33", "h": 20.0, "id": "r.1.1.0.20.0", "radius": 5, "sc": "settings", "t": "rect", "w": 20.0, "x": 16.0, "y": 875.5}
+{"align": "left", "c": "e8e8e8", "h": 25.0, "id": "r.1.1.0.20.1", "sc": "settings", "size": 20, "t": "text", "text": "Mouse Back/Forward Buttons Skip Chapters", "w": 397.2, "x": 46.0, "y": 873.0}
+{"align": "left", "c": "9aa0a6", "h": 17.5, "id": "r.1.1.0.21", "sc": "settings", "size": 14, "t": "text", "text": "During playback only \u2014 in the library those buttons stay Back and Forward. Off by default because they are easy to hit by accident on some mice. Takes effect after a restart.", "w": 1238.0, "x": 16.0, "y": 906.0}
+{"click": true, "h": 25.0, "hover": {"c": "747474"}, "id": "set-raise_mpv", "sc": "settings", "t": "rect", "w": 1238.0, "x": 16.0, "y": 931.5}
+{"fill": "00a4dc", "h": 20.0, "id": "r.1.1.0.22.0", "radius": 5, "sc": "settings", "t": "rect", "w": 20.0, "x": 16.0, "y": 934.0}
+{"align": "center", "c": "ffffff", "h": 18.8, "id": "r.1.1.0.22.0.0", "sc": "settings", "size": 15, "t": "text", "text": "\u2713", "w": 20.0, "x": 16.0, "y": 934.6}
+{"align": "left", "c": "e8e8e8", "h": 25.0, "id": "r.1.1.0.22.1", "sc": "settings", "size": 20, "t": "text", "text": "Raise MPV", "w": 94.6, "x": 46.0, "y": 931.5}
+{"click": true, "h": 25.0, "hover": {"c": "747474"}, "id": "set-discord_presence", "sc": "settings", "t": "rect", "w": 1238.0, "x": 16.0, "y": 964.5}
+{"bc": "3a3d42", "bw": 1, "fill": "2a2d33", "h": 20.0, "id": "r.1.1.0.23.0", "radius": 5, "sc": "settings", "t": "rect", "w": 20.0, "x": 16.0, "y": 967.0}
+{"align": "left", "c": "e8e8e8", "h": 25.0, "id": "r.1.1.0.23.1", "sc": "settings", "size": 20, "t": "text", "text": "Show What You're Watching in Discord", "w": 351.4, "x": 46.0, "y": 964.5}
+{"align": "left", "c": "9aa0a6", "h": 17.5, "id": "r.1.1.0.24", "sc": "settings", "size": 14, "t": "text", "text": "Discord Rich Presence. Takes effect after a restart.", "w": 1238.0, "x": 16.0, "y": 997.5}
+{"click": true, "h": 25.0, "hover": {"c": "747474"}, "id": "set-check_updates", "sc": "settings", "t": "rect", "w": 1238.0, "x": 16.0, "y": 1023.0}
+{"fill": "00a4dc", "h": 20.0, "id": "r.1.1.0.25.0", "radius": 5, "sc": "settings", "t": "rect", "w": 20.0, "x": 16.0, "y": 1025.5}
+{"align": "center", "c": "ffffff", "h": 18.8, "id": "r.1.1.0.25.0.0", "sc": "settings", "size": 15, "t": "text", "text": "\u2713", "w": 20.0, "x": 16.0, "y": 1026.1}
+{"align": "left", "c": "e8e8e8", "h": 25.0, "id": "r.1.1.0.25.1", "sc": "settings", "size": 20, "t": "text", "text": "Check Updates", "w": 131.6, "x": 46.0, "y": 1023.0}
+{"click": true, "h": 25.0, "hover": {"c": "747474"}, "id": "set-notify_updates", "sc": "settings", "t": "rect", "w": 1238.0, "x": 16.0, "y": 1056.0}
+{"fill": "00a4dc", "h": 20.0, "id": "r.1.1.0.26.0", "radius": 5, "sc": "settings", "t": "rect", "w": 20.0, "x": 16.0, "y": 1058.5}
+{"align": "center", "c": "ffffff", "h": 18.8, "id": "r.1.1.0.26.0.0", "sc": "settings", "size": 15, "t": "text", "text": "\u2713", "w": 20.0, "x": 16.0, "y": 1059.1}
+{"align": "left", "c": "e8e8e8", "h": 25.0, "id": "r.1.1.0.26.1", "sc": "settings", "size": 20, "t": "text", "text": "Notify Updates", "w": 130.4, "x": 46.0, "y": 1056.0}
+{"align": "left", "bold": true, "c": "e8e8e8", "h": 25.0, "id": "r.1.1.0.27", "sc": "settings", "size": 20, "t": "text", "text": "Theme", "w": 1238.0, "x": 16.0, "y": 1089.0}
+{"align": "left", "c": "9aa0a6", "h": 21.2, "id": "r.1.1.0.28.0", "sc": "settings", "size": 17, "t": "text", "text": "Theme", "w": 340.0, "x": 16.0, "y": 1130.4}
+{"force": true, "h": 38.0, "id": "set-theme", "items": ["Default", "Apple TV (Jellyfin)", "Blue Radiance (Jellyfin)", "Light (Jellyfin)", "Nebula", "Purple Haze (Jellyfin)", "Windows Media Center (Jellyfin)"], "sc": "settings", "sel": 0, "size": 20, "t": "dropdown", "w": 340.0, "x": 368.0, "y": 1122.0}
+{"align": "left", "c": "9aa0a6", "h": 17.5, "id": "r.1.1.0.29", "sc": "settings", "size": 14, "t": "text", "text": "Palette, glow, cover style and default cover size. Colours change immediately; cover and heading sizes take effect after a restart.", "w": 1238.0, "x": 16.0, "y": 1168.0}
+{"align": "left", "c": "9aa0a6", "h": 21.2, "id": "r.1.1.0.30.0", "sc": "settings", "size": 17, "t": "text", "text": "Cover Size", "w": 340.0, "x": 16.0, "y": 1201.9}
+{"force": true, "h": 38.0, "id": "set-poster_scale", "items": ["Theme default", "Extra Compact", "Compact", "Small", "Medium", "Large", "Extra Large"], "sc": "settings", "sel": 0, "size": 20, "t": "dropdown", "w": 340.0, "x": 368.0, "y": 1193.5}
+{"align": "left", "c": "9aa0a6", "h": 17.5, "id": "r.1.1.0.31", "sc": "settings", "size": 14, "t": "text", "text": "Overrides the theme's cover size. Applies immediately, and is also on the View menu of any library.", "w": 1238.0, "x": 16.0, "y": 1239.5}
+{"align": "left", "c": "9aa0a6", "h": 21.2, "id": "r.1.1.0.32.0", "sc": "settings", "size": 17, "t": "text", "text": "Interface Scale", "w": 340.0, "x": 16.0, "y": 1273.4}
+{"force": true, "h": 38.0, "id": "set-ui_scale", "items": ["Follow display", "100% (no scaling)", "125%", "150%", "200%"], "sc": "settings", "sel": 0, "size": 20, "t": "dropdown", "w": 340.0, "x": 368.0, "y": 1265.0}
+{"align": "left", "c": "9aa0a6", "h": 17.5, "id": "r.1.1.0.33", "sc": "settings", "size": 14, "t": "text", "text": "Takes effect after a restart. \"Follow display\" uses the scale your desktop reports, which is 100% on X11.", "w": 1238.0, "x": 16.0, "y": 1311.0}
+{"align": "left", "c": "9aa0a6", "h": 17.5, "id": "r.1.1.0.34", "sc": "settings", "size": 14, "t": "text", "text": "Cover size and interface scale require a restart.", "w": 1238.0, "x": 16.0, "y": 1336.5}
+{"align": "left", "bold": true, "c": "e8e8e8", "h": 25.0, "id": "r.1.1.0.35", "sc": "settings", "size": 20, "t": "text", "text": "Playback", "w": 1238.0, "x": 16.0, "y": 1362.0}
+{"click": true, "h": 25.0, "hover": {"c": "747474"}, "id": "set-auto_play", "sc": "settings", "t": "rect", "w": 1238.0, "x": 16.0, "y": 1395.0}
+{"fill": "00a4dc", "h": 20.0, "id": "r.1.1.0.36.0", "radius": 5, "sc": "settings", "t": "rect", "w": 20.0, "x": 16.0, "y": 1397.5}
+{"align": "center", "c": "ffffff", "h": 18.8, "id": "r.1.1.0.36.0.0", "sc": "settings", "size": 15, "t": "text", "text": "\u2713", "w": 20.0, "x": 16.0, "y": 1398.1}
+{"align": "left", "c": "e8e8e8", "h": 25.0, "id": "r.1.1.0.36.1", "sc": "settings", "size": 20, "t": "text", "text": "Auto Play", "w": 84.4, "x": 46.0, "y": 1395.0}
+{"click": true, "h": 25.0, "hover": {"c": "747474"}, "id": "set-always_transcode", "sc": "settings", "t": "rect", "w": 1238.0, "x": 16.0, "y": 1428.0}
+{"bc": "3a3d42", "bw": 1, "fill": "2a2d33", "h": 20.0, "id": "r.1.1.0.37.0", "radius": 5, "sc": "settings", "t": "rect", "w": 20.0, "x": 16.0, "y": 1430.5}
+{"align": "left", "c": "e8e8e8", "h": 25.0, "id": "r.1.1.0.37.1", "sc": "settings", "size": 20, "t": "text", "text": "Always Transcode", "w": 166.2, "x": 46.0, "y": 1428.0}
+{"align": "left", "c": "9aa0a6", "h": 21.2, "id": "r.1.1.0.38.0", "sc": "settings", "size": 17, "t": "text", "text": "Local kbps", "w": 340.0, "x": 16.0, "y": 1469.4}
+{"h": 38.0, "id": "set-local_kbps", "ph": "", "sc": "settings", "size": 20, "t": "textbox", "text": "2147483", "w": 340.0, "x": 368.0, "y": 1461.0}
+{"align": "left", "c": "9aa0a6", "h": 21.2, "id": "r.1.1.0.39.0", "sc": "settings", "size": 17, "t": "text", "text": "Remote kbps", "w": 340.0, "x": 16.0, "y": 1515.4}
+{"h": 38.0, "id": "set-remote_kbps", "ph": "", "sc": "settings", "size": 20, "t": "textbox", "text": "10000", "w": 340.0, "x": 368.0, "y": 1507.0}
+{"click": true, "h": 25.0, "hover": {"c": "747474"}, "id": "set-direct_paths", "sc": "settings", "t": "rect", "w": 1238.0, "x": 16.0, "y": 1553.0}
+{"bc": "3a3d42", "bw": 1, "fill": "2a2d33", "h": 20.0, "id": "r.1.1.0.40.0", "radius": 5, "sc": "settings", "t": "rect", "w": 20.0, "x": 16.0, "y": 1555.5}
+{"align": "left", "c": "e8e8e8", "h": 25.0, "id": "r.1.1.0.40.1", "sc": "settings", "size": 20, "t": "text", "text": "Direct Paths", "w": 108.8, "x": 46.0, "y": 1553.0}
+{"click": true, "h": 25.0, "hover": {"c": "747474"}, "id": "set-remote_direct_paths", "sc": "settings", "t": "rect", "w": 1238.0, "x": 16.0, "y": 1586.0}
+{"bc": "3a3d42", "bw": 1, "fill": "2a2d33", "h": 20.0, "id": "r.1.1.0.41.0", "radius": 5, "sc": "settings", "t": "rect", "w": 20.0, "x": 16.0, "y": 1588.5}
+{"align": "left", "c": "e8e8e8", "h": 25.0, "id": "r.1.1.0.41.1", "sc": "settings", "size": 20, "t": "text", "text": "Remote Direct Paths", "w": 181.8, "x": 46.0, "y": 1586.0}
+{"align": "left", "c": "9aa0a6", "h": 21.2, "id": "r.1.1.0.42.0", "sc": "settings", "size": 17, "t": "text", "text": "Playback Timeout", "w": 340.0, "x": 16.0, "y": 1627.4}
+{"h": 38.0, "id": "set-playback_timeout", "ph": "", "sc": "settings", "size": 20, "t": "textbox", "text": "30", "w": 340.0, "x": 368.0, "y": 1619.0}
+{"align": "left", "bold": true, "c": "e8e8e8", "h": 25.0, "id": "r.1.1.0.43", "sc": "settings", "size": 20, "t": "text", "text": "Audio", "w": 1238.0, "x": 16.0, "y": 1665.0}
+{"align": "left", "c": "9aa0a6", "h": 21.2, "id": "r.1.1.0.44.0", "sc": "settings", "size": 17, "t": "text", "text": "Audio Output Device", "w": 340.0, "x": 16.0, "y": 1706.4}
+{"h": 38.0, "id": "set-audio_device", "ph": "", "sc": "settings", "size": 20, "t": "textbox", "text": "", "w": 340.0, "x": 368.0, "y": 1698.0}
+{"align": "left", "c": "9aa0a6", "h": 17.5, "id": "r.1.1.0.45", "sc": "settings", "size": 14, "t": "text", "text": "Leave this to Default unless setting up passthrough. Note some audio servers like Pipewire don't like passthrough and will need to be disabled for a card before it'll let *any* audio through in", "w": 1238.0, "x": 16.0, "y": 1744.0}
+{"align": "left", "c": "9aa0a6", "h": 17.5, "id": "r.1.1.0.45.l1", "sc": "settings", "size": 14, "t": "text", "text": "passthrough mode. In my tests I got silence otherwise, but results may vary.", "w": 1238.0, "x": 16.0, "y": 1761.5}
+{"align": "left", "c": "9aa0a6", "h": 21.2, "id": "r.1.1.0.46.0", "sc": "settings", "size": 17, "t": "text", "text": "Audio Output Mode", "w": 340.0, "x": 16.0, "y": 1795.4}
+{"force": true, "h": 38.0, "id": "set-audio_mode", "items": ["Default (auto)", "Force Stereo", "Optical Surround", "HDMI Passthrough"], "sc": "settings", "sel": 0, "size": 20, "t": "dropdown", "w": 340.0, "x": 368.0, "y": 1787.0}
+{"align": "left", "c": "9aa0a6", "h": 17.5, "id": "r.1.1.0.47", "sc": "settings", "size": 14, "t": "text", "text": "\"Default\" changes nothing and lets MPV (and your own mpv.conf) decide. Pick a mode only if you are sending audio to a receiver.", "w": 1238.0, "x": 16.0, "y": 1833.0}
+{"click": true, "h": 25.0, "hover": {"c": "747474"}, "id": "set-audio_night_mode", "sc": "settings", "t": "rect", "w": 1238.0, "x": 16.0, "y": 1858.5}
+{"bc": "3a3d42", "bw": 1, "fill": "2a2d33", "h": 20.0, "id": "r.1.1.0.48.0", "radius": 5, "sc": "settings", "t": "rect", "w": 20.0, "x": 16.0, "y": 1861.0}
+{"align": "left", "c": "e8e8e8", "h": 25.0, "id": "r.1.1.0.48.1", "sc": "settings", "size": 20, "t": "text", "text": "Night Mode (Auto Volume Adj)", "w": 267.6, "x": 46.0, "y": 1858.5}
+{"align": "left", "c": "9aa0a6", "h": 17.5, "id": "r.1.1.0.49", "sc": "settings", "size": 14, "t": "text", "text": "Evens out loud effects and quiet dialogue. This turns passthrough off while it is enabled, because the volume has to be adjusted before your receiver gets the audio.", "w": 1238.0, "x": 16.0, "y": 1891.5}
+{"align": "left", "bold": true, "c": "e8e8e8", "h": 25.0, "id": "r.1.1.0.50", "sc": "settings", "size": 20, "t": "text", "text": "Subtitles & Languages", "w": 1238.0, "x": 16.0, "y": 1917.0}
+{"align": "left", "c": "9aa0a6", "h": 21.2, "id": "r.1.1.0.51.0", "sc": "settings", "size": 17, "t": "text", "text": "Subtitle Size", "w": 340.0, "x": 16.0, "y": 1958.4}
+{"h": 38.0, "id": "set-subtitle_size", "ph": "", "sc": "settings", "size": 20, "t": "textbox", "text": "100", "w": 340.0, "x": 368.0, "y": 1950.0}
+{"align": "left", "c": "9aa0a6", "h": 21.2, "id": "r.1.1.0.52.0", "sc": "settings", "size": 17, "t": "text", "text": "Subtitle Color", "w": 340.0, "x": 16.0, "y": 2004.4}
+{"h": 38.0, "id": "set-subtitle_color", "ph": "", "sc": "settings", "size": 20, "t": "textbox", "text": "#FFFFFFFF", "w": 340.0, "x": 368.0, "y": 1996.0}
+{"align": "left", "c": "9aa0a6", "h": 21.2, "id": "r.1.1.0.53.0", "sc": "settings", "size": 17, "t": "text", "text": "Subtitle Position", "w": 340.0, "x": 16.0, "y": 2050.4}
+{"force": true, "h": 38.0, "id": "set-subtitle_position", "items": ["top", "bottom", "middle"], "sc": "settings", "sel": 1, "size": 20, "t": "dropdown", "w": 340.0, "x": 368.0, "y": 2042.0}
+{"align": "left", "c": "9aa0a6", "h": 21.2, "id": "r.1.1.0.54.0", "sc": "settings", "size": 17, "t": "text", "text": "Language Preference", "w": 340.0, "x": 16.0, "y": 2096.4}
+{"force": true, "h": 38.0, "id": "set-language_preference", "items": ["Unset", "Dubbed (shows only)", "Subbed (shows only)", "Dubbed (all)", "Subbed (all)", "Custom (set in config)"], "sc": "settings", "sel": 5, "size": 20, "t": "dropdown", "w": 340.0, "x": 368.0, "y": 2088.0}
+{"align": "left", "c": "9aa0a6", "h": 21.2, "id": "r.1.1.0.55.0", "sc": "settings", "size": 17, "t": "text", "text": "Preferred Language", "w": 340.0, "x": 16.0, "y": 2142.4}
+{"h": 38.0, "id": "set-preferred_language", "ph": "", "sc": "settings", "size": 20, "t": "textbox", "text": "eng", "w": 340.0, "x": 368.0, "y": 2134.0}
+{"click": true, "h": 25.0, "hover": {"c": "747474"}, "id": "set-remember_audio_track", "sc": "settings", "t": "rect", "w": 1238.0, "x": 16.0, "y": 2180.0}
+{"fill": "00a4dc", "h": 20.0, "id": "r.1.1.0.56.0", "radius": 5, "sc": "settings", "t": "rect", "w": 20.0, "x": 16.0, "y": 2182.5}
+{"align": "center", "c": "ffffff", "h": 18.8, "id": "r.1.1.0.56.0.0", "sc": "settings", "size": 15, "t": "text", "text": "\u2713", "w": 20.0, "x": 16.0, "y": 2183.1}
+{"align": "left", "c": "e8e8e8", "h": 25.0, "id": "r.1.1.0.56.1", "sc": "settings", "size": 20, "t": "text", "text": "Remember Audio Track", "w": 206.8, "x": 46.0, "y": 2180.0}
+{"click": true, "h": 25.0, "hover": {"c": "747474"}, "id": "set-remember_subtitle_track", "sc": "settings", "t": "rect", "w": 1238.0, "x": 16.0, "y": 2213.0}
+{"fill": "00a4dc", "h": 20.0, "id": "r.1.1.0.57.0", "radius": 5, "sc": "settings", "t": "rect", "w": 20.0, "x": 16.0, "y": 2215.5}
+{"align": "center", "c": "ffffff", "h": 18.8, "id": "r.1.1.0.57.0.0", "sc": "settings", "size": 15, "t": "text", "text": "\u2713", "w": 20.0, "x": 16.0, "y": 2216.1}
+{"align": "left", "c": "e8e8e8", "h": 25.0, "id": "r.1.1.0.57.1", "sc": "settings", "size": 20, "t": "text", "text": "Remember Subtitle Track", "w": 227.2, "x": 46.0, "y": 2213.0}
+{"align": "left", "c": "9aa0a6", "h": 21.2, "id": "r.1.1.0.58.0", "sc": "settings", "size": 17, "t": "text", "text": "Lang Filter", "w": 340.0, "x": 16.0, "y": 2254.4}
+{"h": 38.0, "id": "set-lang_filter", "ph": "", "sc": "settings", "size": 20, "t": "textbox", "text": "und,eng,jpn,mis,mul,zxx", "w": 340.0, "x": 368.0, "y": 2246.0}
+{"click": true, "h": 25.0, "hover": {"c": "747474"}, "id": "set-lang_filter_sub", "sc": "settings", "t": "rect", "w": 1238.0, "x": 16.0, "y": 2292.0}
+{"bc": "3a3d42", "bw": 1, "fill": "2a2d33", "h": 20.0, "id": "r.1.1.0.59.0", "radius": 5, "sc": "settings", "t": "rect", "w": 20.0, "x": 16.0, "y": 2294.5}
+{"align": "left", "c": "e8e8e8", "h": 25.0, "id": "r.1.1.0.59.1", "sc": "settings", "size": 20, "t": "text", "text": "Lang Filter Sub", "w": 136.4, "x": 46.0, "y": 2292.0}
+{"click": true, "h": 25.0, "hover": {"c": "747474"}, "id": "set-lang_filter_audio", "sc": "settings", "t": "rect", "w": 1238.0, "x": 16.0, "y": 2325.0}
+{"bc": "3a3d42", "bw": 1, "fill": "2a2d33", "h": 20.0, "id": "r.1.1.0.60.0", "radius": 5, "sc": "settings", "t": "rect", "w": 20.0, "x": 16.0, "y": 2327.5}
+{"align": "left", "c": "e8e8e8", "h": 25.0, "id": "r.1.1.0.60.1", "sc": "settings", "size": 20, "t": "text", "text": "Lang Filter Audio", "w": 154.0, "x": 46.0, "y": 2325.0}
+{"align": "left", "bold": true, "c": "e8e8e8", "h": 25.0, "id": "r.1.1.0.61", "sc": "settings", "size": 20, "t": "text", "text": "Transcoding", "w": 1238.0, "x": 16.0, "y": 2358.0}
+{"click": true, "h": 25.0, "hover": {"c": "747474"}, "id": "set-allow_transcode_to_h265", "sc": "settings", "t": "rect", "w": 1238.0, "x": 16.0, "y": 2391.0}
+{"bc": "3a3d42", "bw": 1, "fill": "2a2d33", "h": 20.0, "id": "r.1.1.0.62.0", "radius": 5, "sc": "settings", "t": "rect", "w": 20.0, "x": 16.0, "y": 2393.5}
+{"align": "left", "c": "e8e8e8", "h": 25.0, "id": "r.1.1.0.62.1", "sc": "settings", "size": 20, "t": "text", "text": "Allow Transcode To H265", "w": 228.2, "x": 46.0, "y": 2391.0}
+{"click": true, "h": 25.0, "hover": {"c": "747474"}, "id": "set-prefer_transcode_to_h265", "sc": "settings", "t": "rect", "w": 1238.0, "x": 16.0, "y": 2424.0}
+{"bc": "3a3d42", "bw": 1, "fill": "2a2d33", "h": 20.0, "id": "r.1.1.0.63.0", "radius": 5, "sc": "settings", "t": "rect", "w": 20.0, "x": 16.0, "y": 2426.5}
+{"align": "left", "c": "e8e8e8", "h": 25.0, "id": "r.1.1.0.63.1", "sc": "settings", "size": 20, "t": "text", "text": "Prefer Transcode To H265", "w": 228.8, "x": 46.0, "y": 2424.0}
+{"click": true, "h": 25.0, "hover": {"c": "747474"}, "id": "set-transcode_hevc", "sc": "settings", "t": "rect", "w": 1238.0, "x": 16.0, "y": 2457.0}
+{"bc": "3a3d42", "bw": 1, "fill": "2a2d33", "h": 20.0, "id": "r.1.1.0.64.0", "radius": 5, "sc": "settings", "t": "rect", "w": 20.0, "x": 16.0, "y": 2459.5}
+{"align": "left", "c": "e8e8e8", "h": 25.0, "id": "r.1.1.0.64.1", "sc": "settings", "size": 20, "t": "text", "text": "Transcode HEVC", "w": 142.4, "x": 46.0, "y": 2457.0}
+{"click": true, "h": 25.0, "hover": {"c": "747474"}, "id": "set-transcode_av1", "sc": "settings", "t": "rect", "w": 1238.0, "x": 16.0, "y": 2490.0}
+{"bc": "3a3d42", "bw": 1, "fill": "2a2d33", "h": 20.0, "id": "r.1.1.0.65.0", "radius": 5, "sc": "settings", "t": "rect", "w": 20.0, "x": 16.0, "y": 2492.5}
+{"align": "left", "c": "e8e8e8", "h": 25.0, "id": "r.1.1.0.65.1", "sc": "settings", "size": 20, "t": "text", "text": "Transcode AV1", "w": 131.6, "x": 46.0, "y": 2490.0}
+{"click": true, "h": 25.0, "hover": {"c": "747474"}, "id": "set-transcode_4k", "sc": "settings", "t": "rect", "w": 1238.0, "x": 16.0, "y": 2523.0}
+{"bc": "3a3d42", "bw": 1, "fill": "2a2d33", "h": 20.0, "id": "r.1.1.0.66.0", "radius": 5, "sc": "settings", "t": "rect", "w": 20.0, "x": 16.0, "y": 2525.5}
+{"align": "left", "c": "e8e8e8", "h": 25.0, "id": "r.1.1.0.66.1", "sc": "settings", "size": 20, "t": "text", "text": "Transcode 4K", "w": 120.8, "x": 46.0, "y": 2523.0}
+{"click": true, "h": 25.0, "hover": {"c": "747474"}, "id": "set-transcode_hdr", "sc": "settings", "t": "rect", "w": 1238.0, "x": 16.0, "y": 2556.0}
+{"bc": "3a3d42", "bw": 1, "fill": "2a2d33", "h": 20.0, "id": "r.1.1.0.67.0", "radius": 5, "sc": "settings", "t": "rect", "w": 20.0, "x": 16.0, "y": 2558.5}
+{"align": "left", "c": "e8e8e8", "h": 25.0, "id": "r.1.1.0.67.1", "sc": "settings", "size": 20, "t": "text", "text": "Transcode HDR", "w": 131.6, "x": 46.0, "y": 2556.0}
+{"click": true, "h": 25.0, "hover": {"c": "747474"}, "id": "set-transcode_hi10p", "sc": "settings", "t": "rect", "w": 1238.0, "x": 16.0, "y": 2589.0}
+{"bc": "3a3d42", "bw": 1, "fill": "2a2d33", "h": 20.0, "id": "r.1.1.0.68.0", "radius": 5, "sc": "settings", "t": "rect", "w": 20.0, "x": 16.0, "y": 2591.5}
+{"align": "left", "c": "e8e8e8", "h": 25.0, "id": "r.1.1.0.68.1", "sc": "settings", "size": 20, "t": "text", "text": "Transcode Hi10P", "w": 149.2, "x": 46.0, "y": 2589.0}
+{"click": true, "h": 25.0, "hover": {"c": "747474"}, "id": "set-transcode_dolby_vision", "sc": "settings", "t": "rect", "w": 1238.0, "x": 16.0, "y": 2622.0}
+{"bc": "3a3d42", "bw": 1, "fill": "2a2d33", "h": 20.0, "id": "r.1.1.0.69.0", "radius": 5, "sc": "settings", "t": "rect", "w": 20.0, "x": 16.0, "y": 2624.5}
+{"align": "left", "c": "e8e8e8", "h": 25.0, "id": "r.1.1.0.69.1", "sc": "settings", "size": 20, "t": "text", "text": "Transcode Dolby Vision", "w": 212.0, "x": 46.0, "y": 2622.0}
+{"align": "left", "c": "9aa0a6", "h": 21.2, "id": "r.1.1.0.70.0", "sc": "settings", "size": 17, "t": "text", "text": "Force Video Codec", "w": 340.0, "x": 16.0, "y": 2663.4}
+{"h": 38.0, "id": "set-force_video_codec", "ph": "", "sc": "settings", "size": 20, "t": "textbox", "text": "", "w": 340.0, "x": 368.0, "y": 2655.0}
+{"align": "left", "c": "9aa0a6", "h": 21.2, "id": "r.1.1.0.71.0", "sc": "settings", "size": 17, "t": "text", "text": "Force Audio Codec", "w": 340.0, "x": 16.0, "y": 2709.4}
+{"h": 38.0, "id": "set-force_audio_codec", "ph": "", "sc": "settings", "size": 20, "t": "textbox", "text": "", "w": 340.0, "x": 368.0, "y": 2701.0}
+{"align": "left", "bold": true, "c": "e8e8e8", "h": 25.0, "id": "r.1.1.0.72", "sc": "settings", "size": 20, "t": "text", "text": "Video Enhancement", "w": 1238.0, "x": 16.0, "y": 2747.0}
+{"click": true, "h": 25.0, "hover": {"c": "747474"}, "id": "set-shader_pack_enable", "sc": "settings", "t": "rect", "w": 1238.0, "x": 16.0, "y": 2780.0}
+{"fill": "00a4dc", "h": 20.0, "id": "r.1.1.0.73.0", "radius": 5, "sc": "settings", "t": "rect", "w": 20.0, "x": 16.0, "y": 2782.5}
+{"align": "center", "c": "ffffff", "h": 18.8, "id": "r.1.1.0.73.0.0", "sc": "settings", "size": 15, "t": "text", "text": "\u2713", "w": 20.0, "x": 16.0, "y": 2783.1}
+{"align": "left", "c": "e8e8e8", "h": 25.0, "id": "r.1.1.0.73.1", "sc": "settings", "size": 20, "t": "text", "text": "Enable Video Playback Profiles", "w": 281.6, "x": 46.0, "y": 2780.0}
+{"align": "left", "c": "9aa0a6", "h": 21.2, "id": "r.1.1.0.74.0", "sc": "settings", "size": 17, "t": "text", "text": "Profile Group", "w": 340.0, "x": 16.0, "y": 2821.4}
+{"force": true, "h": 38.0, "id": "set-shader_pack_subtype", "items": ["lq", "hq"], "sc": "settings", "sel": 0, "size": 20, "t": "dropdown", "w": 340.0, "x": 368.0, "y": 2813.0}
+{"align": "left", "c": "9aa0a6", "h": 17.5, "id": "r.1.1.0.75", "sc": "settings", "size": 14, "t": "text", "text": "\"hq\" offers heavier profiles. Pick it if you have a fast graphics card.", "w": 1238.0, "x": 16.0, "y": 2859.0}
+{"click": true, "h": 25.0, "hover": {"c": "747474"}, "id": "set-shader_pack_remember", "sc": "settings", "t": "rect", "w": 1238.0, "x": 16.0, "y": 2884.5}
+{"fill": "00a4dc", "h": 20.0, "id": "r.1.1.0.76.0", "radius": 5, "sc": "settings", "t": "rect", "w": 20.0, "x": 16.0, "y": 2887.0}
+{"align": "center", "c": "ffffff", "h": 18.8, "id": "r.1.1.0.76.0.0", "sc": "settings", "size": 15, "t": "text", "text": "\u2713", "w": 20.0, "x": 16.0, "y": 2887.6}
+{"align": "left", "c": "e8e8e8", "h": 25.0, "id": "r.1.1.0.76.1", "sc": "settings", "size": 20, "t": "text", "text": "Remember Last Used Profile", "w": 254.8, "x": 46.0, "y": 2884.5}
+{"align": "left", "c": "9aa0a6", "h": 21.2, "id": "r.1.1.0.77.0", "sc": "settings", "size": 17, "t": "text", "text": "Graphics API for Shaders", "w": 340.0, "x": 16.0, "y": 2925.9}
+{"force": true, "h": 38.0, "id": "set-shader_pack_gpu_api", "items": ["Automatic (recommended)", "Vulkan", "Direct3D 11 (Windows only)", "OpenGL (compatibility)"], "sc": "settings", "sel": 0, "size": 20, "t": "dropdown", "w": 340.0, "x": 368.0, "y": 2917.5}
+{"align": "left", "c": "9aa0a6", "h": 17.5, "id": "r.1.1.0.78", "sc": "settings", "size": 14, "t": "text", "text": "Leave on Automatic unless video breaks when a profile is loaded. This only applies while a profile is active, and OpenGL can cost you HDR output.", "w": 1238.0, "x": 16.0, "y": 2963.5}
+{"align": "left", "bold": true, "c": "e8e8e8", "h": 25.0, "id": "r.1.1.0.79", "sc": "settings", "size": 20, "t": "text", "text": "Skip Intro / Credits", "w": 1238.0, "x": 16.0, "y": 2989.0}
+{"click": true, "h": 25.0, "hover": {"c": "747474"}, "id": "set-skip_intro_enable", "sc": "settings", "t": "rect", "w": 1238.0, "x": 16.0, "y": 3022.0}
+{"fill": "00a4dc", "h": 20.0, "id": "r.1.1.0.80.0", "radius": 5, "sc": "settings", "t": "rect", "w": 20.0, "x": 16.0, "y": 3024.5}
+{"align": "center", "c": "ffffff", "h": 18.8, "id": "r.1.1.0.80.0.0", "sc": "settings", "size": 15, "t": "text", "text": "\u2713", "w": 20.0, "x": 16.0, "y": 3025.1}
+{"align": "left", "c": "e8e8e8", "h": 25.0, "id": "r.1.1.0.80.1", "sc": "settings", "size": 20, "t": "text", "text": "Skip Intro Enable", "w": 154.0, "x": 46.0, "y": 3022.0}
+{"click": true, "h": 25.0, "hover": {"c": "747474"}, "id": "set-skip_intro_always", "sc": "settings", "t": "rect", "w": 1238.0, "x": 16.0, "y": 3055.0}
+{"bc": "3a3d42", "bw": 1, "fill": "2a2d33", "h": 20.0, "id": "r.1.1.0.81.0", "radius": 5, "sc": "settings", "t": "rect", "w": 20.0, "x": 16.0, "y": 3057.5}
+{"align": "left", "c": "e8e8e8", "h": 25.0, "id": "r.1.1.0.81.1", "sc": "settings", "size": 20, "t": "text", "text": "Skip Intro Always", "w": 160.2, "x": 46.0, "y": 3055.0}
+{"click": true, "h": 25.0, "hover": {"c": "747474"}, "id": "set-skip_credits_enable", "sc": "settings", "t": "rect", "w": 1238.0, "x": 16.0, "y": 3088.0}
+{"fill": "00a4dc", "h": 20.0, "id": "r.1.1.0.82.0", "radius": 5, "sc": "settings", "t": "rect", "w": 20.0, "x": 16.0, "y": 3090.5}
+{"align": "center", "c": "ffffff", "h": 18.8, "id": "r.1.1.0.82.0.0", "sc": "settings", "size": 15, "t": "text", "text": "\u2713", "w": 20.0, "x": 16.0, "y": 3091.1}
+{"align": "left", "c": "e8e8e8", "h": 25.0, "id": "r.1.1.0.82.1", "sc": "settings", "size": 20, "t": "text", "text": "Skip Credits Enable", "w": 175.6, "x": 46.0, "y": 3088.0}
+{"click": true, "h": 25.0, "hover": {"c": "747474"}, "id": "set-skip_credits_always", "sc": "settings", "t": "rect", "w": 1238.0, "x": 16.0, "y": 3121.0}
+{"bc": "3a3d42", "bw": 1, "fill": "2a2d33", "h": 20.0, "id": "r.1.1.0.83.0", "radius": 5, "sc": "settings", "t": "rect", "w": 20.0, "x": 16.0, "y": 3123.5}
+{"align": "left", "c": "e8e8e8", "h": 25.0, "id": "r.1.1.0.83.1", "sc": "settings", "size": 20, "t": "text", "text": "Skip Credits Always", "w": 181.8, "x": 46.0, "y": 3121.0}
+{"click": true, "h": 25.0, "hover": {"c": "747474"}, "id": "set-skip_intro_on_seek", "sc": "settings", "t": "rect", "w": 1238.0, "x": 16.0, "y": 3154.0}
+{"bc": "3a3d42", "bw": 1, "fill": "2a2d33", "h": 20.0, "id": "r.1.1.0.84.0", "radius": 5, "sc": "settings", "t": "rect", "w": 20.0, "x": 16.0, "y": 3156.5}
+{"align": "left", "c": "e8e8e8", "h": 25.0, "id": "r.1.1.0.84.1", "sc": "settings", "size": 20, "t": "text", "text": "Skip Intro On Seek", "w": 164.0, "x": 46.0, "y": 3154.0}
+{"align": "left", "bold": true, "c": "e8e8e8", "h": 25.0, "id": "r.1.1.0.85", "sc": "settings", "size": 20, "t": "text", "text": "Library Browser", "w": 1238.0, "x": 16.0, "y": 3187.0}
+{"align": "left", "c": "9aa0a6", "h": 21.2, "id": "r.1.1.0.86.0", "sc": "settings", "size": 17, "t": "text", "text": "Library Image Cache Mb", "w": 340.0, "x": 16.0, "y": 3228.4}
+{"h": 38.0, "id": "set-library_image_cache_mb", "ph": "", "sc": "settings", "size": 20, "t": "textbox", "text": "256", "w": 340.0, "x": 368.0, "y": 3220.0}
+{"align": "left", "c": "9aa0a6", "h": 21.2, "id": "r.1.1.0.87.0", "sc": "settings", "size": 17, "t": "text", "text": "Scroll Wheel Pixels", "w": 340.0, "x": 16.0, "y": 3274.4}
+{"h": 38.0, "id": "set-scroll_wheel_pixels", "ph": "", "sc": "settings", "size": 20, "t": "textbox", "text": "80", "w": 340.0, "x": 368.0, "y": 3266.0}
+{"align": "left", "c": "9aa0a6", "h": 17.5, "id": "r.1.1.0.88", "sc": "settings", "size": 14, "t": "text", "text": "Pixels one wheel notch scrolls. On a grid this is rounded so a whole number of notches spans one row, whichever scroll mode you are in \u2014 a trackpad or trackball never leaves you a sliver of a", "w": 1238.0, "x": 16.0, "y": 3312.0}
+{"align": "left", "c": "9aa0a6", "h": 17.5, "id": "r.1.1.0.88.l1", "sc": "settings", "size": 14, "t": "text", "text": "row off. Raise it to scroll faster, lower it for finer control.", "w": 1238.0, "x": 16.0, "y": 3329.5}
+{"align": "left", "c": "9aa0a6", "h": 21.2, "id": "r.1.1.0.89.0", "sc": "settings", "size": 17, "t": "text", "text": "Scroll Mode", "w": 340.0, "x": 16.0, "y": 3363.4}
+{"force": true, "h": 38.0, "id": "set-scroll_mode", "items": ["Continuous", "Aligned to rows", "One row per notch"], "sc": "settings", "sel": 0, "size": 20, "t": "dropdown", "w": 340.0, "x": 368.0, "y": 3355.0}
+{"align": "left", "c": "9aa0a6", "h": 17.5, "id": "r.1.1.0.90", "sc": "settings", "size": 14, "t": "text", "text": "\"Continuous\" scrolls by pixels and lands wherever the wheel puts it; it lines rows up by itself if the display cannot keep up. Pick \"Aligned to rows\" if scrolling still stutters \u2014 on a very large", "w": 1238.0, "x": 16.0, "y": 3401.0}
+{"align": "left", "c": "9aa0a6", "h": 17.5, "id": "r.1.1.0.90.l1", "sc": "settings", "size": 14, "t": "text", "text": "display, a slow or remote one, or with an external MPV. Pick \"One row per notch\" to move a whole row (or one home-screen section) at a time.", "w": 1238.0, "x": 16.0, "y": 3418.5}
+{"click": true, "h": 25.0, "hover": {"c": "747474"}, "id": "set-paginated", "sc": "settings", "t": "rect", "w": 1238.0, "x": 16.0, "y": 3444.0}
+{"bc": "3a3d42", "bw": 1, "fill": "2a2d33", "h": 20.0, "id": "r.1.1.0.91.0", "radius": 5, "sc": "settings", "t": "rect", "w": 20.0, "x": 16.0, "y": 3446.5}
+{"align": "left", "c": "e8e8e8", "h": 25.0, "id": "r.1.1.0.91.1", "sc": "settings", "size": 20, "t": "text", "text": "Paginated", "w": 89.2, "x": 46.0, "y": 3444.0}
+{"align": "left", "c": "9aa0a6", "h": 17.5, "id": "r.1.1.0.92", "sc": "settings", "size": 14, "t": "text", "text": "Page the library and music tile grids instead of scrolling: each page is one screenful with First / Previous / Next / Last controls and a page number you can type into. Easier than precise", "w": 1238.0, "x": 16.0, "y": 3477.0}
+{"align": "left", "c": "9aa0a6", "h": 17.5, "id": "r.1.1.0.92.l1", "sc": "settings", "size": 14, "t": "text", "text": "scrolling on a trackpad.", "w": 1238.0, "x": 16.0, "y": 3494.5}
+{"align": "left", "bold": true, "c": "e8e8e8", "h": 25.0, "id": "r.1.1.0.93", "sc": "settings", "size": 20, "t": "text", "text": "Downloads", "w": 1238.0, "x": 16.0, "y": 3520.0}
+{"align": "left", "c": "9aa0a6", "h": 21.2, "id": "r.1.1.0.94.0", "sc": "settings", "size": 17, "t": "text", "text": "Download Folder", "w": 340.0, "x": 16.0, "y": 3564.9}
+{"h": 38.0, "id": "set-sync_path", "ph": "", "sc": "settings", "size": 20, "t": "textbox", "text": "", "w": 250.0, "x": 368.0, "y": 3556.5}
+{"click": true, "fill": "2e3138", "h": 45.0, "hover": {"fill": "3a3e46"}, "id": "set-sync-move", "radius": 6, "sc": "settings", "t": "rect", "w": 69.4, "x": 626.0, "y": 3553.0}
+{"align": "center", "c": "e8e8e8", "h": 25.0, "id": "r.1.1.0.94.1.1.0", "sc": "settings", "size": 20, "t": "text", "text": "Move", "w": 49.4, "x": 636.0, "y": 3563.0}
+{"click": true, "h": 25.0, "hover": {"c": "747474"}, "id": "set-prefer_downloaded", "sc": "settings", "t": "rect", "w": 1238.0, "x": 16.0, "y": 3606.0}
+{"fill": "00a4dc", "h": 20.0, "id": "r.1.1.0.95.0", "radius": 5, "sc": "settings", "t": "rect", "w": 20.0, "x": 16.0, "y": 3608.5}
+{"align": "center", "c": "ffffff", "h": 18.8, "id": "r.1.1.0.95.0.0", "sc": "settings", "size": 15, "t": "text", "text": "\u2713", "w": 20.0, "x": 16.0, "y": 3609.1}
+{"align": "left", "c": "e8e8e8", "h": 25.0, "id": "r.1.1.0.95.1", "sc": "settings", "size": 20, "t": "text", "text": "Prefer Downloaded Copy", "w": 218.2, "x": 46.0, "y": 3606.0}
+{"click": true, "h": 25.0, "hover": {"c": "747474"}, "id": "set-auto_download_enable", "sc": "settings", "t": "rect", "w": 1238.0, "x": 16.0, "y": 3639.0}
+{"bc": "3a3d42", "bw": 1, "fill": "2a2d33", "h": 20.0, "id": "r.1.1.0.96.0", "radius": 5, "sc": "settings", "t": "rect", "w": 20.0, "x": 16.0, "y": 3641.5}
+{"align": "left", "c": "e8e8e8", "h": 25.0, "id": "r.1.1.0.96.1", "sc": "settings", "size": 20, "t": "text", "text": "Automatically Download Upcoming Episodes", "w": 404.2, "x": 46.0, "y": 3639.0}
+{"align": "left", "c": "9aa0a6", "h": 17.5, "id": "r.1.1.0.97", "sc": "settings", "size": 14, "t": "text", "text": "Applies to srv1, enable other servers in servers tab.", "w": 1238.0, "x": 16.0, "y": 3672.0}
+{"click": true, "h": 25.0, "hover": {"c": "747474"}, "id": "set-auto_download_next_up", "sc": "settings", "t": "rect", "w": 1238.0, "x": 16.0, "y": 3697.5}
+{"fill": "00a4dc", "h": 20.0, "id": "r.1.1.0.98.0", "radius": 5, "sc": "settings", "t": "rect", "w": 20.0, "x": 16.0, "y": 3700.0}
+{"align": "center", "c": "ffffff", "h": 18.8, "id": "r.1.1.0.98.0.0", "sc": "settings", "size": 15, "t": "text", "text": "\u2713", "w": 20.0, "x": 16.0, "y": 3700.6}
+{"align": "left", "c": "e8e8e8", "h": 25.0, "id": "r.1.1.0.98.1", "sc": "settings", "size": 20, "t": "text", "text": "Include Next Up", "w": 140.4, "x": 46.0, "y": 3697.5}
+{"align": "left", "c": "9aa0a6", "h": 21.2, "id": "r.1.1.0.99.0", "sc": "settings", "size": 17, "t": "text", "text": "Next Up Entries to Consider", "w": 340.0, "x": 16.0, "y": 3738.9}
+{"h": 38.0, "id": "set-auto_download_next_up_limit", "ph": "", "sc": "settings", "size": 20, "t": "textbox", "text": "10", "w": 340.0, "x": 368.0, "y": 3730.5}
+{"align": "left", "c": "9aa0a6", "h": 21.2, "id": "r.1.1.0.100.0", "sc": "settings", "size": 17, "t": "text", "text": "Episodes to Keep Ahead (0 = off)", "w": 340.0, "x": 16.0, "y": 3784.9}
+{"h": 38.0, "id": "set-auto_download_lookahead", "ph": "", "sc": "settings", "size": 20, "t": "textbox", "text": "2", "w": 340.0, "x": 368.0, "y": 3776.5}
+{"align": "left", "c": "9aa0a6", "h": 21.2, "id": "r.1.1.0.101.0", "sc": "settings", "size": 17, "t": "text", "text": "Storage Limit for Automatic Downloads (GB)", "w": 340.0, "x": 16.0, "y": 3830.9}
+{"h": 38.0, "id": "set-auto_download_max_gb", "ph": "", "sc": "settings", "size": 20, "t": "textbox", "text": "20", "w": 340.0, "x": 368.0, "y": 3822.5}
+{"click": true, "h": 25.0, "hover": {"c": "747474"}, "id": "set-auto_download_delete_watched", "sc": "settings", "t": "rect", "w": 1238.0, "x": 16.0, "y": 3868.5}
+{"fill": "00a4dc", "h": 20.0, "id": "r.1.1.0.102.0", "radius": 5, "sc": "settings", "t": "rect", "w": 20.0, "x": 16.0, "y": 3871.0}
+{"align": "center", "c": "ffffff", "h": 18.8, "id": "r.1.1.0.102.0.0", "sc": "settings", "size": 15, "t": "text", "text": "\u2713", "w": 20.0, "x": 16.0, "y": 3871.6}
+{"align": "left", "c": "e8e8e8", "h": 25.0, "id": "r.1.1.0.102.1", "sc": "settings", "size": 20, "t": "text", "text": "Delete Automatic Downloads Once Watched", "w": 392.6, "x": 46.0, "y": 3868.5}
+{"align": "left", "c": "9aa0a6", "h": 21.2, "id": "r.1.1.0.103.0", "sc": "settings", "size": 17, "t": "text", "text": "Delete Unwatched After (days, 0 = never)", "w": 340.0, "x": 16.0, "y": 3909.9}
+{"h": 38.0, "id": "set-auto_download_keep_days", "ph": "", "sc": "settings", "size": 20, "t": "textbox", "text": "30", "w": 340.0, "x": 368.0, "y": 3901.5}
+{"align": "left", "c": "9aa0a6", "h": 21.2, "id": "r.1.1.0.104.0", "sc": "settings", "size": 17, "t": "text", "text": "Check Every (minutes)", "w": 340.0, "x": 16.0, "y": 3955.9}
+{"h": 38.0, "id": "set-auto_download_interval_mins", "ph": "", "sc": "settings", "size": 20, "t": "textbox", "text": "60", "w": 340.0, "x": 368.0, "y": 3947.5}
+{"click": true, "h": 25.0, "hover": {"c": "747474"}, "id": "set-adv", "sc": "settings", "t": "rect", "w": 1238.0, "x": 16.0, "y": 3993.5}
+{"bc": "3a3d42", "bw": 1, "fill": "2a2d33", "h": 20.0, "id": "r.1.1.0.105.0", "radius": 5, "sc": "settings", "t": "rect", "w": 20.0, "x": 16.0, "y": 3996.0}
+{"align": "left", "c": "e8e8e8", "h": 25.0, "id": "r.1.1.0.105.1", "sc": "settings", "size": 20, "t": "text", "text": "Show advanced settings", "w": 222.2, "x": 46.0, "y": 3993.5}
+{"align": "left", "c": "9aa0a6", "h": 17.5, "id": "r.1.1.0.106", "sc": "settings", "size": 14, "t": "text", "text": "Some changes take effect after restarting.", "w": 1238.0, "x": 16.0, "y": 4026.5}

--- a/tests/snapshots/settings.jsonl
+++ b/tests/snapshots/settings.jsonl
@@ -24,7 +24,7 @@
 {"align": "center", "c": "e8e8e8", "h": 25.0, "id": "r.1.0.0.4.0", "size": 20, "t": "text", "text": "Downloads", "w": 99.4, "x": 532.0, "y": 82.0}
 {"click": true, "fill": "2e3138", "h": 45.0, "hover": {"fill": "3a3e46"}, "id": "stab-logs", "radius": 6, "t": "rect", "w": 63.2, "x": 649.4, "y": 72.0}
 {"align": "center", "c": "e8e8e8", "h": 25.0, "id": "r.1.0.0.5.0", "size": 20, "t": "text", "text": "Logs", "w": 43.2, "x": 659.4, "y": 82.0}
-{"axis": "y", "bar": true, "ch": 3931.0, "cw": 1270.0, "h": 591.0, "id": "settings", "t": "scroll", "w": 1280.0, "x": 0.0, "y": 129.0}
+{"axis": "y", "bar": true, "ch": 4029.0, "cw": 1270.0, "h": 591.0, "id": "settings", "t": "scroll", "w": 1280.0, "x": 0.0, "y": 129.0}
 {"align": "left", "bold": true, "c": "e8e8e8", "h": 25.0, "id": "r.1.1.0.0", "sc": "settings", "size": 20, "t": "text", "text": "Interface", "w": 1238.0, "x": 16.0, "y": 145.0}
 {"align": "left", "c": "9aa0a6", "h": 21.2, "id": "r.1.1.0.1.0", "sc": "settings", "size": 17, "t": "text", "text": "Player Name", "w": 340.0, "x": 16.0, "y": 186.4}
 {"h": 38.0, "id": "set-player_name", "ph": "", "sc": "settings", "size": 20, "t": "textbox", "text": "izzie-pc", "w": 340.0, "x": 368.0, "y": 178.0}
@@ -204,71 +204,67 @@
 {"force": true, "h": 38.0, "id": "set-shader_pack_gpu_api", "items": ["Automatic (recommended)", "Vulkan", "Direct3D 11 (Windows only)", "OpenGL (compatibility)"], "sc": "settings", "sel": 0, "size": 20, "t": "dropdown", "w": 340.0, "x": 368.0, "y": 2917.5}
 {"align": "left", "c": "9aa0a6", "h": 17.5, "id": "r.1.1.0.78", "sc": "settings", "size": 14, "t": "text", "text": "Leave on Automatic unless video breaks when a profile is loaded. This only applies while a profile is active, and OpenGL can cost you HDR output.", "w": 1238.0, "x": 16.0, "y": 2963.5}
 {"align": "left", "bold": true, "c": "e8e8e8", "h": 25.0, "id": "r.1.1.0.79", "sc": "settings", "size": 20, "t": "text", "text": "Skip Intro / Credits", "w": 1238.0, "x": 16.0, "y": 2989.0}
-{"click": true, "h": 25.0, "hover": {"c": "747474"}, "id": "set-skip_intro_enable", "sc": "settings", "t": "rect", "w": 1238.0, "x": 16.0, "y": 3022.0}
-{"fill": "00a4dc", "h": 20.0, "id": "r.1.1.0.80.0", "radius": 5, "sc": "settings", "t": "rect", "w": 20.0, "x": 16.0, "y": 3024.5}
-{"align": "center", "c": "ffffff", "h": 18.8, "id": "r.1.1.0.80.0.0", "sc": "settings", "size": 15, "t": "text", "text": "\u2713", "w": 20.0, "x": 16.0, "y": 3025.1}
-{"align": "left", "c": "e8e8e8", "h": 25.0, "id": "r.1.1.0.80.1", "sc": "settings", "size": 20, "t": "text", "text": "Skip Intro Enable", "w": 154.0, "x": 46.0, "y": 3022.0}
-{"click": true, "h": 25.0, "hover": {"c": "747474"}, "id": "set-skip_intro_always", "sc": "settings", "t": "rect", "w": 1238.0, "x": 16.0, "y": 3055.0}
-{"bc": "3a3d42", "bw": 1, "fill": "2a2d33", "h": 20.0, "id": "r.1.1.0.81.0", "radius": 5, "sc": "settings", "t": "rect", "w": 20.0, "x": 16.0, "y": 3057.5}
-{"align": "left", "c": "e8e8e8", "h": 25.0, "id": "r.1.1.0.81.1", "sc": "settings", "size": 20, "t": "text", "text": "Skip Intro Always", "w": 160.2, "x": 46.0, "y": 3055.0}
-{"click": true, "h": 25.0, "hover": {"c": "747474"}, "id": "set-skip_credits_enable", "sc": "settings", "t": "rect", "w": 1238.0, "x": 16.0, "y": 3088.0}
-{"fill": "00a4dc", "h": 20.0, "id": "r.1.1.0.82.0", "radius": 5, "sc": "settings", "t": "rect", "w": 20.0, "x": 16.0, "y": 3090.5}
-{"align": "center", "c": "ffffff", "h": 18.8, "id": "r.1.1.0.82.0.0", "sc": "settings", "size": 15, "t": "text", "text": "\u2713", "w": 20.0, "x": 16.0, "y": 3091.1}
-{"align": "left", "c": "e8e8e8", "h": 25.0, "id": "r.1.1.0.82.1", "sc": "settings", "size": 20, "t": "text", "text": "Skip Credits Enable", "w": 175.6, "x": 46.0, "y": 3088.0}
-{"click": true, "h": 25.0, "hover": {"c": "747474"}, "id": "set-skip_credits_always", "sc": "settings", "t": "rect", "w": 1238.0, "x": 16.0, "y": 3121.0}
-{"bc": "3a3d42", "bw": 1, "fill": "2a2d33", "h": 20.0, "id": "r.1.1.0.83.0", "radius": 5, "sc": "settings", "t": "rect", "w": 20.0, "x": 16.0, "y": 3123.5}
-{"align": "left", "c": "e8e8e8", "h": 25.0, "id": "r.1.1.0.83.1", "sc": "settings", "size": 20, "t": "text", "text": "Skip Credits Always", "w": 181.8, "x": 46.0, "y": 3121.0}
-{"click": true, "h": 25.0, "hover": {"c": "747474"}, "id": "set-skip_intro_on_seek", "sc": "settings", "t": "rect", "w": 1238.0, "x": 16.0, "y": 3154.0}
-{"bc": "3a3d42", "bw": 1, "fill": "2a2d33", "h": 20.0, "id": "r.1.1.0.84.0", "radius": 5, "sc": "settings", "t": "rect", "w": 20.0, "x": 16.0, "y": 3156.5}
-{"align": "left", "c": "e8e8e8", "h": 25.0, "id": "r.1.1.0.84.1", "sc": "settings", "size": 20, "t": "text", "text": "Skip Intro On Seek", "w": 164.0, "x": 46.0, "y": 3154.0}
-{"align": "left", "bold": true, "c": "e8e8e8", "h": 25.0, "id": "r.1.1.0.85", "sc": "settings", "size": 20, "t": "text", "text": "Library Browser", "w": 1238.0, "x": 16.0, "y": 3187.0}
-{"align": "left", "c": "9aa0a6", "h": 21.2, "id": "r.1.1.0.86.0", "sc": "settings", "size": 17, "t": "text", "text": "Library Image Cache Mb", "w": 340.0, "x": 16.0, "y": 3228.4}
-{"h": 38.0, "id": "set-library_image_cache_mb", "ph": "", "sc": "settings", "size": 20, "t": "textbox", "text": "256", "w": 340.0, "x": 368.0, "y": 3220.0}
-{"align": "left", "c": "9aa0a6", "h": 21.2, "id": "r.1.1.0.87.0", "sc": "settings", "size": 17, "t": "text", "text": "Scroll Wheel Pixels", "w": 340.0, "x": 16.0, "y": 3274.4}
-{"h": 38.0, "id": "set-scroll_wheel_pixels", "ph": "", "sc": "settings", "size": 20, "t": "textbox", "text": "80", "w": 340.0, "x": 368.0, "y": 3266.0}
-{"align": "left", "c": "9aa0a6", "h": 17.5, "id": "r.1.1.0.88", "sc": "settings", "size": 14, "t": "text", "text": "Pixels one wheel notch scrolls. On a grid this is rounded so a whole number of notches spans one row, whichever scroll mode you are in \u2014 a trackpad or trackball never leaves you a sliver of a", "w": 1238.0, "x": 16.0, "y": 3312.0}
-{"align": "left", "c": "9aa0a6", "h": 17.5, "id": "r.1.1.0.88.l1", "sc": "settings", "size": 14, "t": "text", "text": "row off. Raise it to scroll faster, lower it for finer control.", "w": 1238.0, "x": 16.0, "y": 3329.5}
-{"align": "left", "c": "9aa0a6", "h": 21.2, "id": "r.1.1.0.89.0", "sc": "settings", "size": 17, "t": "text", "text": "Scroll Mode", "w": 340.0, "x": 16.0, "y": 3363.4}
-{"force": true, "h": 38.0, "id": "set-scroll_mode", "items": ["Continuous", "Aligned to rows", "One row per notch"], "sc": "settings", "sel": 0, "size": 20, "t": "dropdown", "w": 340.0, "x": 368.0, "y": 3355.0}
-{"align": "left", "c": "9aa0a6", "h": 17.5, "id": "r.1.1.0.90", "sc": "settings", "size": 14, "t": "text", "text": "\"Continuous\" scrolls by pixels and lands wherever the wheel puts it; it lines rows up by itself if the display cannot keep up. Pick \"Aligned to rows\" if scrolling still stutters \u2014 on a very large", "w": 1238.0, "x": 16.0, "y": 3401.0}
-{"align": "left", "c": "9aa0a6", "h": 17.5, "id": "r.1.1.0.90.l1", "sc": "settings", "size": 14, "t": "text", "text": "display, a slow or remote one, or with an external MPV. Pick \"One row per notch\" to move a whole row (or one home-screen section) at a time.", "w": 1238.0, "x": 16.0, "y": 3418.5}
-{"click": true, "h": 25.0, "hover": {"c": "747474"}, "id": "set-paginated", "sc": "settings", "t": "rect", "w": 1238.0, "x": 16.0, "y": 3444.0}
-{"bc": "3a3d42", "bw": 1, "fill": "2a2d33", "h": 20.0, "id": "r.1.1.0.91.0", "radius": 5, "sc": "settings", "t": "rect", "w": 20.0, "x": 16.0, "y": 3446.5}
-{"align": "left", "c": "e8e8e8", "h": 25.0, "id": "r.1.1.0.91.1", "sc": "settings", "size": 20, "t": "text", "text": "Paginated", "w": 89.2, "x": 46.0, "y": 3444.0}
-{"align": "left", "c": "9aa0a6", "h": 17.5, "id": "r.1.1.0.92", "sc": "settings", "size": 14, "t": "text", "text": "Page the library and music tile grids instead of scrolling: each page is one screenful with First / Previous / Next / Last controls and a page number you can type into. Easier than precise", "w": 1238.0, "x": 16.0, "y": 3477.0}
-{"align": "left", "c": "9aa0a6", "h": 17.5, "id": "r.1.1.0.92.l1", "sc": "settings", "size": 14, "t": "text", "text": "scrolling on a trackpad.", "w": 1238.0, "x": 16.0, "y": 3494.5}
-{"align": "left", "bold": true, "c": "e8e8e8", "h": 25.0, "id": "r.1.1.0.93", "sc": "settings", "size": 20, "t": "text", "text": "Downloads", "w": 1238.0, "x": 16.0, "y": 3520.0}
-{"align": "left", "c": "9aa0a6", "h": 21.2, "id": "r.1.1.0.94.0", "sc": "settings", "size": 17, "t": "text", "text": "Download Folder", "w": 340.0, "x": 16.0, "y": 3564.9}
-{"h": 38.0, "id": "set-sync_path", "ph": "", "sc": "settings", "size": 20, "t": "textbox", "text": "", "w": 250.0, "x": 368.0, "y": 3556.5}
-{"click": true, "fill": "2e3138", "h": 45.0, "hover": {"fill": "3a3e46"}, "id": "set-sync-move", "radius": 6, "sc": "settings", "t": "rect", "w": 69.4, "x": 626.0, "y": 3553.0}
-{"align": "center", "c": "e8e8e8", "h": 25.0, "id": "r.1.1.0.94.1.1.0", "sc": "settings", "size": 20, "t": "text", "text": "Move", "w": 49.4, "x": 636.0, "y": 3563.0}
-{"click": true, "h": 25.0, "hover": {"c": "747474"}, "id": "set-prefer_downloaded", "sc": "settings", "t": "rect", "w": 1238.0, "x": 16.0, "y": 3606.0}
-{"fill": "00a4dc", "h": 20.0, "id": "r.1.1.0.95.0", "radius": 5, "sc": "settings", "t": "rect", "w": 20.0, "x": 16.0, "y": 3608.5}
-{"align": "center", "c": "ffffff", "h": 18.8, "id": "r.1.1.0.95.0.0", "sc": "settings", "size": 15, "t": "text", "text": "\u2713", "w": 20.0, "x": 16.0, "y": 3609.1}
-{"align": "left", "c": "e8e8e8", "h": 25.0, "id": "r.1.1.0.95.1", "sc": "settings", "size": 20, "t": "text", "text": "Prefer Downloaded Copy", "w": 218.2, "x": 46.0, "y": 3606.0}
-{"click": true, "h": 25.0, "hover": {"c": "747474"}, "id": "set-auto_download_enable", "sc": "settings", "t": "rect", "w": 1238.0, "x": 16.0, "y": 3639.0}
-{"bc": "3a3d42", "bw": 1, "fill": "2a2d33", "h": 20.0, "id": "r.1.1.0.96.0", "radius": 5, "sc": "settings", "t": "rect", "w": 20.0, "x": 16.0, "y": 3641.5}
-{"align": "left", "c": "e8e8e8", "h": 25.0, "id": "r.1.1.0.96.1", "sc": "settings", "size": 20, "t": "text", "text": "Automatically Download Upcoming Episodes", "w": 404.2, "x": 46.0, "y": 3639.0}
-{"align": "left", "c": "9aa0a6", "h": 17.5, "id": "r.1.1.0.97", "sc": "settings", "size": 14, "t": "text", "text": "Applies to srv1, enable other servers in servers tab.", "w": 1238.0, "x": 16.0, "y": 3672.0}
-{"click": true, "h": 25.0, "hover": {"c": "747474"}, "id": "set-auto_download_next_up", "sc": "settings", "t": "rect", "w": 1238.0, "x": 16.0, "y": 3697.5}
-{"fill": "00a4dc", "h": 20.0, "id": "r.1.1.0.98.0", "radius": 5, "sc": "settings", "t": "rect", "w": 20.0, "x": 16.0, "y": 3700.0}
-{"align": "center", "c": "ffffff", "h": 18.8, "id": "r.1.1.0.98.0.0", "sc": "settings", "size": 15, "t": "text", "text": "\u2713", "w": 20.0, "x": 16.0, "y": 3700.6}
-{"align": "left", "c": "e8e8e8", "h": 25.0, "id": "r.1.1.0.98.1", "sc": "settings", "size": 20, "t": "text", "text": "Include Next Up", "w": 140.4, "x": 46.0, "y": 3697.5}
-{"align": "left", "c": "9aa0a6", "h": 21.2, "id": "r.1.1.0.99.0", "sc": "settings", "size": 17, "t": "text", "text": "Next Up Entries to Consider", "w": 340.0, "x": 16.0, "y": 3738.9}
-{"h": 38.0, "id": "set-auto_download_next_up_limit", "ph": "", "sc": "settings", "size": 20, "t": "textbox", "text": "10", "w": 340.0, "x": 368.0, "y": 3730.5}
-{"align": "left", "c": "9aa0a6", "h": 21.2, "id": "r.1.1.0.100.0", "sc": "settings", "size": 17, "t": "text", "text": "Episodes to Keep Ahead (0 = off)", "w": 340.0, "x": 16.0, "y": 3784.9}
-{"h": 38.0, "id": "set-auto_download_lookahead", "ph": "", "sc": "settings", "size": 20, "t": "textbox", "text": "2", "w": 340.0, "x": 368.0, "y": 3776.5}
-{"align": "left", "c": "9aa0a6", "h": 21.2, "id": "r.1.1.0.101.0", "sc": "settings", "size": 17, "t": "text", "text": "Storage Limit for Automatic Downloads (GB)", "w": 340.0, "x": 16.0, "y": 3830.9}
-{"h": 38.0, "id": "set-auto_download_max_gb", "ph": "", "sc": "settings", "size": 20, "t": "textbox", "text": "20", "w": 340.0, "x": 368.0, "y": 3822.5}
-{"click": true, "h": 25.0, "hover": {"c": "747474"}, "id": "set-auto_download_delete_watched", "sc": "settings", "t": "rect", "w": 1238.0, "x": 16.0, "y": 3868.5}
-{"fill": "00a4dc", "h": 20.0, "id": "r.1.1.0.102.0", "radius": 5, "sc": "settings", "t": "rect", "w": 20.0, "x": 16.0, "y": 3871.0}
-{"align": "center", "c": "ffffff", "h": 18.8, "id": "r.1.1.0.102.0.0", "sc": "settings", "size": 15, "t": "text", "text": "\u2713", "w": 20.0, "x": 16.0, "y": 3871.6}
-{"align": "left", "c": "e8e8e8", "h": 25.0, "id": "r.1.1.0.102.1", "sc": "settings", "size": 20, "t": "text", "text": "Delete Automatic Downloads Once Watched", "w": 392.6, "x": 46.0, "y": 3868.5}
-{"align": "left", "c": "9aa0a6", "h": 21.2, "id": "r.1.1.0.103.0", "sc": "settings", "size": 17, "t": "text", "text": "Delete Unwatched After (days, 0 = never)", "w": 340.0, "x": 16.0, "y": 3909.9}
-{"h": 38.0, "id": "set-auto_download_keep_days", "ph": "", "sc": "settings", "size": 20, "t": "textbox", "text": "30", "w": 340.0, "x": 368.0, "y": 3901.5}
-{"align": "left", "c": "9aa0a6", "h": 21.2, "id": "r.1.1.0.104.0", "sc": "settings", "size": 17, "t": "text", "text": "Check Every (minutes)", "w": 340.0, "x": 16.0, "y": 3955.9}
-{"h": 38.0, "id": "set-auto_download_interval_mins", "ph": "", "sc": "settings", "size": 20, "t": "textbox", "text": "60", "w": 340.0, "x": 368.0, "y": 3947.5}
-{"click": true, "h": 25.0, "hover": {"c": "747474"}, "id": "set-adv", "sc": "settings", "t": "rect", "w": 1238.0, "x": 16.0, "y": 3993.5}
-{"bc": "3a3d42", "bw": 1, "fill": "2a2d33", "h": 20.0, "id": "r.1.1.0.105.0", "radius": 5, "sc": "settings", "t": "rect", "w": 20.0, "x": 16.0, "y": 3996.0}
-{"align": "left", "c": "e8e8e8", "h": 25.0, "id": "r.1.1.0.105.1", "sc": "settings", "size": 20, "t": "text", "text": "Show advanced settings", "w": 222.2, "x": 46.0, "y": 3993.5}
-{"align": "left", "c": "9aa0a6", "h": 17.5, "id": "r.1.1.0.106", "sc": "settings", "size": 14, "t": "text", "text": "Some changes take effect after restarting.", "w": 1238.0, "x": 16.0, "y": 4026.5}
+{"align": "left", "c": "9aa0a6", "h": 21.2, "id": "r.1.1.0.80.0", "sc": "settings", "size": 17, "t": "text", "text": "Skip Intros", "w": 340.0, "x": 16.0, "y": 3030.4}
+{"force": true, "h": 38.0, "id": "set-segment_intro", "items": ["Never", "Ask", "Always"], "sc": "settings", "sel": 1, "size": 20, "t": "dropdown", "w": 340.0, "x": 368.0, "y": 3022.0}
+{"align": "left", "c": "9aa0a6", "h": 21.2, "id": "r.1.1.0.81.0", "sc": "settings", "size": 17, "t": "text", "text": "Skip Credits", "w": 340.0, "x": 16.0, "y": 3076.4}
+{"force": true, "h": 38.0, "id": "set-segment_outro", "items": ["Never", "Ask", "Always"], "sc": "settings", "sel": 1, "size": 20, "t": "dropdown", "w": 340.0, "x": 368.0, "y": 3068.0}
+{"align": "left", "c": "9aa0a6", "h": 21.2, "id": "r.1.1.0.82.0", "sc": "settings", "size": 17, "t": "text", "text": "Skip Commercials", "w": 340.0, "x": 16.0, "y": 3122.4}
+{"force": true, "h": 38.0, "id": "set-segment_commercial", "items": ["Never", "Ask", "Always"], "sc": "settings", "sel": 0, "size": 20, "t": "dropdown", "w": 340.0, "x": 368.0, "y": 3114.0}
+{"align": "left", "c": "9aa0a6", "h": 21.2, "id": "r.1.1.0.83.0", "sc": "settings", "size": 17, "t": "text", "text": "Skip Previews", "w": 340.0, "x": 16.0, "y": 3168.4}
+{"force": true, "h": 38.0, "id": "set-segment_preview", "items": ["Never", "Ask", "Always"], "sc": "settings", "sel": 0, "size": 20, "t": "dropdown", "w": 340.0, "x": 368.0, "y": 3160.0}
+{"align": "left", "c": "9aa0a6", "h": 21.2, "id": "r.1.1.0.84.0", "sc": "settings", "size": 17, "t": "text", "text": "Skip Recaps", "w": 340.0, "x": 16.0, "y": 3214.4}
+{"force": true, "h": 38.0, "id": "set-segment_recap", "items": ["Never", "Ask", "Always"], "sc": "settings", "sel": 0, "size": 20, "t": "dropdown", "w": 340.0, "x": 368.0, "y": 3206.0}
+{"click": true, "h": 25.0, "hover": {"c": "747474"}, "id": "set-skip_intro_on_seek", "sc": "settings", "t": "rect", "w": 1238.0, "x": 16.0, "y": 3252.0}
+{"bc": "3a3d42", "bw": 1, "fill": "2a2d33", "h": 20.0, "id": "r.1.1.0.85.0", "radius": 5, "sc": "settings", "t": "rect", "w": 20.0, "x": 16.0, "y": 3254.5}
+{"align": "left", "c": "e8e8e8", "h": 25.0, "id": "r.1.1.0.85.1", "sc": "settings", "size": 20, "t": "text", "text": "Skip Intro On Seek", "w": 164.0, "x": 46.0, "y": 3252.0}
+{"align": "left", "bold": true, "c": "e8e8e8", "h": 25.0, "id": "r.1.1.0.86", "sc": "settings", "size": 20, "t": "text", "text": "Library Browser", "w": 1238.0, "x": 16.0, "y": 3285.0}
+{"align": "left", "c": "9aa0a6", "h": 21.2, "id": "r.1.1.0.87.0", "sc": "settings", "size": 17, "t": "text", "text": "Library Image Cache Mb", "w": 340.0, "x": 16.0, "y": 3326.4}
+{"h": 38.0, "id": "set-library_image_cache_mb", "ph": "", "sc": "settings", "size": 20, "t": "textbox", "text": "256", "w": 340.0, "x": 368.0, "y": 3318.0}
+{"align": "left", "c": "9aa0a6", "h": 21.2, "id": "r.1.1.0.88.0", "sc": "settings", "size": 17, "t": "text", "text": "Scroll Wheel Pixels", "w": 340.0, "x": 16.0, "y": 3372.4}
+{"h": 38.0, "id": "set-scroll_wheel_pixels", "ph": "", "sc": "settings", "size": 20, "t": "textbox", "text": "80", "w": 340.0, "x": 368.0, "y": 3364.0}
+{"align": "left", "c": "9aa0a6", "h": 17.5, "id": "r.1.1.0.89", "sc": "settings", "size": 14, "t": "text", "text": "Pixels one wheel notch scrolls. On a grid this is rounded so a whole number of notches spans one row, whichever scroll mode you are in \u2014 a trackpad or trackball never leaves you a sliver of a", "w": 1238.0, "x": 16.0, "y": 3410.0}
+{"align": "left", "c": "9aa0a6", "h": 17.5, "id": "r.1.1.0.89.l1", "sc": "settings", "size": 14, "t": "text", "text": "row off. Raise it to scroll faster, lower it for finer control.", "w": 1238.0, "x": 16.0, "y": 3427.5}
+{"align": "left", "c": "9aa0a6", "h": 21.2, "id": "r.1.1.0.90.0", "sc": "settings", "size": 17, "t": "text", "text": "Scroll Mode", "w": 340.0, "x": 16.0, "y": 3461.4}
+{"force": true, "h": 38.0, "id": "set-scroll_mode", "items": ["Continuous", "Aligned to rows", "One row per notch"], "sc": "settings", "sel": 0, "size": 20, "t": "dropdown", "w": 340.0, "x": 368.0, "y": 3453.0}
+{"align": "left", "c": "9aa0a6", "h": 17.5, "id": "r.1.1.0.91", "sc": "settings", "size": 14, "t": "text", "text": "\"Continuous\" scrolls by pixels and lands wherever the wheel puts it; it lines rows up by itself if the display cannot keep up. Pick \"Aligned to rows\" if scrolling still stutters \u2014 on a very large", "w": 1238.0, "x": 16.0, "y": 3499.0}
+{"align": "left", "c": "9aa0a6", "h": 17.5, "id": "r.1.1.0.91.l1", "sc": "settings", "size": 14, "t": "text", "text": "display, a slow or remote one, or with an external MPV. Pick \"One row per notch\" to move a whole row (or one home-screen section) at a time.", "w": 1238.0, "x": 16.0, "y": 3516.5}
+{"click": true, "h": 25.0, "hover": {"c": "747474"}, "id": "set-paginated", "sc": "settings", "t": "rect", "w": 1238.0, "x": 16.0, "y": 3542.0}
+{"bc": "3a3d42", "bw": 1, "fill": "2a2d33", "h": 20.0, "id": "r.1.1.0.92.0", "radius": 5, "sc": "settings", "t": "rect", "w": 20.0, "x": 16.0, "y": 3544.5}
+{"align": "left", "c": "e8e8e8", "h": 25.0, "id": "r.1.1.0.92.1", "sc": "settings", "size": 20, "t": "text", "text": "Paginated", "w": 89.2, "x": 46.0, "y": 3542.0}
+{"align": "left", "c": "9aa0a6", "h": 17.5, "id": "r.1.1.0.93", "sc": "settings", "size": 14, "t": "text", "text": "Page the library and music tile grids instead of scrolling: each page is one screenful with First / Previous / Next / Last controls and a page number you can type into. Easier than precise", "w": 1238.0, "x": 16.0, "y": 3575.0}
+{"align": "left", "c": "9aa0a6", "h": 17.5, "id": "r.1.1.0.93.l1", "sc": "settings", "size": 14, "t": "text", "text": "scrolling on a trackpad.", "w": 1238.0, "x": 16.0, "y": 3592.5}
+{"align": "left", "bold": true, "c": "e8e8e8", "h": 25.0, "id": "r.1.1.0.94", "sc": "settings", "size": 20, "t": "text", "text": "Downloads", "w": 1238.0, "x": 16.0, "y": 3618.0}
+{"align": "left", "c": "9aa0a6", "h": 21.2, "id": "r.1.1.0.95.0", "sc": "settings", "size": 17, "t": "text", "text": "Download Folder", "w": 340.0, "x": 16.0, "y": 3662.9}
+{"h": 38.0, "id": "set-sync_path", "ph": "", "sc": "settings", "size": 20, "t": "textbox", "text": "", "w": 250.0, "x": 368.0, "y": 3654.5}
+{"click": true, "fill": "2e3138", "h": 45.0, "hover": {"fill": "3a3e46"}, "id": "set-sync-move", "radius": 6, "sc": "settings", "t": "rect", "w": 69.4, "x": 626.0, "y": 3651.0}
+{"align": "center", "c": "e8e8e8", "h": 25.0, "id": "r.1.1.0.95.1.1.0", "sc": "settings", "size": 20, "t": "text", "text": "Move", "w": 49.4, "x": 636.0, "y": 3661.0}
+{"click": true, "h": 25.0, "hover": {"c": "747474"}, "id": "set-prefer_downloaded", "sc": "settings", "t": "rect", "w": 1238.0, "x": 16.0, "y": 3704.0}
+{"fill": "00a4dc", "h": 20.0, "id": "r.1.1.0.96.0", "radius": 5, "sc": "settings", "t": "rect", "w": 20.0, "x": 16.0, "y": 3706.5}
+{"align": "center", "c": "ffffff", "h": 18.8, "id": "r.1.1.0.96.0.0", "sc": "settings", "size": 15, "t": "text", "text": "\u2713", "w": 20.0, "x": 16.0, "y": 3707.1}
+{"align": "left", "c": "e8e8e8", "h": 25.0, "id": "r.1.1.0.96.1", "sc": "settings", "size": 20, "t": "text", "text": "Prefer Downloaded Copy", "w": 218.2, "x": 46.0, "y": 3704.0}
+{"click": true, "h": 25.0, "hover": {"c": "747474"}, "id": "set-auto_download_enable", "sc": "settings", "t": "rect", "w": 1238.0, "x": 16.0, "y": 3737.0}
+{"bc": "3a3d42", "bw": 1, "fill": "2a2d33", "h": 20.0, "id": "r.1.1.0.97.0", "radius": 5, "sc": "settings", "t": "rect", "w": 20.0, "x": 16.0, "y": 3739.5}
+{"align": "left", "c": "e8e8e8", "h": 25.0, "id": "r.1.1.0.97.1", "sc": "settings", "size": 20, "t": "text", "text": "Automatically Download Upcoming Episodes", "w": 404.2, "x": 46.0, "y": 3737.0}
+{"align": "left", "c": "9aa0a6", "h": 17.5, "id": "r.1.1.0.98", "sc": "settings", "size": 14, "t": "text", "text": "Applies to srv1, enable other servers in servers tab.", "w": 1238.0, "x": 16.0, "y": 3770.0}
+{"click": true, "h": 25.0, "hover": {"c": "747474"}, "id": "set-auto_download_next_up", "sc": "settings", "t": "rect", "w": 1238.0, "x": 16.0, "y": 3795.5}
+{"fill": "00a4dc", "h": 20.0, "id": "r.1.1.0.99.0", "radius": 5, "sc": "settings", "t": "rect", "w": 20.0, "x": 16.0, "y": 3798.0}
+{"align": "center", "c": "ffffff", "h": 18.8, "id": "r.1.1.0.99.0.0", "sc": "settings", "size": 15, "t": "text", "text": "\u2713", "w": 20.0, "x": 16.0, "y": 3798.6}
+{"align": "left", "c": "e8e8e8", "h": 25.0, "id": "r.1.1.0.99.1", "sc": "settings", "size": 20, "t": "text", "text": "Include Next Up", "w": 140.4, "x": 46.0, "y": 3795.5}
+{"align": "left", "c": "9aa0a6", "h": 21.2, "id": "r.1.1.0.100.0", "sc": "settings", "size": 17, "t": "text", "text": "Next Up Entries to Consider", "w": 340.0, "x": 16.0, "y": 3836.9}
+{"h": 38.0, "id": "set-auto_download_next_up_limit", "ph": "", "sc": "settings", "size": 20, "t": "textbox", "text": "10", "w": 340.0, "x": 368.0, "y": 3828.5}
+{"align": "left", "c": "9aa0a6", "h": 21.2, "id": "r.1.1.0.101.0", "sc": "settings", "size": 17, "t": "text", "text": "Episodes to Keep Ahead (0 = off)", "w": 340.0, "x": 16.0, "y": 3882.9}
+{"h": 38.0, "id": "set-auto_download_lookahead", "ph": "", "sc": "settings", "size": 20, "t": "textbox", "text": "2", "w": 340.0, "x": 368.0, "y": 3874.5}
+{"align": "left", "c": "9aa0a6", "h": 21.2, "id": "r.1.1.0.102.0", "sc": "settings", "size": 17, "t": "text", "text": "Storage Limit for Automatic Downloads (GB)", "w": 340.0, "x": 16.0, "y": 3928.9}
+{"h": 38.0, "id": "set-auto_download_max_gb", "ph": "", "sc": "settings", "size": 20, "t": "textbox", "text": "20", "w": 340.0, "x": 368.0, "y": 3920.5}
+{"click": true, "h": 25.0, "hover": {"c": "747474"}, "id": "set-auto_download_delete_watched", "sc": "settings", "t": "rect", "w": 1238.0, "x": 16.0, "y": 3966.5}
+{"fill": "00a4dc", "h": 20.0, "id": "r.1.1.0.103.0", "radius": 5, "sc": "settings", "t": "rect", "w": 20.0, "x": 16.0, "y": 3969.0}
+{"align": "center", "c": "ffffff", "h": 18.8, "id": "r.1.1.0.103.0.0", "sc": "settings", "size": 15, "t": "text", "text": "\u2713", "w": 20.0, "x": 16.0, "y": 3969.6}
+{"align": "left", "c": "e8e8e8", "h": 25.0, "id": "r.1.1.0.103.1", "sc": "settings", "size": 20, "t": "text", "text": "Delete Automatic Downloads Once Watched", "w": 392.6, "x": 46.0, "y": 3966.5}
+{"align": "left", "c": "9aa0a6", "h": 21.2, "id": "r.1.1.0.104.0", "sc": "settings", "size": 17, "t": "text", "text": "Delete Unwatched After (days, 0 = never)", "w": 340.0, "x": 16.0, "y": 4007.9}
+{"h": 38.0, "id": "set-auto_download_keep_days", "ph": "", "sc": "settings", "size": 20, "t": "textbox", "text": "30", "w": 340.0, "x": 368.0, "y": 3999.5}
+{"align": "left", "c": "9aa0a6", "h": 21.2, "id": "r.1.1.0.105.0", "sc": "settings", "size": 17, "t": "text", "text": "Check Every (minutes)", "w": 340.0, "x": 16.0, "y": 4053.9}
+{"h": 38.0, "id": "set-auto_download_interval_mins", "ph": "", "sc": "settings", "size": 20, "t": "textbox", "text": "60", "w": 340.0, "x": 368.0, "y": 4045.5}
+{"click": true, "h": 25.0, "hover": {"c": "747474"}, "id": "set-adv", "sc": "settings", "t": "rect", "w": 1238.0, "x": 16.0, "y": 4091.5}
+{"bc": "3a3d42", "bw": 1, "fill": "2a2d33", "h": 20.0, "id": "r.1.1.0.106.0", "radius": 5, "sc": "settings", "t": "rect", "w": 20.0, "x": 16.0, "y": 4094.0}
+{"align": "left", "c": "e8e8e8", "h": 25.0, "id": "r.1.1.0.106.1", "sc": "settings", "size": 20, "t": "text", "text": "Show advanced settings", "w": 222.2, "x": 46.0, "y": 4091.5}
+{"align": "left", "c": "9aa0a6", "h": 17.5, "id": "r.1.1.0.107", "sc": "settings", "size": 14, "t": "text", "text": "Some changes take effect after restarting.", "w": 1238.0, "x": 16.0, "y": 4124.5}

--- a/tests/test_docs_coverage.py
+++ b/tests/test_docs_coverage.py
@@ -99,6 +99,8 @@ class DocsCoverageTest(unittest.TestCase):
             "continuous", "aligned", "row",
             # hud_scrim / hud_autohide values
             "half", "panel", "hover", "always", "paused",
+            # segment_* values
+            "off", "ask",
             # language_config rule keys
             "type", "subtype", "alang", "slang", "amatch", "smatch",
             "aprefer", "sprefer", "aexclude", "sexclude",

--- a/tests/test_docs_coverage.py
+++ b/tests/test_docs_coverage.py
@@ -97,6 +97,8 @@ class DocsCoverageTest(unittest.TestCase):
             "none", "null", "jellyfin", "nebula",
             # scroll_mode values
             "continuous", "aligned", "row",
+            # hud_scrim / hud_autohide values
+            "half", "panel", "hover", "always", "paused",
             # language_config rule keys
             "type", "subtype", "alang", "slang", "amatch", "smatch",
             "aprefer", "sprefer", "aexclude", "sexclude",

--- a/tests/test_playstate_payload.py
+++ b/tests/test_playstate_payload.py
@@ -315,7 +315,7 @@ class TestTheButtonSurvivesSeekToSkipBeingOff(unittest.TestCase):
     def test_the_button_is_offered_with_seek_to_skip_turned_off(self):
         self.assertIsNotNone(
             self._hud_skip_after_update(skip_intro_on_seek=False,
-                                        skip_intro_enable=True),
+                                        segment_intro="ask"),
             "turning seek-to-skip off took the button with it")
 
     def test_turning_the_button_itself_off_does_remove_it(self):
@@ -323,10 +323,13 @@ class TestTheButtonSurvivesSeekToSkipBeingOff(unittest.TestCase):
         can never be turned off at all."""
         self.assertIsNone(
             self._hud_skip_after_update(skip_intro_on_seek=True,
-                                        skip_intro_enable=False,
-                                        skip_intro_always=False,
-                                        skip_credits_enable=False,
-                                        skip_credits_always=False))
+                                        segment_intro="off",
+                                        segment_outro="off"))
+
+    def test_always_skips_instead_of_offering(self):
+        """The third state the booleans could only express as a pair."""
+        self.assertIsNone(
+            self._hud_skip_after_update(segment_intro="always"))
 
 
 class TestReportingIsWiredIn(unittest.TestCase):
@@ -528,3 +531,140 @@ class TestNoPlayerControls(unittest.TestCase):
 
     def test_the_setting_is_gone_rather_than_migrated(self):
         self.assertFalse(hasattr(settings, "enable_osc"))
+
+
+class TestMediaSegmentTypes(unittest.TestCase):
+    """#575: intros and credits were two pairs of booleans; the server
+    publishes five kinds of segment and jellyfin-web offers three actions
+    for each."""
+
+    def test_every_type_has_a_setting_and_an_action(self):
+        from jellyfin_mpv_shim import conf
+
+        for seg_type, key in conf.SEGMENT_SETTINGS.items():
+            with self.subTest(seg_type):
+                self.assertTrue(hasattr(settings, key))
+                self.assertIn(conf.segment_action(seg_type),
+                              conf.SEGMENT_ACTIONS)
+
+    def test_intros_and_credits_still_ask_by_default(self):
+        self.assertEqual(settings.segment_intro, "ask")
+        self.assertEqual(settings.segment_outro, "ask")
+
+    def test_the_new_three_are_off_by_default(self):
+        """A segment skipped out from under you is worse than one you have
+        to skip yourself, and these are far less common."""
+        for key in ("segment_commercial", "segment_preview",
+                    "segment_recap"):
+            self.assertEqual(getattr(settings, key), "off", key)
+
+    def test_an_unknown_type_is_left_alone(self):
+        """A newer server, or a hand-edited value. Skipping something we
+        cannot name is the one unrecoverable answer."""
+        from jellyfin_mpv_shim import conf
+
+        self.assertEqual(conf.segment_action("Unknown"), "off")
+        self.assertEqual(conf.segment_action("SomethingNew"), "off")
+
+    def test_only_wanted_types_are_requested(self):
+        from jellyfin_mpv_shim import conf
+
+        with mock.patch.object(settings, "segment_intro", "ask"), \
+                mock.patch.object(settings, "segment_outro", "off"), \
+                mock.patch.object(settings, "segment_recap", "always"):
+            self.assertEqual(sorted(conf.wanted_segment_types()),
+                             ["Intro", "Recap"])
+            self.assertTrue(conf.any_segment_wanted())
+
+    def test_nothing_wanted_means_no_request_at_all(self):
+        from jellyfin_mpv_shim import conf
+
+        patches = [mock.patch.object(settings, k, "off")
+                   for k in conf.SEGMENT_SETTINGS.values()]
+        for p in patches:
+            p.start()
+            self.addCleanup(p.stop)
+        self.assertFalse(conf.any_segment_wanted())
+        self.assertEqual(conf.wanted_segment_types(), [])
+
+    def test_each_type_names_itself_in_its_labels(self):
+        """"Skip Recap" is not "Skip Intro" -- and whole phrases, because a
+        language that inflects the verb with its object cannot fix a
+        sentence assembled after translation."""
+        from jellyfin_mpv_shim.media import segment_labels
+
+        seen = {t: segment_labels(t)[0]
+                for t in ("Intro", "Outro", "Commercial", "Preview", "Recap")}
+        self.assertEqual(len(set(seen.values())), 5, seen)
+        # An unknown type still has something to put on the button.
+        self.assertTrue(segment_labels("Whatever")[0])
+
+
+class TestSegmentSettingsMigration(unittest.TestCase):
+    """The four booleans carried a real choice, so unlike the other
+    migrations this one is about preserving it rather than overriding it."""
+
+    def _migrated(self, **old):
+        from jellyfin_mpv_shim.conf import Settings
+
+        cfg = Settings()
+        cfg.config_version = 1
+        cfg._migrate(old)
+        return cfg
+
+    def test_always_wins_over_ask(self):
+        cfg = self._migrated(skip_intro_always=True, skip_intro_enable=True)
+        self.assertEqual(cfg.segment_intro, "always")
+
+    def test_ask_carries_over(self):
+        cfg = self._migrated(skip_credits_always=False,
+                             skip_credits_enable=True)
+        self.assertEqual(cfg.segment_outro, "ask")
+
+    def test_off_carries_over(self):
+        cfg = self._migrated(skip_intro_always=False,
+                             skip_intro_enable=False,
+                             skip_credits_always=False,
+                             skip_credits_enable=False)
+        self.assertEqual(cfg.segment_intro, "off")
+        self.assertEqual(cfg.segment_outro, "off")
+
+    def test_a_config_without_the_old_keys_keeps_the_defaults(self):
+        cfg = self._migrated()
+        self.assertEqual(cfg.segment_intro, "ask")
+        self.assertEqual(cfg.segment_outro, "ask")
+
+    def test_a_quoted_boolean_is_read_the_way_the_schema_read_it(self):
+        """The keys being migrated were declared `bool`, which in this
+        schema means adv_bool -- and adv_bool says the STRINGS "false"/"no"/
+        "0"/"off" are False while Python's bool() says all four are True.
+
+        A hand-edited or templated conf.json that quotes its booleans would
+        otherwise migrate "skip_intro_always": "false" to `always`: silently
+        skipping intros for someone who had asked to be prompted, with the
+        source keys dropped on the next save so the evidence goes too.
+        """
+        for false_ish in ("false", "no", "0", "off", "False", False, 0):
+            with self.subTest(value=false_ish):
+                cfg = self._migrated(skip_intro_always=false_ish,
+                                     skip_intro_enable="true")
+                self.assertEqual(cfg.segment_intro, "ask",
+                                 "%r read as always" % (false_ish,))
+                cfg = self._migrated(skip_intro_always=false_ish,
+                                     skip_intro_enable=false_ish)
+                self.assertEqual(cfg.segment_intro, "off",
+                                 "%r read as ask" % (false_ish,))
+
+    def test_a_quoted_true_still_migrates(self):
+        """The other direction, or the check above is just a way of never
+        migrating anything."""
+        cfg = self._migrated(skip_intro_always="true")
+        self.assertEqual(cfg.segment_intro, "always")
+        cfg = self._migrated(skip_credits_enable="yes")
+        self.assertEqual(cfg.segment_outro, "ask")
+
+    def test_it_stamps_the_version_so_it_runs_once(self):
+        from jellyfin_mpv_shim.conf import CONFIG_VERSION
+
+        cfg = self._migrated(skip_intro_enable=False)
+        self.assertEqual(cfg.config_version, CONFIG_VERSION)

--- a/tests/test_shell_playback.py
+++ b/tests/test_shell_playback.py
@@ -215,6 +215,118 @@ class TestPlaybackHudLayout(unittest.TestCase):
         self.assertIn(("chapter_seek", (-1,)), ctl.transport)
         self.assertIn(("chapter_seek", (1,)), ctl.transport)
 
+class TestHudScrimAndAutohide(unittest.TestCase):
+    """#620: the shading over the picture was the first thing anyone
+    mentioned, and the controls never hid on a paused film."""
+
+    def setUp(self):
+        from jellyfin_mpv_shim.conf import settings
+        self.settings = settings
+        for key in ("hud_scrim", "hud_autohide", "hud_hide_secs",
+                    "hud_sub_margin"):
+            self.addCleanup(setattr, settings, key, getattr(settings, key))
+
+    def _browser(self):
+        ctl = HudController()
+        b = MpvtkBrowser(app=None, source=FakeSource(), controller=ctl)
+        b._browsing = False
+        b.hud.shown = True
+        b.hud.state = {"stopped": False, "is_audio": False,
+                       "title": "Movie", "position": 50.0,
+                       "duration": 100.0, "paused": False,
+                       "volume": 80, "muted": False}
+        return b, ctl
+
+    def _scrims(self, style):
+        self.settings.hud_scrim = style
+        b, _ctl = self._browser()
+        nodes, _h = build_scene(b, (1280, 720))
+        return [n for n in nodes if n.get("t") == "grad"]
+
+    def test_the_default_shading_is_shorter_than_it_was(self):
+        """It was ~2.2x the bar plus headroom that bought nothing; what is
+        left is the part the controls actually sit on."""
+        grads = self._scrims("default")
+        self.assertTrue(grads)
+        self.assertLessEqual(max(g["h"] for g in grads), 300)
+
+    def test_half_halves_the_bottom_ramp(self):
+        full = max(g["h"] for g in self._scrims("default"))
+        half = max(g["h"] for g in self._scrims("half"))
+        self.assertAlmostEqual(half, full / 2, delta=2)
+
+    def test_half_leaves_the_TOP_band_alone(self):
+        """Halving it too put the title and the top-row buttons in the
+        fading half of a 65px ramp — unreadable over a bright frame, for a
+        strip of picture nobody was looking at."""
+        top_full = min(g["h"] for g in self._scrims("default"))
+        top_half = min(g["h"] for g in self._scrims("half"))
+        self.assertEqual(top_half, top_full,
+                         "the top scrim was halved with the bottom one")
+
+    def _bar(self, style):
+        self.settings.hud_scrim = style
+        b, _ctl = self._browser()
+        nodes, _h = build_scene(b, (1280, 720))
+        return next(n for n in nodes if n.get("id") == "hud-bar")
+
+    def test_panel_draws_no_gradient_and_backs_the_bars_instead(self):
+        self.assertEqual(self._scrims("panel"), [])
+        self.assertTrue(self._bar("panel").get("a", 255) > 0,
+                        "the bar has no band behind it")
+
+    def test_the_bars_exist_as_nodes_even_with_nothing_drawn(self):
+        """The renderer holds the auto-hide off while the pointer is over
+        them, which means it has to find them in the scene -- and layout
+        only emits a container that has something to draw."""
+        self.assertEqual(self._bar("none").get("a"), 0)
+
+    def test_none_draws_nothing_and_asks_for_the_text_halo(self):
+        """Legibility has to come from somewhere: with no shading the
+        renderer gives the glyphs a dark halo instead."""
+        from jellyfin_mpv_shim.mpvtk_browser.gateway.hud import HudMixin
+
+        self.assertEqual(self._scrims("none"), [])
+        self.settings.hud_scrim = "none"
+        self.assertTrue(HudMixin().hud_key_opts()["shadow"])
+        self.settings.hud_scrim = "default"
+        self.assertFalse(HudMixin().hud_key_opts()["shadow"])
+
+    def test_the_bars_carry_the_ids_the_renderer_hover_test_needs(self):
+        b, _ctl = self._browser()
+        nodes, _h = build_scene(b, (1280, 720))
+        present = ids(nodes)
+        for nid in ("hud-bar", "hud-topbar"):
+            self.assertIn(nid, present)
+
+    def test_the_autohide_policy_travels_with_the_engage(self):
+        """Which is what makes a settings change stick without a restart:
+        engage re-sends it every time."""
+        from jellyfin_mpv_shim.mpvtk_browser.gateway.hud import HudMixin
+
+        self.settings.hud_autohide = "always"
+        self.settings.hud_hide_secs = 1.5
+        opts = HudMixin().hud_key_opts()
+        self.assertEqual(opts["mode"], "always")
+        self.assertEqual(opts["hide"], 1.5)
+
+    def test_subtitles_can_be_left_where_they_are(self):
+        from unittest import mock
+        from jellyfin_mpv_shim.mpvtk_browser.gateway.hud import HudMixin
+        import jellyfin_mpv_shim.player as player_mod
+
+        class _P:
+            sub_pos = 100
+            sub_margin_y = 22
+
+        pm = mock.Mock(_player=_P())
+        gw = HudMixin()
+        self.settings.hud_sub_margin = False
+        with mock.patch.object(player_mod, "playerManager", pm):
+            gw.hud_sub_margin(True)
+        self.assertEqual(_P.sub_margin_y, 22, "subtitles were moved anyway")
+
+
 class TestPlaybackHudMenusAndFavorite(unittest.TestCase):
     def _browser(self, size=(1280, 720)):
         ctl = HudController()


### PR DESCRIPTION
UI settings and configuration improvements.

**#620** makes the Jellyfin UI OSC more configurable:
- Make shading on gradient less obtrusive and provide a solid block and shadow-based alternative.
- Allows configuring how auto-hide works and how long it takes to activate.

**#575** Adds support for commercials, previews, and recaps. It updates these settings to be drop-downs like web uses instead of 10 checkboxes.

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>