### PR TITLE
hud: draw the scrub preview in the renderer (#618, #612)

### DIFF
--- a/docs/UI_UX_FIXES_2026-08.md
+++ b/docs/UI_UX_FIXES_2026-08.md
@@ -11,18 +11,24 @@ changes (renderer-side scrub preview, true virtual scroll) landing as their
 own commits separate from the small fixes. Shared groundwork (the mpvtk
 disabled state) lands before the issue that needs it.
 
-| # | Title | Size |
+| # | Title | State |
 |---|---|---|
-| [612](#612--hover-bubble-position-depends-on-chapter-title-length) | Hover bubble position depends on chapter-title length | S (or folded into 618) |
-| [613](#613--hiding-titles-also-hides-the-year) | Hiding titles also hides the year | S + groundwork |
-| [614](#614--mouse-backforward-buttons-seek-chapters) | Mouse back/forward → chapter seek | S |
-| [615](#615--enable-osc-does-nothing-under-the-jellyfin-ui) | "Enable OSC" does nothing under the Jellyfin UI | S |
-| [616](#616--cover-size-in-the-library-view-dialog) | Cover Size in the library View dialog | M |
-| [617](#617--scrollbar-loses-the-drag-while-items-page-in) | Scrollbar loses the drag while items page in | L |
-| [618](#618--controls-slow-to-update-visually) | Controls slow to update visually | S + L |
-| [620](#620--playback-hud-design-feedback) | Playback HUD design feedback | M |
-| [575](#575--commercial--preview--recap-segments) | Commercial / Preview / Recap segments | M |
-| [560](#560--continue-watching-doesnt-update) | Continue Watching doesn't update | M |
+| — | Groundwork: mpvtk disabled state | done `c968d588` |
+| [618(a)](#618--controls-slow-to-update-visually) | Mute/volume lag behind the ticker | done `29921e31` |
+| [613](#613--hiding-titles-also-hides-the-year) | Hiding titles also hides the year | done `53e14fc6` |
+| [614](#614--mouse-backforward-buttons-seek-chapters) | Mouse back/forward → chapter seek | done `d35e5e38` |
+| [615](#615--enable-osc-does-nothing-under-the-jellyfin-ui) | "Enable OSC" does nothing under the Jellyfin UI | done `f6a2210d` |
+| [616](#616--cover-size-in-the-library-view-dialog) | Cover Size in the library View dialog | done `ee8415dc` |
+| [560](#560--continue-watching-doesnt-update) | Continue Watching doesn't update | done `fbd119c9` |
+| [620](#620--playback-hud-design-feedback) | Playback HUD design feedback | done `456682c5` |
+| [575](#575--commercial--preview--recap-segments) | Commercial / Preview / Recap segments | done `88da297a` |
+| [618(b)](#618b--renderer-side-scrub-preview) + [612](#612--hover-bubble-position-depends-on-chapter-title-length) | Renderer-side scrub preview | **TODO** |
+| [617](#617--scrollbar-loses-the-drag-while-items-page-in) | True virtual scroll | **TODO** |
+
+Everything above the line is on `ui-ux-fixes`, one commit each, with the full
+unit suite green after each. What is left is the two structural changes; the
+implementation notes gathered while doing the rest are under
+[Notes for the remaining two](#notes-for-the-remaining-two).
 
 ---
 
@@ -264,6 +270,7 @@ Applies to every infinite-scroll route: grid, person, music, music_genre.
 ---
 
 ## #618 — controls slow to update visually
+<a id="618b--renderer-side-scrub-preview"></a>
 
 Two separate problems behind one report.
 
@@ -454,24 +461,123 @@ through `enter_browse`, which does not reload.
 
 ---
 
+## Notes for the remaining two
+
+Everything below was learned while doing the other eight. It is here because
+none of it is discoverable from the issue text, and some of it is a trap.
+
+### 618(b) — renderer-side scrub preview
+
+**The data is already there, in the shape the renderer wants.**
+
+- `trickplay.py` writes **raw BGRA frames back to back**, which is exactly what
+  `overlay-add` consumes, and frame *n* starts at `n * w * h * 4`. No decode,
+  no PIL, nothing on the loop thread.
+- Two messages already exist and are still sent:
+  `shim-trickplay-bif` (count, multiplier, width, height, path) and
+  `shim-trickplay-chapters` (width, height, path, comma-separated start
+  times) — the second is the fallback when the server has no BIF data. Both
+  need handling; today the mpvtk HUD ignores both and reads
+  `player.trickplay_meta` from Python instead.
+- The renderer's image path (`renderer.lua`, `_arrange_image`'s consumer)
+  already does the crop-offset arithmetic: `offset = sy * stride + sx * 4`.
+  A trickplay frame needs that plus a **base** offset. Note the `&`-address
+  branch right there: for the same-process memory form the crop offset is
+  folded into the address instead, and a trickplay tile is a *file* path, so
+  the plain offset argument is the one that applies.
+- **Chapters need no push at all.** mpv has `chapter-list` natively; the
+  renderer can read it the same way it reads `pause`. The gateway's
+  `chapters()` exists for the Python-built pickers, not for this.
+
+**What comes out**, once the renderer owns the bubble: `hud._preview_float`,
+`hud._trickplay_frame`, `HudController.hover` / `hover_move` / `hover_end`,
+and the seek slider's `on_hover` / `on_hover_end` wiring.
+
+**Do not remove the hover machinery wholesale.** `update_slider_hover`
+handles *two* different things that read alike:
+
+- `hoverev` — the slider's throttled **value** reporting, which is what this
+  change makes unnecessary (`notify_hover` / `fire_hover` / `hover_watch`,
+  the 0.15s throttle).
+- `hev` / `on_hover` — plain enter/leave events on ordinary nodes, which the
+  **tile play-chip** depends on. Untouched.
+
+**Constraints.** `renderer.lua` is at LuaJIT's 200-file-scope-local ceiling
+(`tests/test_renderer_lua.py` reports the headroom and skips with an
+explanation when it is gone), so anything new hangs off `state` or shares a
+table — `PHUD_HIDE` is the pattern. The preview bitmap is one more overlay
+against `MAX_OVERLAYS`. `_SLIDER_PAD` is already pinned across the two sides
+by `tests/test_python_lua_constants.py`; whatever geometry the bubble grows
+belongs there too.
+
+**#612 closes with this**, not before: the renderer measures its own text, so
+the "assume a width, draw another" bug has nowhere to live. Both the hover
+case and the drag case are covered — the renderer knows the dragged value
+locally.
+
+### 617 — true virtual scroll
+
+- `tile_renderer.grid_of` takes `nrows` from `len(items)`; it needs the total.
+  `route["_total"]` is already set by every loader and already drawn in the
+  header's "%(shown)d of %(total)d".
+- `Paginator.more` (append-from-the-end) and `Paginator._fetch` (arbitrary
+  offset, bounded window) are the two halves; this is closer to unifying them
+  than to writing a third mode.
+- **`_items` goes sparse**: 5 files, 28 sites. The consumers to audit are the
+  ones that mean "everything on screen" — Play All and Shuffle
+  (`pages/grid.py`), the count line, `pages/queue_edit.py`,
+  `settings/home.py`, `tiles.py`.
+- **The Random-sort trap.** `PersonPage.load` (and the grid loader) deliberately
+  set `_total = len(items)` when the sort is Random, because the server
+  reshuffles per request and paging it yields duplicates and gaps. A grid
+  sized from `_total` must keep that: random cannot be windowed, and sizing it
+  to the real total would ask for pages that come back scrambled.
+- Renderer drag anchoring rides along: `state.drag` keeps a fixed `start_off`
+  and multiplies by a live `maxs`. The fix is the pattern already used by the
+  dropdown's own scrollbar a few hundred lines away — store the grab offset
+  *inside the thumb* and derive the offset from absolute `y`.
+- Unchanged: `snap` / `snap_off` on the VScroll, `PAGE_SLOP`, `PAGE_MAX`.
+
+**Two questions worth settling before writing it** (see the message that
+accompanied this update):
+
+1. Does Play All / Shuffle over a sparsely-loaded grid fetch the full id list,
+   or keep today's "whatever is loaded" behaviour?
+2. Is paginated mode in scope, or does it stay as it is? (It has no scrollbar,
+   so it has none of this bug.)
+
+## Working notes
+
+Conventions this branch had to follow, collected so the next session does not
+rediscover them:
+
+- **Run the suite as `xvfb-run -a python3 -m unittest discover tests` from the
+  repo root.** Two pre-existing warts: several modules (`test_shell_playback`,
+  …) cannot be run *by name* because they rely on discover to set `sys.argv`
+  before the app parses it; and `tests.test_mpv_options` plus
+  `tests.test_playstate_payload` **segfault at interpreter exit when run
+  together** — on the untouched tree too. `discover` hits neither.
+- **Any new setting** needs: an entry in `docs/configuration.md` (enforced by
+  `tests/test_docs_coverage.py`), its *values* added to that test's
+  `vocabulary` set if it is an enum, a row in `mpvtk_browser/config.py`
+  (SECTIONS + LABELS + NOTES), a regenerated
+  `tests/snapshots/settings.jsonl` (`python3 tests/test_scene_snapshots.py
+  --update`), and `./regen_pot.sh`.
+- **`./regen_pot.sh` only.** Never `--merge`, never touch the per-locale `.po`
+  files; that is Weblate's job and merging locally collides with master in
+  files nobody on the branch edited.
+
 ## Order of work
 
 Groundwork first, then the small fixes, then the two structural changes. One
 commit each.
 
-1. This document.
-2. Groundwork — mpvtk disabled state.
-3. #618(a) — observe `mute` / `volume`.
-4. #613 — year-only captions.
-5. #614 — mouse chapter navigation.
-6. #615 — `osc_style: none`.
-7. #616 — live cover size.
-8. #560 — `UserDataChanged` + refresh on return.
-9. #620 — HUD scrim / auto-hide / subtitle-margin settings (+ renderer text
-   shadow).
-10. #575 — media segment types.
+Steps 1–10 are done (see the table at the top). What remains:
+
 11. #618(b) + #612 — renderer-side scrub preview.
 12. #617 — true virtual scroll.
+
+Either order; they touch nothing in common.
 
 ## Decisions taken without asking
 
@@ -483,3 +589,16 @@ Small enough to reverse, recorded so they are not mistaken for oversights.
   ±10s/+30s would be a different feature wearing the same setting's name.
 - **#613 greying:** none, for the reason recorded under that issue — the
   premise for it turned out not to hold.
+- **#620's zero delay is floored at 0.5s.** `hud_hide_secs: 0` forces hover
+  mode as intended, but a literal zero would also blink the controls out in
+  the same frame as the mouse motion that summoned them. If 0 should instead
+  mean "no timer at all, visibility is purely the hover test", that is a
+  different mechanism — the controls would only ever appear with the pointer
+  in the bottom band — and wants building separately.
+- **#620's `panel` scrim is a full-width band** the height of each bar, and it
+  is painted as the bars' own background rather than as a separate node. The
+  bars therefore carry a fill in *every* mode (transparent when there is no
+  panel), because `layout` only emits a container node that has something to
+  draw and the renderer needs those two rects to exist — it tests the pointer
+  against them for the hover-hold. Their ids (`hud-bar`, `hud-topbar`) are a
+  contract with `renderer.lua`'s `phud_busy`.

--- a/docs/UI_UX_FIXES_2026-08.md
+++ b/docs/UI_UX_FIXES_2026-08.md
@@ -538,13 +538,33 @@ locally.
   *inside the thumb* and derive the offset from absolute `y`.
 - Unchanged: `snap` / `snap_off` on the VScroll, `PAGE_SLOP`, `PAGE_MAX`.
 
-**Two questions worth settling before writing it** (see the message that
-accompanied this update):
+**Play All and Shuffle are not affected** — checked against jellyfin-web at
+Izzie's suggestion, and the answer is that neither client plays "what is
+loaded".
 
-1. Does Play All / Shuffle over a sparsely-loaded grid fetch the full id list,
-   or keep today's "whatever is loaded" behaviour?
-2. Is paginated mode in scope, or does it stay as it is? (It has no scrollbar,
-   so it has none of this bug.)
+jellyfin-web hands the *query* to the playback manager and lets the server
+select: `getItemsForPlayback` (`playbackmanager.js:132`) caps every playback
+query at **`Limit: 300`**, and the only caller that opts out is PhotoAlbum,
+via the explicit `UNLIMITED_ITEMS = -1` sentinel. Its legacy library Shuffle
+runs its own `SortBy: Random, StartIndex: 0, Limit: 300`; the modern one
+passes `queryOptions` with `SortBy: Random` and takes the default cap. Play
+All fetches the *library folder* and lets the folder expand server-side —
+still through the same 300 cap.
+
+The shim already works this way: `_play_all` and `_shuffle`
+(`pages/grid.py:853-877`) call `get_play_all_ids` / `get_shuffle_ids`, which
+ask the server with the grid's own sort, filters and collection type, capped
+at 200. Neither reads `route["_items"]`, so making that sparse cannot reach
+them, and the "Play All plays the first hundred" hazard was designed out
+before this branch existed.
+
+One alignment taken while here: **our cap was 200 and web's is 300**, for no
+reason beyond when each was written. It is now `repository.QUEUE_LIMIT`, so
+the number has somewhere to explain itself.
+
+**Paginated mode stays as it is.** It has no scrollbar and no growing
+content, so none of this bug — unifying the two modes is a separate question
+from fixing the one that is broken.
 
 ## Working notes
 

--- a/docs/UI_UX_FIXES_2026-08.md
+++ b/docs/UI_UX_FIXES_2026-08.md
@@ -22,7 +22,7 @@ disabled state) lands before the issue that needs it.
 | [560](#560--continue-watching-doesnt-update) | Continue Watching doesn't update | done `fbd119c9` |
 | [620](#620--playback-hud-design-feedback) | Playback HUD design feedback | done `456682c5` |
 | [575](#575--commercial--preview--recap-segments) | Commercial / Preview / Recap segments | done `88da297a` |
-| [618(b)](#618b--renderer-side-scrub-preview) + [612](#612--hover-bubble-position-depends-on-chapter-title-length) | Renderer-side scrub preview | **TODO** |
+| [618(b)](#618b--renderer-side-scrub-preview) + [612](#612--hover-bubble-position-depends-on-chapter-title-length) | Renderer-side scrub preview | done `cb24f92d` |
 | [617](#617--scrollbar-loses-the-drag-while-items-page-in) | True virtual scroll | **TODO** |
 
 Everything above the line is on `ui-ux-fixes`, one commit each, with the full
@@ -466,54 +466,50 @@ through `enter_browse`, which does not reload.
 Everything below was learned while doing the other eight. It is here because
 none of it is discoverable from the issue text, and some of it is a trap.
 
-### 618(b) — renderer-side scrub preview
+### 618(b) — renderer-side scrub preview — DONE
 
-**The data is already there, in the shape the renderer wants.**
+Shipped as described below; what follows is what it actually came to, kept
+because the shape of the boundary is the useful part.
 
-- `trickplay.py` writes **raw BGRA frames back to back**, which is exactly what
-  `overlay-add` consumes, and frame *n* starts at `n * w * h * 4`. No decode,
-  no PIL, nothing on the loop thread.
-- Two messages already exist and are still sent:
-  `shim-trickplay-bif` (count, multiplier, width, height, path) and
-  `shim-trickplay-chapters` (width, height, path, comma-separated start
-  times) — the second is the fallback when the server has no BIF data. Both
-  need handling; today the mpvtk HUD ignores both and reads
-  `player.trickplay_meta` from Python instead.
-- The renderer's image path (`renderer.lua`, `_arrange_image`'s consumer)
-  already does the crop-offset arithmetic: `offset = sy * stride + sx * 4`.
-  A trickplay frame needs that plus a **base** offset. Note the `&`-address
-  branch right there: for the same-process memory form the crop offset is
-  folded into the address instead, and a trickplay tile is a *file* path, so
-  the plain offset argument is the one that applies.
-- **Chapters need no push at all.** mpv has `chapter-list` natively; the
-  renderer can read it the same way it reads `pause`. The gateway's
-  `chapters()` exists for the Python-built pickers, not for this.
+**The bubble is drawn in `render()`, from data that was already local.** The
+tile file is raw BGRA frames back to back and `overlay-add` consumes exactly
+that, so frame *n* is a byte offset — `draw_image` grew a `node.base` that is
+added to the crop offset it already computed, and nothing decodes anything.
+The chapter caption comes from mpv's own `chapter-list`, observed. Text is
+measured by the renderer, which is what closes **#612**: there is no longer
+an assumed width and a drawn width to disagree.
 
-**What comes out**, once the renderer owns the bubble: `hud._preview_float`,
-`hud._trickplay_frame`, `HudController.hover` / `hover_move` / `hover_end`,
-and the seek slider's `on_hover` / `on_hover_end` wiring.
+**The three `shim-trickplay-*` messages are handled directly.** They are the
+TrickPlay worker's own, already sent for thumbfast.lua, so nothing extra
+crosses the boundary and the two consumers cannot disagree about which
+generation of the file is live. `player.trickplay_meta` and the gateway's
+`trickplay()` are gone with the Python decode path.
 
-**Do not remove the hover machinery wholesale.** `update_slider_hover`
-handles *two* different things that read alike:
+**The seek slider's opt-in is `preview=True` → `node.pv`.** `hoverev` and the
+whole throttled value-reporting path (`notify_hover` / `fire_hover` /
+`hover_watch`) are deleted; `hev` — plain enter/leave for the tile play-chip
+— is untouched, and still shares `update_slider_hover` for the reason the
+comment there gives. Deleting those four file-scope locals is also what
+bought the headroom this needed: `renderer.lua` was **at** the 200-local
+ceiling and is no longer.
 
-- `hoverev` — the slider's throttled **value** reporting, which is what this
-  change makes unnecessary (`notify_hover` / `fire_hover` / `hover_watch`,
-  the 0.15s throttle).
-- `hev` / `on_hover` — plain enter/leave events on ordinary nodes, which the
-  **tile play-chip** depends on. Untouched.
+**Three positions feed it, in order:** an in-flight mouse drag, an
+arrow-adjust that has actually moved (`nav_scrubbed`, so merely focusing the
+bar does not raise a bubble), then the pointer. `state.pv_rect` is the drawn
+result and is reported in the debug state — the bubble is not a scene node,
+so that is the only way a test can see it.
 
-**Constraints.** `renderer.lua` is at LuaJIT's 200-file-scope-local ceiling
-(`tests/test_renderer_lua.py` reports the headroom and skips with an
-explanation when it is gone), so anything new hangs off `state` or shares a
-table — `PHUD_HIDE` is the pattern. The preview bitmap is one more overlay
-against `MAX_OVERLAYS`. `_SLIDER_PAD` is already pinned across the two sides
-by `tests/test_python_lua_constants.py`; whatever geometry the bubble grows
-belongs there too.
+`_SLIDER_PAD` left `hud.py` with `_preview_float`, so
+`tests/test_python_lua_constants.py` lost that pair: the inset now exists in
+one place. Coverage is `tests/lua/test_renderer.lua` (16 cases: placement,
+centring, frame indexing for both tile layouts, clamping past the last tile,
+and the clear) plus the two integration tests, which now read the renderer's
+state instead of looking for a `hud-preview` node.
 
-**#612 closes with this**, not before: the renderer measures its own text, so
-the "assume a width, draw another" bug has nowhere to live. Both the hover
-case and the drag case are covered — the renderer knows the dragged value
-locally.
+**Known, not caused by this:** `test_full_lifecycle` and
+`test_paused_video_keeps_hud_up` in `tests/integration/test_mpvtk_hud.py`
+fail on both backends, and fail identically on the commit before this one.
+They are #620 fallout — see the entry below.
 
 ### 617 — true virtual scroll
 
@@ -592,12 +588,12 @@ rediscover them:
 Groundwork first, then the small fixes, then the two structural changes. One
 commit each.
 
-Steps 1–10 are done (see the table at the top). What remains:
+Steps 1–11 are done (see the table at the top). What remains:
 
-11. #618(b) + #612 — renderer-side scrub preview.
 12. #617 — true virtual scroll.
-
-Either order; they touch nothing in common.
+13. The two `test_mpvtk_hud` integration failures #620 left behind (see
+    the note under 618(b)); they are on the branch already and predate the
+    scrub-preview commit.
 
 ## Decisions taken without asking
 

--- a/docs/UI_UX_FIXES_2026-08.md
+++ b/docs/UI_UX_FIXES_2026-08.md
@@ -384,6 +384,31 @@ Keyboard/remote caveat: `hover` cannot mean "hide instantly" when there is no
 pointer driving. A HUD summoned by key/remote (`state.phud.kbd`) keeps the
 timer; `hover` applies to the pointer-driven case.
 
+**Follow-up (found by the integration suite, fixed in `793d8793`).** "The
+pointer is on the controls" was asked of `state.mouse`, which turned out to
+answer for a pointer that was not there:
+
+1. A mouse that has not been touched still reports a position. Left anywhere
+   in the top or bottom band it read as a hover, and a HUD summoned with the
+   keyboard then never hid. `phud_busy` now requires the pointer to have
+   *moved* since this summon (`state.phud.moved`), which is what "reaching
+   for a button" always involves.
+2. The idle-HUD branch of the `mouse-pos` observer returns before
+   `on_mouse_move`, so a **mouse** summon left `state.mouse` holding the
+   position from before HUD mode. The observer records it for both branches
+   now.
+3. mpv keeps reporting the last coordinates with `hover=false` once the
+   pointer leaves the window; those are forgotten now.
+
+Two `test_mpvtk_hud` integration tests were failing on both backends because
+of (1) — under a bare X server the pointer parks at 0,0 and the top bar is
+drawn under it, so the HUD was held up for ever. `test_paused_video_keeps_hud_up`
+was also stale: it asserted the *old* rule, and now drives `mode: "paused"`
+through `hud_key_opts` with a companion test for the new default. The fake
+controller sends conf.py's `hide`/`mode` defaults rather than omitting them,
+because an absent `hide` means zero, and a HUD that hides half a second after
+each keypress cannot be walked with the arrow keys at all.
+
 ### Subtitle margin
 
 `gateway/hud.py:111` raises `sub_margin_y` to 130 while the HUD is up (already
@@ -506,10 +531,9 @@ centring, frame indexing for both tile layouts, clamping past the last tile,
 and the clear) plus the two integration tests, which now read the renderer's
 state instead of looking for a `hud-preview` node.
 
-**Known, not caused by this:** `test_full_lifecycle` and
-`test_paused_video_keeps_hud_up` in `tests/integration/test_mpvtk_hud.py`
-fail on both backends, and fail identically on the commit before this one.
-They are #620 fallout — see the entry below.
+(`test_full_lifecycle` and `test_paused_video_keeps_hud_up` were failing on
+both backends when this landed. Not this change — #620 fallout, fixed in
+`793d8793`; see the follow-up under that issue.)
 
 ### 617 — true virtual scroll
 
@@ -591,9 +615,6 @@ commit each.
 Steps 1–11 are done (see the table at the top). What remains:
 
 12. #617 — true virtual scroll.
-13. The two `test_mpvtk_hud` integration failures #620 left behind (see
-    the note under 618(b)); they are on the branch already and predate the
-    scrub-preview commit.
 
 ## Decisions taken without asking
 

--- a/jellyfin_mpv_shim/mpvtk/layout.py
+++ b/jellyfin_mpv_shim/mpvtk/layout.py
@@ -671,15 +671,13 @@ def _arrange_slider(ctx, el, x, y, w, h, sc, path):
             [round(float(a), 4), round(float(b), 4)]
             for a, b in el.ranges
         ]
-    if el.on_hover is not None:
-        node["hoverev"] = True
+    if el.preview:
+        node["pv"] = True
     if el.always_adjust:
         node["aadj"] = True
     _reg(ctx, node["id"], "change", el.on_change)
     _reg(ctx, node["id"], "commit", el.on_commit)
     _reg(ctx, node["id"], "cancel", el.on_cancel)
-    _reg(ctx, node["id"], "hover", el.on_hover)
-    _reg(ctx, node["id"], "hover_end", el.on_hover_end)
     ctx.nodes.append(node)
     return
 

--- a/jellyfin_mpv_shim/mpvtk/renderer.lua
+++ b/jellyfin_mpv_shim/mpvtk/renderer.lua
@@ -187,6 +187,18 @@ local state = {
              -- auto-hide policy and the no-scrim text halo, pushed
              -- with the engage (mpvtk-hud) so setting changes stick
              hide_s = 4, hide_mode = 'hover', shadow = false },
+    -- Scrub preview: the seek bar's trickplay/chapter bubble, drawn HERE
+    -- rather than asked for from Python. A hover that has to round-trip,
+    -- rebuild the whole HUD tree and come back as a scene is a preview that
+    -- visibly trails the pointer, and it made every other control in the
+    -- bar feel slow while it did (#618). Everything the bubble needs is
+    -- already local: the tile file is raw BGRA that overlay-add consumes
+    -- directly, and mpv owns the chapter list.
+    tp = nil,               -- tiles: {file, iw, ih, count, mult} or {..., times}
+    chlist = nil,           -- mpv's chapter-list, for the bubble's caption
+    pv_hover = nil,         -- id of the preview slider under the pointer
+    pv_secs = 0,            -- the position it is pointing at, in seconds
+    pv_rect = nil,          -- last drawn bubble rect (nil = not shown)
     ready_sent = false,
     mouse = { x = -1, y = -1, hover = false },
     hover_id = nil,
@@ -798,7 +810,12 @@ local function draw_image(node, ex, ey, clip, idx)
             end
             pidx = pidx + 1
             local src = node.src
-            local offset = sy * stride + sx * 4
+            -- node.base: a byte offset INTO the source, for a file that
+            -- holds several frames back to back rather than one image.
+            -- The trickplay tile file is the only such source (frame n at
+            -- n * w * h * 4); the crop maths above is unchanged, it just
+            -- starts from there instead of from zero.
+            local offset = sy * stride + sx * 4 + (node.base or 0)
             if src:sub(1, 1) == '&' then
                 -- same-process memory source (libmpv backend): fold
                 -- the crop offset into the address so overlay-add's
@@ -1673,6 +1690,15 @@ local function slider_set_from_x(node, x)
     local s = sl_state(node)
     local v = (node.min or 0) +
         frac * ((node.max or 100) - (node.min or 0))
+    if node.pv then
+        -- Carry the scrub preview's position along with the drag. A drag
+        -- returns out of on_mouse_move before update_slider_hover, so
+        -- pv_secs would otherwise still hold wherever the pointer was when
+        -- the drag STARTED -- and releasing the button, which drops
+        -- slider_drag and falls the preview back to the hover position,
+        -- made the bubble jump back there for a frame.
+        state.pv_hover, state.pv_secs = node.id, v
+    end
     if v ~= s.value then
         s.value = v
         notify_slider(node.id)
@@ -1680,52 +1706,24 @@ local function slider_set_from_x(node, x)
     end
 end
 
--- Passive-hover position reporting for sliders that opt in with
--- hoverev (the HUD's seek bar): while the pointer rests on the
--- slider, the app gets throttled {t=hover, value} events (it floats
--- the trickplay/time bubble there), then one {t=hover_end} when the
--- pointer moves off. Same 0.15s cadence as drag notifications — this
--- is a preview, not a per-frame interaction.
-local hover_notify_timers = {}
-local hover_last_notify = {}
-
-local function fire_hover(id)
-    hover_last_notify[id] = mp.get_time()
-    if state.hover_watch == id then
-        send({ t = 'hover', id = id, value = state.hover_value })
-    end
-end
-
-local function notify_hover(id)
-    if hover_notify_timers[id] then return end
-    local elapsed = mp.get_time() - (hover_last_notify[id] or -1e9)
-    if elapsed >= 0.15 then
-        fire_hover(id)
-    else
-        hover_notify_timers[id] = mp.add_timeout(0.15 - elapsed,
-            function()
-                hover_notify_timers[id] = nil
-                fire_hover(id)
-            end)
-    end
-end
-
--- Both pointer-enter/leave notifications the app can ask for. ONE function
--- for two unrelated features because this chunk sits on LuaJIT's ceiling of
--- 200 locals in a main function -- a new top-level local here does not fail
--- at the call, it fails to load the renderer at all.
+-- Pointer-enter/leave notification, plus the seek bar's own hover
+-- tracking. ONE function for two features because this chunk sits on
+-- LuaJIT's ceiling of 200 locals in a main function -- a new top-level
+-- local here does not fail at the call, it fails to load the renderer at
+-- all.
 --
 -- `hev` is enter/leave for a node that wants a control drawn over it: the
 -- tile strips' hit regions, and the play chip that then appears on one. The
 -- chip opts in too, or the pointer moving onto it would read as leaving the
 -- tile, the app would take the chip away, and the two would alternate for as
--- long as the pointer sat there. Unthrottled, unlike the slider below: this
--- is a control appearing under the pointer, and 150ms of that reads as
--- broken. One event per tile crossed is the same order as the hover ring
--- this already re-renders for.
+-- long as the pointer sat there. One event per tile crossed is the same
+-- order as the hover ring this already re-renders for.
 --
--- `hoverev` is the slider's throttled value reporting (the HUD's seek bar
--- floating its trickplay bubble), which is a preview rather than a control.
+-- `pv` is the seek bar's scrub preview, and it sends NOTHING. It used to:
+-- a throttled {t=hover, value} that the app answered with a whole rebuilt
+-- HUD scene, which is why the bubble trailed the pointer by a frame or
+-- three (#618). The renderer draws it now (see render), so all that is
+-- left here is remembering where on the bar the pointer is.
 local function update_slider_hover(node)
     local hid = (node and node.hev) and node.id or nil
     if hid ~= state.hover_region then
@@ -1740,28 +1738,25 @@ local function update_slider_hover(node)
         if hid then send({ t = 'hover', id = hid }) end
         if prev then send({ t = 'hover_end', id = prev }) end
     end
-    local id = nil
-    if node and node.t == 'slider' and node.hoverev
-        and state.slider_drag ~= node.id then
-        id = node.id
-    end
-    local prev = state.hover_watch
-    if prev and prev ~= id then
-        state.hover_watch = nil
-        send({ t = 'hover_end', id = prev })
-    end
+    local id = (node and node.t == 'slider' and node.pv) and node.id or nil
+    local prev = state.pv_hover
+    state.pv_hover = id
     if id then
-        state.hover_watch = id
         local ex = select(1, eff(node))
         local frac = clamp(
             (state.mouse.x - ex - SLIDER_PAD) /
             (node.w - 2 * SLIDER_PAD), 0, 1)
         local v = (node.min or 0) +
             frac * ((node.max or 100) - (node.min or 0))
-        if v ~= state.hover_value or prev ~= id then
-            state.hover_value = v
-            notify_hover(id)
+        if v ~= state.pv_secs or prev ~= id then
+            state.pv_secs = v
+            -- on_mouse_move only re-renders when the hovered NODE changes,
+            -- and moving along the bar never does; without this the bubble
+            -- would stick at the position it first appeared at.
+            request_render()
         end
+    elseif prev then
+        request_render()
     end
 end
 
@@ -2120,6 +2115,108 @@ render = function()
         ass:append(esc(label))
     else
         state.phud.skip_rect = nil
+    end
+    -- Scrub preview bubble: the trickplay frame for the position under the
+    -- pointer (or being dragged / arrow-adjusted), the chapter that position
+    -- falls in, and the timestamp. Everything it needs is already here --
+    -- the tile file is raw BGRA that overlay-add takes as-is, and mpv owns
+    -- chapter-list -- so it tracks the pointer at render cadence instead of
+    -- at the speed of a round trip through a rebuilt HUD scene (#618).
+    --
+    -- Measuring its own text is the other half: Python could only *assume* a
+    -- width for a box it did not draw, and the width it assumed was right
+    -- only when a thumbnail was the widest thing in it. Without trickplay
+    -- the bubble drifted by half the difference, which is #612.
+    state.pv_rect = nil
+    local pv_id, pv_secs
+    if state.slider_drag then
+        pv_id = state.slider_drag
+    elseif state.nav_adjust and state.nav_scrubbed then
+        pv_id = state.nav
+    end
+    if pv_id then
+        local n = state.byid[pv_id]
+        if n and n.pv then pv_secs = sl_state(n).value else pv_id = nil end
+    end
+    if not pv_id and state.pv_hover then
+        pv_id, pv_secs = state.pv_hover, state.pv_secs
+    end
+    local pv_node = pv_id and state.byid[pv_id]
+    if pv_node and pv_secs and (pv_node.max or 0) > 0 then
+        local pad, gap = ui_px(8), ui_px(4)
+        local fs = ui_px(14)
+        local lh = math.floor(fs * PHUD_SKIP_LINE_H)
+        -- Which frame of the tile file, if there is one. BIF data is
+        -- evenly spaced (multiplier ms apart); the chapter-image fallback
+        -- carries one frame per chapter start.
+        local tp = state.tp
+        local fw, fh, base = 0, 0, 0
+        local idx
+        if tp and (tp.iw or 0) > 0 and (tp.ih or 0) > 0 then
+            if tp.times and #tp.times > 0 then
+                idx = 0
+                for i = #tp.times, 1, -1 do
+                    if tp.times[i] <= pv_secs then idx = i - 1 break end
+                end
+                if idx > #tp.times - 1 then idx = #tp.times - 1 end
+            elseif (tp.count or 0) > 0 and (tp.mult or 0) > 0 then
+                idx = math.floor(pv_secs * 1000 / tp.mult)
+                if idx > tp.count - 1 then idx = tp.count - 1 end
+                if idx < 0 then idx = 0 end
+            end
+        end
+        if idx then
+            fw, fh = tp.iw, tp.ih
+            base = idx * tp.iw * tp.ih * 4
+        end
+        local cap
+        for _, c in ipairs(state.chlist or {}) do
+            if (c.time or 0) <= pv_secs and c.title and c.title ~= '' then
+                cap = c.title
+            end
+        end
+        local whole = math.floor(pv_secs)
+        local ts
+        if whole >= 3600 then
+            ts = string.format('%d:%02d:%02d', math.floor(whole / 3600),
+                               math.floor(whole % 3600 / 60), whole % 60)
+        else
+            ts = string.format('%d:%02d', math.floor(whole / 60), whole % 60)
+        end
+        local bw = math.max(fw, text_w(ts, fs, true),
+                            cap and text_w(cap, fs, false) or 0) + 2 * pad
+        local bh = 2 * pad + lh + (fh > 0 and (fh + gap) or 0)
+                   + (cap and (lh + gap) or 0)
+        local ex, ey = eff(pv_node)
+        local frac = clamp(pv_secs / pv_node.max, 0, 1)
+        local px = math.floor(clamp(
+            ex + SLIDER_PAD + (pv_node.w - 2 * SLIDER_PAD) * frac - bw / 2,
+            ui_px(8), state.w - bw - ui_px(8)))
+        -- Pinned by its BOTTOM edge, so a bubble that grows a thumbnail or
+        -- a chapter line grows upwards and never over the bar it describes.
+        local py = math.floor(math.max(0, ey - ui_px(10) - bh))
+        state.pv_rect = { x = px, y = py, w = bw, h = bh,
+                          secs = pv_secs, frame = idx }
+        draw_rect(ass, px, py, bw, bh,
+                  { fill = '282828', radius = ui_px(6) })
+        local ty = py + pad
+        if fh > 0 then
+            -- Native size: overlay-add does not scale, and the worker
+            -- already decoded these at thumbnail_preferred_size.
+            draw_image({ id = 'hud-preview', src = tp.file, base = base,
+                         iw = fw, ih = fh, w = fw, h = fh },
+                       math.floor(px + (bw - fw) / 2), ty)
+            ty = ty + fh + gap
+        end
+        if cap then
+            draw_text(ass, { w = bw - 2 * pad, h = lh, size = fs,
+                             align = 'center' },
+                      px + pad, ty, nil, cap, 'dddddd')
+            ty = ty + lh + gap
+        end
+        draw_text(ass, { w = bw - 2 * pad, h = lh, size = fs,
+                         align = 'center', bold = true },
+                  px + pad, ty, nil, ts, 'ffffff')
     end
     if state.hud then
         -- input-diagnostics overlay (toggle: F12)
@@ -4087,8 +4184,8 @@ local function reconcile()
         local node = state.byid[id]
         if not node or node.t ~= 'slider' then state.sl[id] = nil end
     end
-    if state.hover_watch and not state.byid[state.hover_watch] then
-        state.hover_watch = nil  -- slider left the scene mid-hover
+    if state.pv_hover and not state.byid[state.pv_hover] then
+        state.pv_hover = nil  -- seek bar left the scene mid-hover
     end
     if state.hover_region and not state.byid[state.hover_region] then
         -- Scrolled away, navigated away, or the app dropped the node.
@@ -4788,6 +4885,44 @@ mp.register_script_message('mpvtk-hud-skip', function(label)
     end
 end)
 
+-- Trickplay tiles for the scrub preview. These three messages are the
+-- TrickPlay worker's, not mpvtk's: they predate this renderer and are what
+-- the lua OSCs consume (see thumbfast.lua), so nothing extra is sent for us
+-- and the two consumers cannot disagree about which file is live. The
+-- worker guarantees the path is unique per generation and only unlinks the
+-- previous one after pointing everybody at the new one.
+mp.register_script_message('shim-trickplay-bif',
+    function(count, mult, w, h, path)
+        state.tp = { file = path, iw = tonumber(w), ih = tonumber(h),
+                     count = tonumber(count), mult = tonumber(mult) }
+        request_render()
+    end)
+
+-- The fallback when the server has no BIF data: one frame per chapter,
+-- indexed by the chapter start times (seconds) rather than by a cadence.
+mp.register_script_message('shim-trickplay-chapters',
+    function(w, h, path, times)
+        local t = {}
+        for s in tostring(times or ''):gmatch('[^,]+') do
+            t[#t + 1] = tonumber(s)
+        end
+        state.tp = { file = path, iw = tonumber(w), ih = tonumber(h),
+                     times = t }
+        request_render()
+    end)
+
+mp.register_script_message('shim-trickplay-clear', function()
+    -- The bytes go away right after this, so forget them first.
+    state.tp = nil
+    request_render()
+end)
+
+-- The bubble's caption. mpv has the chapters already; asking Python for
+-- them would be a round trip for something sitting in a property.
+mp.observe_property('chapter-list', 'native', function(_, v)
+    state.chlist = v
+end)
+
 -- ---------------------------------------------------------- test hooks
 
 local function center_of(id)
@@ -5014,6 +5149,10 @@ mp.register_script_message('mpvtk-debug', function(json)
             phud_shown = state.phud.shown,
             phud_intro = state.phud.intro,
             phud_skip = state.phud.skip_show or false,
+            -- the scrub preview bubble ({x, y, w, h, secs, frame}), nil
+            -- when it is not up. It is not a scene node, so this is the
+            -- only way anything outside the renderer can see it.
+            preview = state.pv_rect,
             -- is the HUD taking the arrow keys (keyboard-driven), or
             -- only the pointer (hud_grab_keys off, mouse summon)?
             phud_kbd = state.phud.kbd or false,

--- a/jellyfin_mpv_shim/mpvtk/renderer.lua
+++ b/jellyfin_mpv_shim/mpvtk/renderer.lua
@@ -186,7 +186,10 @@ local state = {
     phud = { mode = false, shown = false, timer = nil, mx = -1, my = -1,
              -- auto-hide policy and the no-scrim text halo, pushed
              -- with the engage (mpvtk-hud) so setting changes stick
-             hide_s = 4, hide_mode = 'hover', shadow = false },
+             hide_s = 4, hide_mode = 'hover', shadow = false,
+             -- has the pointer MOVED since this summon? The bar-hover
+             -- hold below is meaningless without it: see phud_busy
+             moved = false },
     -- Scrub preview: the seek bar's trickplay/chapter bubble, drawn HERE
     -- rather than asked for from Python. A hover that has to round-trip,
     -- rebuild the whole HUD tree and come back as a scene is a preview that
@@ -2857,6 +2860,8 @@ end
 
 local function on_mouse_move(x, y)
     phud_touch()
+    -- The observer only fires on a change, so reaching here IS movement.
+    state.phud.moved = true
     state.mouse.x, state.mouse.y = x, y
     if state.tb_drag then
         local node = state.byid[state.tb_drag.id]
@@ -4043,6 +4048,10 @@ mp.observe_property('mouse-pos', 'native', function(_, pos)
     if not pos then return end
     if pos.hover == false then
         state.mouse.hover = false
+        -- and forget WHERE it was. The coordinates outlive the pointer
+        -- otherwise, and phud_busy would go on reading a mouse that had
+        -- left the window as resting on the controls.
+        state.mouse.x, state.mouse.y = -1, -1
         state.tip = nil
         if state.tip_timer then
             state.tip_timer:kill()
@@ -4056,6 +4065,12 @@ mp.observe_property('mouse-pos', 'native', function(_, pos)
         return
     end
     state.mouse.hover = true
+    -- Record it for BOTH branches. The idle-HUD branch below returns
+    -- without reaching on_mouse_move, so a mouse summon used to leave
+    -- state.mouse holding whatever was there before HUD mode -- and
+    -- phud_busy would then decide "is the pointer on the controls?"
+    -- against a position the pointer had left long ago.
+    state.mouse.x, state.mouse.y = pos.x, pos.y
     if state.phud.mode and not state.phud.shown then
         -- HUD idle: real pointer movement summons it. The first event
         -- after entering idle only records the position (mx = -1 means
@@ -4638,11 +4653,18 @@ local function phud_busy()
         and mp.get_property_native('pause', false) then
         return true
     end
-    if state.phud.hide_mode ~= 'always' then
+    if state.phud.hide_mode ~= 'always' and state.phud.moved then
         -- Over either bar: the ids are the contract (hud.py gives the top
         -- row and the transport column one for exactly this). Falling back
         -- to "over any clickable node" would flicker in the gaps between
         -- buttons, which is most of the bar's area.
+        --
+        -- Only once the pointer has MOVED since this summon, though. A
+        -- mouse that has sat untouched in the bottom strip of the screen
+        -- all evening is not reaching for anything, and taking it as a
+        -- hover left a keyboard-summoned HUD up forever -- which is also
+        -- how it reads under a bare X server, where the pointer parks at
+        -- 0,0 and the top bar is drawn under it.
         local mx, my = state.mouse.x, state.mouse.y
         for _, id in ipairs({ 'hud-bar', 'hud-topbar' }) do
             local bar = state.byid[id]
@@ -4703,6 +4725,9 @@ function phud_summon(src)
     -- the scene immediately, though: it activates the focused node.
     phud_skip_unbind()
     state.phud.shown = true
+    -- A mouse summon IS movement; a key summon starts with the pointer
+    -- wherever it happened to be, which means nothing.
+    state.phud.moved = src == 'mouse'
     -- a keyboard/remote summon lands spatial-nav focus on the scene's
     -- autofocus node (play/pause) once Python pushes the HUD; a mouse
     -- summon leaves the pointer in charge
@@ -5156,6 +5181,8 @@ mp.register_script_message('mpvtk-debug', function(json)
             -- is the HUD taking the arrow keys (keyboard-driven), or
             -- only the pointer (hud_grab_keys off, mouse summon)?
             phud_kbd = state.phud.kbd or false,
+            mouse = { x = state.mouse.x, y = state.mouse.y,
+                      hover = state.mouse.hover },
         })
     elseif cmd.cmd == 'phud' then
         -- drive the playback-HUD lifecycle from tests

--- a/jellyfin_mpv_shim/mpvtk/widgets.py
+++ b/jellyfin_mpv_shim/mpvtk/widgets.py
@@ -410,8 +410,11 @@ class Slider(Element):
         on_change=None,
         on_commit=None,
         on_cancel=None,
-        on_hover=None,  # throttled pointer-rest position (seek preview)
-        on_hover_end=None,
+        # Scrub preview: the renderer floats its own bubble (trickplay
+        # frame + chapter + timestamp) at the pointer, or at the value
+        # being dragged/arrow-adjusted. No events come back for it -- the
+        # whole point is that it never leaves the renderer.
+        preview=False,
         force=False,
         # Drawn over VIDEO rather than over app chrome: keeps the light
         # track and pale thumb that read on a picture, instead of following
@@ -433,8 +436,7 @@ class Slider(Element):
         self.on_change = on_change
         self.on_commit = on_commit
         self.on_cancel = on_cancel
-        self.on_hover = on_hover
-        self.on_hover_end = on_hover_end
+        self.preview = preview
         self.force = force
         self.on_video = on_video
         self.marks = marks

--- a/jellyfin_mpv_shim/mpvtk_browser/gateway/hud.py
+++ b/jellyfin_mpv_shim/mpvtk_browser/gateway/hud.py
@@ -21,12 +21,6 @@ class HudMixin(GatewayCore):
         return getattr(playerManager, "_osc_style_resolved",
                        None) == "mpvtk"
 
-    def trickplay(self):
-        """Decoded trickplay tile metadata for the current video, or None
-        ({count, multiplier, width, height, file} — see TrickPlay)."""
-        from ...player import playerManager
-        return playerManager.trickplay_meta
-
     def hud_key_opts(self):
         """Everything the renderer owns about the HUD, sent with the engage.
 

--- a/jellyfin_mpv_shim/mpvtk_browser/hud.py
+++ b/jellyfin_mpv_shim/mpvtk_browser/hud.py
@@ -27,7 +27,6 @@ from ..mpvtk.widgets import (
     Dropdown,
     Element,
     Gradient,
-    Image,
     Menu,
     Row,
     Slider,
@@ -128,51 +127,6 @@ def _clock(secs):
         return "%d:%02d:%02d" % (
             secs // 3600, (secs % 3600) // 60, secs % 60)
     return "%d:%02d" % (secs // 60, secs % 60)
-
-
-def _trickplay_frame(b, secs):
-    """Scrub preview bitmap for ``secs``, via the TrickPlay worker's
-    decoded raw-BGRA tile file (player.trickplay_meta). Returns a
-    strips.bitmap entry {"src", "iw", "ih", "v"} or None (no trickplay data
-    for this video / frame not readable)."""
-    get = getattr(b.controller, "trickplay", None)
-    if get is None or b.strips is None:
-        return None
-    try:
-        meta = get()
-    except Exception:
-        return None
-    if not meta or not meta.get("count"):
-        return None
-    w, h = meta["width"], meta["height"]
-    idx = max(0, min(meta["count"] - 1,
-                     int(secs * 1000 / max(1, meta["multiplier"]))))
-    key = ("trickplay", meta["file"], meta["count"],
-           meta["multiplier"], idx)
-    # one-slot cache: repaints at the same scrub index (1s ticker while
-    # holding still) skip the file read + decode
-    last = b.hud.frame
-    if last is not None and last[0] == key:
-        return last[1]
-    frame = w * h * 4
-    try:
-        with open(meta["file"], "rb") as fh:
-            fh.seek(idx * frame)
-            data = fh.read(frame)
-    except OSError:
-        return None
-    if len(data) < frame:
-        return None
-    try:
-        from PIL import Image as PILImage
-
-        img = PILImage.frombytes("RGBA", (w, h), data, "raw", "BGRA")
-    except Exception:
-        log.debug("trickplay frame decode failed", exc_info=True)
-        return None
-    entry = b.strips.bitmap(key, img)
-    b.hud.frame = (key, entry)
-    return entry
 
 
 def _hud_action(b, verb, arg=None):
@@ -650,8 +604,8 @@ def build_hud(b, size):
         on_change=b.hud.scrub_change,
         on_commit=b.hud.scrub_commit,
         on_cancel=b.hud.scrub_cancel,
-        on_hover=b.hud.hover_move,
-        on_hover_end=b.hud.hover_end)
+        # the renderer floats the trickplay/chapter bubble itself
+        preview=True)
 
     menu_state = None
     if b.controller is not None and hasattr(b.controller, "hud_menu_state"):
@@ -801,65 +755,12 @@ def build_hud(b, size):
     if skip is not None:
         children.append(skip)
 
-    preview_at = scrub if scrub is not None else b.hud.hover
-    preview = _preview_float(b, preview_at, dur, size, chapters)
-    if preview is not None:
-        children.append(preview)
+    # The scrub preview bubble is NOT here. The renderer draws it, from the
+    # trickplay tiles and mpv's chapter list, without asking (#618/#612) —
+    # see renderer.lua's `pv` slider flag.
 
     menu = _settings_menu(b, menu_state, size)
     if menu is not None:
         children.append(menu)
 
     return Stack(children, w=w, h=h)
-
-
-# Must match renderer.lua's SLIDER_PAD (track inset inside the slider node —
-# the thumb travels between the insets). A click is mapped back to a seek
-# time through this, so drift puts the seek off where the user clicked.
-# Enforced by tests/test_python_lua_constants.py.
-_SLIDER_PAD = 8
-
-
-def _preview_float(b, secs, dur, size, chapters):
-    """Seek-preview bubble floated above the slider at ``secs``: the
-    trickplay thumbnail (when the video has tiles) over the chapter
-    name and timestamp — the lua OSC's hover bubble. Shown while
-    scrubbing or while the pointer rests on the bar. Geometry comes
-    from the previous scene's laid-out slider rect — one frame stale,
-    which is fine: the bar doesn't move while the HUD is up."""
-    if secs is None or dur <= 0:
-        return None
-    rect = None
-    if b.app is not None and hasattr(b.app, "node_rect"):
-        rect = b.app.node_rect("hud-seek")
-    if rect is None:
-        return None
-    w, h = size
-    entry = _trickplay_frame(b, secs)
-    rows: list[Element] = []          # the frame Image plus its Text captions
-    if entry is not None:
-        rows.append(Image(entry["src"], entry["iw"], entry["ih"],
-                          v=entry.get("v", 0)))
-    chapter = None
-    for ch in chapters:
-        if ch["time"] <= secs and ch.get("title"):
-            chapter = ch["title"]
-    if chapter:
-        rows.append(Text(chapter, size=14, color="dddddd",
-                         align="center"))
-    rows.append(Text(_clock(secs), size=14, bold=True, align="center"))
-    # lw, not iw: this is bubble geometry in logical space, and iw is the
-    # frame's physical width (trickplay frames are sized by the video, not
-    # by a logical box, so the two differ at any scale != 1).
-    bw = max(entry["lw"] if entry is not None else 0, 120) + 16
-    frac = max(0.0, min(1.0, secs / dur))
-    track_x = rect["x"] + _SLIDER_PAD
-    track_w = rect["w"] - 2 * _SLIDER_PAD
-    px = track_x + frac * track_w - bw / 2
-    px = max(8, min(w - bw - 8, px))
-    # anchor sw + negative dy pins the bubble's BOTTOM just above the
-    # slider whatever its content height turns out to be
-    return Box(
-        [Column(rows, gap=4, align="center")],
-        id="hud-preview", bg="282828", radius=6, pad=8,
-        anchor="sw", dx=px, dy=rect["y"] - 10 - h)

--- a/jellyfin_mpv_shim/mpvtk_browser/hud_control.py
+++ b/jellyfin_mpv_shim/mpvtk_browser/hud_control.py
@@ -24,17 +24,15 @@ at a renderer that is not showing one.
     *we* paused playback to make the position inspectable. The second flag
     is what stops a commit from resuming playback the user had paused
     themselves.
-``hover``
-    Pointer resting on the seek bar. Drives the preview bubble; ``scrub``
-    takes precedence over it.
 ``menu`` / ``menu_anchor``
     The open settings-menu level ("root", "speed", …) and the node it hangs
     off. One level at a time.
 ``tc_remaining``
     Clock shows remaining rather than total. A click toggles it.
-``frame``
-    Cached scrub-preview frame, keyed so the same position is not decoded
-    twice.
+
+The scrub preview bubble is deliberately absent: the renderer draws it from
+the trickplay tiles and mpv's chapter list, so no hover state reaches here
+at all (#618).
 """
 
 import logging
@@ -58,7 +56,6 @@ class HudController:
         self._start_ticker = start_ticker
         self.reset()
         self.state = None
-        self.frame = None
 
     @property
     def app(self):
@@ -82,7 +79,6 @@ class HudController:
         self.menu = None
         self.menu_anchor = "hud-settings"
         self.tc_remaining = False
-        self.hover = None
 
     # -- is the HUD in play at all ----------------------------------------
 
@@ -133,16 +129,6 @@ class HudController:
     def scrub_cancel(self):
         self.scrub_done()
 
-    # -- hover -------------------------------------------------------------
-
-    def hover_move(self, v):
-        self.hover = float(v)
-        self._invalidate()
-
-    def hover_end(self):
-        self.hover = None
-        self._invalidate()
-
     # -- menu / events -----------------------------------------------------
 
     def on_skip(self):
@@ -181,7 +167,6 @@ class HudController:
             # keep a menu opened in the same beat as a summon
             # (open_menu sets it right before the hud event lands)
             self.menu = None
-        self.hover = None
         if getattr(self.controller, "hud_sub_margin", None) is not None:
             # raise bottom subtitles clear of the bar while it shows
             try:

--- a/jellyfin_mpv_shim/mpvtk_browser/repository.py
+++ b/jellyfin_mpv_shim/mpvtk_browser/repository.py
@@ -227,6 +227,20 @@ QUEUEABLE_MEDIA = frozenset({"Video", "Audio", "Photo"})
 #: stable, which matters only for reading logs.
 QUEUEABLE_MEDIA_PARAM = ",".join(sorted(QUEUEABLE_MEDIA))
 
+#: How many items Play All / Shuffle queue from a library.
+#:
+#: The number is jellyfin-web's: ``getItemsForPlayback`` caps every playback
+#: query at 300 unless the caller passes its explicit "unlimited" sentinel,
+#: which only a photo album does. Matching it means the same button builds
+#: the same queue in both clients -- ours was 200 for no reason beyond when
+#: it was written.
+#:
+#: A cap at all, rather than the whole library, because this is a queue to
+#: play and not a list to browse: 300 is more than anyone watches in a
+#: sitting, and the alternative is asking a server for forty thousand ids to
+#: use the first few.
+QUEUE_LIMIT = 300
+
 #: Fields a list of guide entries needs on top of ``LIST_FIELDS``.
 #:
 #: **Two fields, not one.** ``ChannelInfo`` alone gets ``ChannelName`` and
@@ -1849,7 +1863,8 @@ class LibrarySource:
         result = api.get_collections(limit=limit, sort_by="SortName") or {}
         return result.get("Items", [])
 
-    def get_shuffle_ids(self, server_uuid, parent_id, limit=200):
+    def get_shuffle_ids(self, server_uuid, parent_id,
+                        limit=QUEUE_LIMIT):
         """Random playable item ids under a library, for shuffle play. The
         server does the shuffling so the sample spans the whole library, not
         just the loaded pages."""
@@ -1862,7 +1877,8 @@ class LibrarySource:
         return [i["Id"] for i in result.get("Items", []) if i.get("Id")]
 
     def get_play_all_ids(self, server_uuid, parent_id, sort_by="SortName",
-                         sort_order="Ascending", filters=None, limit=200,
+                         sort_order="Ascending", filters=None,
+                         limit=QUEUE_LIMIT,
                          collection_type=None):
         """Ids Play All should queue, in the grid's own order.
 
@@ -2528,7 +2544,8 @@ class OfflineLibrarySource:
     def get_collections(self, server_uuid, limit=300):
         return []  # collections aren't cached offline (editing is online-only)
 
-    def get_shuffle_ids(self, server_uuid, parent_id, limit=200):
+    def get_shuffle_ids(self, server_uuid, parent_id,
+                        limit=QUEUE_LIMIT):
         snap = self._snap
         if parent_id == "offline:tv":
             pool = [i for i in snap.items if i.get("Type") == "Episode"]
@@ -2543,7 +2560,8 @@ class OfflineLibrarySource:
         return ids[:limit]
 
     def get_play_all_ids(self, server_uuid, parent_id, sort_by="SortName",
-                         sort_order="Ascending", filters=None, limit=200,
+                         sort_order="Ascending", filters=None,
+                         limit=QUEUE_LIMIT,
                          collection_type=None):
         """Downloaded items of a library, in the grid's order.
 

--- a/jellyfin_mpv_shim/player.py
+++ b/jellyfin_mpv_shim/player.py
@@ -392,12 +392,6 @@ class PlayerManager(AudioMixin, ReportingMixin, WindowMixin):
         # own controls (seekbar/buttons); such seeks never intro-skip.
         self._last_ui_seek_time = 0.0
         self.trickplay = None
-        # Decoded trickplay tile metadata for the CURRENT video, set by the
-        # TrickPlay worker once tiles land ({count, multiplier, width,
-        # height, file} — file is raw BGRA frames back to back). The mpvtk
-        # playback HUD reads frames straight out of it for scrub previews;
-        # the lua OSCs get the same data via shim-trickplay-bif instead.
-        self.trickplay_meta = None
         # Skippable segment the playback HUD should offer a button for
         # (an Intro object, or None).
         self._hud_skip = None

--- a/jellyfin_mpv_shim/trickplay.py
+++ b/jellyfin_mpv_shim/trickplay.py
@@ -98,7 +98,6 @@ class TrickPlay(threading.Thread):
         # The worker still exits promptly on its next loop turn via `halt`.
         self.halt = True
         self.trigger.set()
-        self.player.trickplay_meta = None
         # No shim-trickplay-clear here, unlike clear(): stop() runs while mpv
         # is being torn down (and may run under the player lock, which
         # script_message also takes), so talking to that instance is both
@@ -114,7 +113,6 @@ class TrickPlay(threading.Thread):
         self.trigger.set()
 
     def clear(self):
-        self.player.trickplay_meta = None
         # Renderer first, file second: overlay-remove has to land before the
         # bytes behind it go away.
         self.player.script_message("shim-trickplay-clear")
@@ -216,12 +214,10 @@ class TrickPlay(threading.Thread):
                             _unlink(path)
                             continue
 
-                        # Same data both ways: the lua OSCs get a script
-                        # message; the mpvtk HUD reads the raw frames via
-                        # this metadata (see player.trickplay_meta).
-                        self.player.trickplay_meta = dict(
-                            bif_meta, file=path
-                        )
+                        # One message, every consumer: thumbfast.lua for
+                        # the lua OSCs, and mpvtk's renderer.lua, which
+                        # reads the frames out of `path` itself for the
+                        # playback HUD's scrub preview.
                         self.player.script_message(
                             "shim-trickplay-bif",
                             str(bif_meta["count"]),

--- a/tests/integration/test_mpvtk_hud.py
+++ b/tests/integration/test_mpvtk_hud.py
@@ -27,7 +27,6 @@ class FakeController:
 
     def __init__(self):
         self.calls = []
-        self.trickplay_meta = None
         self.menu_state = None
         self.chapter_list = []
         # tests drive summons with arrow keypresses, so opt into the
@@ -36,9 +35,6 @@ class FakeController:
 
     def hud_key_opts(self):
         return dict(self.key_opts)
-
-    def trickplay(self):
-        return self.trickplay_meta
 
     def hud_menu_state(self):
         return self.menu_state
@@ -285,17 +281,18 @@ class TestPlaybackHudLifecycle(h.TmpDirTest):
 
     def test_scrub_commit_cancel_and_preview(self):
         # Fake trickplay data: 10 raw-BGRA frames, 3s apart (the format
-        # the TrickPlay worker writes to raw_images.bin).
+        # the TrickPlay worker writes to raw_images.<seq>.bin), announced
+        # exactly as the worker announces it. Nothing in Python reads this
+        # file -- the renderer opens it itself and hands mpv a byte offset
+        # into it, which is the point of #618.
         tw, th, count = 64, 36, 10
         raw = os.path.join(self.tmp, "raw_images.bin")
         with open(raw, "wb") as fh:
             for i in range(count):
                 px = bytes((20 * i % 256, 128, 255 - 20 * i % 256, 255))
                 fh.write(px * (tw * th))
-        self.ctl.trickplay_meta = {
-            "count": count, "multiplier": 3000,
-            "width": tw, "height": th, "file": raw,
-        }
+        self.handle.command("script-message", "shim-trickplay-bif",
+                            str(count), "3000", str(tw), str(th), raw)
 
         self._play_video()
         self._wait(lambda: self._state().get("phud_mode"),
@@ -317,8 +314,11 @@ class TestPlaybackHudLifecycle(h.TmpDirTest):
         self.assertIn(("set_paused", (True,)), [
             c for c in self.ctl.calls if isinstance(c, tuple)],
             "scrub start must pause playback")
-        self._wait(lambda: self.app.node_rect("hud-preview") is not None,
+        self._wait(lambda: self._state().get("preview") is not None,
                    msg="trickplay preview never appeared")
+        # ...with a real frame in it, read straight out of the tile file.
+        self.assertIsNotNone(self._state()["preview"].get("frame"),
+                             "the bubble drew no trickplay frame")
 
         # ENTER commits: exactly one seek at the scrubbed position.
         target = self.browser.hud.scrub
@@ -348,7 +348,7 @@ class TestPlaybackHudLifecycle(h.TmpDirTest):
         seeks = [c for c in self.ctl.calls if isinstance(c, tuple)
                  and c[0] == "seek"]
         self.assertEqual(len(seeks), 1, "cancel must not seek")
-        self._wait(lambda: self.app.node_rect("hud-preview") is None,
+        self._wait(lambda: self._state().get("preview") is None,
                    msg="preview never cleared after cancel")
 
     def test_pickers_chapters_and_skip_button(self):
@@ -410,8 +410,13 @@ class TestPlaybackHudLifecycle(h.TmpDirTest):
                    msg="skip button never dispatched: %r" % self.ctl.calls)
 
     def test_seek_hover_bubble(self):
-        self.ctl.chapter_list = [{"title": "Opening", "time": 0.0},
-                                 {"title": "Late", "time": 20.0}]
+        """Hovering the bar floats the bubble WITHOUT touching Python.
+
+        The chapters come from mpv, not from the fake controller: the
+        renderer reads chapter-list itself, so nothing here has to send
+        them. Nothing reaches the browser at all -- the assertion is that
+        the bubble exists in the renderer and that no scene node does.
+        """
         self._play_video()
         self._wait(lambda: self._state().get("phud_mode"),
                    msg="never entered HUD-idle")
@@ -419,19 +424,17 @@ class TestPlaybackHudLifecycle(h.TmpDirTest):
                           msg="summon failed")
         self._wait(lambda: self.app.node_rect("hud-seek") is not None,
                    msg="seek bar never materialized")
-        # park the pointer on the middle of the seek bar: throttled
-        # hover events flow to the browser, which floats the bubble
+        # park the pointer on the middle of the seek bar
         self.app.debug(cmd="hover", id="hud-seek")
-        self._wait(lambda: self.browser.hud.hover is not None,
-                   msg="hover position never reached the browser")
-        self.assertAlmostEqual(self.browser.hud.hover, 15.0, delta=3.0)
-        self._wait(lambda: self.app.node_rect("hud-preview") is not None,
+        self._wait(lambda: self._state().get("preview") is not None,
                    msg="hover bubble never appeared")
+        bubble = self._state()["preview"]
+        self.assertAlmostEqual(bubble["secs"], 15.0, delta=3.0)
+        self.assertIsNone(self.app.node_rect("hud-preview"),
+                          "the bubble must not be a scene node any more")
         # moving off the bar retracts it
         self.app.debug(cmd="hover", id="hud-pp")
-        self._wait(lambda: self.browser.hud.hover is None,
-                   msg="hover_end never reached the browser")
-        self._wait(lambda: self.app.node_rect("hud-preview") is None,
+        self._wait(lambda: self._state().get("preview") is None,
                    msg="hover bubble never cleared")
 
     def test_settings_menu_keyboard_flow(self):

--- a/tests/integration/test_mpvtk_hud.py
+++ b/tests/integration/test_mpvtk_hud.py
@@ -30,8 +30,14 @@ class FakeController:
         self.menu_state = None
         self.chapter_list = []
         # tests drive summons with arrow keypresses, so opt into the
-        # grab (the no-grab default has its own test)
-        self.key_opts = {"grab": True, "key": "ENTER"}
+        # grab (the no-grab default has its own test).
+        #
+        # hide/mode are conf.py's defaults rather than omitted: an absent
+        # `hide` means zero, which the renderer floors at 0.5s -- and a
+        # HUD that hides half a second after each keypress cannot be
+        # walked with the arrow keys at all.
+        self.key_opts = {"grab": True, "key": "ENTER",
+                         "hide": 4, "mode": "hover"}
 
     def hud_key_opts(self):
         return dict(self.key_opts)
@@ -676,6 +682,15 @@ class TestPlaybackHudLifecycle(h.TmpDirTest):
         self.assertFalse(self.browser.hud.shown)
 
     def test_paused_video_keeps_hud_up(self):
+        """hud_autohide "paused", end to end through hud_key_opts.
+
+        #620 turned this from a rule into a mode: pausing used to hold the
+        controls up for everybody, which is wrong if what you paused to look
+        at is behind them. Asking for it still works, and the whole path --
+        setting to gateway to engage message to renderer -- is what this
+        covers; the modes themselves are pinned in tests/lua.
+        """
+        self.ctl.key_opts = dict(self.ctl.key_opts, hide=4, mode="paused")
         self._play_video()
         self._wait(lambda: self._state().get("phud_mode"),
                    msg="renderer never entered HUD-idle")
@@ -689,6 +704,17 @@ class TestPlaybackHudLifecycle(h.TmpDirTest):
         self._set_pause(False)
         self._wait(lambda: not self.browser.hud.shown, timeout=10,
                    msg="HUD never auto-hid after unpausing")
+
+    def test_the_default_hides_on_a_paused_video(self):
+        """...and the default does not. The other half of the same change."""
+        self._play_video()
+        self._wait(lambda: self._state().get("phud_mode"),
+                   msg="renderer never entered HUD-idle")
+        self._set_pause(True)
+        self._press_until("RIGHT", lambda: self.browser.hud.shown,
+                          msg="summon failed")
+        self._wait(lambda: not self.browser.hud.shown, timeout=10,
+                   msg="the default mode kept the HUD up on a paused video")
 
 
 if __name__ == "__main__":

--- a/tests/lua/test_renderer.lua
+++ b/tests/lua/test_renderer.lua
@@ -1220,6 +1220,48 @@ hud_wait()
 ok(hud_hidden(), "the default hides them on a paused film")
 fake.log.props["pause"] = nil
 
+-- "The pointer is on the controls" has to mean the pointer was PUT there.
+-- A mouse that has sat untouched wherever it was left is not reaching for
+-- anything, and treating it as a hover left a keyboard-summoned HUD up for
+-- ever. (It is also how a bare X server reads: the pointer parks at 0,0 and
+-- the top bar is drawn under it.)
+--- The two bars, as hud.py pushes them once the HUD is up. A hide clears
+--- the renderer's node table (ui_suspend), so this has to be re-sent after
+--- every summon -- which is exactly what the browser does.
+local function hud_bars()
+    scene({ { id = "hud-topbar", t = "rect", x = 0, y = 0, w = 1280, h = 60 },
+            { id = "hud-bar", t = "rect", x = 0, y = 640, w = 1280, h = 80 } })
+end
+
+fake.send("mpvtk-hud", "no")
+fake.send("mpvtk-hud", "yes", fake.token({ hide = 4, mode = "hover" }))
+-- The first pointer event after engaging only records the position, so this
+-- parks the mouse on the bar without summoning anything.
+hud_pointer(600, 680)
+fake.send("mpvtk-hud-summon", "nav")
+hud_bars()
+fake.reset_events()
+hud_wait()
+ok(hud_hidden(), "a key summon under an unmoved pointer still auto-hides")
+
+-- ...and moving it there does hold them, which is the case that gate must
+-- not have broken. (Two events again: the first after a hide only records
+-- the position, the second is movement and summons.)
+hud_pointer(600, 680)
+hud_pointer(600, 690)
+hud_bars()
+fake.reset_events()
+hud_wait()
+ok(not hud_hidden(), "moving the pointer onto them holds them up again")
+
+-- A pointer that leaves the window entirely takes its position with it.
+-- mpv keeps reporting the last coordinates with hover=false, which used to
+-- read as a mouse still resting on the bar.
+fake.observe("mouse-pos", { x = 600, y = 690, hover = false })
+fake.reset_events()
+hud_wait()
+ok(hud_hidden(), "a pointer that left the window stops holding them up")
+
 -- ================================================== scrub preview bubble
 
 -- The seek bar's trickplay/chapter/timestamp bubble is drawn HERE. It used

--- a/tests/lua/test_renderer.lua
+++ b/tests/lua/test_renderer.lua
@@ -1220,6 +1220,142 @@ hud_wait()
 ok(hud_hidden(), "the default hides them on a paused film")
 fake.log.props["pause"] = nil
 
+-- ================================================== scrub preview bubble
+
+-- The seek bar's trickplay/chapter/timestamp bubble is drawn HERE. It used
+-- to be a scene node Python rebuilt from a throttled hover event, which is
+-- why it trailed the pointer (#618) and why its width was a guess that only
+-- came out right when a thumbnail was the widest thing in it (#612).
+
+local function pv_paint()
+    fake.advance(0.1)
+    fake.fire_timers()
+end
+
+--- The bubble's rect, or nil when it is not up.
+local function preview()
+    fake.reset_events()
+    fake.send("mpvtk-debug", fake.token({ cmd = "state" }))
+    return (last_event("debug_state") or {}).preview
+end
+
+--- The summoned HUD's seek bar as hud.py lays it out: 10 minutes over a
+--- 1080px node at x=100, so the track runs 108..1172 and its midpoint is
+--- 5:00.
+local function seek_scene()
+    scene({ { id = "hud-bar", t = "rect", x = 0, y = 640, w = 1280, h = 80 },
+            { id = "hud-seek", t = "slider", x = 100, y = 660, w = 1080,
+              h = 26, min = 0, max = 600, value = 0, pv = true } })
+end
+
+hud_engage({ hide = 4, mode = "hover" })
+seek_scene()
+hud_pointer(640, 300)
+pv_paint()
+ok(preview() == nil, "no bubble with the pointer off the bar")
+
+hud_pointer(640, 670)
+pv_paint()
+local pv = preview()
+ok(pv ~= nil, "the bubble appears with the pointer on the bar")
+ok(pv and math.abs(pv.secs - 300) < 1,
+   "the bubble reads the position under the pointer",
+   pv and ("secs=" .. tostring(pv.secs)))
+ok(pv and pv.y + pv.h <= 660, "the bubble sits above the bar it describes")
+
+-- #612: the box is centred on the position it describes, whatever is in it.
+-- Python assumed a flat 136px and drew whatever the content came to, so a
+-- short chapter title pulled the bubble left of the point it was labelling.
+ok(pv and math.abs((pv.x + pv.w / 2) - 640) < 2,
+   "the bubble is centred on the pointer",
+   pv and ("centre=" .. tostring(pv.x + pv.w / 2)))
+
+-- No trickplay data yet, so no frame: the bubble is text only.
+eq(pv and pv.frame, nil, "no frame before any trickplay data arrives")
+
+-- ...and no overlay was issued for it either.
+local function preview_overlay()
+    local found
+    for _, c in ipairs(fake.log.commands) do
+        if c[1] == "overlay-add" and c[5] == "/tiles.bin" then found = c end
+    end
+    return found
+end
+
+fake.log.commands = {}
+hud_pointer(640, 671)
+pv_paint()
+ok(preview_overlay() == nil, "a bubble with no tiles issues no overlay")
+
+-- BIF tiles: 10s apart, so 5:00 is frame 30 and its bytes start at
+-- 30 * w * h * 4 -- the offset argument, which is what lets the renderer
+-- read one frame out of a file of them without decoding anything.
+fake.send("shim-trickplay-bif", "60", "10000", "32", "18", "/tiles.bin")
+fake.log.commands = {}
+hud_pointer(640, 672)
+pv_paint()
+local ov = preview_overlay()
+ok(ov ~= nil, "the trickplay frame is composited into the bubble")
+eq(ov and tonumber(ov[6]), 30 * 32 * 18 * 4,
+   "the overlay reads the frame for the hovered position")
+eq(preview().frame, 30, "the bubble reports the frame it drew")
+
+-- Past the end of the tiles clamps rather than reading past EOF, which
+-- mpv mmaps and would answer with SIGBUS.
+fake.send("shim-trickplay-bif", "10", "10000", "32", "18", "/tiles.bin")
+hud_pointer(1100, 672)
+pv_paint()
+eq(preview().frame, 9, "a position past the last tile clamps to it")
+
+-- The chapter-image fallback indexes by chapter start instead of a cadence.
+fake.send("shim-trickplay-chapters", "32", "18", "/tiles.bin", "0,120,480")
+hud_pointer(640, 673)
+pv_paint()
+eq(preview().frame, 1, "chapter tiles index by start time (5:00 is in #2)")
+
+-- The bytes are unlinked right after the clear, so the renderer must stop
+-- pointing at them before that happens.
+fake.send("shim-trickplay-clear")
+fake.log.commands = {}
+hud_pointer(640, 674)
+pv_paint()
+ok(preview() ~= nil, "the bubble survives the tiles going away")
+ok(preview_overlay() == nil, "...but stops reading the cleared file")
+
+-- The pointer leaving the bar takes it away.
+hud_pointer(640, 300)
+pv_paint()
+ok(preview() == nil, "the bubble goes with the pointer")
+
+-- Releasing a drag must not make the bubble jump. A drag returns out of
+-- on_mouse_move before the hover tracking, so the position it falls back to
+-- when the button comes up has to have been kept current on the way.
+hud_pointer(400, 672)                   -- park the pointer left of centre
+pv_paint()
+local before = preview().secs
+fake.mouse(900, 672)
+fake.key("mbtn_left")                   -- press ON the bar: the drag starts
+fake.mouse(1000, 672)                   -- ...and drags right
+pv_paint()
+local dragged = preview().secs
+ok(dragged > before, "the bubble did not follow the drag",
+   string.format("%s -> %s", tostring(before), tostring(dragged)))
+fake.send("mpvtk-debug", fake.token({ cmd = "click", x = 1000, y = 672 }))
+pv_paint()
+ok(preview() ~= nil and math.abs(preview().secs - dragged) < 20,
+   "releasing the drag snapped the bubble back to where it started",
+   string.format("released at %s, was dragged to %s",
+                 tostring(preview() and preview().secs), tostring(dragged)))
+
+-- A bar that does not ask for a preview never gets one: this is opt-in
+-- (the volume slider is the same widget).
+scene({ { id = "hud-bar", t = "rect", x = 0, y = 640, w = 1280, h = 80 },
+        { id = "hud-vol", t = "slider", x = 100, y = 660, w = 1080,
+          h = 26, min = 0, max = 100, value = 50 } })
+hud_pointer(642, 670)
+pv_paint()
+ok(preview() == nil, "a slider without pv draws no bubble")
+
 -- ========================================================== teardown
 
 scene({})

--- a/tests/test_gateway_mixins.py
+++ b/tests/test_gateway_mixins.py
@@ -35,6 +35,11 @@ PKG = os.path.dirname(inspect.getfile(gw))
 #: Every method the gateway had as one class, immediately before the split.
 #: Pinned as data rather than derived, so the check is against what shipped
 #: rather than against whatever the code now happens to say.
+#:
+#: A name leaves this set only when the method is *deliberately* retired --
+#: so far only ``trickplay``, whose caller went away when the scrub preview
+#: moved into renderer.lua (#618). Anything else disappearing is the bug this
+#: is here to catch.
 BEFORE_SPLIT = {
     "add_server", "add_user", "any_client", "apply_audio_settings",
     "cancel_load", "chapters", "check_updates", "client_for",
@@ -59,7 +64,7 @@ BEFORE_SPLIT = {
     "stop", "stop_for_close", "switch_user", "sync_active", "sync_join",
     "sync_leave", "sync_new", "sync_state", "toggle_favorite",
     "toggle_fullscreen", "toggle_mute", "toggle_night_mode", "toggle_pause",
-    "toggle_stats", "trickplay", "unlock", "unlock_user", "use_hud",
+    "toggle_stats", "unlock", "unlock_user", "use_hud",
     # private, but part of the contract other tests pin
     "_act", "_edit", "_queue_offline_watched", "_sync", "_ui_seek",
 }

--- a/tests/test_python_lua_constants.py
+++ b/tests/test_python_lua_constants.py
@@ -1,20 +1,24 @@
 """Constants duplicated across Python and renderer.lua.
 
-Two values are computed on both sides of the mpv boundary and have to agree,
-and until now the only thing holding them together was a "keep in sync"
-comment:
+Some values are computed on both sides of the mpv boundary and have to
+agree; the only thing that used to hold them together was a "keep in sync"
+comment.
 
-* the heuristic char-width table — layout.py measures text to decide how
-  much room a node needs, renderer.lua measures it again to place the glyphs.
-  Drift means Python reserves one width and Lua draws another, which shows up
-  as text that wraps a word early or overflows its box.
-* SLIDER_PAD — hud.py maps a click position back to a seek time using the
-  track inset renderer.lua drew the track with. Drift means the seek lands
-  slightly off where you clicked, worst at the ends of the bar.
+The heuristic char-width table is the main one — layout.py measures text to
+decide how much room a node needs, renderer.lua measures it again to place
+the glyphs. Drift means Python reserves one width and Lua draws another,
+which shows up as text that wraps a word early or overflows its box. It is a
+*fallback*: measured font metrics replace it at runtime, so a mismatch only
+bites on the path taken before (or without) metrics — which is exactly the
+path nobody would notice being wrong.
 
-Both are *fallbacks*: measured font metrics replace them at runtime, so a
-mismatch only bites on the path taken before (or without) metrics — which is
-exactly the path nobody would notice being wrong.
+The Skip button's geometry is the other: two implementations of one widget
+that hand off to each other mid-segment.
+
+SLIDER_PAD used to be here too — hud.py positioned the scrub-preview bubble
+with its own copy of the renderer's track inset. That bubble is drawn in
+renderer.lua now, so the inset exists in one place and there is nothing left
+to cross-check.
 """
 
 import ast
@@ -85,18 +89,6 @@ class TestCharWidthTable(unittest.TestCase):
     def test_a_narrow_char_is_not_also_wide(self):
         self.assertEqual(self._py_set("_NARROW") & self._py_set("_WIDE"),
                          set())
-
-
-class TestSliderPad(unittest.TestCase):
-    """hud.py's _SLIDER_PAD vs renderer.lua's SLIDER_PAD."""
-
-    def test_they_match(self):
-        py = int(_one(r"^_SLIDER_PAD = (\d+)$", _read(HUD), "_SLIDER_PAD"))
-        lua = int(_one(r"^local SLIDER_PAD = (\d+)$", _read(RENDERER),
-                       "lua SLIDER_PAD"))
-        self.assertEqual(py, lua,
-                         "a click maps to a seek time using this inset; "
-                         "drift puts the seek off where the user clicked")
 
 
 class TestSkipButtonGeometry(unittest.TestCase):

--- a/tests/test_shell_playback.py
+++ b/tests/test_shell_playback.py
@@ -147,37 +147,25 @@ class TestPlaybackHudLayout(unittest.TestCase):
         nodes, _h = build_scene(b, (1280, 720))
         seek = next(n for n in nodes if n.get("id") == "hud-seek")
         self.assertEqual(seek.get("ranges"), [[0.1, 0.4], [0.9, 1.0]])
-        self.assertTrue(seek.get("hoverev"),
-                        "seek bar must opt into hover events")
+        self.assertTrue(seek.get("pv"),
+                        "seek bar must opt into the renderer's preview")
 
-    def test_hover_bubble_shows_chapter_and_time(self):
-        b, ctl = self._browser()
+    def test_no_python_side_preview_bubble(self):
+        """The scrub bubble is the renderer's, not a scene node.
+
+        It used to be built here from a hover event, which meant a whole
+        HUD rebuild per pointer move (#618) and a box whose width Python
+        guessed rather than measured (#612). All that is left on this side
+        is the flag that tells the renderer the bar has one.
+        """
+        b, _ctl = self._browser()
         nodes, handlers = build_scene(b, (1280, 720))
         self.assertNotIn("hud-preview", ids(nodes))
-        # need a laid-out slider rect for the float: fake node_rect via
-        # a stub app that serves the previous scene's geometry
-        seek = next(n for n in nodes if n.get("id") == "hud-seek")
-
-        class GeoApp(StubHudApp):
-            def node_rect(self, node_id):
-                return seek if node_id == "hud-seek" else None
-
-            def invalidate(self):
-                pass
-
-        b.app = GeoApp()
-        handlers["hud-seek"]["hover"](45.0)
-        self.assertEqual(b.hud.hover, 45.0)
-        nodes, handlers = build_scene(b, (1280, 720))
-        self.assertIn("hud-preview", ids(nodes))
-        texts = [n.get("text") for n in nodes if n.get("text")]
-        self.assertIn("0:45", texts, "bubble timestamp missing")
-        self.assertIn("Middle", texts,
-                      "bubble chapter name missing (45s is in Middle)")
-        handlers["hud-seek"]["hover_end"]()
-        self.assertIsNone(b.hud.hover)
-        nodes, _h = build_scene(b, (1280, 720))
-        self.assertNotIn("hud-preview", ids(nodes))
+        self.assertNotIn("hover", handlers["hud-seek"],
+                         "the seek bar must not ask for hover events")
+        self.assertNotIn("hover_end", handlers["hud-seek"])
+        self.assertFalse(hasattr(b.hud, "hover"),
+                         "hover state has no owner on this side any more")
 
     def test_hud_show_hide_adjusts_sub_margin(self):
         b, ctl = self._browser()


### PR DESCRIPTION
HUD now renders trickplay itself, directly from the `shim-trickplay-bif` and `shim-trickplay-chapters` messages, the same way the old OSC did it. Makes trickplay way more responsive.

This PR also fixes text dimensions on the hover too, reported as issue **#612**.

Also fixes an issue where untouched players didn't hide the UI on pointer idle (e.g. headless device).

Play All and Shuffle also now use 300 item queries instead of 200 item queries, matching jf-web.

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>