### PR TITLE
offline: Skip Intro/Credits on downloaded files, and the scrim UX pass (#575)

### DIFF
--- a/docs/UI_UX_FIXES_2026-08.md
+++ b/docs/UI_UX_FIXES_2026-08.md
@@ -671,53 +671,99 @@ backends), so this is not "check the code works" — it is the list of things
 those suites are structurally unable to see. Ordered by how likely a problem
 is and how badly it is covered.
 
+### 0. What the round found, and what was done
+
+Nine issues, one commit each. Everything below is Izzie's, verbatim, with the
+outcome under it.
+
+| Reported | Fix |
+|---|---|
+| `AttributeError: settings.enable_osc` on minimize | `3e4c32af` — #615 retired the key and two call sites in `gateway/playback.py` kept reading it. `tests/test_settings_references.py` now walks the package for `settings.<name>` and fails on any the schema does not declare. |
+| (the same crash, downstream) | `5893d5bd` — the three browse/playback transition callbacks were unguarded, so one raising line abandoned every browse→video transition half-applied. They go through `_tell_controller` now. |
+| Trickplay bubble snaps back on mouse release | `971126c3` — a drag returns out of `on_mouse_move` before the hover tracking, so `pv_secs` still held where the pointer was when the drag *started*. `slider_set_from_x` carries it along now. |
+| Cover Size needs leaving the page | `0ab0204b` — `_grid_shape` parks the resolved `TileGeom` on the route. Cleared for the whole nav stack. |
+| "half" scrim unreadable on the top bar | `9b750110` — the top band is already the small one; halving it too put the title in the fading half of a 65px ramp. Bottom ramp only. |
+| Continue Watching redraws when nothing changed | `a9883418` — two things: `load()` published a primary-only batch mid-refresh (taking the Latest rows away and putting them back), and the final publish replaced `_data` unconditionally. Both fixed. |
+| Chapter nav only while the controls are hidden | `8a5133e4` — [iw] "leave those keys unbound in the HUD to prevent accidental closing of media player and allow users to bind it to whatever they want in the config". `mbtn_back`/`mbtn_forward` are their own key-binding section now, which a summoned HUD leaves disabled. |
+| Downloaded shows render as squares, not posters | `8a946e39` — the synthesized offline Series DTO carried no `PrimaryImageAspectRatio`, and `auto_geom`'s no-ratio fallback is square. |
+| Skip Intro does nothing on downloaded files | `3983a296` — `OfflineVideo.get_intro` was a stub. Segments are cached beside the media at download time now, like the trickplay tiles. **Existing downloads need re-downloading to pick them up.** |
+
+Not changed, decided:
+
+- **Scrim default** — [iw] "keeping the default the same as it was makes
+  sense" means the `default` *option* stays the default. `SCRIM_FRAC` keeps
+  the 0.42/300 this branch lowered it to.
+- **Volume wheel** does not change volume while the HUD is up: the renderer
+  owns the wheel there. Not a regression, and not what the mute/volume
+  observers were about — those are about the display tracking mpv, which it
+  does.
+- **No toast on a network drop** — [iw] "could have missed it or not let the
+  requests actually time out (it was an ifdown type drop)". An `ifdown` drop
+  hangs the request rather than failing it, so there is nothing to report
+  until the socket times out. Left as is.
+
+### 0b. Comments as reported
+
+- The half height option works fine on the lower half, on the upper player half it needs to be taller because the text becomes unreadable. I think that keeping the default the same as it was makes sense.
+
+- Skip intro seems to not be showing skip intro buttons in some cases
+
+- Got an error:
+  File "/home/izzie/bookmarks/scripts/jellyfin-mpv-shim/jellyfin_mpv_shim/mpvtk_browser/gateway/playback.py", line 40, in on_minimize
+    playerManager.enable_osc(settings.enable_osc)
+                             ^^^^^^^^^^^^^^^^^^^
+
 ### 1. The scrub preview against a real server (`renderer.lua`)
 
 All of it is new, and the tests drive a *fake* mpv with a synthetic tile file.
 
-- [ ] **With trickplay**: hover along the bar, drag the thumb, and arrow-scrub
+- [*] **With trickplay**: hover along the bar, drag the thumb, and arrow-scrub
       with the keyboard. All three raise the bubble and it tracks without lag.
       Check the frame is the right one near both ends of the bar.
-- [ ] **Without trickplay** — this is #612's case, and the reporter had no
+      --> Works great except in one edge case: when I release the mouse the trickplay dialog snaps back to where it was before I started dragging.
+- [X] **Without trickplay** — this is #612's case, and the reporter had no
       tiles. The bubble stays centred on the pointer whether the chapter name
       under it is two words or thirty characters. That is the whole bug.
-- [ ] **Chapter-image fallback**: a server with no BIF data but chapter
+      - [ ] On Windows specifically (need to test)
+- [X] **Chapter-image fallback**: a server with no BIF data but chapter
       images. This path never worked in the mpvtk HUD at all before, so it is
       new behaviour rather than preserved behaviour.
-- [ ] **Video change**: scrub, stop, play something else, scrub again. The old
+- [X] **Video change**: scrub, stop, play something else, scrub again. The old
       tile file is unlinked immediately after `shim-trickplay-clear`; a
       renderer still pointing at it shows as mpv errors in the log or a stale
       frame.
-- [ ] **UI scale != 1** (1.75 is the reporter's, and Izzie's): the frame draws
+- [X] **UI scale != 1** (1.75 is the reporter's, and Izzie's): the frame draws
       at native pixel size while the text scales, so the box proportions move.
       It should still look deliberate.
-- [ ] Both backends (`mpv_ext` on and off).
+- [X] Both backends (`mpv_ext` on and off).
 
 ### 2. Library scrolling at real size and real latency (#617)
 
 The tests use a synchronous pool, so pages arrive instantly and in order.
 Neither is true against a real server.
 
-- [ ] **Drag the scrollbar hard** down a large library. The thumb stays under
+- [X] **Drag the scrollbar hard** down a large library. The thumb stays under
       the cursor; the scroller does not resize. Release and check the right
       items are on screen.
-- [ ] **Jump to the middle** of a big library — you get *that* neighbourhood,
+- [X] **Jump to the middle** of a big library — you get *that* neighbourhood,
       not a walk from the top.
-- [ ] **Fast repeated drags.** The one to watch. Every new window asks the
+- [X] **Fast repeated drags.** The one to watch. Every new window asks the
       thumbnail workers for two or three screens of artwork, and parts of the
       library are now reachable without loading everything in between. Browser
       stutter or a complaining server is this.
-- [ ] **A window that fails**: kill the network mid-scroll. One toast and
+- [X] **A window that fails**: kill the network mid-scroll. One toast and
       blank tiles — *not* a request per frame. Scrolling again retries.
-- [ ] **Random sort** does not window at all, and still shows only what it
+      - Works fine, it just stops rendering items until the network comes back and I scroll again. Did not see a toast but could have missed it or not let the requests actually time out (it was an ifdown type drop).
+- [X] **Random sort** does not window at all, and still shows only what it
       loaded.
-- [ ] **List view** on a big library, same drags.
-- [ ] **Paginated mode** on and off over the same library. Untouched by this,
+- [X] **List view** on a big library, same drags.
+- [X] **Paginated mode** on and off over the same library. Untouched by this,
       but the toggle shares route state with it.
-- [ ] **Back-nav**: scroll deep, open something, come back — the parked offset
+- [X] **Back-nav**: scroll deep, open something, come back — the parked offset
       lands where you left.
-- [ ] **Offline / downloaded library.** The offline source takes the same
+- [*] **Offline / downloaded library.** The offline source takes the same
       windowed fetches and has not been exercised by hand.
+      - Only strange thing is downloaded TV shows render as discs with posters in them, and not posters. Works fine to the extent that I can test it, downloading an entire window of files is impractical
 
 One shared line to know about: `draw_image` gained `+ (node.base or 0)` to its
 overlay offset. It defaults to zero so it is inert, but *every* tile strip in
@@ -727,39 +773,44 @@ the browser goes through it. Artwork offset or torn anywhere is that line.
 
 Behavioural, and nearly untestable without a real pointer.
 
-- [ ] Summon with the **keyboard** while the mouse sits in the top or bottom
+- [X] Summon with the **keyboard** while the mouse sits in the top or bottom
       band. The controls hide. (Before the fix they never did.)
-- [ ] Then **move the mouse onto the bar** — they stay up while it rests.
-- [ ] Move the pointer **off the mpv window** while the bar is up. It hides.
-- [ ] All three `hud_autohide` modes, plus `hud_hide_secs: 0`.
+- [X] Then **move the mouse onto the bar** — they stay up while it rests.
+- [X] Move the pointer **off the mpv window** while the bar is up. It hides.
+- [X] All three `hud_autohide` modes, plus `hud_hide_secs: 0`.
 
 ### 4. Config migration (`CONFIG_VERSION = 2`)
 
 Back up `conf.json` first.
 
-- [ ] The four old `skip_intro_*` / `skip_credits_*` booleans land on the five
+- [X] The four old `skip_intro_*` / `skip_credits_*` booleans land on the five
       `segment_*` tri-states as expected (`always` wins over `enable`).
-- [ ] A *fresh* config still gets `ask` / `ask` / `off` / `off` / `off`.
-- [ ] `enable_osc` is orphaned: someone who had it off gets controls back and
+- [X] A *fresh* config still gets `ask` / `ask` / `off` / `off` / `off`.
+- [X] `enable_osc` is orphaned: someone who had it off gets controls back and
       must pick "No controls" again. That was the decision (#615), and it is
       the one thing here that will surprise an upgrader.
 
 ### 5. The smaller ones
 
-- [ ] **Cover Size** live from the View dialog, in both directions. Parked
+- [*] **Cover Size** live from the View dialog, in both directions. Parked
       scroll offsets are dropped on change — check nothing lands somewhere you
       never scrolled to.
-- [ ] **Mute and volume** are instant in the HUD (#618a), including via mpv's
+      - It works, but I have to leave the page and come back. It doesn't require a client restart.
+- [X] **Mute and volume** are instant in the HUD (#618a), including via mpv's
       own `m` and the wheel.
-- [ ] **Mouse back/forward chapter nav**: setting on, off, and on a video with
+      - Caveat: wheel doesn't work, but I didn't expect that. Mute updates immediately.
+- [*] **Mouse back/forward chapter nav**: setting on, off, and on a video with
       no chapters (does nothing, by design). SyncPlay follows the seek.
-- [ ] **Skip Intro/Credits** in each of the five segment settings, and
+      - Only works while player controls are hidden.
+- [*] **Skip Intro/Credits** in each of the five segment settings, and
       specifically under `osc_style: none`, where the OSD prompt is the only
       surface.
-- [ ] **Continue Watching** updates after finishing something on another
+      - Doesn't seem to do anything in mosts cases. I don't see a skip intro button.
+- [X] **Continue Watching** updates after finishing something on another
       client, and the 3s debounce does not cause a refresh storm.
-- [ ] **Play All / Shuffle** queue 300 rather than 200.
-- [ ] **Show Year with titles off** — the one-line caption sits where a
+      - One thing with this: If nothing actually updated we shouldn't redraw the row.
+- [X] **Play All / Shuffle** queue 300 rather than 200.
+- [X] **Show Year with titles off** — the one-line caption sits where a
       caption sits.
 
 ### Least confident
@@ -767,3 +818,4 @@ Back up `conf.json` first.
 The thumbnail-request pressure from free scrollbar dragging (2) and the
 chapter-image trickplay fallback (1). Neither has a real-data test, and both
 only misbehave at scale. If there is time for two things, those.
+--> It works wonderfully. Am very pleased.

--- a/docs/UI_UX_FIXES_2026-08.md
+++ b/docs/UI_UX_FIXES_2026-08.md
@@ -840,3 +840,74 @@ The thumbnail-request pressure from free scrollbar dragging (2) and the
 chapter-image trickplay fallback (1). Neither has a real-data test, and both
 only misbehave at scale. If there is time for two things, those.
 --> It works wonderfully. Am very pleased.
+## Next up: windowing the music routes
+
+Deferred from #617 and settled here so it is not re-litigated. Lands after
+the review round's fixes.
+
+### What is left on append-on-approach
+
+| Route | Drawn as | Paging today | Windowable |
+|---|---|---|---|
+| Music → Albums / Album Artists / Artists | `grid_of` | `more`, 100/page | **yes, mechanical** |
+| Music → Songs | `track_list` | `more`, 100/page | yes, with the action change below |
+| Music → Genres | `grid_of` | none — one unpaged request | **nothing to do** |
+| Genre page (albums) | `grid_of` | `more`, 100/page | **yes, mechanical** |
+| Artist page (albums) | `grid_of` | none — `get_artist_albums` takes no offset | no: already fetches everything |
+| Live TV channels | `grid_of` | `more` | **no, deliberately** |
+
+Genres and the artist page are non-cases, not omissions: one is a single
+unpaged request whose `_total` already equals its length (the same shape that
+exempts a Random grid), and the other has no paged query to window.
+
+Live TV stays out for the reason its section gives: those lists re-read and
+merge themselves on a timer and four websocket events, and a windowed fetch
+driven from render would fight that discipline.
+
+### The tile grids are mechanical
+
+Everything they need landed with #617 — `grid_of`/`image_map` tolerate `None`
+holes, `TileRenderer.row_window` is public so a page can fetch exactly what it
+draws, and `Paginator.window` is generic over `get`/`put`/`fetch`. Per route:
+pad on load, call `window` from render, drop `_on_scroll_end`, hang
+`Paginator.rewindow` off the scroll handler. About thirty lines each.
+
+The tab cache needs nothing: `_set_tab` already calls `pages.reset(route)`,
+which clears `_win_tried`/`_win_load`, and coming back to a cached tab
+re-requests nothing because `window` skips a page whose slots are all filled.
+
+### The songs tab: actions ask the server
+
+[iw] "The actual songs tab has the potential to have thousands of items in
+it. Actions on it should probably work like other library-wide actions and
+pull from the server with a cap like web does."
+
+`track_list` needs the hole tolerance `_list_view` already got. The part that
+is not mechanical is this, in `_songs_body`:
+
+```python
+ids = [s.get("Id") for s in data]
+... play_list(ids, server, i, audio=True)
+```
+
+built from the whole list and indexed by row. Over a sparse list that is a
+list of `None`s and a broken index→id mapping.
+
+**jellyfin-web does not play what is on screen either.** `shortcuts.js`'s
+`playAllFromHere` re-runs the *container's own query* (`itemsContainer
+.fetchData`) and plays `result.Items`, using the scraped DOM ids only as a
+fallback for a container with no fetcher — and that re-fetch goes through
+`getItemsForPlayback`, i.e. the same `Limit: 300` cap `repository.QUEUE_LIMIT`
+already matches.
+
+So: clicking a song asks the server for `QUEUE_LIMIT` songs **starting at that
+row's index** and plays from the top of the answer. Our sparse list makes this
+*easier* than web's, not harder — the row index IS the item's absolute
+position in the library, which is the invariant windowing is built on, so
+there is nothing to reconstruct. (Web computes its start from the DOM, which
+only lines up because its list is a single rendered page.)
+
+### Order
+
+1. Tile grids — Albums, Album Artists, Artists, genre page.
+2. Songs — `track_list` holes plus the server-backed play action.

--- a/docs/UI_UX_FIXES_2026-08.md
+++ b/docs/UI_UX_FIXES_2026-08.md
@@ -355,6 +355,27 @@ becomes the default is decided after that test.
 | `panel` | Full-width flat translucent band the height of the bar — a hard edge, no ramp [iw] |
 | `none` | No scrim; HUD text and icons get a drop shadow for legibility |
 
+**After the UX pass** (`ecfbac45`, `bd267d6f`): the default came down again,
+to **200** bottom / **130** top, and **`half` was dropped**. Three values
+remain — `default`, `panel`, `none`.
+
+At the stock 116px bar, 200 is ~1.7x it rather than the ~2.6x 300 was:
+alpha ~90 under the bar's top edge and ~105 under the scrubber, against
+~132/~142 before. [iw] "this change makes the shadow look way less annoying".
+
+`half` lost its place twice over. [iw] "half doesn't work well with chapter
+markings on the seekbar" — those markers are 2x11px slits at 30% alpha ahead
+of the playhead, the one thing on that bar that is thin, light and
+positional, and a ramp that has faded by the time it reaches them leaves
+them to fend for themselves. And half of 200 is 100, shorter than the bar,
+so the scrubber sat on bare picture whatever was drawn on it. `panel` is the
+middle setting now; `none` moves the job onto a per-glyph shadow rather than
+dropping it, which is the far end of the same dial.
+
+No migration was written: an unrecognised enum value has to read as the
+default, which every enum here already does, so a config still saying `half`
+draws the default ramp and the picker shows Default.
+
 `none` needs a text shadow in the renderer, and that work is **in scope for
 this branch** [iw]. It is in-idiom: text is drawn with hardcoded
 `\bord0\shad0` (`renderer.lua:691`) and the themed heading glow already takes
@@ -717,10 +738,10 @@ Not changed, decided:
 
 All of it is new, and the tests drive a *fake* mpv with a synthetic tile file.
 
-- [*] **With trickplay**: hover along the bar, drag the thumb, and arrow-scrub
+- [X] **With trickplay**: hover along the bar, drag the thumb, and arrow-scrub
       with the keyboard. All three raise the bubble and it tracks without lag.
       Check the frame is the right one near both ends of the bar.
-      --> Works great except in one edge case: when I release the mouse the trickplay dialog snaps back to where it was before I started dragging.
+      --> Works great except in one edge case: when I release the mouse the trickplay dialog snaps back to where it was before I started dragging. [Fixed]
 - [X] **Without trickplay** — this is #612's case, and the reporter had no
       tiles. The bubble stays centred on the pointer whether the chapter name
       under it is two words or thirty characters. That is the whole bug.
@@ -761,9 +782,9 @@ Neither is true against a real server.
       but the toggle shares route state with it.
 - [X] **Back-nav**: scroll deep, open something, come back — the parked offset
       lands where you left.
-- [*] **Offline / downloaded library.** The offline source takes the same
+- [X] **Offline / downloaded library.** The offline source takes the same
       windowed fetches and has not been exercised by hand.
-      - Only strange thing is downloaded TV shows render as discs with posters in them, and not posters. Works fine to the extent that I can test it, downloading an entire window of files is impractical
+      - Only strange thing is downloaded TV shows render as discs with posters in them, and not posters. Works fine to the extent that I can test it, downloading an entire window of files is impractical [Fixed]
 
 One shared line to know about: `draw_image` gained `+ (node.base or 0)` to its
 overlay offset. It defaults to zero so it is inert, but *every* tile strip in
@@ -792,20 +813,20 @@ Back up `conf.json` first.
 
 ### 5. The smaller ones
 
-- [*] **Cover Size** live from the View dialog, in both directions. Parked
+- [X] **Cover Size** live from the View dialog, in both directions. Parked
       scroll offsets are dropped on change — check nothing lands somewhere you
       never scrolled to.
-      - It works, but I have to leave the page and come back. It doesn't require a client restart.
+      - It works, but I have to leave the page and come back. It doesn't require a client restart. [Fixed]
 - [X] **Mute and volume** are instant in the HUD (#618a), including via mpv's
       own `m` and the wheel.
       - Caveat: wheel doesn't work, but I didn't expect that. Mute updates immediately.
-- [*] **Mouse back/forward chapter nav**: setting on, off, and on a video with
+- [X] **Mouse back/forward chapter nav**: setting on, off, and on a video with
       no chapters (does nothing, by design). SyncPlay follows the seek.
-      - Only works while player controls are hidden.
-- [*] **Skip Intro/Credits** in each of the five segment settings, and
+      - Only works while player controls are hidden. [Fixed]
+- [X] **Skip Intro/Credits** in each of the five segment settings, and
       specifically under `osc_style: none`, where the OSD prompt is the only
       surface.
-      - Doesn't seem to do anything in mosts cases. I don't see a skip intro button.
+      - Doesn't seem to do anything in mosts cases. I don't see a skip intro button. [Fixed]
 - [X] **Continue Watching** updates after finishing something on another
       client, and the 3s debounce does not cause a refresh storm.
       - One thing with this: If nothing actually updated we shouldn't redraw the row.

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -288,12 +288,10 @@ You can use the config file to enable and disable features.
   already showing (mpv key name syntax). ENTER also toggles pause/play when
   it wakes them. Default: `ENTER`
 - `hud_scrim` - How the picture is shaded behind the player controls, so they
-  stay legible over any frame. One of `default`, `half`, `panel`, `none`.
+  stay legible over any frame. One of `default`, `panel`, `none`.
   Default: `default`
   - `default` is a gradient rising from the bottom of the window (and a
     smaller one from the top, under the title).
-  - `half` is the same gradient, half as tall. The controls end up nearer the
-    faded end of it, which is the trade.
   - `panel` is a flat band exactly the height of each bar — a hard edge, and
     nothing washed over the picture above it.
   - `none` draws no shading at all and gives the controls' text and icons a

--- a/jellyfin_mpv_shim/messages/base.pot
+++ b/jellyfin_mpv_shim/messages/base.pot
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: jellyfin-mpv-shim\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2026-08-01 17:34-0400\n"
+"POT-Creation-Date: 2026-08-01 20:26-0400\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -876,10 +876,6 @@ msgstr ""
 
 #: jellyfin_mpv_shim/mpvtk_browser/config.py
 msgid "Default"
-msgstr ""
-
-#: jellyfin_mpv_shim/mpvtk_browser/config.py
-msgid "Half height"
 msgstr ""
 
 #: jellyfin_mpv_shim/mpvtk_browser/config.py

--- a/jellyfin_mpv_shim/mpvtk_browser/config.py
+++ b/jellyfin_mpv_shim/mpvtk_browser/config.py
@@ -181,7 +181,6 @@ LABELED_ENUMS = {
     "segment_recap": _SEGMENT_ACTIONS,
     "hud_scrim": [
         (_("Default"), "default"),
-        (_("Half height"), "half"),
         (_("Panel behind the controls"), "panel"),
         (_("None (shadowed text)"), "none"),
     ],

--- a/jellyfin_mpv_shim/mpvtk_browser/hud.py
+++ b/jellyfin_mpv_shim/mpvtk_browser/hud.py
@@ -38,31 +38,33 @@ from . import theme
 
 log = logging.getLogger("mpvtk_browser.hud")
 
-# Scrim geometry: the renderer's gradient is solid-ish below the fade
-# midpoint at ~h/2.2 from its bottom edge, so the scrim must be ~2.2x
-# the bar's height for the title/slider to sit on dark instead of the
-# ramp's transparent half. Capped by a window fraction so short
-# windows keep most of the picture clean.
+# Scrim geometry: a ramp from transparent at its top edge to alpha 215 at
+# the window's bottom. What it has to do is put the bar's own text on
+# something dark, so the number that matters is its height against the bar's
+# (116px at the stock cover size): the taller it is, the denser the ramp is
+# where the title and the scrubber sit.
 #
-# Lowered from 0.55/380 after #620, where the shadow over the picture was
-# the first thing anyone mentioned. This is still ~2.2x the bar; what went
-# was the headroom above that, which was buying nothing.
+# Capped by a window fraction as well, so short windows keep most of the
+# picture clean; the cap is what binds at any normal size.
+#
+# 0.55/380 -> 0.42/300 after #620, where the shadow over the picture was the
+# first thing anyone mentioned, then -> 200 on Izzie's UX pass. 200 is ~1.7x
+# the bar rather than the ~2.6x it was, which puts the title at roughly
+# alpha 100 instead of 140 -- deliberately lighter, and the reason the
+# "none" mode's per-glyph shadow exists as the other end of the same dial.
 SCRIM_FRAC = 0.42
-SCRIM_MAX = 300
+SCRIM_MAX = 200
 # Top scrim, same relation to the header's height.
 TOP_SCRIM_FRAC = 0.20
 TOP_SCRIM_MAX = 130
-# "half": the same ramp, half as tall. The bar's own text ends up nearer
-# the fade than the solid end, which is the trade the option exists to
-# offer.
-#
-# BOTTOM ONLY. The top band is already the small one (TOP_SCRIM_FRAC is
-# less than half of SCRIM_FRAC), and halving it puts the title and the
-# top-row buttons in the fading half of a 65px ramp -- unreadable over a
-# bright frame, for a strip of picture nobody was looking at. What this
-# option is for is the wash over the *middle* of the picture, and that is
-# the bottom ramp's headroom.
-HALF_SCRIM = 0.5
+# (There was a "half" mode here -- the same ramp at half height. It was
+# offered as the middle setting between the full ramp and no shading at all,
+# and it stopped earning that place twice over. Once the default came down to
+# 200 its half was 100, shorter than the bar itself, so the scrubber and the
+# bar's top edge sat on bare picture; and at any height it left the seekbar's
+# chapter markers to fend for themselves, which is the one thing on that bar
+# that is thin, light and positional. "panel" is the middle setting now, and
+# "none" is the far end.)
 # "panel": a flat band exactly the height of the bar rather than a ramp --
 # a hard edge, and no wash over the picture above it. Opacity, 255 opaque.
 # Black rather than theme.SCRIM: the HUD is drawn over VIDEO and stays dark
@@ -525,13 +527,11 @@ def _scrim(h, w):
     style = settings.hud_scrim
     if style in ("none", "panel"):
         return []          # panel paints as the bars' own background
-    scale = HALF_SCRIM if style == "half" else 1.0
     return [
         Gradient(color="000000", top=0, bottom=215, w=w,
-                 h=int(min(h * SCRIM_FRAC, SCRIM_MAX) * scale), anchor="sw"),
+                 h=int(min(h * SCRIM_FRAC, SCRIM_MAX)), anchor="sw"),
         # top scrim: dense at the top, same relation to the header's height
-        # as the bottom one has to the bar's. Full height even under
-        # "half" -- see HALF_SCRIM.
+        # as the bottom one has to the bar's.
         Gradient(color="000000", top=170, bottom=0, w=w,
                  h=int(min(h * TOP_SCRIM_FRAC, TOP_SCRIM_MAX)),
                  anchor="nw"),

--- a/jellyfin_mpv_shim/mpvtk_browser/repository.py
+++ b/jellyfin_mpv_shim/mpvtk_browser/repository.py
@@ -2387,6 +2387,16 @@ class OfflineLibrarySource:
             episodes_by_series[sid].append(item)
         return [{"Id": sid, "Name": names[sid], "Type": "Series",
                  "ImageTags": {},
+                 # A synthesized DTO has to answer the questions a real one
+                 # would, and the grid asks this one: GridPage._grid_shape
+                 # takes the MEDIAN PrimaryImageAspectRatio across the row and
+                 # falls back to SQUARE when nothing carries one -- so a
+                 # downloaded-shows grid came out as square cards with the
+                 # posters letterboxed inside them. A Series' Primary image is
+                 # a poster; the server says 2:3 for these, and the offline
+                 # catalog stores episodes, not the series, so there is
+                 # nothing else to read it from.
+                 "PrimaryImageAspectRatio": 2 / 3,
                  "UserData": self._aggregate_userdata(episodes_by_series[sid])}
                 for sid in order]
 

--- a/jellyfin_mpv_shim/sync/manager.py
+++ b/jellyfin_mpv_shim/sync/manager.py
@@ -821,6 +821,7 @@ class SyncManager:
             self._download_artwork(client, item, item_dir)
             self._download_subs(client, item_id, source, item_dir)
             self._download_trickplay(client, item_id, source, item_dir)
+            self._download_segments(client, source, item_dir)
             if item.get("Type") == "Episode" and item.get("SeriesId"):
                 self._download_series_art(client, row.get("server_id"),
                                           item["SeriesId"])
@@ -1082,6 +1083,38 @@ class SyncManager:
         with open(os.path.join(item_dir, "trickplay.json"), "w") as fh:
             json.dump({"width": width, "data": data}, fh)
         log.debug("Downloaded %d trickplay tiles for %s.", tiles, item_id)
+
+    def _download_segments(self, client, source, item_dir):
+        """Cache the item's media segments (intro, outro, …) for offline use.
+
+        Best-effort, like the trickplay tiles beside it: segments come from a
+        plugin, so most items legitimately have none and a server without the
+        plugin answers nothing at all. A failure here must not fail the
+        download.
+
+        **Every type, not the ones the settings currently want.** What is on
+        disk outlives the setting that was set when it was written -- turning
+        Recap on months later must not require re-downloading -- so the
+        filtering happens at playback, where conf.segment_action already does
+        it for the online path.
+        """
+        try:
+            data = client.jellyfin.get_media_segments(source.get("Id"))
+        except Exception:
+            log.debug("No media segments for %s", source.get("Id"),
+                      exc_info=True)
+            return
+        items = (data or {}).get("Items") or []
+        if not items:
+            return
+        try:
+            with open(os.path.join(item_dir, "segments.json"), "w") as fh:
+                json.dump(items, fh)
+        except OSError:
+            log.debug("Could not write segments.json", exc_info=True)
+            return
+        log.debug("Downloaded %d media segments for %s.", len(items),
+                  source.get("Id"))
 
     def _download_series_art(self, client, server_id, series_id):
         """Cache series poster/backdrop so offline series tiles + the series page

--- a/jellyfin_mpv_shim/sync/offline_media.py
+++ b/jellyfin_mpv_shim/sync/offline_media.py
@@ -12,9 +12,10 @@ import json
 import logging
 import os
 
+from .. import conf
 from ..conf import settings
 from ..language_config import apply as apply_language_config
-from ..media import Video
+from ..media import Intro, Video
 from .manager import syncManager
 
 log = logging.getLogger("sync.offline_media")
@@ -89,7 +90,10 @@ class OfflineVideo(Video):
         self.playback_info = {"PlaySessionId": "", "MediaSources": [self._source]}
         self.media_source = None
         self.intros = []
-        self.intro_tried = True
+        # Not tried yet -- unlike the rest of this class's stubs, there IS
+        # something to read (see get_intro). Player.get_playback_url calls it
+        # behind conf.any_segment_wanted(), same as online.
+        self.intro_tried = False
 
     def get_playback_url(self, video_bitrate=None, force_transcode=False):
         self.media_source = dict(self._source)
@@ -97,6 +101,10 @@ class OfflineVideo(Video):
         self.media_source["Protocol"] = "File"
         self.media_source["SupportsDirectPlay"] = True
         self.is_transcode = False
+        # Where Video.get_playback_url does it, and behind the same gate:
+        # skippable segments are cached with the download (see get_intro).
+        if conf.any_segment_wanted():
+            self.get_intro(self.media_source.get("Id"))
         self.map_streams()
         log.info("Playing local file: %s", self._local_path)
         return self._local_path
@@ -201,7 +209,48 @@ class OfflineVideo(Video):
         pass  # nothing to tear down for a local file
 
     def get_intro(self, media_source_id):
-        return  # no intro/credits detection for offline playback
+        """Media segments cached beside the file at download time.
+
+        Same shape as the online path, read from segments.json instead of
+        asked of the server. Every type is on disk, because what is stored
+        outlives the settings that were set when it was written -- turning
+        Recap on months later must not mean re-downloading -- and the
+        filtering happens HERE, on the way in.
+
+        On the way in, specifically, because that is where online filters
+        too: ``include_segment_types=conf.wanted_segment_types()`` means an
+        "off" type never reaches ``self.intros`` at all. ``segment_action``
+        at playback is a weaker, later layer -- ``get_current_intro`` picks
+        the FIRST segment covering the position and ``player.update`` sets
+        ``is_in_intro`` for whatever it returns, before consulting the
+        action. Letting an "off" type in would therefore give a downloaded
+        file two behaviours a streamed one cannot have: a forward seek
+        eaten by a Commercial the viewer turned off (``skip_intro_on_seek``),
+        and an off-typed segment masking a wanted one where the two overlap,
+        so the Skip button never appears.
+
+        An item downloaded before this shipped simply has no file, which is
+        the same as an item with no segments.
+        """
+        if self.intro_tried:
+            return
+        self.intro_tried = True
+        path = os.path.join(self._item_dir, "segments.json")
+        try:
+            with open(path) as fh:
+                segments = json.load(fh)
+        except (OSError, ValueError):
+            return
+        wanted = conf.wanted_segment_types()
+        for seg in segments or ():
+            try:
+                if seg["Type"] not in wanted:
+                    continue
+                self.intros.append(Intro(seg["Type"],
+                                         seg["StartTicks"] / 10000000,
+                                         seg["EndTicks"] / 10000000))
+            except (KeyError, TypeError):
+                log.debug("Skipping malformed offline segment %r", seg)
 
     # -- trickplay (scrubbing previews) -----------------------------------
 

--- a/tests/snapshots/settings.jsonl
+++ b/tests/snapshots/settings.jsonl
@@ -56,7 +56,7 @@
 {"align": "left", "c": "9aa0a6", "h": 21.2, "id": "r.1.1.0.11.0", "sc": "settings", "size": 17, "t": "text", "text": "Player Controls Activation Key", "w": 340.0, "x": 16.0, "y": 562.4}
 {"h": 38.0, "id": "set-hud_wake_key", "ph": "", "sc": "settings", "size": 20, "t": "textbox", "text": "ENTER", "w": 340.0, "x": 368.0, "y": 554.0}
 {"align": "left", "c": "9aa0a6", "h": 21.2, "id": "r.1.1.0.12.0", "sc": "settings", "size": 17, "t": "text", "text": "Shading Behind the Player Controls", "w": 340.0, "x": 16.0, "y": 608.4}
-{"force": true, "h": 38.0, "id": "set-hud_scrim", "items": ["Default", "Half height", "Panel behind the controls", "None (shadowed text)"], "sc": "settings", "sel": 0, "size": 20, "t": "dropdown", "w": 340.0, "x": 368.0, "y": 600.0}
+{"force": true, "h": 38.0, "id": "set-hud_scrim", "items": ["Default", "Panel behind the controls", "None (shadowed text)"], "sc": "settings", "sel": 0, "size": 20, "t": "dropdown", "w": 340.0, "x": 368.0, "y": 600.0}
 {"align": "left", "c": "9aa0a6", "h": 17.5, "id": "r.1.1.0.13", "sc": "settings", "size": 14, "t": "text", "text": "The controls have to stay legible over any frame. \"None\" gives the text a drop shadow instead of shading the picture behind it.", "w": 1238.0, "x": 16.0, "y": 646.0}
 {"align": "left", "c": "9aa0a6", "h": 21.2, "id": "r.1.1.0.14.0", "sc": "settings", "size": 17, "t": "text", "text": "When the Player Controls Hide", "w": 340.0, "x": 16.0, "y": 679.9}
 {"force": true, "h": 38.0, "id": "set-hud_autohide", "items": ["Hide unless hovered", "Always hide", "Never hide while paused"], "sc": "settings", "sel": 0, "size": 20, "t": "dropdown", "w": 340.0, "x": 368.0, "y": 671.5}

--- a/tests/test_docs_coverage.py
+++ b/tests/test_docs_coverage.py
@@ -98,7 +98,7 @@ class DocsCoverageTest(unittest.TestCase):
             # scroll_mode values
             "continuous", "aligned", "row",
             # hud_scrim / hud_autohide values
-            "half", "panel", "hover", "always", "paused",
+            "panel", "hover", "always", "paused",
             # segment_* values
             "off", "ask",
             # language_config rule keys

--- a/tests/test_offline_media.py
+++ b/tests/test_offline_media.py
@@ -4,6 +4,7 @@ import tempfile
 import unittest
 from unittest import mock
 
+from jellyfin_mpv_shim.conf import settings
 from jellyfin_mpv_shim.sync import offline_media
 from jellyfin_mpv_shim.sync.db import COLUMNS, SyncDB, STATUS_COMPLETE
 
@@ -107,6 +108,95 @@ class FactoryFileExistsGateTest(unittest.TestCase):
         add_row(self.db, "a", "a/file.mkv")
         video = offline_media.offline_video_factory("a", FakeParent(client=None))
         self.assertIsInstance(video, offline_media.OfflineVideo)
+
+
+class OfflineSegmentsTest(unittest.TestCase):
+    """Skip Intro/Credits over a downloaded file.
+
+    The segments come from a plugin on the server, so they are cached beside
+    the media at download time (SyncManager._download_segments) and read back
+    here. Before this there was simply no offline detection at all, which is
+    what "works, except for downloaded files" meant.
+    """
+
+    def setUp(self):
+        self.tmp = tempfile.TemporaryDirectory()
+        self.root = self.tmp.name
+        self.db = make_db(os.path.join(self.root, "cat.db"))
+        self.sync = FakeSync(self.db, self.root)
+        self._patch = mock.patch.object(offline_media, "syncManager", self.sync)
+        self._patch.start()
+        os.makedirs(os.path.join(self.root, "a"))
+        with open(os.path.join(self.root, "a", "file.mkv"), "wb") as fh:
+            fh.write(b"x")
+        add_row(self.db, "a", "a/file.mkv")
+
+    def tearDown(self):
+        self._patch.stop()
+        self.db.close()
+        self.tmp.cleanup()
+
+    def _write(self, segments):
+        with open(os.path.join(self.root, "a", "segments.json"), "w") as fh:
+            json.dump(segments, fh)
+
+    def _video(self):
+        return offline_media.offline_video_factory("a", FakeParent(client=None))
+
+    def test_cached_segments_are_read_back(self):
+        self._write([{"Type": "Intro", "StartTicks": 100000000,
+                      "EndTicks": 900000000}])
+        video = self._video()
+        video.get_intro("src")
+        self.assertEqual([(i.type, i.start, i.end) for i in video.intros],
+                         [("Intro", 10.0, 90.0)])
+        self.assertEqual(video.get_current_intro(30.0)[1].type, "Intro")
+
+    def test_an_item_downloaded_before_this_shipped_has_none(self):
+        """No file is the same as no segments, not an error."""
+        video = self._video()
+        video.get_intro("src")
+        self.assertEqual(video.intros, [])
+
+    def test_a_malformed_entry_is_skipped_not_fatal(self):
+        self._write([{"Type": "Intro"},
+                     {"Type": "Outro", "StartTicks": 100000000,
+                      "EndTicks": 200000000}])
+        video = self._video()
+        video.get_intro("src")
+        self.assertEqual([i.type for i in video.intros], ["Outro"])
+
+    def test_only_the_wanted_types_are_read_back(self):
+        """Every type is on DISK -- what is stored outlives the settings
+        that wrote it -- but only the wanted ones reach self.intros, which
+        is where online filters too (include_segment_types).
+
+        Letting an "off" type through gives a downloaded file two behaviours
+        a streamed one cannot have: player.update sets is_in_intro for
+        whatever get_current_intro returns *before* consulting the action,
+        so skip_intro_on_seek eats a forward seek inside a segment the
+        viewer turned off; and an off-typed segment masks a wanted one where
+        they overlap, so the Skip button never appears.
+        """
+        self._write([{"Type": t, "StartTicks": 0, "EndTicks": 10000000}
+                     for t in ("Intro", "Recap", "Commercial")])
+        with mock.patch.object(settings, "segment_intro", "ask"), \
+                mock.patch.object(settings, "segment_recap", "off"), \
+                mock.patch.object(settings, "segment_commercial", "off"):
+            video = self._video()
+            video.get_intro("src")
+        self.assertEqual([i.type for i in video.intros], ["Intro"])
+
+    def test_turning_one_on_later_needs_no_redownload(self):
+        """The other half: the file still holds every type, so the filter
+        is the only thing between a setting and a segment."""
+        self._write([{"Type": t, "StartTicks": 0, "EndTicks": 10000000}
+                     for t in ("Intro", "Recap")])
+        with mock.patch.object(settings, "segment_intro", "off"), \
+                mock.patch.object(settings, "segment_recap", "ask"):
+            video = self._video()
+            video.get_intro("src")
+        self.assertEqual([i.type for i in video.intros], ["Recap"])
 
 
 if __name__ == "__main__":

--- a/tests/test_shell_playback.py
+++ b/tests/test_shell_playback.py
@@ -225,32 +225,61 @@ class TestHudScrimAndAutohide(unittest.TestCase):
                        "volume": 80, "muted": False}
         return b, ctl
 
-    def _scrims(self, style):
+    def _scene(self, style):
         self.settings.hud_scrim = style
         b, _ctl = self._browser()
-        nodes, _h = build_scene(b, (1280, 720))
-        return [n for n in nodes if n.get("t") == "grad"]
+        return build_scene(b, (1280, 720))[0]
 
-    def test_the_default_shading_is_shorter_than_it_was(self):
-        """It was ~2.2x the bar plus headroom that bought nothing; what is
-        left is the part the controls actually sit on."""
-        grads = self._scrims("default")
-        self.assertTrue(grads)
-        self.assertLessEqual(max(g["h"] for g in grads), 300)
+    def _scrims(self, style):
+        return [n for n in self._scene(style) if n.get("t") == "grad"]
 
-    def test_half_halves_the_bottom_ramp(self):
-        full = max(g["h"] for g in self._scrims("default"))
-        half = max(g["h"] for g in self._scrims("half"))
-        self.assertAlmostEqual(half, full / 2, delta=2)
+    #: The two ramps are told apart by WHERE they are, not by how tall they
+    #: are: the bottom one is anchored "sw" and the top one "nw". Sorting by
+    #: height was fine only while the bottom was always the taller, which
+    #: stopped being true when the default came down to 200.
+    def _bottom(self, style):
+        return max(self._scrims(style), key=lambda g: g["y"])
 
-    def test_half_leaves_the_TOP_band_alone(self):
-        """Halving it too put the title and the top-row buttons in the
-        fading half of a 65px ramp — unreadable over a bright frame, for a
-        strip of picture nobody was looking at."""
-        top_full = min(g["h"] for g in self._scrims("default"))
-        top_half = min(g["h"] for g in self._scrims("half"))
-        self.assertEqual(top_half, top_full,
-                         "the top scrim was halved with the bottom one")
+    def _top(self, style):
+        return min(self._scrims(style), key=lambda g: g["y"])
+
+    def test_the_default_ramp_reaches_over_the_scrubber(self):
+        """The functional requirement, rather than a number: the ramp has to
+        start above the bar's own controls or they sit on bare picture. This
+        is what a lowered SCRIM_MAX has to keep being true."""
+        nodes = self._scene("default")
+        bottom = max((n for n in nodes if n.get("t") == "grad"),
+                     key=lambda g: g["y"])
+        seek = next(n for n in nodes if n.get("id") == "hud-seek")
+        bar = next(n for n in nodes if n.get("id") == "hud-bar")
+        self.assertLess(bottom["y"], seek["y"],
+                        "the scrubber sits above the shading")
+        self.assertLess(bottom["y"], bar["y"],
+                        "the bar's top edge sits above the shading")
+
+    def test_a_retired_scrim_value_reads_as_the_default(self):
+        """"half" was offered while this branch was in flight and is gone.
+        A config that still says it must draw the default ramp, not nothing
+        -- which is what an unrecognised value has to do for every enum
+        here, and is why no migration was written for it."""
+        self.assertEqual(
+            [(g["y"], g["h"]) for g in self._scrims("half")],
+            [(g["y"], g["h"]) for g in self._scrims("default")])
+
+    def test_the_offered_values_are_the_ones_that_draw(self):
+        """The picker and the renderer agreeing is the whole contract; a
+        value in the list that draws nothing is a dead option."""
+        from jellyfin_mpv_shim.mpvtk_browser import config as cfg
+        offered = {v for _l, v in cfg.LABELED_ENUMS["hud_scrim"]}
+        self.assertEqual(offered, {"default", "panel", "none"})
+        for value in offered:
+            with self.subTest(scrim=value):
+                nodes = self._scene(value)
+                bar = next(n for n in nodes if n.get("id") == "hud-bar")
+                grads = [n for n in nodes if n.get("t") == "grad"]
+                self.assertTrue(
+                    grads or bar.get("a", 0) > 0 or value == "none",
+                    "%r shades nothing at all" % value)
 
     def _bar(self, style):
         self.settings.hud_scrim = style

--- a/tests/test_sync_manager.py
+++ b/tests/test_sync_manager.py
@@ -97,6 +97,7 @@ def make_manager(root, cleanup=None):
     m._download_artwork = lambda *a, **k: None
     m._download_subs = lambda *a, **k: None
     m._download_trickplay = lambda *a, **k: None
+    m._download_segments = lambda *a, **k: None
     m._download_series_art = lambda *a, **k: None
     m._download_season_art = lambda *a, **k: None
     return m
@@ -667,3 +668,54 @@ class QueryClosedCatalogTest(TmpTest):
         t.join(timeout=5)
         self.assertEqual(errors, [], "a concurrent close escaped as %r"
                          % (errors[:1],))
+
+
+class DownloadSegmentsTest(unittest.TestCase):
+    """Media segments are cached beside the file so Skip Intro/Credits works
+    over a downloaded item (there was no offline detection at all before).
+
+    Best-effort like the trickplay tiles beside it: segments come from a
+    plugin, so most items legitimately have none and a server without it
+    answers nothing. A failure must not fail the download.
+    """
+
+    def setUp(self):
+        self.tmp = tempfile.TemporaryDirectory()
+        self.addCleanup(self.tmp.cleanup)
+        self.m = SyncManager.__new__(SyncManager)
+
+    def _client(self, answer):
+        class Api:
+            def get_media_segments(self, _src_id):
+                if isinstance(answer, Exception):
+                    raise answer
+                return answer
+
+        return type("C", (), {"jellyfin": Api()})()
+
+    def _run(self, answer):
+        self.m._download_segments(self._client(answer), {"Id": "src"},
+                                  self.tmp.name)
+        path = os.path.join(self.tmp.name, "segments.json")
+        if not os.path.exists(path):
+            return None
+        with open(path) as fh:
+            return json.load(fh)
+
+    def test_segments_are_written_beside_the_media(self):
+        seg = {"Type": "Intro", "StartTicks": 0, "EndTicks": 10}
+        self.assertEqual(self._run({"Items": [seg]}), [seg])
+
+    def test_every_type_is_kept(self):
+        """The settings filter at playback (conf.segment_action), because
+        what is on disk outlives the settings that wrote it."""
+        segs = [{"Type": t, "StartTicks": 0, "EndTicks": 10}
+                for t in ("Intro", "Recap", "Commercial")]
+        self.assertEqual([s["Type"] for s in self._run({"Items": segs})],
+                         ["Intro", "Recap", "Commercial"])
+
+    def test_no_segments_writes_no_file(self):
+        self.assertIsNone(self._run({"Items": []}))
+
+    def test_a_server_without_the_plugin_is_not_an_error(self):
+        self.assertIsNone(self._run(RuntimeError("404")))

--- a/tests/test_ui_review_fixes.py
+++ b/tests/test_ui_review_fixes.py
@@ -242,6 +242,18 @@ class OfflineUserdataAggregationTest(unittest.TestCase):
         self.assertFalse(series["T"]["UserData"]["Played"])
         self.assertEqual(series["T"]["UserData"]["UnplayedItemCount"], 1)
 
+    def test_a_synthesized_series_is_poster_shaped(self):
+        """GridPage._grid_shape takes the median PrimaryImageAspectRatio
+        across the row and falls back to SQUARE when nothing carries one, so
+        a downloaded-shows grid came out as square cards with the posters
+        letterboxed inside them."""
+        from jellyfin_mpv_shim.mpvtk_browser.tile_renderer import TileRenderer
+        src = _offline_source([_episode("e1", "S", "sea1", played=False)])
+        ratio = src._series_list()[0].get("PrimaryImageAspectRatio")
+        self.assertIsNotNone(ratio, "no shape for the grid to read")
+        self.assertLess(ratio, TileRenderer.SQUARE_RATIO,
+                        "a downloaded show is not square")
+
     def test_get_seasons_aggregates_watched_state(self):
         src = _offline_source([
             _episode("e1", "S", "sea1", played=True),


### PR DESCRIPTION
This PR adds skip intro/credits/etc support for offline downloads.

This also fixes an unrelated regression where downloaded shows displayed as discs due to recent work on library rendering.

This PR also includes a tweak to the prior player OSC to make the gradients narrower.

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>