### PR TITLE
The review round: ten small fixes from reviewing the branch diff

### DIFF
--- a/docs/UI_UX_FIXES_2026-08.md
+++ b/docs/UI_UX_FIXES_2026-08.md
@@ -911,3 +911,111 @@ only lines up because its list is a single rendered page.)
 
 1. Tile grids — Albums, Album Artists, Artists, genre page.
 2. Songs — `track_list` holes plus the server-backed play action.
+
+## Hand-testing round 2: the review fixes
+
+Sixteen fixes from a six-lens agent review of the branch diff. The suites are
+green (2929 unit, 154 Lua, integration matrix on both backends), so again:
+this is what those cannot see.
+
+**Two columns matter here.** *Does the fix work* is the obvious one. *Blast
+radius* is the one worth more attention — several of these landed in code
+every screen goes through (`layout._arrange_box`, `node_at`,
+`slider_set_from_x`, `spread`, `chapter_target`), so the risk is not the
+thing that was fixed but the thing beside it.
+
+### Highest risk — shared code paths
+
+- [ ] **Mouse Back/Forward, everywhere** (`86f113e2`). This is the biggest
+      blast radius on the branch: the buttons moved to their own key-binding
+      section and its enable/disable is now asserted at three points. Check
+      Back in the library, in a dialog, in a modal, on the cast screen, on
+      the settings screen, and from a *summoned* HUD (the path that was
+      broken). Then check Forward as history in the browser. Then over a
+      film with `mouse_chapter_nav` off — it should reach mpv's
+      playlist-prev/next, i.e. previous/next queue item — and with it on.
+      Restart the app and do the library ones again first thing: the bug
+      was that they were dead from launch until a playback round trip.
+- [ ] **Every slider still drags** (`971126c3`). `slider_set_from_x` gained
+      the preview write and is shared by the volume slider and the music
+      now-playing bar, not just the seek bar. Drag all three.
+- [ ] **Any click, anywhere** (`73fbf6ca`). `node_at` gained `dis` to its
+      interactivity test and `_arrange_box` emits a node for a disabled
+      element. Nothing in the app passes `disabled=` yet, so this *should*
+      be inert — but it is the function every hit test goes through. A
+      general poke around the library, dialogs and the HUD is the check.
+- [ ] **Chapter navigation near a boundary** (`9f7a394f`). The forward
+      direction lost its 0.5s tolerance. Test the HUD's chapter buttons AND
+      the mouse buttons, from just before a boundary, exactly on one, and
+      from the last chapter (should do nothing).
+
+### The #617 cluster
+
+- [ ] **Change Image Type on a scrolled library** (`4b0e3afd`) — the fix.
+      Scroll well past the first page, View → Image Type → Banner. Every
+      tile should become a banner, not just the first hundred.
+      *Blast radius:* the refetch now drops the loaded list, so it will
+      re-fetch from the top. Check it does not blink jarringly, and note
+      where the scroll position ends up.
+- [ ] **Favorites, a genre listing, Next Up, a studio, a person page**
+      (`f18088aa`). These were windowing without padding. The scrollbar
+      should be full-length from the first frame and must not jump as pages
+      land. The count line now reads the server's total.
+- [ ] **`--debug` on a library over 100 items** (`fd8c9b94`). It used to
+      throw out of render and leave a spinner. Should just work.
+- [ ] **List view, scrolled into unloaded rows** (`fd8c9b94`). Blank rows
+      must not hover-highlight or respond to a click or right-click.
+- [ ] **A library that shrinks under you** (`375a3763`) — hard to stage; if
+      you can delete items server-side mid-scroll, the count line and the
+      grid height should agree afterwards.
+
+### Playback HUD
+
+- [ ] **Live TV seek bar** (`1cbd3cdb`). Hovering it should show *nothing*.
+      Then a normal file: the bubble should appear once mpv reports a
+      duration, not before.
+- [ ] **A film with long chapter names** (`f46f1635`). The bubble stays
+      inside the window and stays centred on the pointer; the name
+      ellipsizes rather than the box growing.
+- [ ] **Scrub, release, look** (`4038ecdf` fixed the test, `971126c3` the
+      code). Drag the seek bar and let go — the bubble must not jump back.
+- [ ] Auto-hide unchanged in all three modes (`ee08a40a` only made the
+      *toolkit's* default reachable; the shim always sends its own).
+
+### Offline
+
+- [ ] **Re-download an episode, then play it** (`8c1817f8`, `3983a296`).
+      Skip Intro should offer where it does when streaming — and a segment
+      type set to "off" should now behave exactly as it does online, i.e.
+      not eat a forward seek with `skip_intro_on_seek` on.
+- [ ] **Downloaded Shows grid** (`8a946e39`) — posters, not squares.
+- [ ] **Trickplay across an mpv restart** (`6158df6b`). Play a downloaded or
+      streamed file, let mpv be re-created (idle quit, or stop and start),
+      scrub in the new one. Watch for mpv errors in the log.
+
+### Config and text
+
+- [ ] **Upgrade a real 2.x config** (`0f6d55ef`). Back it up first. Confirm
+      the segment settings land where you expect. If you have any
+      hand-edited quoted booleans, this is the case that used to flip them
+      to "always".
+- [ ] **A config still saying `hud_scrim: "half"`** (`bd267d6f`) — draws the
+      default ramp, picker reads Default.
+- [ ] **Minimize to tray, and restore** (`3e4c32af`). This crashed before;
+      also check the OSC state afterwards.
+- [ ] **"Skip Credits" in three places** (`1f9a58ad`): the HUD/OSD Skip
+      button, the settings form row, and the OSD menu row. The button keeps
+      its existing translations; the two labels are a new key and will read
+      English until Weblate catches up.
+- [ ] **The OSD menu's segment rows** now read Never/Ask/Always, matching
+      the settings form.
+- [ ] **Theme settings** no longer claims cover size needs a restart.
+
+### Known and deliberate
+
+- The HUD staying up while the pointer rests in the bottom or top band is
+  the behaviour asked for in #620, not a bug — a reviewer flagged it and it
+  was left alone.
+- `a9883418`'s commit message overstates itself: an unchanged home refresh
+  still repaints, because `AsyncRunner` invalidates in a `finally`
+  regardless. The partial-publish half of that commit is the real fix.

--- a/jellyfin_mpv_shim/menu.py
+++ b/jellyfin_mpv_shim/menu.py
@@ -5,7 +5,7 @@ from .conf import settings
 from .utils import mpv_color_to_plex, get_sub_display_title
 from .video_profile import VideoProfileManager
 from .svp_integration import SVPManager
-from .i18n import _
+from .i18n import _, _p
 
 import time
 import logging
@@ -461,7 +461,11 @@ class OSDMenu(object):
         self.menu_list[self.menu_selection] = self.get_segment_cycle(name, key)
 
     def get_segment_cycle(self, name: str, setting: str):
-        labels = {"off": _("No"), "ask": _("Ask"), "always": _("Always")}
+        # Never/Ask/Always -- the same three words the settings form uses
+        # (config.LABELED_ENUMS). Two vocabularies for one tri-state meant
+        # 86 locales translating both.
+        labels = {"off": _("Never"), "ask": _("Ask"),
+                  "always": _("Always")}
         value = getattr(settings, setting, "off")
         return (
             "{0}: {1}".format(name, labels.get(value, labels["off"])),
@@ -623,7 +627,8 @@ class OSDMenu(object):
                     _("Discord Rich Presence"), "discord_presence"
                 ),
                 self.get_segment_cycle(_("Skip Intros"), "segment_intro"),
-                self.get_segment_cycle(_("Skip Credits"), "segment_outro"),
+                self.get_segment_cycle(_p("setting", "Skip Credits"),
+                                       "segment_outro"),
                 self.get_segment_cycle(_("Skip Commercials"),
                                        "segment_commercial"),
                 self.get_segment_cycle(_("Skip Previews"), "segment_preview"),

--- a/jellyfin_mpv_shim/messages/base.pot
+++ b/jellyfin_mpv_shim/messages/base.pot
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: jellyfin-mpv-shim\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2026-08-01 21:06-0400\n"
+"POT-Creation-Date: 2026-08-01 21:12-0400\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -110,8 +110,7 @@ msgstr ""
 msgid "Could not start Quick Connect."
 msgstr ""
 
-#: jellyfin_mpv_shim/media.py jellyfin_mpv_shim/menu.py
-#: jellyfin_mpv_shim/mpvtk_browser/config.py
+#: jellyfin_mpv_shim/media.py
 msgid "Skip Credits"
 msgstr ""
 
@@ -336,8 +335,8 @@ msgstr ""
 msgid "Manual by Track Index (Less Reliable)"
 msgstr ""
 
-#: jellyfin_mpv_shim/menu.py
-msgid "No"
+#: jellyfin_mpv_shim/menu.py jellyfin_mpv_shim/mpvtk_browser/config.py
+msgid "Never"
 msgstr ""
 
 #: jellyfin_mpv_shim/menu.py jellyfin_mpv_shim/mpvtk_browser/config.py
@@ -455,6 +454,11 @@ msgstr ""
 
 #: jellyfin_mpv_shim/menu.py jellyfin_mpv_shim/mpvtk_browser/config.py
 msgid "Skip Intros"
+msgstr ""
+
+#: jellyfin_mpv_shim/menu.py jellyfin_mpv_shim/mpvtk_browser/config.py
+msgctxt "setting"
+msgid "Skip Credits"
 msgstr ""
 
 #: jellyfin_mpv_shim/menu.py jellyfin_mpv_shim/mpvtk_browser/config.py
@@ -820,10 +824,6 @@ msgstr ""
 #: jellyfin_mpv_shim/mpvtk_browser/settings/downloads.py
 #: jellyfin_mpv_shim/mpvtk_browser/settings/__init__.py
 msgid "Downloads"
-msgstr ""
-
-#: jellyfin_mpv_shim/mpvtk_browser/config.py
-msgid "Never"
 msgstr ""
 
 #: jellyfin_mpv_shim/mpvtk_browser/config.py

--- a/jellyfin_mpv_shim/messages/base.pot
+++ b/jellyfin_mpv_shim/messages/base.pot
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: jellyfin-mpv-shim\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2026-08-01 20:26-0400\n"
+"POT-Creation-Date: 2026-08-01 21:06-0400\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -2739,7 +2739,7 @@ msgid "Show advanced settings"
 msgstr ""
 
 #: jellyfin_mpv_shim/mpvtk_browser/settings/general.py
-msgid "Cover size and interface scale require a restart."
+msgid "Interface scale requires a restart."
 msgstr ""
 
 #: jellyfin_mpv_shim/mpvtk_browser/settings/general.py

--- a/jellyfin_mpv_shim/mpvtk/app.py
+++ b/jellyfin_mpv_shim/mpvtk/app.py
@@ -806,15 +806,25 @@ class MpvtkApp:
         out of the way for other OSCs — HUD mode keeps it attached
         during playback with a blank scene and only a lightweight
         summon surface bound (the wake key + mouse motion). Summoning
-        rebinds the full input sections and fires ``on_hud(True)``;
-        the ~4s inactivity timer drops back to idle with
-        ``on_hud(False)``. ``set_active`` in either direction also
-        leaves HUD mode.
+        rebinds the full input sections and fires ``on_hud(True)``; the
+        inactivity timer drops back to idle with ``on_hud(False)``.
+        ``set_active`` in either direction also leaves HUD mode.
 
-        ``opts`` is the keyboard policy: ``{"grab": bool, "key": str}``
-        — grab summons on all arrows/ENTER while idle; otherwise only
-        ``key`` is taken over (mpv key name; ENTER also pause-toggles
-        on wake)."""
+        ``opts`` is everything the renderer owns about the HUD, and is
+        re-sent on every engage — which is what lets a settings change
+        stick without a restart:
+
+        ``grab`` / ``key``
+            keyboard policy. Grab summons on all arrows/ENTER while idle;
+            otherwise only ``key`` is taken over (an mpv key name; ENTER
+            also pause-toggles on wake).
+        ``hide`` / ``mode``
+            auto-hide delay in seconds and policy ("hover" / "always" /
+            "paused"). Absent means the toolkit's own default
+            (``PHUD_HIDE.def``); ``0`` is not absent, it forces "hover".
+        ``shadow``
+            draw the glyphs with their own dark halo, for the app that
+            paints no scrim behind them."""
         args = ["script-message", "mpvtk-hud", "yes" if on else "no"]
         if on and opts is not None:
             args.append(json.dumps(opts))

--- a/jellyfin_mpv_shim/mpvtk/layout.py
+++ b/jellyfin_mpv_shim/mpvtk/layout.py
@@ -1001,7 +1001,15 @@ def _arrange_stack(ctx, el, x, y, w, h, sc, path):
 
 def _arrange_box(ctx, el, x, y, w, h, sc, path):
     """The workhorse: a padded flex row or column. Also the fallthrough."""
-    if el.bg or el.border or el.on_click:
+    # `el.disabled` counts as something to draw even when nothing else
+    # does. A disabled Button(flat=True) has no bg, no border and no
+    # handler -- it mutes itself by dropping all three (widgets.Button) --
+    # and a Checkbox never had a bg on its outer row. Without a node the
+    # renderer has nothing to absorb the pointer with, so the press reaches
+    # whatever sits under it: over the playback HUD, that is bare video and
+    # a toggled pause. The node also carries the `tip` explaining why the
+    # control is off, and its id.
+    if el.bg or el.border or el.on_click or el.disabled:
         node = _base(el, "rect", x, y, w, h, sc, path)
         if el.bg:
             node["fill"] = el.bg

--- a/jellyfin_mpv_shim/mpvtk/renderer.lua
+++ b/jellyfin_mpv_shim/mpvtk/renderer.lua
@@ -4883,7 +4883,13 @@ mp.register_script_message('mpvtk-hud', function(on, opts_json)
         local opts = opts_json and utils.parse_json(opts_json) or nil
         state.phud.grab = (opts and opts.grab) or false
         state.phud.wake_key = (opts and opts.key) or 'ENTER'
-        state.phud.hide_s = (opts and opts.hide) or 0
+        -- `or` would fold an ABSENT hide into 0, and 0 is meaningful
+        -- here (it forces hover mode below). Absent means "the toolkit's
+        -- own default", which is what PHUD_HIDE.def is for -- it was
+        -- unreachable, so a caller that sent no opts got the 0.5s floor
+        -- instead of the ~4s every docstring promises.
+        local hide = opts and opts.hide
+        state.phud.hide_s = hide ~= nil and hide or PHUD_HIDE.def
         state.phud.hide_mode = (opts and opts.mode) or 'hover'
         state.phud.shadow = (opts and opts.shadow) or false
         if state.phud.hide_s <= 0 then

--- a/jellyfin_mpv_shim/mpvtk/renderer.lua
+++ b/jellyfin_mpv_shim/mpvtk/renderer.lua
@@ -2186,8 +2186,18 @@ render = function()
         else
             ts = string.format('%d:%02d', math.floor(whole / 60), whole % 60)
         end
-        local bw = math.max(fw, text_w(ts, fs, true),
-                            cap and text_w(cap, fs, false) or 0) + 2 * pad
+        -- Capped at the window, and the caption ellipsized to fit it.
+        -- A chapter name comes from container metadata and can run to a
+        -- sentence; clamp() returns its LOW bound when hi < lo, so an
+        -- over-wide bubble pinned itself at x=8, ran off the right edge,
+        -- and stopped being centred on the position it labels -- which is
+        -- #612, the bug this block exists to fix.
+        local bwmax = state.w - 2 * ui_px(8)
+        local bw = math.min(bwmax,
+                            math.max(fw, text_w(ts, fs, true),
+                                     cap and text_w(cap, fs, false) or 0)
+                            + 2 * pad)
+        if cap then cap = ellipsize(cap, fs, false, bw - 2 * pad) end
         local bh = 2 * pad + lh + (fh > 0 and (fh + gap) or 0)
                    + (cap and (lh + gap) or 0)
         local ex, ey = eff(pv_node)

--- a/jellyfin_mpv_shim/mpvtk/renderer.lua
+++ b/jellyfin_mpv_shim/mpvtk/renderer.lua
@@ -2286,7 +2286,7 @@ local function node_at(x, y)
             node.t ~= 'menu' and
             (not modal or node.mod) and
             (node.click or node.ctx or node.dbl or node.tip or
-             node.hev or
+             node.hev or node.dis or
              node.t == 'textbox' or
              node.t == 'dropdown' or node.t == 'slider' or
              node.hover) then

--- a/jellyfin_mpv_shim/mpvtk/widgets.py
+++ b/jellyfin_mpv_shim/mpvtk/widgets.py
@@ -48,9 +48,11 @@ class Element:
         # that flow — ordinary scenes never steal focus.
         self.autofocus = autofocus
         # A control that is on screen but cannot be used right now: the
-        # renderer draws it muted and the pointer passes through it, so it
-        # takes no hover, no click and no spatial-nav focus (see
-        # renderer.lua's node_at / nav_candidates). Say WHY next to the
+        # renderer draws it muted and it takes no hover, no click and no
+        # spatial-nav focus. It still ABSORBS the pointer -- node_at keeps
+        # returning it and each consumer drops it (renderer.lua's
+        # on_mouse_move / on_mouse_down), so a press stops there instead of
+        # reaching whatever the control sits over. Say WHY next to the
         # control -- a disabled thing with no explanation reads as broken.
         #
         # Composite widgets (Button, Checkbox) additionally mute their own

--- a/jellyfin_mpv_shim/mpvtk_browser/config.py
+++ b/jellyfin_mpv_shim/mpvtk_browser/config.py
@@ -10,7 +10,7 @@ import sys
 import typing
 
 from ..conf import Settings, settings
-from ..i18n import _
+from ..i18n import _, _p
 
 # Structured / non-scalar config that the flat form can't express, plus
 # internal bookkeeping. Everything else is editable.
@@ -245,7 +245,13 @@ LABEL_OVERRIDES = {
     "hud_grab_keys": _("Always Bind Arrow Keys to Player Controls"),
     "hud_wake_key": _("Player Controls Activation Key"),
     "segment_intro": _("Skip Intros"),
-    "segment_outro": _("Skip Credits"),
+    # The one segment label that collides with its own Skip BUTTON:
+    # gettext keys on the English, the other four are pluralised ("Skip
+    # Intros" vs the button's "Skip Intro"), and "Credits" is already
+    # plural. The context goes on the LABEL rather than the button because
+    # the button is the string people actually see, and a context discards
+    # every existing translation of the string it is added to.
+    "segment_outro": _p("setting", "Skip Credits"),
     "segment_commercial": _("Skip Commercials"),
     "segment_preview": _("Skip Previews"),
     "segment_recap": _("Skip Recaps"),

--- a/jellyfin_mpv_shim/mpvtk_browser/config.py
+++ b/jellyfin_mpv_shim/mpvtk_browser/config.py
@@ -169,9 +169,6 @@ LABELED_ENUMS = {
         (_("Aligned to rows"), "aligned"),
         (_("One row per notch"), "row"),
     ],
-    # Every label points at the value it has always pointed at -- "Small" is
-    # the base size, which reads oddly beside two smaller steps but is the
-    # price of not silently re-pointing a string 86 locales have translated.
     # One list, five settings: the three things that can be done about a
     # media segment (jellyfin-web offers the same three).
     "segment_intro": _SEGMENT_ACTIONS,
@@ -189,6 +186,9 @@ LABELED_ENUMS = {
         (_("Always hide"), "always"),
         (_("Never hide while paused"), "paused"),
     ],
+    # Every label points at the value it has always pointed at -- "Small" is
+    # the base size, which reads oddly beside two smaller steps but is the
+    # price of not silently re-pointing a string 86 locales have translated.
     "poster_scale": [
         (_("Theme default"), None),
         (_("Extra Compact"), 0.75),

--- a/jellyfin_mpv_shim/mpvtk_browser/hud.py
+++ b/jellyfin_mpv_shim/mpvtk_browser/hud.py
@@ -3,7 +3,8 @@
 Rendered by the browser while it is yielded to video playback, via the
 renderer's attached-but-idle lifecycle (``mpvtk-hud``): playback runs
 clean until an arrow key / ENTER / mouse motion summons the HUD, and
-~4s without input hides it again (both renderer-side; see
+``hud_hide_secs`` without input hides it again, on the policy
+``hud_autohide`` sets (both renderer-side; see
 renderer.lua). ``hud_control.HudController`` owns the summoned flag and
 calls :func:`build_hud` from ``build()``; playstate comes from the
 same ``push_playstate`` snapshots that feed the audio now-playing bar,

--- a/jellyfin_mpv_shim/mpvtk_browser/hud.py
+++ b/jellyfin_mpv_shim/mpvtk_browser/hud.py
@@ -604,8 +604,15 @@ def build_hud(b, size):
         on_change=b.hud.scrub_change,
         on_commit=b.hud.scrub_commit,
         on_cancel=b.hud.scrub_cancel,
-        # the renderer floats the trickplay/chapter bubble itself
-        preview=True)
+        # The renderer floats the trickplay/chapter bubble itself -- but
+        # only where there is a timeline to describe. `max` is floored at
+        # 1.0 above so the renderer's frac has a divisor, which also
+        # defeats its own `max > 0` guard; a live channel reports no
+        # duration, and without this the bubble tracked the pointer along
+        # the bar reading 0:00 the whole way. Guarded like `marks` and
+        # `ranges` beside it. (The deleted _preview_float opened with the
+        # same test.)
+        preview=dur > 0)
 
     menu_state = None
     if b.controller is not None and hasattr(b.controller, "hud_menu_state"):

--- a/jellyfin_mpv_shim/mpvtk_browser/hud_control.py
+++ b/jellyfin_mpv_shim/mpvtk_browser/hud_control.py
@@ -2,9 +2,8 @@
 
 ``hud.py`` builds the HUD's widget tree; this owns what that tree reads. The
 two halves were split across two files for no reason other than history: the
-builders went into ``hud.py`` when it was written, and the eight pieces of
-state plus the eleven handlers stayed on ``MpvtkBrowser`` because that is
-where ``__init__`` was.
+builders went into ``hud.py`` when it was written, and the state plus the
+handlers stayed on ``MpvtkBrowser`` because that is where ``__init__`` was.
 
 Nothing here is browser chrome. The HUD belongs to *video playback* — the
 renderer owns its summon/auto-hide lifecycle and reports it through
@@ -92,8 +91,13 @@ class HudController:
                 and c.use_hud())
 
     def engage(self):
-        """``set_hud(True)`` with the controller's keyboard policy attached
-        (grab arrows vs. wake-key-only; see hud_grab_keys)."""
+        """``set_hud(True)`` with everything the renderer owns attached:
+        the keyboard policy (grab arrows vs. wake-key-only), the auto-hide
+        delay and mode, and whether the glyphs carry their own shadow.
+
+        Idempotent, and that matters — re-engaging is the ONLY thing that
+        carries a changed setting to the renderer, so those settings apply
+        without a restart."""
         opts = None
         get = getattr(self.controller, "hud_key_opts", None)
         if get is not None:

--- a/jellyfin_mpv_shim/mpvtk_browser/settings/general.py
+++ b/jellyfin_mpv_shim/mpvtk_browser/settings/general.py
@@ -72,7 +72,7 @@ class GeneralTabMixin:
                 # back to the ordinary note colour: it is a footnote, not a
                 # warning about the control you are looking at.
                 rows.append(Text(
-                    _("Cover size and interface scale require a restart."),
+                    _("Interface scale requires a restart."),
                     size=14, color=theme.SUBTLE_FG, wrap=True))
         rows.append(Text(_("Some changes take effect after restarting."),
                          size=14, color=theme.SUBTLE_FG))

--- a/jellyfin_mpv_shim/trickplay.py
+++ b/jellyfin_mpv_shim/trickplay.py
@@ -32,6 +32,26 @@ log = logging.getLogger("trickplay")
 IMG_PREFIX = "raw_images"
 IMG_SUFFIX = ".bin"
 
+# Module-level, not per-instance. A new TrickPlay is built on every mpv
+# re-creation, so a per-instance counter restarts at 0 and the SECOND
+# generation of the second worker reuses the first's path -- which is the
+# one thing the comment above says cannot happen. stop(join=False) lets a
+# straggler finish and publish, and script_message resolves the live mpv at
+# call time, so the new renderer can be pointed at a name the new worker is
+# about to open("wb"). mpv mmaps what it is handed and reading past a
+# truncated EOF is a SIGBUS in the mpv process; the mpvtk HUD reads these
+# frames through mpv now rather than in Python, so that stopped being a
+# missing thumbnail and became a crash.
+_seq_lock = threading.Lock()
+_seq = 0
+
+
+def _next_seq():
+    global _seq
+    with _seq_lock:
+        _seq += 1
+        return _seq
+
 
 def _img_path(seq):
     return conffile.get(APP_NAME, "%s.%d%s" % (IMG_PREFIX, seq, IMG_SUFFIX))
@@ -79,10 +99,9 @@ class TrickPlay(threading.Thread):
         self.trigger = threading.Event()
         self.halt = False
         self.player = player
-        # Generation counter for frame-file names, and the file the renderer
-        # is currently pointed at. Only the worker thread advances _seq; both
-        # it and stop()/clear() touch _current, hence the lock.
-        self._seq = 0
+        # The file the renderer is currently pointed at. The generation
+        # counter behind the names is module-level (see _next_seq); this is
+        # touched by the worker thread and by stop()/clear(), hence the lock.
         self._current = None
         self._file_lock = threading.Lock()
 
@@ -121,10 +140,9 @@ class TrickPlay(threading.Thread):
     # -- frame-file lifecycle ---------------------------------------------
 
     def _next_file(self):
-        """A fresh path for the next set of frames. Never an existing one."""
-        with self._file_lock:
-            self._seq += 1
-            return _img_path(self._seq)
+        """A fresh path for the next set of frames. Never an existing one,
+        for the life of the PROCESS -- see _next_seq."""
+        return _img_path(_next_seq())
 
     def _publish(self, path):
         """Adopt `path` as the live frame file and drop the previous one.

--- a/tests/integration/_harness.py
+++ b/tests/integration/_harness.py
@@ -328,8 +328,11 @@ def import_player_with_fake_mpv():
     settings.menu_mouse = False
     settings.svp_enable = False
     settings.discord_presence = False
-    settings.enable_osc = False
-    settings.osc_style = "default"  # keep the OSC lua out of these legs
+    # "none": no shim OSC lua loaded AND mpv's own OSC suppressed. This
+    # was `osc_style = "default"` plus `enable_osc = False` until #615
+    # retired the second half, which left the write dead and these legs
+    # quietly running with mpv's OSC up.
+    settings.osc_style = "none"
     settings.check_updates = False
 
     # Flip the import-time backend selector: player.py imports libmpv when
@@ -439,7 +442,6 @@ def build_player(player_module, video=None):
     pm.repeat_mode = "none"
     pm._osc_script_loaded = False
     pm.mpvtk_active = False
-    pm.trickplay_meta = None
     pm._hud_skip = None
     pm._trickplay_pending = False
 

--- a/tests/integration/test_realmpv_smoke.py
+++ b/tests/integration/test_realmpv_smoke.py
@@ -41,13 +41,16 @@ def _import_real_player():
     settings.svp_enable = False
     settings.discord_presence = False
     settings.check_updates = False
-    settings.enable_osc = False
     # Keep the OSC lua out of the in-process libmpv: these tests target the
     # player state machine, and a loaded lua script makes libmpv's teardown
     # at interpreter exit racy (rare SIGABRT/SIGSEGV after all tests pass).
     # The OSC scripts get their own leg (test_jf_osc_script) that drives the
     # external mpv binary instead.
-    settings.osc_style = "default"
+    #
+    # "none" rather than "default": it keeps the lua out AND suppresses
+    # mpv's own OSC, which is what the `enable_osc = False` beside it did
+    # until #615 retired that setting and left the write dead.
+    settings.osc_style = "none"
     settings.fullscreen = False
     settings.mpv_ext = (h.BACKEND == "jsonipc")
     # import_player_with_fake_mpv sets this False on the SHARED settings

--- a/tests/lua/test_renderer.lua
+++ b/tests/lua/test_renderer.lua
@@ -1495,8 +1495,13 @@ local dragged = preview().secs
 ok(dragged > before, "the bubble did not follow the drag",
    string.format("%s -> %s", tostring(before), tostring(dragged)))
 fake.send("mpvtk-debug", fake.token({ cmd = "click", x = 1000, y = 672 }))
+-- The release itself requests no render, so pv_rect still holds the rect
+-- painted DURING the drag -- which is the right answer either way and made
+-- this test pass on unfixed code. Push the scene Python pushes in response
+-- to the commit, which is what actually repaints, then look.
+seek_scene()
 pv_paint()
-ok(preview() ~= nil and math.abs(preview().secs - dragged) < 20,
+ok(preview() ~= nil and math.abs(preview().secs - dragged) < 2,
    "releasing the drag snapped the bubble back to where it started",
    string.format("released at %s, was dragged to %s",
                  tostring(preview() and preview().secs), tostring(dragged)))

--- a/tests/lua/test_renderer.lua
+++ b/tests/lua/test_renderer.lua
@@ -1145,6 +1145,20 @@ type_text("Z")
 click("elsewhere")
 ok(last_event("commit") == nil, "a disabled textbox cannot be edited")
 
+-- A disabled control that mutes itself in Python carries ONLY `dis` -- no
+-- click, no hover, no tip. node_at has to keep returning it anyway, or the
+-- press it is supposed to swallow reaches whatever it sits over. Over the
+-- playback HUD that is bare video, where a click toggles pause.
+scene({ { id = "card", t = "rect", x = 0, y = 0, w = 400, h = 200,
+          click = true },
+        { id = "muted", t = "rect", x = 50, y = 50, w = 120, h = 40,
+          dis = true } })
+fake.reset_events()
+fake.send("mpvtk-debug", fake.token({ cmd = "click", x = 100, y = 70 }))
+eq(last_event("click"), nil,
+   "a press on a self-muted disabled control fell through to the node "
+   .. "underneath")
+
 -- ================================================ thumb-button sections
 
 -- The thumb buttons are the browser's Back/Forward, but over a FILM they

--- a/tests/lua/test_renderer.lua
+++ b/tests/lua/test_renderer.lua
@@ -1345,6 +1345,21 @@ local function hud_bars()
             { id = "hud-bar", t = "rect", x = 0, y = 640, w = 1280, h = 80 } })
 end
 
+-- A caller that sends no opts at all gets the toolkit's own default, not
+-- the 0.5s floor: `or 0` folded "absent" into "zero", and zero is
+-- meaningful here (it forces hover mode), so PHUD_HIDE.def was unreachable.
+fake.send("mpvtk-hud", "no")
+fake.send("mpvtk-hud", "yes")
+hud_pointer(600, 300)
+hud_pointer(600, 310)
+hud_bars()
+fake.reset_events()
+fake.advance(1.0)
+fake.fire_timers()
+ok(not hud_hidden(), "no opts hid the controls after under a second")
+hud_wait()
+ok(hud_hidden(), "...and then never hid them at all")
+
 fake.send("mpvtk-hud", "no")
 fake.send("mpvtk-hud", "yes", fake.token({ hide = 4, mode = "hover" }))
 -- The first pointer event after engaging only records the position, so this

--- a/tests/lua/test_renderer.lua
+++ b/tests/lua/test_renderer.lua
@@ -1487,6 +1487,27 @@ ok(preview() ~= nil and math.abs(preview().secs - dragged) < 20,
    string.format("released at %s, was dragged to %s",
                  tostring(preview() and preview().secs), tostring(dragged)))
 
+-- A chapter name comes from container metadata and can run to a sentence.
+-- clamp() returns its LOW bound when hi < lo, so an over-wide bubble pinned
+-- itself at x=8 and ran off the right edge -- and stopped being centred on
+-- the position it labels, which is #612 all over again.
+fake.log.props["chapter-list"] = {
+    { title = string.rep("A very long chapter name ", 12), time = 0 },
+}
+fake.observe("chapter-list", fake.log.props["chapter-list"])
+hud_pointer(640, 675)
+pv_paint()
+local wide = preview()
+ok(wide ~= nil, "no bubble to measure")
+ok(wide and wide.x >= 0 and wide.x + wide.w <= 1280,
+   "the bubble runs off the window",
+   wide and string.format("x=%d w=%d right=%d", wide.x, wide.w,
+                          wide.x + wide.w))
+ok(wide and math.abs((wide.x + wide.w / 2) - 640) < 2,
+   "a long chapter name knocked the bubble off centre",
+   wide and ("centre=" .. tostring(wide.x + wide.w / 2)))
+fake.observe("chapter-list", {})
+
 -- A bar that does not ask for a preview never gets one: this is opt-in
 -- (the volume slider is the same widget).
 scene({ { id = "hud-bar", t = "rect", x = 0, y = 640, w = 1280, h = 80 },

--- a/tests/snapshots/settings.jsonl
+++ b/tests/snapshots/settings.jsonl
@@ -99,7 +99,7 @@
 {"align": "left", "c": "9aa0a6", "h": 21.2, "id": "r.1.1.0.32.0", "sc": "settings", "size": 17, "t": "text", "text": "Interface Scale", "w": 340.0, "x": 16.0, "y": 1273.4}
 {"force": true, "h": 38.0, "id": "set-ui_scale", "items": ["Follow display", "100% (no scaling)", "125%", "150%", "200%"], "sc": "settings", "sel": 0, "size": 20, "t": "dropdown", "w": 340.0, "x": 368.0, "y": 1265.0}
 {"align": "left", "c": "9aa0a6", "h": 17.5, "id": "r.1.1.0.33", "sc": "settings", "size": 14, "t": "text", "text": "Takes effect after a restart. \"Follow display\" uses the scale your desktop reports, which is 100% on X11.", "w": 1238.0, "x": 16.0, "y": 1311.0}
-{"align": "left", "c": "9aa0a6", "h": 17.5, "id": "r.1.1.0.34", "sc": "settings", "size": 14, "t": "text", "text": "Cover size and interface scale require a restart.", "w": 1238.0, "x": 16.0, "y": 1336.5}
+{"align": "left", "c": "9aa0a6", "h": 17.5, "id": "r.1.1.0.34", "sc": "settings", "size": 14, "t": "text", "text": "Interface scale requires a restart.", "w": 1238.0, "x": 16.0, "y": 1336.5}
 {"align": "left", "bold": true, "c": "e8e8e8", "h": 25.0, "id": "r.1.1.0.35", "sc": "settings", "size": 20, "t": "text", "text": "Playback", "w": 1238.0, "x": 16.0, "y": 1362.0}
 {"click": true, "h": 25.0, "hover": {"c": "747474"}, "id": "set-auto_play", "sc": "settings", "t": "rect", "w": 1238.0, "x": 16.0, "y": 1395.0}
 {"fill": "00a4dc", "h": 20.0, "id": "r.1.1.0.36.0", "radius": 5, "sc": "settings", "t": "rect", "w": 20.0, "x": 16.0, "y": 1397.5}

--- a/tests/test_mpvtk_adopt.py
+++ b/tests/test_mpvtk_adopt.py
@@ -204,3 +204,54 @@ class TestAdoptBackend(unittest.TestCase):
 
 if __name__ == "__main__":
     unittest.main()
+
+
+class DisabledControlsAbsorbThePointer(unittest.TestCase):
+    """A disabled control has to EXIST as a node.
+
+    Button and Checkbox mute themselves in Python -- they drop their
+    handler, their hover and (flat) their background -- because a
+    composite's colours live in child nodes the renderer cannot recognise.
+    That left `layout` with nothing to emit: no bg, no border, no on_click.
+
+    With no node there is nothing to absorb the press, so it reached
+    whatever the control sat over. Over the playback HUD that is bare video,
+    where renderer.lua toggles pause -- so a disabled flat button paused the
+    film. The node also carries the tooltip explaining why the control is
+    off, which is the one thing the feature's docstring insists on.
+    """
+
+    def _nodes(self, el):
+        from jellyfin_mpv_shim.mpvtk.layout import layout
+        from jellyfin_mpv_shim.mpvtk.widgets import Column
+        nodes, _h = layout(Column([el], w=300, h=60), 300, 60)
+        return nodes
+
+    def _node(self, el):
+        return next((n for n in self._nodes(el) if n.get("id") == el.id), None)
+
+    def test_a_disabled_flat_button_still_emits_a_node(self):
+        from jellyfin_mpv_shim.mpvtk.widgets import Button
+        node = self._node(Button("x", id="b", flat=True, disabled=True,
+                                 tip="not now", on_click=lambda: None))
+        self.assertIsNotNone(node, "nothing for the pointer to land on")
+        self.assertTrue(node.get("dis"))
+        self.assertEqual(node.get("tip"), "not now",
+                         "the reason it is disabled never reached the "
+                         "renderer")
+        self.assertFalse(node.get("click"), "a disabled button is clickable")
+
+    def test_a_disabled_checkbox_still_emits_a_node(self):
+        from jellyfin_mpv_shim.mpvtk.widgets import Checkbox
+        node = self._node(Checkbox("x", False, id="c", disabled=True,
+                                   on_toggle=lambda: None))
+        self.assertIsNotNone(node, "nothing for the pointer to land on")
+        self.assertTrue(node.get("dis"))
+        self.assertFalse(node.get("click"))
+
+    def test_an_enabled_one_is_unchanged(self):
+        from jellyfin_mpv_shim.mpvtk.widgets import Button
+        node = self._node(Button("x", id="b", flat=True,
+                                 on_click=lambda: None))
+        self.assertTrue(node.get("click"))
+        self.assertFalse(node.get("dis"))

--- a/tests/test_shell_chrome.py
+++ b/tests/test_shell_chrome.py
@@ -485,10 +485,6 @@ class TestOneBlue(unittest.TestCase):
         self._check("grid filter bar with checked boxes")
 
 
-if __name__ == "__main__":
-    unittest.main()
-
-
 class TestATransitionSurvivesARaisingController(unittest.TestCase):
     """The browse/playback transitions must complete even if the controller
     throws halfway through one.
@@ -515,21 +511,37 @@ class TestATransitionSurvivesARaisingController(unittest.TestCase):
         b.server = "srv1"
         return b
 
-    def test_yield_still_leaves_browse(self):
+    def test_yield_still_engages_the_hud(self):
+        """The step BEHIND the callback, which is what actually went
+        missing: _browsing is cleared before the controller is told, so
+        asserting on it only proves the exception did not propagate."""
         b = self._browser()
         b._browsing = True
+        engaged = []
+        b.hud.available = lambda: True
+        b.hud.engage = lambda: engaged.append(True)
         b._yield()
         self.assertFalse(b._browsing, "the yield was abandoned")
+        self.assertEqual(engaged, [True],
+                         "the HUD engage behind the callback was skipped")
 
     def test_enter_browse_still_reactivates_the_renderer(self):
         b = self._browser()
         b.nav_stack = [{"kind": "home", "server": "srv1"}]
         b._browsing = False
+        active = []
+        b._set_renderer_active = lambda on: active.append(on)
         b.enter_browse()
         self.assertTrue(b._browsing, "the return to browse was abandoned")
+        self.assertIn(True, active,
+                      "the renderer was never re-activated")
 
     def test_minimize_still_minimizes(self):
         b = self._browser()
         b.nav_stack = [{"kind": "home", "server": "srv1"}]
         b.minimize()
         self.assertTrue(b.minimized, "the minimize was abandoned")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_shell_playback.py
+++ b/tests/test_shell_playback.py
@@ -257,6 +257,23 @@ class TestHudScrimAndAutohide(unittest.TestCase):
         self.assertLess(bottom["y"], bar["y"],
                         "the bar's top edge sits above the shading")
 
+    def test_a_stream_with_no_duration_gets_no_scrub_preview(self):
+        """A live channel reports no duration. `max` is floored at 1.0 so
+        the renderer's frac has a divisor, which also defeats its own
+        `max > 0` guard -- so the bubble tracked the pointer along the bar
+        reading 0:00 the whole way. Guarded like `marks` and `ranges`."""
+        self.settings.hud_scrim = "default"
+        b, _ctl = self._browser()
+        b.hud.state = dict(b.hud.state, duration=0)
+        nodes, _h = build_scene(b, (1280, 720))
+        seek = next(n for n in nodes if n.get("id") == "hud-seek")
+        self.assertFalse(seek.get("pv"),
+                         "a durationless stream offers a scrub preview")
+        b.hud.state = dict(b.hud.state, duration=100.0)
+        nodes, _h = build_scene(b, (1280, 720))
+        seek = next(n for n in nodes if n.get("id") == "hud-seek")
+        self.assertTrue(seek.get("pv"), "a real timeline lost its preview")
+
     def test_a_retired_scrim_value_reads_as_the_default(self):
         """"half" was offered while this branch was in flight and is gone.
         A config that still says it must draw the default ramp, not nothing

--- a/tests/test_trickplay_files.py
+++ b/tests/test_trickplay_files.py
@@ -77,6 +77,21 @@ class FrameFileLifetimeTest(unittest.TestCase):
         self.assertIn(("shim-trickplay-clear",), self.player.messages)
         self.assertFalse(os.path.exists(a))
 
+    def test_a_second_worker_never_reuses_the_first_worker_path(self):
+        """A new TrickPlay is built on every mpv re-creation. With the
+        counter on the instance it restarted at 0, so the second worker's
+        first file was the first worker's first file -- and stop(join=False)
+        lets a straggler publish into the NEW mpv, whose renderer mmaps
+        whatever it is handed. open("wb") over that is a SIGBUS in mpv."""
+        first = [self.tp._next_file() for _ in range(3)]
+        second = trickplay.TrickPlay.__new__(trickplay.TrickPlay)
+        second._file_lock = threading.Lock()
+        second._current = None
+        again = [second._next_file() for _ in range(3)]
+        self.assertFalse(set(first) & set(again),
+                         "the second worker reused %r"
+                         % sorted(set(first) & set(again)))
+
     def test_retiring_twice_is_harmless(self):
         a = self.tp._next_file()
         self._write(a)

--- a/tests/test_trickplay_files.py
+++ b/tests/test_trickplay_files.py
@@ -25,7 +25,6 @@ import jellyfin_mpv_shim.trickplay as trickplay  # noqa: E402
 
 class FakePlayer:
     def __init__(self):
-        self.trickplay_meta = None
         self.messages = []
 
     def script_message(self, *args):
@@ -77,7 +76,6 @@ class FrameFileLifetimeTest(unittest.TestCase):
         self.tp.clear()
         self.assertIn(("shim-trickplay-clear",), self.player.messages)
         self.assertFalse(os.path.exists(a))
-        self.assertIsNone(self.player.trickplay_meta)
 
     def test_retiring_twice_is_harmless(self):
         a = self.tp._next_file()


### PR DESCRIPTION
Catch-all bugfix PR for work in this stack.

- Fix issue, primarily in tests, where trickplay files had contention between MPV instances.
- Fix disabled state not stopping event propagation on some controls.
- Fix durationless seek bar hover. (In practice unlikely to happen, but cleans the edge case.)
- Prevent scrub container clipping edge of screen.
- Fix unit tests that couldn't fail.
- Make "Skip Credits" two separate strings. One for the action and one for the configuration.

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>