### PR TITLE
browser: window the music routes (#617), and the hand-test record

### DIFF
--- a/docs/UI_UX_FIXES_2026-08.md
+++ b/docs/UI_UX_FIXES_2026-08.md
@@ -909,8 +909,29 @@ only lines up because its list is a single rendered page.)
 
 ### Order
 
-1. Tile grids — Albums, Album Artists, Artists, genre page.
-2. Songs — `track_list` holes plus the server-backed play action.
+1. Tile grids — Albums, Album Artists, Artists, genre page. `b6d24a1e`
+2. Songs — `track_list` holes plus the server-backed play action. `aedee927`
+
+### Done — what it came to
+
+Both landed as planned. Two things worth recording:
+
+`track_list` needed the **same two changes** `_list_view` did, and for the
+same reason — blank cells so the row keeps its place, *and* no handlers so a
+hole cannot be clicked into opening None. The review round had just caught
+`item_list` shipping only the first of those, which is why it was looked for
+here rather than assumed.
+
+The songs play action came out **simpler than jellyfin-web's**, not harder.
+Web's `playAllFromHere` computes its start index from the DOM, which only
+lines up because its list is a single rendered page; ours is the row index
+itself, because the row index *is* the track's absolute position — the
+invariant the whole sparse-list design rests on.
+
+`more` now has exactly one caller left in the browser: Live TV's channel
+list, which stays deliberately. `TestPagersShareTheirInvariants` follows it
+rather than being deleted — the code still runs, so its rules still need
+asserting.
 
 ## Hand-testing round 2: the review fixes
 
@@ -1010,6 +1031,26 @@ thing that was fixed but the thing beside it.
 - [ ] **The OSD menu's segment rows** now read Never/Ask/Always, matching
       the settings form.
 - [ ] **Theme settings** no longer claims cover size needs a restart.
+
+### Music windowing (`b6d24a1e`, `aedee927`)
+
+- [ ] **Albums / Album Artists / Artists** on a big library: full-length
+      scrollbar from the first frame, no jump as pages land, drag to the
+      middle and get *that* neighbourhood.
+- [ ] **A genre with many albums**, same.
+- [ ] **Genres tab** — unpaged, so nothing should change at all.
+- [ ] **Artist page** — not windowed (its query takes no offset); check it
+      still shows a full discography.
+- [ ] **Songs tab**: scroll deep, then click a song. It should play from
+      *that* song, with the next few hundred queued behind it. Check the
+      now-playing bar and the queue view agree.
+- [ ] **Songs tab, unloaded rows**: blank rows must not respond to a click
+      or a right-click, and must not hover-highlight.
+- [ ] **Switch tabs and come back** — the per-tab cache should still work
+      and should not re-request what it had.
+- [ ] **Paginated mode on**, across the music tabs.
+- [ ] **Live TV channels** — deliberately still append-on-approach; check it
+      is unchanged.
 
 ### Known and deliberate
 

--- a/docs/UI_UX_FIXES_2026-08.md
+++ b/docs/UI_UX_FIXES_2026-08.md
@@ -729,7 +729,7 @@ Not changed, decided:
 
 - Skip intro seems to not be showing skip intro buttons in some cases
 
-- Got an error:
+- Got an error: [Fixed]
   File "/home/izzie/bookmarks/scripts/jellyfin-mpv-shim/jellyfin_mpv_shim/mpvtk_browser/gateway/playback.py", line 40, in on_minimize
     playerManager.enable_osc(settings.enable_osc)
                              ^^^^^^^^^^^^^^^^^^^

--- a/docs/UI_UX_FIXES_2026-08.md
+++ b/docs/UI_UX_FIXES_2026-08.md
@@ -947,7 +947,7 @@ thing that was fixed but the thing beside it.
 
 ### Highest risk — shared code paths
 
-- [ ] **Mouse Back/Forward, everywhere** (`86f113e2`). This is the biggest
+- [X] **Mouse Back/Forward, everywhere** (`86f113e2`). This is the biggest
       blast radius on the branch: the buttons moved to their own key-binding
       section and its enable/disable is now asserted at three points. Check
       Back in the library, in a dialog, in a modal, on the cast screen, on
@@ -957,99 +957,101 @@ thing that was fixed but the thing beside it.
       playlist-prev/next, i.e. previous/next queue item — and with it on.
       Restart the app and do the library ones again first thing: the bug
       was that they were dead from launch until a playback round trip.
-- [ ] **Every slider still drags** (`971126c3`). `slider_set_from_x` gained
+- [X] **Every slider still drags** (`971126c3`). `slider_set_from_x` gained
       the preview write and is shared by the volume slider and the music
       now-playing bar, not just the seek bar. Drag all three.
-- [ ] **Any click, anywhere** (`73fbf6ca`). `node_at` gained `dis` to its
+- [X] **Any click, anywhere** (`73fbf6ca`). `node_at` gained `dis` to its
       interactivity test and `_arrange_box` emits a node for a disabled
       element. Nothing in the app passes `disabled=` yet, so this *should*
       be inert — but it is the function every hit test goes through. A
       general poke around the library, dialogs and the HUD is the check.
-- [ ] **Chapter navigation near a boundary** (`9f7a394f`). The forward
+- [X] **Chapter navigation near a boundary** (`9f7a394f`). The forward
       direction lost its 0.5s tolerance. Test the HUD's chapter buttons AND
       the mouse buttons, from just before a boundary, exactly on one, and
       from the last chapter (should do nothing).
 
 ### The #617 cluster
 
-- [ ] **Change Image Type on a scrolled library** (`4b0e3afd`) — the fix.
+- [X] **Change Image Type on a scrolled library** (`4b0e3afd`) — the fix.
       Scroll well past the first page, View → Image Type → Banner. Every
       tile should become a banner, not just the first hundred.
       *Blast radius:* the refetch now drops the loaded list, so it will
       re-fetch from the top. Check it does not blink jarringly, and note
       where the scroll position ends up.
-- [ ] **Favorites, a genre listing, Next Up, a studio, a person page**
+- [X] **Favorites, a genre listing, Next Up, a studio, a person page**
       (`f18088aa`). These were windowing without padding. The scrollbar
       should be full-length from the first frame and must not jump as pages
       land. The count line now reads the server's total.
-- [ ] **`--debug` on a library over 100 items** (`fd8c9b94`). It used to
+- [X] **`--debug` on a library over 100 items** (`fd8c9b94`). It used to
       throw out of render and leave a spinner. Should just work.
-- [ ] **List view, scrolled into unloaded rows** (`fd8c9b94`). Blank rows
+- [X] **List view, scrolled into unloaded rows** (`fd8c9b94`). Blank rows
       must not hover-highlight or respond to a click or right-click.
-- [ ] **A library that shrinks under you** (`375a3763`) — hard to stage; if
+- [-] **A library that shrinks under you** (`375a3763`) — hard to stage; if
       you can delete items server-side mid-scroll, the count line and the
       grid height should agree afterwards.
 
 ### Playback HUD
 
-- [ ] **Live TV seek bar** (`1cbd3cdb`). Hovering it should show *nothing*.
+- [*] **Live TV seek bar** (`1cbd3cdb`). Hovering it should show *nothing*.
       Then a normal file: the bubble should appear once mpv reports a
       duration, not before.
-- [ ] **A film with long chapter names** (`f46f1635`). The bubble stays
+      - It does show a bubble with just the seek time. This is fine.
+- [-] **A film with long chapter names** (`f46f1635`). The bubble stays
       inside the window and stays centred on the pointer; the name
       ellipsizes rather than the box growing.
-- [ ] **Scrub, release, look** (`4038ecdf` fixed the test, `971126c3` the
+- [X] **Scrub, release, look** (`4038ecdf` fixed the test, `971126c3` the
       code). Drag the seek bar and let go — the bubble must not jump back.
-- [ ] Auto-hide unchanged in all three modes (`ee08a40a` only made the
+- [X] Auto-hide unchanged in all three modes (`ee08a40a` only made the
       *toolkit's* default reachable; the shim always sends its own).
 
 ### Offline
 
-- [ ] **Re-download an episode, then play it** (`8c1817f8`, `3983a296`).
+- [X] **Re-download an episode, then play it** (`8c1817f8`, `3983a296`).
       Skip Intro should offer where it does when streaming — and a segment
       type set to "off" should now behave exactly as it does online, i.e.
       not eat a forward seek with `skip_intro_on_seek` on.
-- [ ] **Downloaded Shows grid** (`8a946e39`) — posters, not squares.
-- [ ] **Trickplay across an mpv restart** (`6158df6b`). Play a downloaded or
+- [X] **Downloaded Shows grid** (`8a946e39`) — posters, not squares.
+- [X] **Trickplay across an mpv restart** (`6158df6b`). Play a downloaded or
       streamed file, let mpv be re-created (idle quit, or stop and start),
       scrub in the new one. Watch for mpv errors in the log.
 
 ### Config and text
 
-- [ ] **Upgrade a real 2.x config** (`0f6d55ef`). Back it up first. Confirm
+- [X] **Upgrade a real 2.x config** (`0f6d55ef`). Back it up first. Confirm
       the segment settings land where you expect. If you have any
       hand-edited quoted booleans, this is the case that used to flip them
       to "always".
-- [ ] **A config still saying `hud_scrim: "half"`** (`bd267d6f`) — draws the
+- [-] **A config still saying `hud_scrim: "half"`** (`bd267d6f`) — draws the
       default ramp, picker reads Default.
-- [ ] **Minimize to tray, and restore** (`3e4c32af`). This crashed before;
+      - Will never happen to end user.
+- [X] **Minimize to tray, and restore** (`3e4c32af`). This crashed before;
       also check the OSC state afterwards.
-- [ ] **"Skip Credits" in three places** (`1f9a58ad`): the HUD/OSD Skip
+- [X] **"Skip Credits" in three places** (`1f9a58ad`): the HUD/OSD Skip
       button, the settings form row, and the OSD menu row. The button keeps
       its existing translations; the two labels are a new key and will read
       English until Weblate catches up.
-- [ ] **The OSD menu's segment rows** now read Never/Ask/Always, matching
+- [X] **The OSD menu's segment rows** now read Never/Ask/Always, matching
       the settings form.
-- [ ] **Theme settings** no longer claims cover size needs a restart.
+- [X] **Theme settings** no longer claims cover size needs a restart.
 
 ### Music windowing (`b6d24a1e`, `aedee927`)
 
-- [ ] **Albums / Album Artists / Artists** on a big library: full-length
+- [X] **Albums / Album Artists / Artists** on a big library: full-length
       scrollbar from the first frame, no jump as pages land, drag to the
       middle and get *that* neighbourhood.
-- [ ] **A genre with many albums**, same.
-- [ ] **Genres tab** — unpaged, so nothing should change at all.
-- [ ] **Artist page** — not windowed (its query takes no offset); check it
+- [X] **A genre with many albums**, same.
+- [X] **Genres tab** — unpaged, so nothing should change at all.
+- [X] **Artist page** — not windowed (its query takes no offset); check it
       still shows a full discography.
-- [ ] **Songs tab**: scroll deep, then click a song. It should play from
+- [X] **Songs tab**: scroll deep, then click a song. It should play from
       *that* song, with the next few hundred queued behind it. Check the
       now-playing bar and the queue view agree.
-- [ ] **Songs tab, unloaded rows**: blank rows must not respond to a click
+- [X] **Songs tab, unloaded rows**: blank rows must not respond to a click
       or a right-click, and must not hover-highlight.
-- [ ] **Switch tabs and come back** — the per-tab cache should still work
+- [X] **Switch tabs and come back** — the per-tab cache should still work
       and should not re-request what it had.
-- [ ] **Paginated mode on**, across the music tabs.
-- [ ] **Live TV channels** — deliberately still append-on-approach; check it
+- [X] **Paginated mode on**, across the music tabs.
+- [X] **Live TV channels** — deliberately still append-on-approach; check it
       is unchanged.
 
 ### Known and deliberate

--- a/jellyfin_mpv_shim/mpvtk_browser/pages/music.py
+++ b/jellyfin_mpv_shim/mpvtk_browser/pages/music.py
@@ -10,7 +10,7 @@ a mixin was the only place two pages could both reach; a base class is what
 from ...i18n import _
 from ...mpvtk.widgets import (
     Checkbox, Column, Row, Spacer, Text, VScroll)
-from .. import theme
+from .. import pagination, theme
 from ..components import chrome, controls, detail as detail_components
 from ..tile_renderer import GRID_GAP
 from .base import Page
@@ -93,11 +93,34 @@ class MusicLibraryPage(MusicPage):
 
         def done(res):
             items, total = res
-            route["_data"], route["_total"] = items, total
+            route["_total"] = total
+            # `total` slots from the first frame, most of them holes (#617).
+            # The genres tab reports its own length, so it pads to exactly
+            # what it loaded and windows to nothing -- the same shape that
+            # exempts a Random library grid.
+            route["_data"] = pagination.spread([], total, items, 0)
             route["_loading"] = False
 
         fetch = self._fetch_for_tab()      # bind the tab here, not later
         self.route_async(lambda: fetch(0), done, epoch)
+
+    def _window(self, first, last):
+        """Fetch the tiles in ``[first, last)`` that are not loaded yet.
+
+        Called from render, like GridPage's: which items are visible is a
+        question about geometry. The tab is bound HERE, on the loop thread,
+        for the reason _fetch_for_tab's docstring gives -- reading it when
+        the page lands resolves against whichever tab the user switched to.
+        """
+        fetch = self._fetch_for_tab()
+
+        def put(r, items, total):
+            r["_data"], r["_total"] = items, total
+
+        self.ctx.art.pages.window(
+            self.route, first, last,
+            lambda r: (r.get("_data") or [], r.get("_total") or 0),
+            put, lambda start, limit: fetch(start, limit))
 
     def _fetch_for_tab(self, limit=None):
         """``fetch(start)`` (or ``fetch(start, limit)``) for the current tab.
@@ -199,12 +222,19 @@ class MusicLibraryPage(MusicPage):
 
     def _grid_body(self, data, size, tab):
         art = self.ctx.art
+        route = self.route
         # Every music tab is square, genres included. jellyfin-web renders a
         # MusicGenre as shape:'auto' with nothing to measure -- a genre carries
         # no Primary image -- and setCardData's no-aspect-ratio fallback is
         # square, so square is what it draws. The modern app says it outright:
         # Music -> SquareOverflow, everything else PortraitOverflow.
         geom = art.geom_square
+        # Ask for the rows about to be drawn, from the SAME window the
+        # renderer composites (TileRenderer.row_window). head_h is 0: the
+        # tab bar lives outside this scroll, so the grid starts at its top.
+        cols = art.tiles.cols(size[0], geom)
+        first, last = art.tiles.row_window(size, geom, "music-grid")
+        self._window(first * cols, (last + 1) * cols)
         return VScroll(
             Column(art.tiles.grid_of(data, "music", size, geom=geom,
                                      scroll_id="music-grid"),
@@ -216,9 +246,12 @@ class MusicLibraryPage(MusicPage):
             # sits at the top pad, hence snap_off = CONTENT_PAD.
             snap=geom.strip_h + GRID_GAP,
             snap_off=chrome.CONTENT_PAD,
+            # The callback is what lets a window that FAILED be asked for
+            # again -- render cannot retry on its own without becoming a
+            # request per frame. See Paginator.rewindow.
             on_scroll=lambda off, mx: art.scroll.on_scroll(
                 "music-grid", off, mx,
-                lambda o, m: self._on_scroll_end(o, m)))
+                lambda o, m: art.pages.rewindow(route)))
 
     def _paged_grid(self, size, geom, tabbar):
         """One screenful of album/artist tiles, no scroll — the bottom
@@ -250,9 +283,12 @@ class MusicLibraryPage(MusicPage):
     # -- paging / tabs -----------------------------------------------------
 
     def _on_scroll_end(self, offset, maximum):
-        """Page the current music tab in near the bottom (the Tk browser's
-        _MusicGrid did this per tab; without it a library is capped at the
-        first 100 albums)."""
+        """Page the SONGS tab in near the bottom.
+
+        The tile tabs are windowed now (#617) and reach this from nothing;
+        songs is a table whose rows are built by index and whose play action
+        is built from the list, so it keeps appending until that is dealt
+        with. See the work list's music section."""
         def put(r, items, total):
             r["_data"], r["_total"] = items, total
 

--- a/jellyfin_mpv_shim/mpvtk_browser/pages/music.py
+++ b/jellyfin_mpv_shim/mpvtk_browser/pages/music.py
@@ -203,22 +203,67 @@ class MusicLibraryPage(MusicPage):
         art = self.ctx.art
         route = self.route
         server = route.get("server") or self.ctx.server
-        ids = [s.get("Id") for s in data]
+        # The visible window, so the table fetches the rows it draws.
+        head_h = chrome.CONTENT_PAD
+        first, last = art.tiles.list_window(len(data), "music-songs", head_h)
+        self._window(first, last)
         # art=True: this is a whole library's worth of songs from every
         # album at once, which is exactly the mixed-album case the art
         # column is for (the album page redundantly omits it). Safe
         # because the list is virtualized — only visible rows composite
         # an overlay, so the 63-overlay budget holds.
         return VScroll(Column([art.tiles.track_list(
-            data, "song",
-            lambda i: self.ctx.actions.play_list(ids, server, i, audio=True),
+            data, "song", self._play_songs_from,
             art=True, scroll_id="music-songs", menu=True)],
             pad=chrome.CONTENT_PAD, align="stretch"),
             id="music-songs", flex=1,
             offset=self.parked_scroll("music-songs"),
             on_scroll=lambda off, mx: art.scroll.on_scroll(
                 "music-songs", off, mx,
-                lambda o, m: self._on_scroll_end(o, m)))
+                lambda o, m: art.pages.rewindow(route)))
+
+    def _play_songs_from(self, index):
+        """Play from a row of the songs tab, asking the SERVER for the queue.
+
+        A music library's songs tab runs to thousands of rows and is
+        windowed, so "everything on screen" is a handful of loaded pages
+        with holes between them -- there is no full list to index into.
+
+        jellyfin-web does not use its rendered rows either: shortcuts.js's
+        playAllFromHere re-runs the container's own query and plays
+        result.Items, falling back to scraped DOM ids only where the
+        container has no fetcher. That re-fetch goes through
+        getItemsForPlayback, i.e. the same Limit: 300 repository.QUEUE_LIMIT
+        matches.
+
+        Ours is the simpler shape, because the row index IS the track's
+        absolute position in the library -- that is the invariant windowing
+        is built on, so there is nothing to reconstruct from the DOM the way
+        web has to. Ask for QUEUE_LIMIT songs starting there and play from
+        the top of the answer.
+        """
+        from ..repository import QUEUE_LIMIT
+
+        route = self.route
+        source = self.ctx.source
+        srv = route.get("server") or self.ctx.server
+        parent = route["parent_id"]
+
+        def work():
+            return source.get_songs(srv, parent, start_index=index,
+                                    limit=QUEUE_LIMIT)
+
+        def done(res):
+            items, _total = res
+            items = [i for i in items if i]
+            if not items:
+                return
+            self.ctx.actions.play_list([i.get("Id") for i in items], srv, 0,
+                                       audio=True, items=items)
+
+        self.ctx.run.run(work, done, self.ctx.run.epoch,
+                         on_error=lambda _e: self.ctx.status(
+                             _("Could not start playback.")))
 
     def _grid_body(self, data, size, tab):
         art = self.ctx.art

--- a/jellyfin_mpv_shim/mpvtk_browser/pages/music_detail.py
+++ b/jellyfin_mpv_shim/mpvtk_browser/pages/music_detail.py
@@ -6,6 +6,7 @@ is the whole reason that base exists.
 
 from ...i18n import _
 from ...mpvtk.widgets import Column, Row, Spacer, Text, VScroll
+from .. import pagination
 from ..components import chrome
 from ..tile_renderer import GRID_GAP
 from .music import MusicPage
@@ -144,7 +145,11 @@ class MusicGenrePage(MusicPage):
                 pass
             albums, total = source.get_genre_albums(
                 srv, route.get("parent_id"), route["item_id"])
-            return {"albums": albums, "songs": songs, "total": total}
+            # `total` slots from the first frame, most of them holes: the
+            # grid is its full height and the scrollbar its full length
+            # before anything past the first page exists (#617).
+            return {"albums": pagination.spread([], total, albums, 0),
+                    "songs": songs, "total": total}
 
         self.route_async(work, lambda d: route.__setitem__("_data", d), epoch)
 
@@ -161,19 +166,32 @@ class MusicGenrePage(MusicPage):
         rows: list = [Text(route.get("title", ""), size=26, bold=True),
                       Spacer(h=4),
                       self.action_bar(server, ids, route["item_id"], "gen")]
+        # Ask for the rows about to be drawn, from the SAME window the
+        # renderer composites.
+        cols = art.tiles.cols(size[0], art.geom_square)
+        first, last = art.tiles.row_window(size, art.geom_square,
+                                           "mgenre", 110)
+        self._window(first * cols, (last + 1) * cols)
         rows += art.tiles.grid_of(albums, "mgenre", size,
                                   geom=art.geom_square,
                                   scroll_id="mgenre", head_h=110)
         return VScroll(Column(rows, pad=chrome.CONTENT_PAD, gap=GRID_GAP),
                        id="mgenre", flex=1,
                        offset=self.parked_scroll("mgenre"),
+                       # Lets a window that FAILED be asked for again;
+                       # render cannot retry without a request per frame.
                        on_scroll=lambda off, mx: art.scroll.on_scroll(
                            "mgenre", off, mx,
-                           lambda o, m: self._on_scroll_end(o, m)))
+                           lambda o, m: art.pages.rewindow(route)))
 
-    def _on_scroll_end(self, offset, maximum):
-        """Page a genre's albums. It rendered one 100-album page with no
-        scroll handler, so a large genre simply stopped there."""
+    def _window(self, first, last):
+        """Fetch the albums in ``[first, last)`` that are not loaded yet.
+
+        Called from render, like every other windowed route: which items are
+        visible is a question about geometry. The query is bound here, on
+        the loop thread, so a page is fetched with the genre it was asked
+        for rather than whatever the route says when it lands.
+        """
         route = self.route
         source = self.ctx.source
         srv = route.get("server") or self.ctx.server
@@ -184,10 +202,10 @@ class MusicGenrePage(MusicPage):
             data = r.get("_data") or {}
             data["albums"], data["total"] = items, total
 
-        self.ctx.art.pages.more(
-            route, offset, maximum,
+        self.ctx.art.pages.window(
+            route, first, last,
             lambda r: ((r.get("_data") or {}).get("albums") or [],
                        (r.get("_data") or {}).get("total") or 0),
             put,
-            lambda start: source.get_genre_albums(srv, parent, gid,
-                                                  start_index=start))
+            lambda start, limit: source.get_genre_albums(
+                srv, parent, gid, start_index=start, limit=limit))

--- a/jellyfin_mpv_shim/mpvtk_browser/tile_renderer.py
+++ b/jellyfin_mpv_shim/mpvtk_browser/tile_renderer.py
@@ -1258,6 +1258,16 @@ class TileRenderer:
 
         rows = []
         for i, tr in enumerate(tracks):
+            if not tr:
+                # A slot a windowed list has not filled yet (see
+                # pagination.spread). It keeps its place -- the row index IS
+                # the track's position -- and does nothing: no handlers, no
+                # art cell to composite, the same treatment image_map and
+                # item_list give a hole.
+                cells = ([self._art_placeholder()] if art else []) + \
+                    ["", "", ""] + ([""] if album else []) + [""]
+                rows.append({"id": "%s-%d" % (prefix, i), "cells": cells})
+                continue
             playing = playing_id is not None and tr.get("Id") == playing_id
             cells = [first_cell(i, tr), tr.get("Name", ""), components.track_artists(tr)]
             if art:

--- a/tests/_shell_harness.py
+++ b/tests/_shell_harness.py
@@ -46,8 +46,21 @@ def music_page(b, route=None):
     seam the music screens' helpers moved to in 6c."""
     return b._page_for(route if route is not None else b.route)
 
-def music_scroll(b, route, offset, maximum):
-    """The music library's infinite-scroll handler, now on the page."""
+def music_scroll(b, route, offset, maximum, scroll_id="music-grid"):
+    """Scroll a windowed music route and let it ask for what that brings in.
+
+    The tile tabs and the genre page are windowed since #617: there is no
+    page-on-approach callback, so scrolling means moving the offset and
+    rendering. Same shape as grid_scroll.
+    """
+    from jellyfin_mpv_shim.mpvtk_browser.pagination import Paginator
+    Paginator.rewindow(route)     # what the view's on_scroll callback does
+    b._scroll.on_scroll(scroll_id, offset, maximum)
+    build_scene(b)
+
+
+def music_songs_scroll(b, route, offset, maximum):
+    """The SONGS tab's infinite scroll, which still appends on approach."""
     b._page_for(route)._on_scroll_end(offset, maximum)
 
 def grid_scroll(b, route, offset, maximum):

--- a/tests/_shell_harness.py
+++ b/tests/_shell_harness.py
@@ -313,9 +313,17 @@ class FakeSource:
     def get_artists(self, server_uuid, parent_id, **kw):
         return ([{"Id": "ar2", "Name": "Artist 2", "Type": "MusicArtist"}], 1)
 
-    def get_songs(self, server_uuid, parent_id, **kw):
+    def get_songs(self, server_uuid, parent_id, start_index=0, limit=100,
+                  **kw):
+        # start_index honoured, because the songs tab is windowed and its
+        # play action asks the server from the clicked row (see
+        # MusicLibraryPage._play_songs_from). A fake that ignored it would
+        # make that indistinguishable from playing the first page.
+        total = 5
         return ([{"Id": "so%d" % i, "Name": "Song %d" % i, "Type": "Audio",
-                  "IndexNumber": i + 1} for i in range(5)], 5)
+                  "IndexNumber": i + 1}
+                 for i in range(start_index,
+                                min(total, start_index + limit))], total)
 
     def get_artist_songs(self, server_uuid, artist_id, limit=500):
         return [{"Id": "as%d" % i, "Name": "AS %d" % i, "Type": "Audio"}

--- a/tests/test_shell_music.py
+++ b/tests/test_shell_music.py
@@ -157,31 +157,56 @@ class TestMusicPaging(unittest.TestCase):
         self.b = MpvtkBrowser(app=None, source=FakeSource())
         self.b._pool = _SyncPool()
 
-    def test_near_end_scroll_pages_the_tab(self):
+    def _albums(self, total=5000):
         src = self.b.source
-        page = [{"Id": "al%d" % i, "Name": "Album %d" % i,
-                 "Type": "MusicAlbum"} for i in range(100)]
         calls = []
 
-        def get_music_albums(server_uuid, parent_id, start_index=0, **kw):
+        def get_music_albums(server_uuid, parent_id, start_index=0,
+                             limit=100, **kw):
             calls.append(start_index)
-            return (page if start_index == 0 else page[:20]), 120
+            return ([{"Id": "al%d" % (start_index + i),
+                      "Name": "Album %d" % (start_index + i),
+                      "Type": "MusicAlbum"} for i in range(limit)], total)
         src.get_music_albums = get_music_albums
-
         self.b.navigate({"kind": "music", "server": "srv1",
                          "parent_id": "lib1", "title": "Music"})
-        self.assertEqual(len(self.b.route["_data"]), 100)
-        music_scroll(self.b, self.b.route, 9500, 10000)
-        self.assertEqual(calls, [0, 100])
-        self.assertEqual(len(self.b.route["_data"]), 120)
+        return calls
 
-    def test_far_from_the_end_does_not_page(self):
+    def test_the_tab_is_sized_from_the_server_total(self):
+        """Windowed since #617: the list is `total` slots from the first
+        frame, so the scrollbar is full-length and does not resize as pages
+        land."""
+        calls = self._albums()
+        self.assertEqual(len(self.b.route["_data"]), 5000)
+        self.assertEqual(calls, [0], "the first frame fetched more than one "
+                                     "page: %r" % calls)
+
+    def test_scrolling_far_down_fetches_that_window(self):
+        calls = self._albums()
+        music_scroll(self.b, self.b.route, 40_000, 60_000)
+        self.assertTrue(len(calls) > 1, "nothing was fetched for the window")
+        self.assertTrue(all(c >= 100 for c in calls[1:]),
+                        "walked the tab from the top: %r" % calls)
+        self.assertEqual(len(self.b.route["_data"]), 5000,
+                         "the list changed length as a window landed")
+
+    def test_the_top_of_the_tab_asks_for_nothing_more(self):
+        calls = self._albums()
+        music_scroll(self.b, self.b.route, 0, 60_000)
+        self.assertEqual(calls, [0], "re-fetched items it already had")
+
+    def test_genres_window_to_nothing(self):
+        """Genres are unpaged server-side and report their own length, so
+        the padded list has no holes -- the same shape that exempts a
+        Random library grid."""
         self.b.navigate({"kind": "music", "server": "srv1",
                          "parent_id": "lib1", "title": "Music"})
-        self.b.route["_total"] = 500
-        before = len(self.b.route["_data"])
-        music_scroll(self.b, self.b.route, 100, 10000)
-        self.assertEqual(len(self.b.route["_data"]), before)
+        page = self.b._page_for(self.b.route)
+        page._set_tab("genres")
+        data = self.b.route.get("_data") or []
+        self.assertTrue(data, "the genres tab loaded nothing")
+        self.assertTrue(all(i is not None for i in data),
+                        "an unpaged tab was padded with holes")
 
 class TestTrackListVirtualization(unittest.TestCase):
     """Track tables must window their rows. With the album-art column each

--- a/tests/test_shell_music.py
+++ b/tests/test_shell_music.py
@@ -76,9 +76,22 @@ class TestMusicDepth(unittest.TestCase):
     def test_songs_tab_is_track_list(self):
         _n, h = self._music(tab="songs")
         self.assertTrue(any(k.startswith("song-") for k in h))
-        h[next(k for k in h if k == "song-2")]["click"]()
+
+    def test_playing_a_song_asks_the_server_from_that_row(self):
+        """A music library's songs tab runs to thousands of rows and is
+        windowed, so "everything on screen" is a few loaded pages with holes
+        between them -- there is no full list to index into.
+
+        jellyfin-web does the same thing: playAllFromHere re-runs the
+        container's own query rather than using its rendered rows. Ours is
+        simpler because the row index IS the track's absolute position.
+        """
+        _n, h = self._music(tab="songs")
+        h["song-2"]["click"]()
         ids_, _srv, start = self.ctl.played[-1]
-        self.assertEqual(start, 2)
+        self.assertEqual(start, 0, "played into a queue instead of from it")
+        self.assertEqual(ids_[0], "so2",
+                         "the queue does not start at the clicked row")
 
     def test_album_action_bar(self):
         self.b.navigate({"kind": "album", "server": "srv1", "item_id": "al1",
@@ -207,6 +220,49 @@ class TestMusicPaging(unittest.TestCase):
         self.assertTrue(data, "the genres tab loaded nothing")
         self.assertTrue(all(i is not None for i in data),
                         "an unpaged tab was padded with holes")
+
+class TestSongsTabWindows(unittest.TestCase):
+    """The songs tab is the one most likely to run to thousands of rows."""
+
+    def setUp(self):
+        self.b = MpvtkBrowser(app=None, source=FakeSource(),
+                              controller=FakeController())
+        self.b._pool = _SyncPool()
+
+    def _songs(self, total=4000):
+        calls = []
+
+        def get_songs(server_uuid, parent_id, start_index=0, limit=100, **kw):
+            calls.append((start_index, limit))
+            return ([{"Id": "so%d" % (start_index + i),
+                      "Name": "Song %d" % (start_index + i),
+                      "Type": "Audio"} for i in range(limit)], total)
+        self.b.source.get_songs = get_songs
+        self.b.navigate({"kind": "music", "server": "srv1",
+                         "parent_id": "ml", "title": "Music", "_tab": "songs"})
+        return calls
+
+    def test_the_table_is_sized_from_the_server_total(self):
+        calls = self._songs()
+        self.assertEqual(len(self.b.route["_data"]), 4000)
+        self.assertEqual([c[0] for c in calls], [0])
+
+    def test_a_hole_row_is_drawn_but_inert(self):
+        """Two things, not one: the cells have to be blank AND the handlers
+        have to go. _list_view needed both and only got the first at
+        first."""
+        self._songs()
+        nodes, handlers = build_scene(self.b)
+        holes = [k for k in handlers if k.startswith("song-")
+                 and int(k.rsplit("-", 1)[-1]) > 200]
+        self.assertFalse(holes, "unloaded rows carry handlers: %r" % holes[:3])
+
+    def test_playing_a_hole_is_impossible(self):
+        """There is no id to play, so there must be no way to ask."""
+        self._songs()
+        _n, handlers = build_scene(self.b)
+        self.assertIn("song-0", handlers, "the loaded rows lost their click")
+
 
 class TestTrackListVirtualization(unittest.TestCase):
     """Track tables must window their rows. With the album-art column each

--- a/tests/test_shell_paging.py
+++ b/tests/test_shell_paging.py
@@ -17,7 +17,7 @@ from tests._shell_harness import (
     _SyncPool,
     build_scene,
     grid_scroll,
-    music_scroll,
+    music_songs_scroll,
 )
 
 
@@ -467,12 +467,11 @@ class TestPagersShareTheirInvariants(unittest.TestCase):
     page left _loading set and that tab could not page again for the rest of
     the session.
 
-    They are one _page_more now, so assert the invariants once per view: what
-    used to differ between the copies is exactly what regressions look like.
-
-    The grid left this family in #617 — it is windowed rather than appended
-    to now, and TestGridWindowing above is its contract. These are the views
-    that still page on approach.
+    They became one Paginator.more, and then most of them stopped using it:
+    the grid was windowed in #617 and the music tile tabs and genre page in
+    its follow-up. The songs tab is what is left, and `more` is still its
+    code — so the invariants stay asserted against the caller that runs
+    them.
     """
 
     def _make(self, view, fail=False, page=None):
@@ -486,33 +485,24 @@ class TestPagersShareTheirInvariants(unittest.TestCase):
             return page if page is not None else ([], 100)
 
         items = [{"Id": "i%d" % i, "Name": "N%d" % i} for i in range(20)]
-        if view == "grid":
-            src.get_library_items = fetch
-            route = {"kind": "grid", "server": "srv1", "parent_id": "lib1",
-                     "_items": list(items), "_total": 100}
-            read = lambda r: r["_items"]           # noqa: E731
-        elif view == "music":
-            src.get_music_albums = fetch
-            route = {"kind": "music", "server": "srv1", "parent_id": "lib1",
-                     "_tab": "albums", "_data": list(items), "_total": 100}
-            read = lambda r: r["_data"]            # noqa: E731
-        else:
-            src.get_genre_albums = fetch
-            route = {"kind": "music_genre", "server": "srv1",
-                     "parent_id": "lib1", "item_id": "g1",
-                     "_data": {"albums": list(items), "total": 100}}
-            read = lambda r: r["_data"]["albums"]  # noqa: E731
+        src.get_songs = fetch
+        route = {"kind": "music", "server": "srv1", "parent_id": "lib1",
+                 "_tab": "songs", "_data": list(items), "_total": 100}
+        read = lambda r: r["_data"]            # noqa: E731
 
         b = MpvtkBrowser(app=None, source=src)
         b._pool = _SyncPool()
         b.server = "srv1"
         b.nav_stack = [route]
-        scroll = {"grid": lambda r, o, m: grid_scroll(b, r, o, m),
-                  "music": lambda r, o, m: music_scroll(b, r, o, m),
-                  "genre": lambda r, o, m: music_scroll(b, r, o, m)}[view]
-        return b, route, calls, scroll, read
+        return (b, route, calls,
+                lambda r, o, m: music_songs_scroll(b, r, o, m), read)
 
-    VIEWS = ("music", "genre")
+    #: What still pages on approach and is reachable from this harness. The
+    #: grid, the music tile tabs and the genre page were windowed in #617
+    #: and its follow-up; Live TV is deliberately not windowed but has its
+    #: own tests. Songs is the last one here, and stays until its play
+    #: action stops being built from the loaded list.
+    VIEWS = ("songs",)
 
     def test_a_failed_page_does_not_deadlock_paging(self):
         for view in self.VIEWS:
@@ -569,12 +559,7 @@ class TestPagersShareTheirInvariants(unittest.TestCase):
         for view in self.VIEWS:
             with self.subTest(view=view):
                 b, route, calls, scroll, _r = self._make(view)
-                if view == "genre":
-                    route["_data"] = {"albums": [], "total": 100}
-                elif view == "music":
-                    route["_data"] = []
-                else:
-                    route["_items"] = []
+                route["_data"] = []
                 scroll(route, 0, 100)
                 self.assertEqual(calls, [], "re-ran the initial load")
 

--- a/tests/test_shell_playlists.py
+++ b/tests/test_shell_playlists.py
@@ -18,7 +18,7 @@ from tests._shell_harness import (
     home_page,
     ids,
     menu_pick,
-    music_scroll,
+    music_songs_scroll,
 )
 
 
@@ -935,7 +935,8 @@ class TestRollbackSurvivesNavigation(unittest.TestCase):
         return b
 
     def _pagers(self):
-        """(name, route, scroll_fn) for each of the three infinite scrolls."""
+        """(name, route, scroll_fn) per paging route still reachable here:
+        the windowed grid and the songs tab, which still appends."""
         items = [{"Id": "i%d" % i, "Name": "N%d" % i} for i in range(20)]
         b = self.b
         return [
@@ -943,15 +944,10 @@ class TestRollbackSurvivesNavigation(unittest.TestCase):
              {"kind": "grid", "server": "srv1", "parent_id": "lib1",
               "_items": list(items), "_total": 99},
              lambda r: grid_scroll(b, r, 0, 100)),
-            ("music",
+            ("songs",
              {"kind": "music", "server": "srv1", "parent_id": "lib1",
-              "_tab": "albums", "_data": list(items), "_total": 99},
-             lambda r: music_scroll(b, r, 0, 100)),
-            ("genre",
-             {"kind": "music_genre", "server": "srv1", "parent_id": "lib1",
-              "item_id": "g1",
-              "_data": {"albums": list(items), "total": 99}},
-             lambda r: music_scroll(b, r, 0, 100)),
+              "_tab": "songs", "_data": list(items), "_total": 99},
+             lambda r: music_songs_scroll(b, r, 0, 100)),
         ]
 
     def setUp(self):


### PR DESCRIPTION
This adds virtual scroll to the remaining music pages, except genres. It also fixes the songs page to use a server query like jf-web does instead of playing whatever was displayed.

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>