### PR TITLE
player: a negative chapter timestamp seeked to the end of the file (#614)

### DIFF
--- a/jellyfin_mpv_shim/player.py
+++ b/jellyfin_mpv_shim/player.py
@@ -308,26 +308,40 @@ def chapter_target(chapters, pos, direction):
     The asymmetry is mpv's ``add chapter -1``, and every player's: going
     back restarts the chapter you are in, unless you are still in its first
     couple of seconds, in which case you meant the one before. Going forward
-    has no such grace: it is the next boundary strictly ahead of you.
+    has no grace at all: it is the next boundary strictly ahead of you, and
+    not "ahead by half a second" -- a position is a float from mpv and is
+    never exactly a boundary, while the half second before one is half a
+    second of real playback in which the button would do nothing.
 
-    Strictly, and not "ahead by half a second", which is what it used to
-    say. The tolerance was there so that sitting exactly ON a boundary did
-    not seek to where you already are -- but a position is a float from
-    mpv and is never exactly a boundary, while the half second before one
-    is half a second of real playback in which the button did nothing at
-    all. `> pos` handles the equality case on its own.
+    **The answer is clamped to 0**, which is what #614 turned out to be. A
+    matroska chapter can start at a slightly NEGATIVE timestamp -- container
+    start-time offsets put the first one at -0.005 on an ordinary episode --
+    and mpv reads a negative ABSOLUTE seek as the END of the file rather
+    than clamping it. Measured on mpv v0.41.0: `seek -0.005 absolute+exact`
+    on a 30s file lands at 29.96 with eof-reached true. So "previous
+    chapter" hit EOF and the shim's own EOF observer advanced the queue --
+    the reported "prev chapter plays the next episode". It predates this
+    branch: master's hud._chapter_jump passes ch["time"] on just as
+    unclamped. seek() refuses a negative absolute seek as well, because the
+    chapter PICKER hands it the very same value.
+
+    **Both directions can also answer None, and the caller must not seek.**
+    Back seeds its search with None rather than 0.0 for the same reason
+    forward ends with it: before the first boundary there is nowhere to go,
+    and a button that quietly restarts the file is worse than one that
+    declines. That covers the first seconds of any file, and a file with no
+    chapters at all, where every press used to jump to 0.0.
 
     One definition, because there are two callers with two different reasons
     to jump: the HUD's chapter buttons and the mouse's back/forward buttons
-    (mouse_chapter_nav). They used to be one implementation and a plan to
-    write the second.
+    (mouse_chapter_nav).
     """
     if direction < 0:
-        target = 0.0
+        target = None
         for ch in chapters:
             if ch["time"] < pos - 2.0:
                 target = ch["time"]
-        return target
+        return None if target is None else max(0.0, target)
     for ch in chapters:
         if ch["time"] > pos:
             return ch["time"]
@@ -2092,6 +2106,17 @@ class PlayerManager(AudioMixin, ReportingMixin, WindowMixin):
         """
         if exact is None:
             exact = absolute
+        if absolute and offset < 0:
+            # mpv reads a negative absolute target as the END of the file,
+            # not as 0 (v0.41.0: `seek -0.005 absolute+exact` on a 30s file
+            # lands at 29.96 with eof-reached true). Every caller that gets
+            # here with one means the start: a chapter whose container
+            # timestamp is fractionally negative, which ordinary matroska
+            # episodes carry, reaching us from chapter_target or straight
+            # off the chapter picker. Left alone it reads as "the file
+            # finished" and the queue advances (#614).
+            log.debug("Clamping negative absolute seek %r to 0.", offset)
+            offset = 0.0
         if self.syncplay.is_enabled() and not force:
             if not absolute:
                 offset += self._player.playback_time

--- a/tests/test_playstate_payload.py
+++ b/tests/test_playstate_payload.py
@@ -444,8 +444,24 @@ class TestChapterJump(unittest.TestCase):
         mean "no, the previous one"."""
         self.assertEqual(self.target(41.0, -1), 0.0)
 
-    def test_back_from_the_first_chapter_goes_to_the_start(self):
-        self.assertEqual(self.target(1.0, -1), 0.0)
+    def test_back_from_the_first_chapter_declines(self):
+        """None, not 0.0. There is no boundary behind the first one, so the
+        button has nowhere to go and must not seek -- the same answer
+        forward gives at the last one.
+
+        This is not cosmetic. The old 0.0 seed meant back ALWAYS issued a
+        seek, and a redundant `seek 0 absolute+exact` at the head of a file
+        is what made the buttons advance the queue: mpv answered it with an
+        immediate EOF and the shim's finished_callback started the next
+        episode. Predates this branch -- master's hud._chapter_jump seeds
+        the same 0.0."""
+        self.assertIsNone(self.target(1.0, -1))
+        self.assertIsNone(self.target(0.0, -1))
+
+    def test_back_still_restarts_the_chapter_you_are_in(self):
+        """The grace only reaches backwards two seconds; ten seconds into
+        the first chapter there IS somewhere to go, and it is 0.0."""
+        self.assertEqual(self.target(10.0, -1), 0.0)
 
     def test_forward_takes_the_next_boundary(self):
         self.assertEqual(self.target(50.0, 1), 80.0)
@@ -467,10 +483,70 @@ class TestChapterJump(unittest.TestCase):
         self.assertEqual(self.target(39.6, 1), 40.0)
         self.assertEqual(self.target(39.999, 1), 40.0)
 
-    def test_a_file_with_no_chapters_answers_nothing_useful(self):
+    def test_a_file_with_no_chapters_answers_nothing_in_either_direction(self):
+        """Back used to answer 0.0 here, so a chapter button on a file with
+        no chapters restarted the film."""
         from jellyfin_mpv_shim.player import chapter_target
         self.assertIsNone(chapter_target([], 10.0, 1))
-        self.assertEqual(chapter_target([], 10.0, -1), 0.0)
+        self.assertIsNone(chapter_target([], 10.0, -1))
+
+    def test_a_negative_first_chapter_is_clamped_to_zero(self):
+        """#614, and the whole of it. Matroska start-time offsets put the
+        first chapter at a fractionally negative timestamp -- -0.005 on the
+        episode this was reported against -- and mpv reads a NEGATIVE
+        absolute seek as the end of the file, not as 0. So "previous
+        chapter" seeked to EOF and the shim's EOF observer started the next
+        episode.
+
+        Measured against mpv v0.41.0: `seek -0.005 absolute+exact` on a 30s
+        file lands at 29.96 with eof-reached true."""
+        from jellyfin_mpv_shim.player import chapter_target
+        chapters = [{"time": -0.005}, {"time": 40.0}, {"time": 80.0}]
+        self.assertEqual(chapter_target(chapters, 9.468, -1), 0.0)
+        self.assertEqual(chapter_target(chapters, 50.0, -1), 40.0)
+        # forward is unaffected -- it only ever returns a boundary > pos
+        self.assertEqual(chapter_target(chapters, 9.468, 1), 40.0)
+
+
+class TestNegativeAbsoluteSeekIsClamped(unittest.TestCase):
+    """seek() is the choke point, because chapter_target is not the only
+    thing that hands it a raw chapter timestamp: the HUD's chapter PICKER
+    seeks to chs[i]["time"] directly, so selecting the first chapter of the
+    same file reproduced #614 on its own."""
+
+    def _pm(self):
+        import threading
+
+        class FakePlayer:
+            playback_abort = False
+            def __init__(self): self.cmds = []
+            def command(self, *a): self.cmds.append(a)
+
+        pm = PlayerManager.__new__(PlayerManager)
+        pm._lock = threading.RLock()
+        pm._player = FakePlayer()
+        pm.syncplay = type("S", (), {"is_enabled": lambda self: False})()
+        pm.timeline_handle = lambda: None
+        pm.push_playstate = lambda: None
+        return pm
+
+    def test_negative_absolute_seek_becomes_zero(self):
+        pm = self._pm()
+        PlayerManager.seek(pm, -0.005, absolute=True)
+        self.assertEqual(pm._player.cmds, [("seek", 0.0, "absolute+exact")])
+
+    def test_a_normal_absolute_seek_is_untouched(self):
+        pm = self._pm()
+        PlayerManager.seek(pm, 42.5, absolute=True)
+        self.assertEqual(pm._player.cmds, [("seek", 42.5, "absolute+exact")])
+
+    def test_a_relative_seek_may_still_be_negative(self):
+        """The HUD's back-10 button, and every keyboard seek: a negative
+        RELATIVE offset is the ordinary way to go backwards and must not be
+        clamped."""
+        pm = self._pm()
+        PlayerManager.seek(pm, -10, absolute=False)
+        self.assertEqual(pm._player.cmds, [("seek", -10)])
 
 
 class TestMouseChapterNavIsOptional(unittest.TestCase):


### PR DESCRIPTION
Reported as "previous chapter plays the next episode", and it is neither a
chapter bug nor a queue bug: mpv reads a negative ABSOLUTE seek as the END
of the file rather than clamping it to 0. Measured on mpv v0.41.0 -- `seek
-0.005 absolute+exact` on a 30s file lands at 29.96 with eof-reached true.

The episode that reproduced it has six chapters and the first starts at
-0.005. Matroska carries container start-time offsets, so a fractionally
negative first chapter is ordinary and nothing is wrong with the file. Back
from 9.4s correctly picked that chapter, handed its raw timestamp to seek(),
and mpv went to EOF; the shim's own eof-reached observer then did exactly
its job and started the next episode.

Predates this branch -- master's hud._chapter_jump passes ch["time"] on just
as unclamped. #614 only made it easier to reach, by adding the mouse buttons
as a second way in.

Clamped in two places, because chapter_target is not the only thing that
hands seek() a raw chapter timestamp: the HUD's chapter PICKER seeks to
chs[i]["time"] directly, so selecting the first chapter of that file
reproduced it on its own. seek() refuses a negative absolute target, while a
negative RELATIVE offset is untouched -- that is how the back-10 button and
every keyboard seek work.

Back also answers None now where it used to answer 0.0: before the first
boundary there is nowhere to go, and a button that quietly restarts the file
is worse than one that declines. That covers the first seconds of any file,
and a file with no chapters at all, where every press used to jump to 0.0.
Not the fix for this bug -- the clamp is -- but the same button being wrong
in a second way.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01A4F5JEXViYQLphF56RTjrA

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>