### PR TITLE
mpvtk: give mpv's console the keyboard while it is open

### DIFF
--- a/jellyfin_mpv_shim/mpvtk/renderer.lua
+++ b/jellyfin_mpv_shim/mpvtk/renderer.lua
@@ -4011,12 +4011,14 @@ local function bind_nav_keys()
         mp.add_forced_key_binding(k[1], 'mpvtk_nav_' .. k[1], k[2],
             { repeatable = true })
     end
+    state.kb_nav = true
 end
 
 local function unbind_nav_keys()
     for _, k in ipairs(NAV_KEYS) do
         mp.remove_key_binding('mpvtk_nav_' .. k[1])
     end
+    state.kb_nav = false
 end
 
 bind_nav_keys()
@@ -4590,11 +4592,13 @@ local function phud_skip_bind()
         send({ t = 'hudskip' })
         phud_skip_hide()
     end)
+    state.kb_skip = true
 end
 
 -- Give ENTER back to the scene without taking the button down.
 function phud_skip_unbind()
     mp.remove_key_binding('mpvtk_skip_enter')
+    state.kb_skip = false
 end
 
 function phud_skip_hide()
@@ -4660,6 +4664,7 @@ function phud_bind_summon()
             mp.commandv('cycle', 'pause')
         end
     end)
+    state.kb_summon = true
 end
 
 local function phud_unbind_summon()
@@ -4668,6 +4673,7 @@ local function phud_unbind_summon()
         mp.remove_key_binding('mpvtk_summon_' .. key)
     end
     mp.remove_key_binding('mpvtk_phud_click')
+    state.kb_summon = false
 end
 
 local function phud_disarm()
@@ -5258,5 +5264,42 @@ mp.register_script_message('mpvtk-debug', function(json)
                 phud_summon('mouse')
             end
         end
+    end
+end)
+
+-- mpv's console (`) wants the keyboard, but our ENTER and arrow bindings
+-- are FORCED and outrank it: typing a command and pressing ENTER summoned
+-- the HUD (and toggled pause) instead of running the command, with no way
+-- back but ESC. Hand the keys over for as long as the console is up, and
+-- take them again when it closes.
+--
+-- Restored from what was actually bound rather than re-derived: which of
+-- the three groups is live depends on browse-vs-HUD, hud_grab_keys and
+-- whether the standalone Skip button is showing, and a second copy of that
+-- decision would drift from ui_resume's. The mouse and wheel sections stay
+-- put -- the console does not want them, and mpvtk_mouse is what dismisses
+-- a stray click.
+--
+-- Everything hangs off `state` and the handler is anonymous deliberately:
+-- this chunk is at 192 of LuaJIT's 200 top-level locals, and going over
+-- does not fail at the call, it fails to load the renderer at all.
+--
+-- The property is mpv >= 0.38 and reads nil both before the console is
+-- first opened and on builds without it. nil is falsy, which is the right
+-- answer for "the console is not up" in either case.
+mp.observe_property('user-data/mpv/console/open', 'bool', function(_, open)
+    if open then
+        if state.kb_saved then return end
+        state.kb_saved = { nav = state.kb_nav, summon = state.kb_summon,
+                           skip = state.kb_skip }
+        if state.kb_nav then unbind_nav_keys() end
+        if state.kb_summon then phud_unbind_summon() end
+        if state.kb_skip then phud_skip_unbind() end
+    elseif state.kb_saved then
+        local was = state.kb_saved
+        state.kb_saved = nil
+        if was.nav then bind_nav_keys() end
+        if was.summon then phud_bind_summon() end
+        if was.skip then phud_skip_bind() end
     end
 end)

--- a/tests/lua/test_renderer.lua
+++ b/tests/lua/test_renderer.lua
@@ -1551,6 +1551,42 @@ hud_pointer(642, 670)
 pv_paint()
 ok(preview() == nil, "a slider without pv draws no bubble")
 
+-- ===================================== mpv's console owns the keyboard
+
+-- Our ENTER/arrow bindings are FORCED, so they outrank the console's own
+-- input: typing a command and pressing ENTER summoned the HUD and toggled
+-- pause instead of running it.
+-- force a real transition into browse: the tests above leave the renderer
+-- in HUD mode, where the arrows are mpv's seek keys
+fake.send("mpvtk-active", "no")
+fake.send("mpvtk-active", "yes")
+ok(fake.log.keybinds["mpvtk_nav_ENTER"] ~= nil,
+   "browse should own ENTER before the console")
+
+fake.observe("user-data/mpv/console/open", true)
+ok(fake.log.keybinds["mpvtk_nav_ENTER"] == nil,
+   "the console is up and ENTER is still ours")
+ok(fake.log.keybinds["mpvtk_nav_UP"] == nil,
+   "the console is up and the arrows are still ours")
+
+fake.observe("user-data/mpv/console/open", false)
+ok(fake.log.keybinds["mpvtk_nav_ENTER"] ~= nil,
+   "ENTER was not taken back when the console closed")
+ok(fake.log.keybinds["mpvtk_nav_UP"] ~= nil,
+   "the arrows were not taken back when the console closed")
+
+-- Restore puts back what was BOUND, not what some second copy of
+-- ui_resume's rules thinks should be. During plain playback the arrows are
+-- mpv's seek keys and nav is suspended, so closing the console there must
+-- not hand them to us.
+fake.send("mpvtk-active", "no")
+ok(fake.log.keybinds["mpvtk_nav_ENTER"] == nil, "playback should not own ENTER")
+fake.observe("user-data/mpv/console/open", true)
+fake.observe("user-data/mpv/console/open", false)
+ok(fake.log.keybinds["mpvtk_nav_ENTER"] == nil,
+   "closing the console bound nav keys that were not bound before it opened")
+fake.send("mpvtk-active", "yes")
+
 -- ========================================================== teardown
 
 scene({})


### PR DESCRIPTION
Pressing ` opens mpv's console, but the renderer's ENTER and arrow bindings
are FORCED and so outrank its input: typing a command and pressing ENTER
summoned the playback HUD and toggled pause instead of running the command,
with no way back but ESC.

The three groups that take keys -- nav (browse), summon/wake (idle HUD) and
the standalone Skip button's ENTER -- are released while
user-data/mpv/console/open is true and taken back when it clears. The mouse
and wheel sections stay put; the console does not want them.

Restored from what was actually BOUND rather than re-derived from state.
Which group is live depends on browse-vs-HUD, hud_grab_keys and whether the
Skip button is showing, and a second copy of that decision would drift from
ui_resume's -- so three flags ride on `state` and the observer puts back
exactly what it took. Closing the console during plain playback therefore
does not hand us the arrows, which are mpv's seek keys there; there is a
test for that case rather than a comment claiming it.

The property is mpv >= 0.38 and reads nil both before the console is first
opened and on builds without it. nil is falsy, which is the right answer for
"not up" in either case.

Everything hangs off `state` and the handler is anonymous deliberately: this
chunk is at 192 of LuaJIT's 200 top-level locals, and going over does not
fail at the call, it fails to load the renderer at all.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01A4F5JEXViYQLphF56RTjrA

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>