### PR TITLE
Review bugfixes: four found by hand-testing the stack (#614, keynav, console, logging)

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -610,7 +610,12 @@ These settings assist with debugging. You will often be asked to configure them 
 
 - `log_decisions` - Log the full media decisions and playback URLs. Default: `false`
 - `mpv_log_level` - Log level to use for mpv. Default: `info`
-  - Options: fatal, error, warn, info, v, debug, trace
+  - Options: fatal, error, warn, info, v, debug, trace, noise
+  - `noise` is `debug` with the shim's own filter turned off. At `debug`
+    the renderer's per-frame scene pushes and gpu-next's per-frame
+    chatter are dropped, because they are the app talking to itself and
+    they bury whatever you turned debug on to read. Warnings and errors
+    are never filtered at any level.
 - `sanitize_output` - Prevent the writing of server auth tokens to logs. Default: `true`
 - `write_logs` - Write logs to the config directory for debugging. Default: `false`
 

--- a/jellyfin_mpv_shim/args.py
+++ b/jellyfin_mpv_shim/args.py
@@ -47,7 +47,7 @@ def _build_parser() -> argparse.ArgumentParser:
     parser.add_argument(
         "--mpv-loglevel",
         dest="mpv_loglevel",
-        choices=("fatal", "error", "warn", "info", "debug"),
+        choices=("fatal", "error", "warn", "info", "debug", "noise"),
         default=None,
         help="override mpv_log_level for this run",
     )

--- a/jellyfin_mpv_shim/log_utils.py
+++ b/jellyfin_mpv_shim/log_utils.py
@@ -12,6 +12,16 @@ bad_patterns = (
         "'X-MediaBrowser-Token': 'REDACTED'",
     ),
     (re.compile("'AccessToken': '[a-f0-9]*'"), "'AccessToken': 'REDACTED'"),
+    # Any `Token="..."`, which is how it appears in strings we did NOT build:
+    # mpv echoes our stream URL back through its own log, and the Authorization
+    # header spells it this way. The escaped form is the same line seen inside
+    # one of mpv's quoted log messages -- a real backslash, not a repr.
+    #
+    # Deliberately not [a-f0-9] like the four above. Those match values we
+    # generate; this one has to survive whatever a server hands us, and a
+    # token that fails the charset assumption would otherwise print in full.
+    (re.compile(r'Token=\\"[^"\\]*\\"'), r'Token=\\"REDACTED\\"'),
+    (re.compile(r'Token="[^"]*"'), 'Token="REDACTED"'),
 )
 
 # The patterns above all need the KEY next to the value, which works on a

--- a/jellyfin_mpv_shim/mpvtk/renderer.lua
+++ b/jellyfin_mpv_shim/mpvtk/renderer.lua
@@ -4011,12 +4011,14 @@ local function bind_nav_keys()
         mp.add_forced_key_binding(k[1], 'mpvtk_nav_' .. k[1], k[2],
             { repeatable = true })
     end
+    state.kb_nav = true
 end
 
 local function unbind_nav_keys()
     for _, k in ipairs(NAV_KEYS) do
         mp.remove_key_binding('mpvtk_nav_' .. k[1])
     end
+    state.kb_nav = false
 end
 
 bind_nav_keys()
@@ -4590,11 +4592,13 @@ local function phud_skip_bind()
         send({ t = 'hudskip' })
         phud_skip_hide()
     end)
+    state.kb_skip = true
 end
 
 -- Give ENTER back to the scene without taking the button down.
 function phud_skip_unbind()
     mp.remove_key_binding('mpvtk_skip_enter')
+    state.kb_skip = false
 end
 
 function phud_skip_hide()
@@ -4660,6 +4664,7 @@ function phud_bind_summon()
             mp.commandv('cycle', 'pause')
         end
     end)
+    state.kb_summon = true
 end
 
 local function phud_unbind_summon()
@@ -4668,6 +4673,7 @@ local function phud_unbind_summon()
         mp.remove_key_binding('mpvtk_summon_' .. key)
     end
     mp.remove_key_binding('mpvtk_phud_click')
+    state.kb_summon = false
 end
 
 local function phud_disarm()
@@ -5258,5 +5264,42 @@ mp.register_script_message('mpvtk-debug', function(json)
                 phud_summon('mouse')
             end
         end
+    end
+end)
+
+-- mpv's console (`) wants the keyboard, but our ENTER and arrow bindings
+-- are FORCED and outrank it: typing a command and pressing ENTER summoned
+-- the HUD (and toggled pause) instead of running the command, with no way
+-- back but ESC. Hand the keys over for as long as the console is up, and
+-- take them again when it closes.
+--
+-- Restored from what was actually bound rather than re-derived: which of
+-- the three groups is live depends on browse-vs-HUD, hud_grab_keys and
+-- whether the standalone Skip button is showing, and a second copy of that
+-- decision would drift from ui_resume's. The mouse and wheel sections stay
+-- put -- the console does not want them, and mpvtk_mouse is what dismisses
+-- a stray click.
+--
+-- Everything hangs off `state` and the handler is anonymous deliberately:
+-- this chunk is at 192 of LuaJIT's 200 top-level locals, and going over
+-- does not fail at the call, it fails to load the renderer at all.
+--
+-- The property is mpv >= 0.38 and reads nil both before the console is
+-- first opened and on builds without it. nil is falsy, which is the right
+-- answer for "the console is not up" in either case.
+mp.observe_property('user-data/mpv/console/open', 'bool', function(_, open)
+    if open then
+        if state.kb_saved then return end
+        state.kb_saved = { nav = state.kb_nav, summon = state.kb_summon,
+                           skip = state.kb_skip }
+        if state.kb_nav then unbind_nav_keys() end
+        if state.kb_summon then phud_unbind_summon() end
+        if state.kb_skip then phud_skip_unbind() end
+    elseif state.kb_saved then
+        local was = state.kb_saved
+        state.kb_saved = nil
+        if was.nav then bind_nav_keys() end
+        if was.summon then phud_bind_summon() end
+        if was.skip then phud_skip_bind() end
     end
 end)

--- a/jellyfin_mpv_shim/mpvtk/renderer.lua
+++ b/jellyfin_mpv_shim/mpvtk/renderer.lua
@@ -3995,6 +3995,83 @@ local function nav_tab(dir)
     nav_set(nxt)
 end
 
+-- Keyboard scrolling: PGUP/PGDWN by a viewport, HOME/END to the ends.
+--
+-- The arrows are NOT here. They move focus (nav_move), and nav_scroll_into_view
+-- already scrolls the container to follow it -- which is the same gesture from
+-- the user's side and the thing the d-pad and the remote both depend on.
+--
+-- Which container? The wheel asks what is under the pointer; a keypress has no
+-- pointer, so it is the focused node's own scroller, falling back to the
+-- tallest scrollable in the scene -- the page body on every route that has one.
+--
+-- Deliberately not routed through on_wheel. Its snap/quantization latch
+-- (snap_live, wheel_lock, GESTURE_WINDOW) measures the cadence of a physical
+-- fling to decide whether to quantize to row boundaries; a discrete keypress
+-- has no cadence to measure and no business latching it for the whole scene.
+-- set_scroll already animates and already clamps.
+local function key_scroll(kind)
+    phud_touch()
+    -- A focused textbox owns these: HOME and END are caret keys there, which
+    -- is why they cannot simply be taken. Same delegation nav_move does for
+    -- LEFT/RIGHT. PGUP/PGDWN are not edit keys, so tb_key ignores them.
+    if state.focus then
+        tb_key(kind)
+        return
+    end
+    -- An open popup floats over the page, so scrolling what is behind it is
+    -- never what was meant -- the rule on_wheel already applies to the wheel.
+    local menu_node = active_menu()
+    if state.dd_open or menu_node then
+        local node = state.dd_open and state.byid[state.dd_open]
+        local n = node and #node.items or (menu_node and #menu_node.items) or 0
+        if kind == 'HOME' or kind == 'END' then
+            if n > 0 then
+                state.nav_pidx = (kind == 'HOME') and 0 or n - 1
+                popup_scroll(0, state.nav_pidx)
+            end
+        else
+            popup_scroll(kind == 'PGUP' and -3 or 3)
+        end
+        request_render()
+        return
+    end
+    local cont
+    local cur = state.nav and state.byid[state.nav]
+    local sc = cur and cur.sc
+    while sc do
+        local c = state.byid[sc]
+        if not c or c.t ~= 'scroll' then break end
+        if c.axis ~= 'x' and scroll_max(c) > 0 then
+            cont = c
+            break
+        end
+        sc = c.sc
+    end
+    if not cont then
+        -- No focus, or focus sits outside any scroller: take the biggest one
+        -- the scene will let us have. modal_active/node.mod is the same gate
+        -- scroll_at applies, so a dialog's backdrop stays put underneath it.
+        local modal = modal_active()
+        for _, node in ipairs(state.nodes) do
+            if node.t == 'scroll' and node.axis ~= 'x'
+                and (not modal or node.mod) and scroll_max(node) > 0
+                and (not cont or node.h > cont.h) then
+                cont = node
+            end
+        end
+    end
+    if not cont then return end
+    if kind == 'HOME' then
+        set_scroll(cont, 0)
+    elseif kind == 'END' then
+        set_scroll(cont, scroll_max(cont))
+    else
+        set_scroll(cont, (state.scroll[cont.id] or 0)
+            + (kind == 'PGUP' and -cont.h or cont.h))
+    end
+end
+
 local NAV_KEYS = {
     { 'UP', function() nav_move(0, -1) end },
     { 'DOWN', function() nav_move(0, 1) end },
@@ -4004,6 +4081,10 @@ local NAV_KEYS = {
     { 'TAB', function() nav_tab(1) end },
     { 'shift+TAB', function() nav_tab(-1) end },
     { 'MENU', function() nav_context() end },
+    { 'PGUP', function() key_scroll('PGUP') end },
+    { 'PGDWN', function() key_scroll('PGDWN') end },
+    { 'HOME', function() key_scroll('HOME') end },
+    { 'END', function() key_scroll('END') end },
 }
 
 local function bind_nav_keys()
@@ -4505,16 +4586,31 @@ end
 mp.register_script_message('mpvtk-active', function(on)
     local want = (on == 'yes' or on == 'true' or on == '1')
     phud_clear()
-    -- Re-assert the thumb section BEFORE the early return. phud_clear may
+    -- Re-assert browse's input BEFORE the early return. phud_clear may
     -- have just left HUD mode, and the return below fires whenever `active`
     -- did not change -- which is the case both at startup (state.active
     -- begins true, so the app's first 'yes' is a no-op) and whenever browse
     -- resumes from a SUMMONED HUD (phud_summon set active itself). In both,
-    -- ui_resume never runs, so a section left disabled by the HUD would
-    -- stay disabled for the rest of the session: mouse Back does nothing in
-    -- the library until a playback round trip happens to hide the bar first.
+    -- ui_resume never runs, so anything the HUD turned off stays off for the
+    -- rest of the session.
+    --
+    -- Two things, and they fail the same way for the same reason. The thumb
+    -- section: mouse Back does nothing in the library until a playback round
+    -- trip happens to hide the bar first. And the NAV KEYS: ui_suspend drops
+    -- them for playback (there the arrows are mpv's seek keys) and only
+    -- ui_resume puts them back, while a summoned HUD calls
+    -- ui_resume(no_nav) itself -- correctly, the bar is driven by the mouse
+    -- unless hud_grab_keys is on. So browse resumed with no arrow, ENTER or
+    -- TAB navigation at all, from the first video played onwards. Browse
+    -- always takes the arrows, so there is no no_nav case to weigh here.
     if want and not state.phud.mode then
         mp.enable_key_bindings('mpvtk_thumb')
+        if state.kb_saved then
+            -- mpv's console has them on loan; let it give them back.
+            state.kb_saved.nav = true
+        else
+            bind_nav_keys()
+        end
     end
     if want == state.active then return end
     state.active = want

--- a/jellyfin_mpv_shim/mpvtk_browser/config.py
+++ b/jellyfin_mpv_shim/mpvtk_browser/config.py
@@ -133,7 +133,7 @@ SECTIONS = [
 # Free-text is wrong for these: an unlisted value silently breaks the feature.
 ENUMS = {
     "subtitle_position": ["top", "bottom", "middle"],
-    "mpv_log_level": ["fatal", "error", "warn", "info", "debug"],
+    "mpv_log_level": ["fatal", "error", "warn", "info", "debug", "noise"],
     "shader_pack_subtype": ["lq", "hq"],
 }
 

--- a/jellyfin_mpv_shim/player.py
+++ b/jellyfin_mpv_shim/player.py
@@ -308,26 +308,40 @@ def chapter_target(chapters, pos, direction):
     The asymmetry is mpv's ``add chapter -1``, and every player's: going
     back restarts the chapter you are in, unless you are still in its first
     couple of seconds, in which case you meant the one before. Going forward
-    has no such grace: it is the next boundary strictly ahead of you.
+    has no grace at all: it is the next boundary strictly ahead of you, and
+    not "ahead by half a second" -- a position is a float from mpv and is
+    never exactly a boundary, while the half second before one is half a
+    second of real playback in which the button would do nothing.
 
-    Strictly, and not "ahead by half a second", which is what it used to
-    say. The tolerance was there so that sitting exactly ON a boundary did
-    not seek to where you already are -- but a position is a float from
-    mpv and is never exactly a boundary, while the half second before one
-    is half a second of real playback in which the button did nothing at
-    all. `> pos` handles the equality case on its own.
+    **The answer is clamped to 0**, which is what #614 turned out to be. A
+    matroska chapter can start at a slightly NEGATIVE timestamp -- container
+    start-time offsets put the first one at -0.005 on an ordinary episode --
+    and mpv reads a negative ABSOLUTE seek as the END of the file rather
+    than clamping it. Measured on mpv v0.41.0: `seek -0.005 absolute+exact`
+    on a 30s file lands at 29.96 with eof-reached true. So "previous
+    chapter" hit EOF and the shim's own EOF observer advanced the queue --
+    the reported "prev chapter plays the next episode". It predates this
+    branch: master's hud._chapter_jump passes ch["time"] on just as
+    unclamped. seek() refuses a negative absolute seek as well, because the
+    chapter PICKER hands it the very same value.
+
+    **Both directions can also answer None, and the caller must not seek.**
+    Back seeds its search with None rather than 0.0 for the same reason
+    forward ends with it: before the first boundary there is nowhere to go,
+    and a button that quietly restarts the file is worse than one that
+    declines. That covers the first seconds of any file, and a file with no
+    chapters at all, where every press used to jump to 0.0.
 
     One definition, because there are two callers with two different reasons
     to jump: the HUD's chapter buttons and the mouse's back/forward buttons
-    (mouse_chapter_nav). They used to be one implementation and a plan to
-    write the second.
+    (mouse_chapter_nav).
     """
     if direction < 0:
-        target = 0.0
+        target = None
         for ch in chapters:
             if ch["time"] < pos - 2.0:
                 target = ch["time"]
-        return target
+        return None if target is None else max(0.0, target)
     for ch in chapters:
         if ch["time"] > pos:
             return ch["time"]
@@ -2092,6 +2106,17 @@ class PlayerManager(AudioMixin, ReportingMixin, WindowMixin):
         """
         if exact is None:
             exact = absolute
+        if absolute and offset < 0:
+            # mpv reads a negative absolute target as the END of the file,
+            # not as 0 (v0.41.0: `seek -0.005 absolute+exact` on a 30s file
+            # lands at 29.96 with eof-reached true). Every caller that gets
+            # here with one means the start: a chapter whose container
+            # timestamp is fractionally negative, which ordinary matroska
+            # episodes carry, reaching us from chapter_target or straight
+            # off the chapter picker. Left alone it reads as "the file
+            # finished" and the queue advances (#614).
+            log.debug("Clamping negative absolute seek %r to 0.", offset)
+            offset = 0.0
         if self.syncplay.is_enabled() and not force:
             if not absolute:
                 offset += self._player.playback_time

--- a/jellyfin_mpv_shim/player.py
+++ b/jellyfin_mpv_shim/player.py
@@ -173,7 +173,43 @@ def last_mpv_error():
         return None
 
 
+#: Our own pseudo-level: `debug` with the filter below turned off. mpv has no
+#: such level, so it is handed `debug` and only our side of the plumbing
+#: changes -- see mpv_loglevel_for().
+MPV_NOISE = "noise"
+
+
+def mpv_loglevel_for(level: str) -> str:
+    """What to hand mpv. Every value is one of mpv's own except `noise`."""
+    return "debug" if level == MPV_NOISE else level
+
+
+#: mpv lines that are almost entirely us talking to ourselves: the renderer's
+#: per-frame scene pushes and metrics (a `mpvtk-scene` line carries the whole
+#: serialized UI, so it is enormous as well as constant) and gpu-next's
+#: per-frame chatter. At `debug` -- which is the level someone turns on to
+#: read one specific thing -- these bury it thousands of lines deep. `noise`
+#: is how you ask for them back.
+_MPV_NOISE_ARGS = re.compile(
+    r'^Run command: script-message, flags=\d+, '
+    r'args=\[args="mpvtk-(?:scene|metrics)"')
+
+
+def _is_mpv_noise(prefix: str, text: str) -> bool:
+    if prefix.startswith("vo/gpu-next"):
+        return True
+    return prefix == "cplayer" and _MPV_NOISE_ARGS.match(text) is not None
+
+
 def mpv_log_handler(level: str, prefix: str, text: str):
+    # Never above info: a real gpu-next failure has to survive the filter, and
+    # _recent_mpv_errors below is the only place a failed load can say *why*.
+    if (
+        level not in ("fatal", "error", "warn")
+        and settings.mpv_log_level != MPV_NOISE
+        and _is_mpv_noise(prefix, text)
+    ):
+        return
     message = "{0}: {1}".format(prefix, text)
     if level in ("fatal", "error"):
         _recent_mpv_errors.append(message.strip())
@@ -657,7 +693,7 @@ class PlayerManager(AudioMixin, ReportingMixin, WindowMixin):
             input_vo_keyboard=True,
             input_media_keys=settings.media_keys,
             log_handler=mpv_log_handler,
-            loglevel=settings.mpv_log_level,
+            loglevel=mpv_loglevel_for(settings.mpv_log_level),
             **mpv_options,
         )
 

--- a/tests/lua/test_renderer.lua
+++ b/tests/lua/test_renderer.lua
@@ -1551,6 +1551,42 @@ hud_pointer(642, 670)
 pv_paint()
 ok(preview() == nil, "a slider without pv draws no bubble")
 
+-- ===================================== mpv's console owns the keyboard
+
+-- Our ENTER/arrow bindings are FORCED, so they outrank the console's own
+-- input: typing a command and pressing ENTER summoned the HUD and toggled
+-- pause instead of running it.
+-- force a real transition into browse: the tests above leave the renderer
+-- in HUD mode, where the arrows are mpv's seek keys
+fake.send("mpvtk-active", "no")
+fake.send("mpvtk-active", "yes")
+ok(fake.log.keybinds["mpvtk_nav_ENTER"] ~= nil,
+   "browse should own ENTER before the console")
+
+fake.observe("user-data/mpv/console/open", true)
+ok(fake.log.keybinds["mpvtk_nav_ENTER"] == nil,
+   "the console is up and ENTER is still ours")
+ok(fake.log.keybinds["mpvtk_nav_UP"] == nil,
+   "the console is up and the arrows are still ours")
+
+fake.observe("user-data/mpv/console/open", false)
+ok(fake.log.keybinds["mpvtk_nav_ENTER"] ~= nil,
+   "ENTER was not taken back when the console closed")
+ok(fake.log.keybinds["mpvtk_nav_UP"] ~= nil,
+   "the arrows were not taken back when the console closed")
+
+-- Restore puts back what was BOUND, not what some second copy of
+-- ui_resume's rules thinks should be. During plain playback the arrows are
+-- mpv's seek keys and nav is suspended, so closing the console there must
+-- not hand them to us.
+fake.send("mpvtk-active", "no")
+ok(fake.log.keybinds["mpvtk_nav_ENTER"] == nil, "playback should not own ENTER")
+fake.observe("user-data/mpv/console/open", true)
+fake.observe("user-data/mpv/console/open", false)
+ok(fake.log.keybinds["mpvtk_nav_ENTER"] == nil,
+   "closing the console bound nav keys that were not bound before it opened")
+fake.send("mpvtk-active", "yes")
+
 -- ========================================================== teardown
 
 scene({})

--- a/tests/lua/test_renderer.lua
+++ b/tests/lua/test_renderer.lua
@@ -1201,6 +1201,18 @@ eq(fake.log.enabled["mpvtk_thumb"], false,
 fake.send("mpvtk-active", "yes")            -- browse resumes from the HUD
 eq(fake.log.enabled["mpvtk_thumb"], true,
    "browse came back from a summoned HUD with mouse Back still dead")
+
+-- The nav keys take the SAME no-op transition, and were the other half of
+-- it. ui_suspend drops them for playback (the arrows are mpv's seek keys
+-- there) and only ui_resume puts them back -- which is below the early
+-- return. A summoned HUD calls ui_resume(no_nav) itself, correctly leaving
+-- them off, and then browse resumed without ever binding them again: no
+-- arrow, ENTER or TAB navigation in the library for the rest of the
+-- session, from the first video played.
+ok(fake.log.keybinds["mpvtk_nav_UP"] ~= nil,
+   "browse came back from a summoned HUD with arrow navigation dead")
+ok(fake.log.keybinds["mpvtk_nav_ENTER"] ~= nil,
+   "browse came back from a summoned HUD with ENTER dead")
 fake.send("mpvtk-hud", "no")
 
 -- ============================================== scrollbar drag anchoring
@@ -1550,6 +1562,57 @@ scene({ { id = "hud-bar", t = "rect", x = 0, y = 640, w = 1280, h = 80 },
 hud_pointer(642, 670)
 pv_paint()
 ok(preview() == nil, "a slider without pv draws no bubble")
+
+-- =========================================== keyboard scrolling (PGUP/etc)
+
+-- The arrows are focus navigation and stay that way; these four are the
+-- keys nothing was reaching. The target is the focused node's own scroller,
+-- or the tallest one in the scene when nothing is focused.
+local function keypress(name)
+    local fn = fake.log.keybinds["mpvtk_nav_" .. name]
+    ok(fn ~= nil, "no binding for " .. name)
+    if fn then fn() end
+end
+
+fake.send("mpvtk-active", "no")
+fake.send("mpvtk-active", "yes")     -- a clean browse state
+scene({ vscroll("body", 400, 4000) })
+eq(offset("body"), 0, "a fresh container should start at the top")
+
+keypress("PGDWN")
+eq(offset("body"), 400, "PGDWN did not page down by a viewport")
+keypress("PGDWN")
+eq(offset("body"), 800, "a second PGDWN did not page again")
+keypress("PGUP")
+eq(offset("body"), 400, "PGUP did not page back")
+
+keypress("END")
+eq(offset("body"), 3600, "END did not go to the bottom (ch - h)")
+keypress("PGDWN")
+eq(offset("body"), 3600, "PGDWN past the end should clamp, not overrun")
+keypress("HOME")
+eq(offset("body"), 0, "HOME did not go back to the top")
+
+-- A scroller with nothing to scroll is not a target, and neither is a
+-- horizontal one: PGUP/PGDWN are a vertical gesture.
+scene({ vscroll("short", 400, 100),
+        { id = "row", t = "scroll", axis = "x", x = 0, y = 0,
+          w = 400, h = 100, cw = 4000, ch = 100 } })
+keypress("PGDWN")
+eq(offset("short"), 0, "paged a container with nothing to scroll")
+eq(offset("row"), 0, "PGDWN scrolled a horizontal carousel")
+
+-- An open popup floats over the page; scrolling what is behind it is never
+-- what was meant. Same rule on_wheel applies to the wheel.
+scene({ vscroll("body", 400, 4000),
+        { id = "dd", t = "dropdown", x = 10, y = 10, w = 200, h = 30,
+          items = { "a", "b", "c", "d", "e", "f", "g", "h" }, sel = 0 } })
+keypress("PGDWN")
+eq(offset("body"), 400, "sanity: the page pages with no popup open")
+click("dd")                          -- open the dropdown
+keypress("PGDWN")
+eq(offset("body"), 400, "PGDWN scrolled the page behind an open popup")
+scene({})                            -- drop the popup with the scene
 
 -- ===================================== mpv's console owns the keyboard
 

--- a/tests/test_docs_coverage.py
+++ b/tests/test_docs_coverage.py
@@ -101,6 +101,8 @@ class DocsCoverageTest(unittest.TestCase):
             "panel", "hover", "always", "paused",
             # segment_* values
             "off", "ask",
+            # mpv_log_level values (mpv's own, plus our "noise")
+            "noise",
             # language_config rule keys
             "type", "subtype", "alang", "slang", "amatch", "smatch",
             "aprefer", "sprefer", "aexclude", "sexclude",

--- a/tests/test_log_sanitization.py
+++ b/tests/test_log_sanitization.py
@@ -88,3 +88,95 @@ class TheWindowTraceSurvivesIt(unittest.TestCase):
 
 if __name__ == "__main__":
     unittest.main()
+
+
+class TokenValuesAreRedacted(unittest.TestCase):
+    """`Token="..."` reaches the log from strings the shim did not build:
+    mpv echoes our stream URL back through its own log handler, and the
+    Authorization header spells the token this way. The four original
+    patterns all assume a hex value we generated, so a token that is not
+    hex used to print in full."""
+
+    def test_the_authorization_header_spelling(self):
+        out = render('auth %s', 'MediaBrowser Token="abc123XYZ-not_hex"')
+        self.assertNotIn("abc123XYZ-not_hex", out)
+        self.assertIn('Token="REDACTED"', out)
+
+    def test_the_escaped_spelling_mpv_logs(self):
+        """A real backslash, not a repr: this is one of mpv's own quoted log
+        lines carrying our URL, which is where it was found."""
+        out = render('%s', r'loadfile url="http://h/s?Token=\"abc123\""')
+        self.assertNotIn("abc123", out)
+        self.assertIn(r'Token=\"REDACTED\"', out)
+
+    def test_a_non_hex_token_is_still_caught(self):
+        """The point of not reusing [a-f0-9]: this is a value a server hands
+        us, so the charset is not ours to assume."""
+        out = render('%s', 'AccessToken="ZZZ-not-hex-at-all"')
+        self.assertNotIn("ZZZ-not-hex-at-all", out)
+
+    def test_ordinary_text_is_untouched(self):
+        self.assertIn("nothing to see", render("%s", "nothing to see"))
+
+
+class MpvNoiseFilter(unittest.TestCase):
+    """`debug` is the level someone turns on to read one specific thing, and
+    the renderer's per-frame traffic buries it thousands of lines deep. The
+    filter drops that; `noise` is how you ask for it back."""
+
+    def setUp(self):
+        from jellyfin_mpv_shim import player
+        from jellyfin_mpv_shim.conf import settings
+        self.player = player
+        self.settings = settings
+        self.addCleanup(setattr, settings, "mpv_log_level",
+                        settings.mpv_log_level)
+
+    SCENE = ('Run command: script-message, flags=64, '
+             'args=[args="mpvtk-scene", args="{...}"]')
+    METRICS = ('Run command: script-message, flags=64, '
+               'args=[args="mpvtk-metrics", args=""]')
+
+    def test_the_three_noisy_shapes_are_noise(self):
+        self.assertTrue(self.player._is_mpv_noise("cplayer", self.SCENE))
+        self.assertTrue(self.player._is_mpv_noise("cplayer", self.METRICS))
+        self.assertTrue(self.player._is_mpv_noise("vo/gpu-next", "anything"))
+
+    def test_other_script_messages_are_not(self):
+        """Only our own per-frame chatter. A trickplay or skip message is
+        rare and worth seeing."""
+        other = ('Run command: script-message, flags=64, '
+                 'args=[args="mpvtk-hud-skip", args=""]')
+        self.assertFalse(self.player._is_mpv_noise("cplayer", other))
+        self.assertFalse(self.player._is_mpv_noise("cplayer", "seek done"))
+        self.assertFalse(self.player._is_mpv_noise("mkv", "EOF reached."))
+
+    def _emit(self, level, prefix, text):
+        seen = []
+        real = self.player.mpv_log.debug
+        self.player.mpv_log.debug = lambda m: seen.append(m)
+        self.addCleanup(setattr, self.player.mpv_log, "debug", real)
+        self.player.mpv_log_handler(level, prefix, text)
+        return seen
+
+    def test_debug_drops_it(self):
+        self.settings.mpv_log_level = "debug"
+        self.assertEqual(self._emit("debug", "cplayer", self.SCENE), [])
+
+    def test_noise_keeps_it(self):
+        self.settings.mpv_log_level = "noise"
+        self.assertEqual(len(self._emit("debug", "cplayer", self.SCENE)), 1)
+
+    def test_a_gpu_next_error_survives_the_filter(self):
+        """Never applied above info: a real gpu-next failure has to reach
+        the user, and _recent_mpv_errors is what a failed load reports."""
+        self.settings.mpv_log_level = "debug"
+        self.player.clear_mpv_errors()
+        self.player.mpv_log_handler("error", "vo/gpu-next", "context init failed")
+        self.assertIn("context init failed", self.player.last_mpv_error() or "")
+
+    def test_noise_is_not_handed_to_mpv(self):
+        """mpv has no such level; it would refuse to start."""
+        self.assertEqual(self.player.mpv_loglevel_for("noise"), "debug")
+        self.assertEqual(self.player.mpv_loglevel_for("debug"), "debug")
+        self.assertEqual(self.player.mpv_loglevel_for("info"), "info")

--- a/tests/test_playstate_payload.py
+++ b/tests/test_playstate_payload.py
@@ -444,8 +444,24 @@ class TestChapterJump(unittest.TestCase):
         mean "no, the previous one"."""
         self.assertEqual(self.target(41.0, -1), 0.0)
 
-    def test_back_from_the_first_chapter_goes_to_the_start(self):
-        self.assertEqual(self.target(1.0, -1), 0.0)
+    def test_back_from_the_first_chapter_declines(self):
+        """None, not 0.0. There is no boundary behind the first one, so the
+        button has nowhere to go and must not seek -- the same answer
+        forward gives at the last one.
+
+        This is not cosmetic. The old 0.0 seed meant back ALWAYS issued a
+        seek, and a redundant `seek 0 absolute+exact` at the head of a file
+        is what made the buttons advance the queue: mpv answered it with an
+        immediate EOF and the shim's finished_callback started the next
+        episode. Predates this branch -- master's hud._chapter_jump seeds
+        the same 0.0."""
+        self.assertIsNone(self.target(1.0, -1))
+        self.assertIsNone(self.target(0.0, -1))
+
+    def test_back_still_restarts_the_chapter_you_are_in(self):
+        """The grace only reaches backwards two seconds; ten seconds into
+        the first chapter there IS somewhere to go, and it is 0.0."""
+        self.assertEqual(self.target(10.0, -1), 0.0)
 
     def test_forward_takes_the_next_boundary(self):
         self.assertEqual(self.target(50.0, 1), 80.0)
@@ -467,10 +483,70 @@ class TestChapterJump(unittest.TestCase):
         self.assertEqual(self.target(39.6, 1), 40.0)
         self.assertEqual(self.target(39.999, 1), 40.0)
 
-    def test_a_file_with_no_chapters_answers_nothing_useful(self):
+    def test_a_file_with_no_chapters_answers_nothing_in_either_direction(self):
+        """Back used to answer 0.0 here, so a chapter button on a file with
+        no chapters restarted the film."""
         from jellyfin_mpv_shim.player import chapter_target
         self.assertIsNone(chapter_target([], 10.0, 1))
-        self.assertEqual(chapter_target([], 10.0, -1), 0.0)
+        self.assertIsNone(chapter_target([], 10.0, -1))
+
+    def test_a_negative_first_chapter_is_clamped_to_zero(self):
+        """#614, and the whole of it. Matroska start-time offsets put the
+        first chapter at a fractionally negative timestamp -- -0.005 on the
+        episode this was reported against -- and mpv reads a NEGATIVE
+        absolute seek as the end of the file, not as 0. So "previous
+        chapter" seeked to EOF and the shim's EOF observer started the next
+        episode.
+
+        Measured against mpv v0.41.0: `seek -0.005 absolute+exact` on a 30s
+        file lands at 29.96 with eof-reached true."""
+        from jellyfin_mpv_shim.player import chapter_target
+        chapters = [{"time": -0.005}, {"time": 40.0}, {"time": 80.0}]
+        self.assertEqual(chapter_target(chapters, 9.468, -1), 0.0)
+        self.assertEqual(chapter_target(chapters, 50.0, -1), 40.0)
+        # forward is unaffected -- it only ever returns a boundary > pos
+        self.assertEqual(chapter_target(chapters, 9.468, 1), 40.0)
+
+
+class TestNegativeAbsoluteSeekIsClamped(unittest.TestCase):
+    """seek() is the choke point, because chapter_target is not the only
+    thing that hands it a raw chapter timestamp: the HUD's chapter PICKER
+    seeks to chs[i]["time"] directly, so selecting the first chapter of the
+    same file reproduced #614 on its own."""
+
+    def _pm(self):
+        import threading
+
+        class FakePlayer:
+            playback_abort = False
+            def __init__(self): self.cmds = []
+            def command(self, *a): self.cmds.append(a)
+
+        pm = PlayerManager.__new__(PlayerManager)
+        pm._lock = threading.RLock()
+        pm._player = FakePlayer()
+        pm.syncplay = type("S", (), {"is_enabled": lambda self: False})()
+        pm.timeline_handle = lambda: None
+        pm.push_playstate = lambda: None
+        return pm
+
+    def test_negative_absolute_seek_becomes_zero(self):
+        pm = self._pm()
+        PlayerManager.seek(pm, -0.005, absolute=True)
+        self.assertEqual(pm._player.cmds, [("seek", 0.0, "absolute+exact")])
+
+    def test_a_normal_absolute_seek_is_untouched(self):
+        pm = self._pm()
+        PlayerManager.seek(pm, 42.5, absolute=True)
+        self.assertEqual(pm._player.cmds, [("seek", 42.5, "absolute+exact")])
+
+    def test_a_relative_seek_may_still_be_negative(self):
+        """The HUD's back-10 button, and every keyboard seek: a negative
+        RELATIVE offset is the ordinary way to go backwards and must not be
+        clamped."""
+        pm = self._pm()
+        PlayerManager.seek(pm, -10, absolute=False)
+        self.assertEqual(pm._player.cmds, [("seek", -10)])
 
 
 class TestMouseChapterNavIsOptional(unittest.TestCase):


### PR DESCRIPTION
Four fixes found during code review/testing phase:
- Chapter skip back button (mouse AND HUD) caused the episode to be skipped. Traced to a negative timestamp in the first chapter of an MKV file.
- Allow using MPV's `\`` console. (Frees up ENTER keybind during console use.)
- Fix two token leaks caused by new apiclient logging related to header auth.
- Fixed so `--mpv-loglevel debug` doesn't create needlessly spammy logs.
- Fixed issue where after playing content it breaks keyboard nav.
- Added scrolling with Home/End/PgDn/PgUp keys,

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>
