### PR TITLE
E2e testing

### DIFF
--- a/docs/E2E_PLAN.md
+++ b/docs/E2E_PLAN.md
@@ -164,6 +164,7 @@ Green on both backends, 8/8 legs, about two minutes for the matrix. See
 | `test_playback_eof` | playback | 2, 3, 4 | last-in-queue, seek-to-end (#541), replay (#157/#323) |
 | `test_playback_failure` | playback | 7, 8 | truncated, zero-byte, single-frame |
 | `test_mpv_reopen` | playback | 6 | close mid-playback → re-open → auto-advance (#458) |
+| `test_input_routing` | playback | — | real keys across every UI transition (f70ad1e7, #614) |
 
 The contract tier never imports `player.py`, so it runs **once** and without a
 display — the whole of it is under two seconds. Only the playback tier pays

--- a/docs/E2E_PLAN.md
+++ b/docs/E2E_PLAN.md
@@ -160,6 +160,7 @@ Green on both backends, 8/8 legs, about two minutes for the matrix. See
 | `test_route_walk` | contract | 18 | every screen loads and renders against the real library |
 | `test_paging` | contract | 19 | virtual scrolling over ~1000 items at real totals (#617) |
 | `test_keyboard_nav` | contract | 20 | keyboard reach/activation of real screens; duplicate node ids |
+| `test_large_queue` | contract | — | 400-id queue metadata; the 414 request-line limit |
 | `test_playback_advance` | playback | 1, 5 | queue advance + watched-marking + resume position |
 | `test_playback_eof` | playback | 2, 3, 4 | last-in-queue, seek-to-end (#541), replay (#157/#323) |
 | `test_playback_failure` | playback | 7, 8 | truncated, zero-byte, single-frame |
@@ -380,3 +381,34 @@ smaller build.
 
 [stdjflib]: ~/Desktop/stdjflib
 [faketvsource]: ~/Desktop/faketvsource
+
+## Attempted and blocked: the mpv console's keyboard handover
+
+Candidate 2 of the transcript survey — `45346365`: "the renderer's ENTER and
+arrow bindings are FORCED and so outrank its input: typing a command and
+pressing ENTER summoned the playback HUD and toggled pause instead of running
+the command, with no way back but ESC."
+
+The renderer's contract is the property `user-data/mpv/console/open`, which
+mpv's console script sets and `renderer.lua` observes to hand the nav, summon
+and skip groups over and take them back. A test would open the console, assert
+arrows no longer move focus, close it, and assert exactly the groups that were
+taken come back — including the case where they must *not*, during plain
+playback where the arrows are mpv's seek keys.
+
+**Both ways in are blocked as the harness stands:**
+
+- The property cannot be injected from Python. `handle.command("set",
+  "user-data/mpv/console/open", "yes")` returns without error and changes
+  nothing, and both a typed read and `set_property` answer "mpv property does
+  not exist" — `user-data` subtrees are node-typed, and the renderer reaches
+  them from Lua (`mp.set_property_native`), which python-mpv's typed path does
+  not reproduce. Measured: arrows kept moving focus with the console
+  ostensibly open, i.e. the observer never fired.
+- The real console is not loaded. `mpvtk.app._SPAWN_OPTS` sets
+  `load_scripts: "no"`, so pressing `` ` `` in the test handle does nothing.
+
+The faithful fix is the second one: spawn this test's handle with scripts
+enabled and drive mpv's actual console, which tests the real precedence rather
+than a simulated signal. That is a change to how `_spawn_handle` builds the
+handle, so it wants doing deliberately rather than as a flag on one test.

--- a/docs/E2E_PLAN.md
+++ b/docs/E2E_PLAN.md
@@ -1,0 +1,326 @@
+# End-to-end testing against a real server — plan
+
+Branch `e2e-testing`. The server is [stdjflib] `serve` against
+`~/Desktop/std-jf-lib` (`--live-tv` wires in [faketvsource]).
+
+The suites are large — ~2900 unit tests, 154 Lua, an integration matrix on
+both mpv backends — and they are green while real bugs ship. So the question
+this document answers is not "what should we test", it is **"what has actually
+broken, and why was every existing test structurally unable to see it"**. The
+test list falls out of that.
+
+Sources mined: `docs/REGRESSION_CHECKLIST_2026-07-25.md`,
+`docs/UI_UX_FIXES_2026-08.md` (three hand-testing rounds),
+`docs/ISSUES_TO_VERIFY.md`, `docs/archive/`, and the fix commits themselves.
+
+## Six failure classes the current suites cannot see
+
+### 1. The request is wrong, and the fake accepts it
+
+Every browse test runs against a hand-written fake source. A fake never
+validates a request — so a wrong parameter name, a wrong type, or a right
+parameter sent to the wrong endpoint is invisible until a human opens the
+screen.
+
+| What broke | How it presented | Commit |
+|---|---|---|
+| `get_channel_listing(enable_images=False)` — no such argument | `TypeError` before the fetch; the Live TV channel page simply did not open | `b97dd523` |
+| Category flags derived as `"is_" + name`, so `is_movies` | `TypeError` on every filtered Guide/Channels fetch. **The unit test asserted the wrong spelling, which is why it was green** | `4bc952c1` |
+| Categories sent to `LiveTv/Programs` as well as `LiveTv/Channels` | Empty guide. `IsMovie` is a column predicate, `IsSports`/`IsNews`/`IsKids` become a tag filter, so two categories AND to nothing | `4bc952c1` |
+| `SyncPlay/Ping` sent a float against a `long` DTO | 400 on **every ping this client has ever sent**; the server silently used its default latency instead | `600022e8` |
+
+`tests/test_source_invariants.py` now walks the AST for `api.*(kw=...)` and
+checks each keyword against the client's signature, which closes the first two
+rows. It cannot close the last two: those are *semantics*, and only a server
+answers about semantics.
+
+`CLAUDE.md` already records a dozen more claims of this kind as prose —
+DisplayPreferences must use client `emby`, guide prefs must be the *strings*
+`"true"`/`"false"`, times are UTC with seven fractional digits and an
+offset-less bound answers the wrong window, per-library Latest rows bypass
+`LatestItemsExcludes` and must apply it client-side. Every one of those is an
+assertion about a running server that nothing executes.
+
+### 2. DTO fields the fake fabricates
+
+The fake source returns dicts that are *plausible*. The bugs are all in the
+same direction: the real DTO is **less** populated than the fake, or carries
+the field somewhere else.
+
+| What broke | Missing field | Commit |
+|---|---|---|
+| Downloaded shows rendered as squares, not posters | synthesized offline Series DTO had no `PrimaryImageAspectRatio`; `auto_geom`'s no-ratio fallback is square | `8a946e39` |
+| Opening a season while offline listed nothing | synthesized offline Season DTO never set `SeriesId`, so `get_episodes` filtered every episode away | `5847cd20` |
+| A `.strm` queue froze on the last frame | `RunTimeTicks` is absent on the Item and present on the MediaSource; no duration disabled the EOF fallback | `8589cc4c` |
+| Stopping a photo printed a traceback | a photo has no `playback_info` at all; `get_timeline_options` was taught that, `_report_stopped_offline` was not | `690fb82f`, `662d4b06` |
+
+**This is the highest-leverage thing in the document.** A conformance test that
+compares the real source's answers against the fake's — and fails when the fake
+is *richer* than reality — keeps ~2900 fake-based tests honest for as long as
+they exist. There is precedent in the repo:
+`tests/test_mpvtk_fake_conformance.py` does exactly this for `FakeMPV`.
+
+### 3. The playback loop with a real server actually in it
+
+`test_realmpv_smoke` plays a real clip through a real mpv — and fakes the
+Jellyfin session, deliberately (see `tests/integration/README.md`). So the
+shim's half of the loop is asserted and the *round trip* is not: whether
+progress lands, whether the resume point comes back, whether the next episode
+plays.
+
+This is the cluster with the worst history — auto-advance and watched-marking
+are one of the two largest open-bug groups in the tracker (#157, #323, #458,
+#541), and the 07-25 checklist calls close-mpv-then-cast-again "the
+highest-value single item on this page".
+
+It is also **cheap**: `stdjflib` episodes are 10 seconds long. "Play an episode,
+watch it finish, watch the next one start" costs about 25 seconds of wall
+clock.
+
+### 4. Server state that another client can see
+
+Nothing in the suite has ever had a second session.
+
+- Continue Watching updating after something finishes elsewhere (#560).
+- The Home Screen tab saving without degrading the same user's jellyfin-web
+  layout — section types the shim cannot draw are meant to be *preserved*.
+- `qa-onesession`: a second login must evict the first.
+- SyncPlay against a real group.
+
+### 5. A route that never renders
+
+`strict_builds` is off in production, so a scene-build exception keeps the last
+good frame. A broken route does not look like a crash; it looks like a UI that
+ignored the click. The 07-25 checklist's procedure is: walk every route by
+hand, **then grep `log.txt` for `scene build failed`**.
+
+That is a human doing a loop's job, and it is how `b97dd523` would have been
+caught before a human found it.
+
+### 6. Real latency, real ordering
+
+`tests/_shell_harness.py` uses a synchronous pool: pages arrive instantly and
+in order. Against a server neither is true.
+
+- The guide-prefs race — saving repaints, repainting refetches, and the fetch
+  is submitted *before* the save (`4bc952c1`). Only a real scheduler loses that
+  race.
+- `a9883418` — `load()` published a primary-only batch mid-refresh, taking the
+  Latest rows away and putting them back.
+- #617's own checklist flags "fast repeated drags" as **the one to watch**, and
+  the "least confident" note at the end of the round is thumbnail pressure
+  under free scrollbar dragging. The `Bulk *` libraries are ~1000 items each
+  and exist for precisely this.
+
+## Structure
+
+`tests/e2e/`, with **no `__init__.py`** — the same trick `tests/integration/`
+uses so `python3 -m unittest discover tests` never recurses into it. Own
+runner, `tests/e2e/run_e2e.py`, reusing `tests/integration/_harness.py`'s
+capability probes.
+
+Server discovery by environment, skipping cleanly when absent, the same
+discipline as the existing capability gating:
+
+```sh
+JMS_E2E_SERVER=http://127.0.0.1:8096 python3 tests/e2e/run_e2e.py
+```
+
+Accounts are stdjflib's fixed twelve, password `stdjflib`. **Do not import
+stdjflib from the shim's tests** — that is a second cross-repo dependency on
+top of the apiclient one, and the suite needs nothing from it but a URL. Talk
+to the server through the apiclient and raw HTTP; standing the server up stays
+an out-of-band step.
+
+### Three tiers
+
+**E1 — contract.** Drives `LibrarySource`, `gateway/` and `clients.py` straight
+at the server. No mpv, no window, no browser. Classes 1, 2 and 4 live here, it
+runs in seconds, and it is roughly two thirds of the value for a fifth of the
+effort. Start here.
+
+**E2 — playback.** Real mpv under xvfb, real server, no browser. Class 3. The
+existing `test_realmpv_smoke` is the template; the change is a real
+`LibrarySource`/session instead of the recording fake.
+
+**E3 — the app.** Real browser attached to a real mpv against a real server —
+`tests/integration/test_mpvtk_browser.py` is the template, with its `FakeSource`
+swapped for the live one. Classes 5 and 6.
+
+## Status
+
+Green on both backends, 8/8 legs, about two minutes for the matrix. See
+`tests/e2e/README.md` to run it.
+
+| Module | Starter items | Covers |
+| --- | --- | --- |
+| `test_playback_advance` | 1, 5 | queue advance + watched-marking + resume position |
+| `test_playback_eof` | 2, 3, 4 | last-in-queue, seek-to-end (#541), replay (#157/#323) |
+| `test_playback_failure` | 7, 8 | truncated, zero-byte, single-frame |
+| `test_mpv_reopen` | 6 | close mid-playback → re-open → auto-advance (#458) |
+
+## Bugs found
+
+Two real defects, both from `test_mpv_reopen`, both invisible to the ~2900
+unit tests and the integration matrix because both need a real player and a
+real server at once.
+
+**1. Segfault closing mpv mid-playback — libmpv only. FIXED.**
+
+Closing the window makes mpv end the file *and* shut down. The end-file event
+queues `finished_callback`, which issues `self._player.command("stop")` on the
+action thread, while `_on_shutdown_event`'s terminate thread is concurrently
+inside `player.terminate()`. The existing guard is `except _mpv_errors`, and
+that is enough on the external backend — there the command is a socket write
+and the race surfaces as `BrokenPipeError`. On in-process libmpv the handle
+has already been freed, so it is a use-after-free: SIGSEGV, which no `except`
+clause can see. Reproduced 2 of 3 runs, stack confirmed by `faulthandler`
+(one thread in `mpv.py:terminate`, one in `mpv.py:command`).
+
+Fixed by checking `_mpv_alive` before the command — the idiom ~15 other sites
+in `player.py` already use, and `_terminate_mpv` clears that flag *before*
+calling `terminate()`, so the ordering favours it. 3/3 clean afterwards, and
+the whole unit suite and integration matrix still pass.
+
+**2. A short item aborted early is reported at full duration. PINNED.**
+
+`_finished_at_eof` decides whether the end that just happened was genuine:
+
+```python
+return position >= duration * 0.95 or duration - position <= 10
+```
+
+The second clause is an absolute ten-second margin, there to absorb the
+timeline tick interval and metadata duration drift. It has no lower bound
+relative to the runtime, so for anything shorter than ten seconds it is true
+at **every** position including zero, and under about twenty it is true across
+most of the file. The abort is then reported at full duration and the server
+records the item as watched.
+
+Measured: a 10.0s episode aborted at 2.58s reported `session_stop` at 10.02s
+and came back `Played=True`; the same on the 3h item reported 0.33s and came
+back `Played=False`. Both backends. This is the residual caveat recorded
+against #458 in `ISSUES_TO_VERIFY.md` ("a residual X-button freeze that also
+*marks the item watched* via `get_timeline_options`") — which that document
+flags as never verified. It reproduces, but only for short media; a
+normal-length episode closed partway is reported correctly.
+
+Pinned as `@expectedFailure` in `AbortReportedPositionTest`, so it becomes a
+hard failure the moment the margin is bounded. Bounding it is a judgement call
+about the right threshold and was left for separate triage. Note the arithmetic
+itself would be cheaper to pin as a unit test on `_finished_at_eof`; the e2e
+test is there for the server-visible consequence.
+
+## Server and harness behaviours confirmed
+
+Each of these produced a failure that read as a shim bug and was not:
+
+- **`NameStartsWith` matches SortName, not Name.** SortName strips the leading
+  article, so `NameStartsWith="The Standard Show"` returns nothing while
+  `"Standard"` returns it. The harness looks up client-side because of it.
+- **The server discards a resume position below `MinResumeDurationSeconds`**
+  (300 by default), on top of the 5%/90% clamp. A 10-second episode can never
+  hold one, so resume tests need `x-long`.
+- **`playerManager` is process-wide**, so terminating it per test class breaks
+  the *next* class — and only on the external backend, where mpv is a separate
+  process rather than an in-process handle that quietly re-creates itself.
+  The backend matrix caught this on its first run.
+- **Closing mpv is a race, so do not build an assertion on it.** Whether
+  `finished_callback` or the shutdown teardown wins decides which report path
+  runs, so a test hung off a window close passes about a third of the time.
+  Tests that need the abort path drive `send_timeline_stopped(finished=True)`
+  instead; the close itself is still exercised, but only for outcomes that do
+  not depend on who won.
+- **A truncated file behaves correctly** — reported at 0.29s, not marked
+  watched — and a zero-byte file is refused with no session at all. Neither is
+  a route to the margin defect above; they were checked as candidates.
+
+## Starter set, priority ordered
+
+Each line names the bug it would have caught. Nothing here needs a fixture that
+does not already exist in the library.
+
+### E2 — playback
+
+1. **The Standard Show S01E01 plays out, auto-advances to E02, both report
+   progress, E01 comes back watched.** The whole point. (§4 of the 07-25
+   checklist, #157/#323)
+2. The **last** episode of a queue played to the very end is marked watched —
+   it ends via `playback-abort`, not `eof-reached`. With `force_set_played` on
+   and off. (§4)
+3. Seek to the last second → EOF fires → advances. (#541)
+4. Replay an already-finished episode → starts at 0, is not re-marked and is
+   not skipped. (#157/#323, reported external-backend-only — run both)
+5. Stop mid-episode → the server's resume position is right → reopening
+   resumes there. (§4 ReportingMixin)
+6. **Close the mpv window mid-playback, cast again → it re-opens, plays, and
+   the next episode auto-advances.** The historic stale-queue bug. (§2 —
+   "the highest-value single item on this page", #458)
+7. `Test Media/Structure/x-truncated` fails cleanly with an error, does not
+   hang, and is not marked watched.
+8. `x-zero-byte` is refused cleanly; `x-single-frame` does not divide by zero
+   in the progress arithmetic.
+9. `x-chapters` (12 named chapters): chapter nav from just before a boundary,
+   exactly on one, and from the last chapter (no-op). (`9f7a394f`)
+10. `x-many-audio` (six tracks, `deu` flagged default): track selection and
+    language preference. (AudioMixin, §2)
+11. `x-long` (three hours, 36 chapters): seek far from the start, resume point,
+    progress over a session that outlives a token.
+
+Every one of these runs per backend — external mpv is the least-tested path and
+one of the two largest open-bug clusters.
+
+### E1 — contract
+
+12. **Fake conformance**: every `LibrarySource` method, real answer vs
+    `_shell_harness`'s fake, failing when the fake invents a field. (Class 2)
+13. Live TV: two categories at once return a **non-empty** guide; window bounds
+    are asymmetric and UTC; timer create/cancel; `single_timer_state` vs
+    `timer_state` on a showing covered by a series rule. (`4bc952c1`)
+14. DisplayPreferences round-trip under client `emby`; guide prefs written as
+    strings; a home-layout save preserves section types the shim cannot draw.
+15. `LatestItemsExcludes` — applied client-side for per-library Latest rows,
+    server-side for Continue Watching and Next Up.
+16. `SyncPlay/Ping` is accepted. A 400 here is invisible in normal use.
+    (`600022e8`)
+17. Per-account behaviour, one test each: `qa-restricted` sees two libraries and
+    the rest are **absent**; `qa-nodownload` has downloads refused rather than
+    offered; `qa-noplayback` browses but cannot play; `qa-kid` gets empty rows
+    and no Live TV; `qa-nopassword` can log in at all.
+
+### E3 — the app
+
+18. **Route walk**: visit every route once against the real library, then assert
+    zero `scene build failed` in the log. Replaces a manual step and would have
+    caught `b97dd523`. (Class 5)
+19. `Bulk Movies` (~1000 items): drag to the middle and get *that*
+    neighbourhood; fast repeated drags do not storm the thumbnail workers.
+    (#617, Class 6)
+20. Continue Watching updates after a second session changes playstate. (#560)
+
+## Hygiene, decided up front
+
+**Never bake an item GUID into a test.** IDs are server-assigned and change on
+every reprovision. Look items up by name or path. The library is otherwise
+fully deterministic by design — `<lockdata>true</lockdata>` everywhere, dates
+from `config.EPOCH`, pseudo-randomness derived by SHA-256 rather than `hash()`.
+
+**Mutating tests need an owner.** Playstate, favourites, DisplayPreferences and
+timers all persist. Either give each mutating area its own account, or reset in
+`tearDown` through the API. The twelve accounts make the first option cheap.
+
+**Live TV is relative to now.** faketvsource generates its guide against the
+clock, so assert relatively — "something is on air", "now/next disagree" — and
+never against an absolute time.
+
+**Known fixture gap: there is no `.strm` in the library**, so `8589cc4c`'s
+freeze-on-last-frame cannot be reproduced. Worth adding upstream to stdjflib;
+it is a `Recipe`-adjacent one-liner and the bug class (Item DTO vs MediaSource
+disagreeing about runtime) is not otherwise reachable.
+
+**The server takes minutes to provision.** E1 and E3 want the `Bulk *`
+libraries scanned; E2 does not. Worth knowing which legs can run against a
+smaller build.
+
+[stdjflib]: ~/Desktop/stdjflib
+[faketvsource]: ~/Desktop/faketvsource

--- a/docs/E2E_PLAN.md
+++ b/docs/E2E_PLAN.md
@@ -156,6 +156,7 @@ Green on both backends, 8/8 legs, about two minutes for the matrix. See
 | --- | --- | --- | --- |
 | `test_account_policy` | contract | 17 | restricted libraries, Live TV access, the awkward logins |
 | `test_source_conformance` | contract | 12 | the fake source still describes the real one |
+| `test_live_tv` | contract | 13 | channels, guide windows, categories, guide prefs, timers |
 | `test_playback_advance` | playback | 1, 5 | queue advance + watched-marking + resume position |
 | `test_playback_eof` | playback | 2, 3, 4 | last-in-queue, seek-to-end (#541), replay (#157/#323) |
 | `test_playback_failure` | playback | 7, 8 | truncated, zero-byte, single-frame |

--- a/docs/E2E_PLAN.md
+++ b/docs/E2E_PLAN.md
@@ -149,8 +149,7 @@ swapped for the live one. Classes 5 and 6.
 
 ## Status
 
-Green on both backends, 8/8 legs, about two minutes for the matrix. See
-`tests/e2e/README.md` to run it.
+Green on both backends. See `tests/e2e/README.md` to run it.
 
 | Module | Tier | Starter items | Covers |
 | --- | --- | --- | --- |
@@ -161,12 +160,16 @@ Green on both backends, 8/8 legs, about two minutes for the matrix. See
 | `test_paging` | contract | 19 | virtual scrolling over ~1000 items at real totals (#617) |
 | `test_keyboard_nav` | contract | 20 | keyboard reach/activation of real screens; duplicate node ids |
 | `test_large_queue` | contract | — | 400-id queue metadata; the 414 request-line limit |
+| `test_connection_loss` | contract | — | server gone / token revoked / a page-in that fails after a screenful drew |
 | `test_playback_advance` | playback | 1, 5 | queue advance + watched-marking + resume position |
 | `test_playback_eof` | playback | 2, 3, 4 | last-in-queue, seek-to-end (#541), replay (#157/#323) |
 | `test_playback_failure` | playback | 7, 8 | truncated, zero-byte, single-frame |
 | `test_mpv_reopen` | playback | 6 | close mid-playback → re-open → auto-advance (#458) |
 | `test_input_routing` | playback | — | real keys across every UI transition (f70ad1e7, #614) |
 | `test_scroll_recovery` | playback | — | wheel-scrolling 1000 items in a real window; blank-tile recovery |
+| `test_track_selection` | playback | — | Jellyfin stream index → mpv track id, both ways, and back to the server |
+| `test_photos` | playback | — | a still is held, an album is a slideshow; the browser's endless display duration |
+| `test_window_resize` | playback | — | the window changes size under the UI, including too small to use |
 
 The contract tier never imports `player.py`, so it runs **once** and without a
 display — the whole of it is under two seconds. Only the playback tier pays
@@ -177,18 +180,19 @@ for the backend matrix.
 None of these is a crash, and none is asserted as a failure; they are recorded
 because each one is a thing somebody will otherwise rediscover.
 
-**The shim reads no user policy fields.** Confirmed by grep: nothing in
-`jellyfin_mpv_shim/` consults `EnableContentDownloading`,
-`EnableMediaPlayback` or `SyncPlayAccess`. The only policy-derived behaviour
-is Live TV, and that is inferred from whether the server put a Live TV view in
-`/Views` rather than read from the policy — which does gate browsing
-correctly, and `LiveTvAccessTest` pins that.
+**The shim read no user policy fields — two of the three gaps are now
+closed.** As found: nothing in `jellyfin_mpv_shim/` consulted
+`EnableContentDownloading`, `EnableMediaPlayback`, `SyncPlayAccess` or
+`EnableLiveTvManagement`, and the only policy-derived behaviour was Live TV
+*browsing*, inferred from whether the server put a Live TV view in `/Views`
+rather than read from the policy — which does gate it correctly, and
+`LiveTvAccessTest` pins that.
 
-The two that matter are written up as work items in
-`docs/PERMISSION_GAPS.md`: SyncPlay has three unconditional entry points and
-never reads `SyncPlayAccess`, and the Settings → Home Screen editor offers
-Live TV sections to users who cannot have them, producing a slot that renders
-nothing forever.
+`user_policy.py` now answers `SyncPlayAccess` and `EnableLiveTvManagement`
+(see `docs/PERMISSION_GAPS.md` for what shipped and why it fails open), and
+`test_account_policy` checks both against the real accounts. Still open: the
+Settings → Home Screen editor offers Live TV sections to users who cannot
+have them, producing a slot that renders nothing forever.
 
 **`EnableMediaPlayback: False` does not stop playback, and cannot.**
 `qa-noplayback` plays a file start to finish: PlaybackInfo returns no error
@@ -214,11 +218,10 @@ account's devices as admin in `setUp`.
 
 ## Bugs found
 
-Two real defects, both from `test_mpv_reopen`, both invisible to the ~2900
-unit tests and the integration matrix because both need a real player and a
-real server at once.
+Three real defects, all invisible to the ~3000 unit tests and the integration
+matrix because each needs a real player, or a real server, or both.
 
-**1. Segfault closing mpv mid-playback — libmpv only. FIXED.**
+**1. Segfault closing mpv mid-playback — libmpv only. FIXED.** (`test_mpv_reopen`)
 
 Closing the window makes mpv end the file *and* shut down. The end-file event
 queues `finished_callback`, which issues `self._player.command("stop")` on the
@@ -235,7 +238,23 @@ in `player.py` already use, and `_terminate_mpv` clears that flag *before*
 calling `terminate()`, so the ordering favours it. 3/3 clean afterwards, and
 the whole unit suite and integration matrix still pass.
 
+**3. A photo opened on its own started a slideshow. FIXED (`02d3329e`).**
+(`test_photos`)
+
+`_play_media` pauses a still when it is the head of the queue and the request
+asked for it — clicking one picture means "show me this". Seventy lines
+further down the same method calls `set_paused(False, False)` to push the
+initial playstate, and that undid it. The feature had therefore never worked:
+the unpause is from the 2020 SyncPlay commit and the photo branch from a week
+ago, which is why the two do not read as related.
+
+`tests/test_photos.py` had a correct three-way truth table for *when* to
+pause and could not see it, because it reimplements the branch as an excerpt
+— and an excerpt cannot know what the rest of the method does to it. That is
+the whole argument for this suite in one bug.
+
 **2. A short item aborted early is reported at full duration. PINNED.**
+(`test_mpv_reopen`)
 
 `_finished_at_eof` decides whether the end that just happened was genuine:
 

--- a/docs/E2E_PLAN.md
+++ b/docs/E2E_PLAN.md
@@ -159,6 +159,7 @@ Green on both backends, 8/8 legs, about two minutes for the matrix. See
 | `test_live_tv` | contract | 13 | channels, guide windows, categories, guide prefs, timers |
 | `test_route_walk` | contract | 18 | every screen loads and renders against the real library |
 | `test_paging` | contract | 19 | virtual scrolling over ~1000 items at real totals (#617) |
+| `test_keyboard_nav` | contract | 20 | keyboard reach/activation of real screens; duplicate node ids |
 | `test_playback_advance` | playback | 1, 5 | queue advance + watched-marking + resume position |
 | `test_playback_eof` | playback | 2, 3, 4 | last-in-queue, seek-to-end (#541), replay (#157/#323) |
 | `test_playback_failure` | playback | 7, 8 | truncated, zero-byte, single-frame |

--- a/docs/E2E_PLAN.md
+++ b/docs/E2E_PLAN.md
@@ -165,6 +165,7 @@ Green on both backends, 8/8 legs, about two minutes for the matrix. See
 | `test_playback_failure` | playback | 7, 8 | truncated, zero-byte, single-frame |
 | `test_mpv_reopen` | playback | 6 | close mid-playback → re-open → auto-advance (#458) |
 | `test_input_routing` | playback | — | real keys across every UI transition (f70ad1e7, #614) |
+| `test_scroll_recovery` | playback | — | wheel-scrolling 1000 items in a real window; blank-tile recovery |
 
 The contract tier never imports `player.py`, so it runs **once** and without a
 display — the whole of it is under two seconds. Only the playback tier pays

--- a/docs/E2E_PLAN.md
+++ b/docs/E2E_PLAN.md
@@ -157,6 +157,7 @@ Green on both backends, 8/8 legs, about two minutes for the matrix. See
 | `test_account_policy` | contract | 17 | restricted libraries, Live TV access, the awkward logins |
 | `test_source_conformance` | contract | 12 | the fake source still describes the real one |
 | `test_live_tv` | contract | 13 | channels, guide windows, categories, guide prefs, timers |
+| `test_route_walk` | contract | 18 | every screen loads and renders against the real library |
 | `test_playback_advance` | playback | 1, 5 | queue advance + watched-marking + resume position |
 | `test_playback_eof` | playback | 2, 3, 4 | last-in-queue, seek-to-end (#541), replay (#157/#323) |
 | `test_playback_failure` | playback | 7, 8 | truncated, zero-byte, single-frame |

--- a/docs/E2E_PLAN.md
+++ b/docs/E2E_PLAN.md
@@ -158,6 +158,7 @@ Green on both backends, 8/8 legs, about two minutes for the matrix. See
 | `test_source_conformance` | contract | 12 | the fake source still describes the real one |
 | `test_live_tv` | contract | 13 | channels, guide windows, categories, guide prefs, timers |
 | `test_route_walk` | contract | 18 | every screen loads and renders against the real library |
+| `test_paging` | contract | 19 | virtual scrolling over ~1000 items at real totals (#617) |
 | `test_playback_advance` | playback | 1, 5 | queue advance + watched-marking + resume position |
 | `test_playback_eof` | playback | 2, 3, 4 | last-in-queue, seek-to-end (#541), replay (#157/#323) |
 | `test_playback_failure` | playback | 7, 8 | truncated, zero-byte, single-frame |

--- a/docs/E2E_PLAN.md
+++ b/docs/E2E_PLAN.md
@@ -278,6 +278,10 @@ Each of these produced a failure that read as a shim bug and was not:
   Tests that need the abort path drive `send_timeline_stopped(finished=True)`
   instead; the close itself is still exercised, but only for outcomes that do
   not depend on who won.
+- **The playback legs must not use the real audio device.** They decode real
+  media, so mpv opens a real output: audible, contending with the desktop, and
+  able to fail on a device something else holds. The runner owns one null sink
+  for the matrix and addresses it explicitly, never touching the default sink.
 - **A truncated file behaves correctly** — reported at 0.29s, not marked
   watched — and a zero-byte file is refused with no session at all. Neither is
   a route to the margin defect above; they were checked as candidates.

--- a/docs/E2E_PLAN.md
+++ b/docs/E2E_PLAN.md
@@ -174,17 +174,23 @@ because each one is a thing somebody will otherwise rediscover.
 `jellyfin_mpv_shim/` consults `EnableContentDownloading`,
 `EnableMediaPlayback` or `SyncPlayAccess`. The only policy-derived behaviour
 is Live TV, and that is inferred from whether the server put a Live TV view in
-`/Views` rather than read from the policy. So Download, Play and SyncPlay are
-offered to accounts the server may refuse — a gap against jellyfin-web, which
-hides them. `qa-nodownload`, `qa-noplayback` and `qa-nosyncplay` exist to make
-this visible.
+`/Views` rather than read from the policy — which does gate browsing
+correctly, and `LiveTvAccessTest` pins that.
 
-**`EnableMediaPlayback: False` does not stop playback.** `qa-noplayback`
-plays a file start to finish: PlaybackInfo returns no error and the server
-serves the `static=true` direct-play URL regardless. So the account cannot
-find the spinner it was built to find, because there is no refusal — worth
-knowing before writing a test that asserts one. Whether the server should
-refuse is a Jellyfin question, not ours.
+The two that matter are written up as work items in
+`docs/PERMISSION_GAPS.md`: SyncPlay has three unconditional entry points and
+never reads `SyncPlayAccess`, and the Settings → Home Screen editor offers
+Live TV sections to users who cannot have them, producing a slot that renders
+nothing forever.
+
+**`EnableMediaPlayback: False` does not stop playback, and cannot.**
+`qa-noplayback` plays a file start to finish: PlaybackInfo returns no error
+and the server serves the `static=true` URL regardless. Jellyfin's video
+endpoints are `AllowAnonymous` — as far as the API is concerned the item id
+*is* the credential — so the server cannot structurally refuse and no
+client-side check would make it able to. That account therefore cannot find
+the spinner it was built to find, because there is no refusal. Worth knowing
+before writing a test that asserts one.
 
 **`qa-onesession` refuses the newcomer rather than evicting the incumbent.**
 The account's description says a second login must evict the first; measured,

--- a/docs/E2E_PLAN.md
+++ b/docs/E2E_PLAN.md
@@ -152,12 +152,52 @@ swapped for the live one. Classes 5 and 6.
 Green on both backends, 8/8 legs, about two minutes for the matrix. See
 `tests/e2e/README.md` to run it.
 
-| Module | Starter items | Covers |
-| --- | --- | --- |
-| `test_playback_advance` | 1, 5 | queue advance + watched-marking + resume position |
-| `test_playback_eof` | 2, 3, 4 | last-in-queue, seek-to-end (#541), replay (#157/#323) |
-| `test_playback_failure` | 7, 8 | truncated, zero-byte, single-frame |
-| `test_mpv_reopen` | 6 | close mid-playback → re-open → auto-advance (#458) |
+| Module | Tier | Starter items | Covers |
+| --- | --- | --- | --- |
+| `test_account_policy` | contract | 17 | restricted libraries, Live TV access, the awkward logins |
+| `test_source_conformance` | contract | 12 | the fake source still describes the real one |
+| `test_playback_advance` | playback | 1, 5 | queue advance + watched-marking + resume position |
+| `test_playback_eof` | playback | 2, 3, 4 | last-in-queue, seek-to-end (#541), replay (#157/#323) |
+| `test_playback_failure` | playback | 7, 8 | truncated, zero-byte, single-frame |
+| `test_mpv_reopen` | playback | 6 | close mid-playback → re-open → auto-advance (#458) |
+
+The contract tier never imports `player.py`, so it runs **once** and without a
+display — the whole of it is under two seconds. Only the playback tier pays
+for the backend matrix.
+
+## Gaps and server behaviours the account tests turned up
+
+None of these is a crash, and none is asserted as a failure; they are recorded
+because each one is a thing somebody will otherwise rediscover.
+
+**The shim reads no user policy fields.** Confirmed by grep: nothing in
+`jellyfin_mpv_shim/` consults `EnableContentDownloading`,
+`EnableMediaPlayback` or `SyncPlayAccess`. The only policy-derived behaviour
+is Live TV, and that is inferred from whether the server put a Live TV view in
+`/Views` rather than read from the policy. So Download, Play and SyncPlay are
+offered to accounts the server may refuse — a gap against jellyfin-web, which
+hides them. `qa-nodownload`, `qa-noplayback` and `qa-nosyncplay` exist to make
+this visible.
+
+**`EnableMediaPlayback: False` does not stop playback.** `qa-noplayback`
+plays a file start to finish: PlaybackInfo returns no error and the server
+serves the `static=true` direct-play URL regardless. So the account cannot
+find the spinner it was built to find, because there is no refusal — worth
+knowing before writing a test that asserts one. Whether the server should
+refuse is a Jellyfin question, not ours.
+
+**`qa-onesession` refuses the newcomer rather than evicting the incumbent.**
+The account's description says a second login must evict the first; measured,
+the server answers the second login 403 and leaves the first working.
+
+**Sessions and devices leak unless you log out.** `client.stop()` closes the
+socket and leaves the session registered, and the server keeps a Device record
+per device id forever. Random per-session device ids left 119 of them behind
+before this was noticed, and the accumulated sessions then exhausted
+`qa-onesession`'s cap so its test failed on the *first* login — which looks
+exactly like the cap working. `Session` now uses one deterministic device id
+per account, `stop()` POSTs `/Sessions/Logout`, and the cap test purges the
+account's devices as admin in `setUp`.
 
 ## Bugs found
 

--- a/docs/PERMISSION_GAPS.md
+++ b/docs/PERMISSION_GAPS.md
@@ -131,11 +131,33 @@ existed as an *apiclient capability* probe with exactly this doctrine, so the
 permission folded into it: both questions have to say yes, and it now takes
 the server it is asking about (it is per server; the probe is not).
 
-The Live TV page hides the **Schedule** and **Series** tabs, and only those —
-`Recordings` stays, because a finished recording is something you watch and
-this permission does not gate watching. A tab carried in on a route that the
-user may not have falls back to the default rather than rendering a screen
-with no way out of it.
+**The tabs all stay.** The first cut hid **Schedule** and **Series** without
+the permission, on the reasoning that they are about scheduling. That was
+wrong, and measuring the server says so: `GET /LiveTv/Timers` and
+`GET /LiveTv/SeriesTimers` both answer **200 for `qa-restricted`**, an account
+that has never had `EnableLiveTvManagement`. The permission gates the writes.
+What is going to record, and which series rules exist, is information the
+server hands to anyone who can see Live TV — and a household member who
+cannot change the DVR still has every reason to want to know what it is
+about to do.
+
+jellyfin-web reaches the same place from the other direction: `getTabs`
+(`livetvsuggested.js:158`) consults no policy at all, and the gating lives on
+the *actions* — `itemContextMenu.js` hides Cancel Recording and Cancel Series
+behind the permission, `itemDetails/index.js` hides the Record buttons.
+
+So the gate moved to where the 403s are:
+
+* the **Record** buttons, via `can_record` (unchanged);
+* the **timer editor**, which now opens read-only — the form renders with the
+  same rows and values, disabled, and Save / Cancel Recording / Cancel Series
+  are not offered at all. Not greyed: a disabled Save invites "why", and the
+  answer is a permission the user cannot do anything about from that dialog.
+
+`tests/e2e/test_account_policy.py` pins the premise (the reads are allowed),
+because no unit test can — that answer belongs to the server. If it ever
+starts refusing them, hiding the tabs becomes right again and that test is
+what will say so.
 
 Pinned by `tests/test_user_policy.py` and
 `tests/e2e/test_account_policy.py:LiveTvManagementPermissionTest`, which

--- a/docs/PERMISSION_GAPS.md
+++ b/docs/PERMISSION_GAPS.md
@@ -108,17 +108,30 @@ on the login response's policy, it is per-server, and whatever holds
 `EnableLiveTvManagement` is offered no Record buttons and no Schedule tab,
 while one with both is offered all of them.
 
-### stdjflib should grant it to `qa-admin`
+### Why this was invisible, and the stdjflib half (fixed)
 
-Not a shim issue, but it blocks testing this one. **No stdjflib account has
-`EnableLiveTvManagement`**, `qa-admin` included — so the entire DVR surface
-(timers, series rules, recordings, the Schedule tab) is unreachable against a
-stock QA server, and every client would find it "broken" identically.
+Jellyfin has **two** sets of user-policy defaults and both are live, on
+different paths:
 
-`tests/e2e/test_live_tv.TimerTest` works around it by granting the flag to
-`qa-admin` in `setUpClass` and restoring the original policy in
-`tearDownClass`, which is only acceptable because the server is disposable.
-The better fix is upstream: `qa-admin` is described as "Administrator.
-Dashboard, scheduled tasks, library management" and plainly ought to have it,
-and an account with Live TV access but *without* management would be a useful
-thirteenth — it is exactly the state this gap is about.
+| Path | Source | `EnableLiveTvManagement` |
+| --- | --- | --- |
+| Account **migrated** from an older install | `UserPolicy` constructor | `true` |
+| Account **created** on a modern server | `AddDefaultPermissions` | `false` |
+
+`MigrateUserDb` deserializes the old policy file into a `UserPolicy`, so any
+field absent from it keeps the constructor's value. That is why someone who
+has carried an install forward has this permission and never remembers
+granting it, while a server built from nothing has it on nobody — and why the
+DTO constructor is the wrong thing to read if you are asking about a new user.
+
+There is no administrator bypass either: `UserPermissionHandler` asks
+`HasPermission` and stops, so `IsAdministrator` does not help. jellyfin-web's
+dashboard does not couple them — "Allow browsing Live TV" and "Allow Live TV
+recording management" are independent checkboxes.
+
+**Fixed in stdjflib** (`b32b586`): `qa-admin` now carries every management
+permission — its policy was previously declared and then never applied,
+because `provision` skipped the account it authenticates as — and `qa-user`
+gets `EnableLiveTvManagement` as well, since its description already claimed
+everything a non-admin can have. The other ten accounts still lack it, which
+is the state this gap is about and is what makes it testable.

--- a/docs/PERMISSION_GAPS.md
+++ b/docs/PERMISSION_GAPS.md
@@ -86,3 +86,39 @@ ecosystem has to move together, so hiding the play button here would only make
 this client look broken against a server that will happily serve the stream.
 
 Recorded so the next person to measure it does not file it as a shim bug.
+
+## 3. Recording is offered to users who cannot record
+
+Found while writing `tests/e2e/test_live_tv.py`, which could not schedule a
+timer as any account on the server.
+
+`EnableLiveTvManagement` is a **third** Live TV permission, separate from
+`EnableLiveTvAccess`: watching Live TV and managing recordings are granted
+independently. The shim never reads it — grep returns nothing — so the Record
+button, the series-rule button and the whole Recordings/Schedule surface are
+offered to every user who can see Live TV at all. Pressing Record then answers
+`403 Forbidden` from `POST /LiveTv/Timers`, and the user sees a generic
+failure.
+
+Same family as the SyncPlay gap above and probably the same fix: the flag is
+on the login response's policy, it is per-server, and whatever holds
+`SyncPlayAccess` should hold this too.
+
+**Testable once fixed**: a user with `EnableLiveTvAccess` but not
+`EnableLiveTvManagement` is offered no Record buttons and no Schedule tab,
+while one with both is offered all of them.
+
+### stdjflib should grant it to `qa-admin`
+
+Not a shim issue, but it blocks testing this one. **No stdjflib account has
+`EnableLiveTvManagement`**, `qa-admin` included — so the entire DVR surface
+(timers, series rules, recordings, the Schedule tab) is unreachable against a
+stock QA server, and every client would find it "broken" identically.
+
+`tests/e2e/test_live_tv.TimerTest` works around it by granting the flag to
+`qa-admin` in `setUpClass` and restoring the original policy in
+`tearDownClass`, which is only acceptable because the server is disposable.
+The better fix is upstream: `qa-admin` is described as "Administrator.
+Dashboard, scheduled tasks, library management" and plainly ought to have it,
+and an account with Live TV access but *without* management would be a useful
+thirteenth — it is exactly the state this gap is about.

--- a/docs/PERMISSION_GAPS.md
+++ b/docs/PERMISSION_GAPS.md
@@ -1,0 +1,88 @@
+# User-permission gaps — work items
+
+Raised by `tests/e2e/test_account_policy.py` running against stdjflib's twelve
+QA accounts, which is the first time anything automatic had exercised them.
+
+The principle, and the reason these are worth doing: **showing UI the server
+will refuse creates confusion and issue reports.** A user with SyncPlay
+revoked who is offered a SyncPlay button does not conclude they lack
+permission; they conclude the client is broken, and they are half right.
+
+Nothing here is a crash, and none of it is asserted as a failure by the test
+suite — `test_account_policy` pins what the code currently promises and its
+docstring names these as known gaps.
+
+## 1. SyncPlay is offered to users who do not have it
+
+`SyncPlayAccess` is never read. Grep for it in `jellyfin_mpv_shim/` returns
+nothing.
+
+The account is `qa-nosyncplay` — "SyncPlay refused, so the client's SyncPlay
+entry points must go". There are three of them, all unconditional:
+
+| Entry point | Where |
+| --- | --- |
+| Top-bar nav button | `mpvtk_browser/window_chrome.py:189` (`nav-syncplay`) |
+| Playback HUD button | `mpvtk_browser/hud.py` (the bar's own SyncPlay button) |
+| OSD menu row | `menu.py:158` |
+
+All three lead to the SyncPlay dialog (`mpvtk_browser/dialogs.py:623`), whose
+join/create then fails against the server and surfaces "Could not join the
+SyncPlay group." — which is indistinguishable from a network problem.
+
+**Shape of the fix.** The policy arrives with the login response
+(`result["User"]["Policy"]["SyncPlayAccess"]`, one of `CreateAndJoinGroups`,
+`JoinGroups`, `None`) so it needs no extra request, and it is per-server —
+whatever holds it has to be keyed by server the way `has_live_tv` is, or a
+two-server user gets the wrong answer. Note `JoinGroups` is a third state, not
+a boolean: that user should reach the dialog but not the create button.
+
+**Testable once fixed**: `qa-nosyncplay` must not be offered any of the three
+entry points, and `qa-user` must still get all of them.
+
+## 2. The home-screen editor offers Live TV sections to users without Live TV
+
+**Browsing Live TV is already correctly gated** — do not "fix" that. The
+server only adds the Live TV view to `/Views` when the user may use Live TV
+*and* a tuner exists, `repository.get_libraries` derives `has_live_tv` from
+its presence, and both the home rows (`repository.py:793`) and search
+(`pages/search.py:46`) consult it. `test_account_policy.LiveTvAccessTest`
+pins this against `qa-kid`, who has the right revoked, and it passes.
+
+The gap is one screen further in. Settings → Home Screen builds its dropdowns
+from `home_sections.section_labels()`, which lists every section type
+unconditionally — including `LIVE_TV` and `ACTIVE_RECORDINGS`. So a user with
+no Live TV access can select "Live TV" for a slot, save it to their server,
+and get a slot that renders nothing, forever, with no explanation. Worse than
+an error: it looks like the section is broken.
+
+**Shape of the fix.** `section_labels()` takes no context today, so it either
+gains an argument or the settings tab filters what it returns; the tab already
+has a source and therefore `has_live_tv`. The screen already has the right
+idiom for this — a section jellyfin-web can draw and the shim cannot is shown
+with a note rather than silently rewritten (`settings/home.py:72`), and the
+same treatment fits a section this *user* cannot have.
+
+Care on save: `home_sections` deliberately preserves section types the shim
+cannot draw so that configuring the shim never degrades the same user's
+jellyfin-web home screen. A Live TV section they set elsewhere must be
+preserved on the same reasoning — hidden from the picker is not the same as
+removed from the layout.
+
+**Testable once fixed**: the section choices offered to `qa-kid` exclude Live
+TV and Active Recordings; those offered to `qa-user` include them; and a Live
+TV section already present in `qa-kid`'s stored layout survives a save.
+
+## Not a gap: playback permission
+
+`qa-noplayback` (`EnableMediaPlayback: False`) plays a file start to finish —
+PlaybackInfo returns no error and the `static=true` URL is served anyway.
+
+This is not something the client can or should paper over. Jellyfin's video
+endpoints are `AllowAnonymous`, so as far as the API is concerned the item id
+*is* the credential; the server cannot structurally refuse playback, and no
+client-side check would make it able to. Worth fixing upstream, but a whole
+ecosystem has to move together, so hiding the play button here would only make
+this client look broken against a server that will happily serve the stream.
+
+Recorded so the next person to measure it does not file it as a shim bug.

--- a/docs/PERMISSION_GAPS.md
+++ b/docs/PERMISSION_GAPS.md
@@ -8,11 +8,11 @@ will refuse creates confusion and issue reports.** A user with SyncPlay
 revoked who is offered a SyncPlay button does not conclude they lack
 permission; they conclude the client is broken, and they are half right.
 
-Nothing here is a crash, and none of it is asserted as a failure by the test
-suite — `test_account_policy` pins what the code currently promises and its
-docstring names these as known gaps.
+**Items 1 and 3 are now fixed** (`jellyfin_mpv_shim/user_policy.py`); their
+sections below are kept as the record of what was wrong and why, with what
+shipped noted at the end of each. Item 2 is still open.
 
-## 1. SyncPlay is offered to users who do not have it
+## 1. SyncPlay is offered to users who do not have it  — FIXED
 
 `SyncPlayAccess` is never read. Grep for it in `jellyfin_mpv_shim/` returns
 nothing.
@@ -37,8 +37,30 @@ whatever holds it has to be keyed by server the way `has_live_tv` is, or a
 two-server user gets the wrong answer. Note `JoinGroups` is a third state, not
 a boolean: that user should reach the dialog but not the create button.
 
-**Testable once fixed**: `qa-nosyncplay` must not be offered any of the three
-entry points, and `qa-user` must still get all of them.
+**What shipped.** `user_policy.py` holds the answer, cached on the client
+object rather than in any one owner — the browser reaches its clients through
+`LibrarySource`, the player through `clientManager`, and both have to get the
+same answer. `GET /Users/Me`, once per server per session, taken lazily: the
+policy does arrive on the login response, but credentials are restored from
+`cred.json` on every run after the first, so most of the time there is no
+login response to read.
+
+It **fails open** throughout, and that is asserted as much as the hiding is.
+Only an answer the server actually gave closes a gate; a fetch that failed, a
+source without the method, an older server with no such field — all leave the
+button where it was. Taking a working feature away because a request failed
+would be a worse bug than the one being fixed. (Same doctrine as
+`ItemActions.can_edit`.)
+
+The three entry points: the top-bar button (`window_chrome._may_syncplay`),
+the HUD button and the OSD menu row (both via `osc_bridge._may_syncplay`,
+which returns `None` from `_syncplay` — the shape hud.py already treats as
+"no button"). `JoinGroups` keeps the dialog and loses only **New Group**.
+
+Pinned by `tests/test_user_policy.py` and, against the real accounts,
+`tests/e2e/test_account_policy.py:SyncPlayPermissionTest` — which is where
+the field name itself is checked, since a unit test with a hand-written
+policy dict proves the branch and not the spelling.
 
 ## 2. The home-screen editor offers Live TV sections to users without Live TV
 
@@ -87,7 +109,7 @@ this client look broken against a server that will happily serve the stream.
 
 Recorded so the next person to measure it does not file it as a shim bug.
 
-## 3. Recording is offered to users who cannot record
+## 3. Recording is offered to users who cannot record  — FIXED
 
 Found while writing `tests/e2e/test_live_tv.py`, which could not schedule a
 timer as any account on the server.
@@ -104,9 +126,22 @@ Same family as the SyncPlay gap above and probably the same fix: the flag is
 on the login response's policy, it is per-server, and whatever holds
 `SyncPlayAccess` should hold this too.
 
-**Testable once fixed**: a user with `EnableLiveTvAccess` but not
-`EnableLiveTvManagement` is offered no Record buttons and no Schedule tab,
-while one with both is offered all of them.
+**What shipped.** Same module, same fail-open rule. `can_record` already
+existed as an *apiclient capability* probe with exactly this doctrine, so the
+permission folded into it: both questions have to say yes, and it now takes
+the server it is asking about (it is per server; the probe is not).
+
+The Live TV page hides the **Schedule** and **Series** tabs, and only those —
+`Recordings` stays, because a finished recording is something you watch and
+this permission does not gate watching. A tab carried in on a route that the
+user may not have falls back to the default rather than rendering a screen
+with no way out of it.
+
+Pinned by `tests/test_user_policy.py` and
+`tests/e2e/test_account_policy.py:LiveTvManagementPermissionTest`, which
+checks it both ways round against `qa-user` (granted) and `qa-restricted`
+(never granted, which is the default for any account created on a modern
+server).
 
 ### Why this was invisible, and the stdjflib half (fixed)
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -226,8 +226,8 @@ You can use the config file to enable and disable features.
     at 1x and will be upscaled.
 - `theme` - Visual theme for the library browser. Default: `default`
   - `default` - The stock look, unchanged from earlier versions.
-  - `nebula` - A deep-violet, glowing theme with rounded, cover-cropped cards
-    and larger covers.
+  - `nebula` - A deep-violet, glowing theme with rounded cards and larger
+    covers.
   - `jf-blueradiance`, `jf-wmc`, `jf-purplehaze`, `jf-light`, `jf-appletv` -
     Translations of jellyfin-web's own Blue Radiance, Windows Media Center,
     Purple Haze, Light and Apple TV themes, so the shim can match the web
@@ -238,10 +238,12 @@ You can use the config file to enable and disable features.
     white HUD over a dark film is unreadable, and jellyfin-web keeps its
     player controls dark for the same reason.
   - A theme sets the palette, the mpv browse background, whether titles and
-    the selected card glow, whether cover cards are rounded and cover-cropped
-    (rather than square and letterboxed), where the carousel page buttons sit,
-    and the default cover, caption and heading sizes. `poster_scale` and
-    `ui_scale` still override the sizing.
+    the selected card glow, whether cover cards are rounded or square, where
+    the carousel page buttons sit, and the default cover, caption and heading
+    sizes. `poster_scale` and `ui_scale` still override the sizing. Artwork is
+    cover-cropped to fill its tile under every theme — except a wordmark or a
+    logo on a transparent background, which is drawn whole because a crop
+    would take a bite out of the name.
   - **Colours apply immediately** when you change this in Settings, including
     the controls the player draws for itself. Cover and heading *sizes* still
     need a restart: changing a poster's dimensions means re-compositing every
@@ -524,7 +526,7 @@ Colours are `"rrggbb"`, with or without a leading `#`.
 | `palette` | Colour table; see below. |
 | `browse_bg` | mpv's `background-color` behind the browser, `"#rrggbb"`. |
 | `glow` | Blurred accent halo behind bold titles and around the selected card. |
-| `rounded` | Rounded, cover-cropped cards instead of square and letterboxed. |
+| `rounded` | Rounded cards instead of square ones. Card shape only — the artwork is cover-cropped to fill its tile under every theme. |
 | `accent_buttons` | Accent-bordered top bar and settings tabs. |
 | `arrow_mode` | `header` (jellyfin-web's: a flat pair in the section heading) or `overlay` (round translucent buttons floating on the artwork). |
 | `arrow_bg`, `arrow_alpha` | Fill and opacity (0–255) of the `overlay` page buttons. |

--- a/jellyfin_mpv_shim/menu.py
+++ b/jellyfin_mpv_shim/menu.py
@@ -155,8 +155,15 @@ class OSDMenu(object):
                 (_("Change Audio"), self.change_audio_menu),
                 (_("Change Subtitles"), self.change_subtitle_menu),
                 (_("Change Video Quality"), self.change_transcode_quality),
-                (_("SyncPlay"), self.playerManager.syncplay.menu_action),
             ]
+            # Omitted for a user the server refuses SyncPlay to: every path
+            # behind this row ends in "Could not join the SyncPlay group.",
+            # which reads as a broken client rather than as a permission.
+            # Same question the HUD's button asks (osc_bridge._may_syncplay).
+            bridge = getattr(self.playerManager, "osc_bridge", None)
+            if bridge is None or bridge._may_syncplay():
+                self.menu_list.append(
+                    (_("SyncPlay"), self.playerManager.syncplay.menu_action))
             if self.playerManager.update_check.new_version is not None:
                 self.menu_list.insert(
                     0,

--- a/jellyfin_mpv_shim/mpvtk/renderer.lua
+++ b/jellyfin_mpv_shim/mpvtk/renderer.lua
@@ -605,11 +605,16 @@ local function compute_geo()
                 vx2 = math.min(vx2, p.x2); vy2 = math.min(vy2, p.y2)
             end
             local off = snap_round(node, state.scroll[node.id] or 0)
-            state.geo[node.id] = {
+            local g = {
                 dx = dx + (node.axis == 'x' and off or 0),
                 dy = dy + (node.axis == 'y' and off or 0),
                 x1 = vx1, y1 = vy1, x2 = vx2, y2 = vy2,
             }
+            -- The OUTERMOST viewport this one sits in (itself, when there is
+            -- no parent). Decorations that are allowed to spill out of their
+            -- own container still may not leave the page -- see glow_clip.
+            g.root = p and p.root or g
+            state.geo[node.id] = g
         end
     end
 end
@@ -633,6 +638,31 @@ local function visible(node)
         ex + node.w > clip.x1 and ey + node.h > clip.y1
 end
 
+-- Clip for a decoration that is allowed to spill OUT of its own viewport,
+-- but not out of the page: the container's rect grown by `spill`, clamped
+-- back to the outermost scroll ancestor.
+--
+-- Both of the themed glows want this. Clipped to their own container the
+-- blur is chopped into a hard edge, which is the box they exist to replace
+-- (a card fills its row's viewport, so the halo is entirely outside it).
+-- Clipped to nothing -- which is what they used to do -- the halo of a card
+-- near the top of the page paints over the header, because chrome is drawn
+-- BEFORE content and ASS has no z-order beyond scene order.
+--
+-- Growing the already-intersected rect and re-clamping gives the same
+-- answer as growing the container's own rect would: where the parent had
+-- already cut this viewport, the clamp puts the edge straight back.
+local function spill_clip(clip, spill)
+    if not clip then return nil end
+    local r = clip.root or clip
+    return {
+        x1 = math.max(clip.x1 - spill, r.x1),
+        y1 = math.max(clip.y1 - spill, r.y1),
+        x2 = math.min(clip.x2 + spill, r.x2),
+        y2 = math.min(clip.y2 + spill, r.y2),
+    }
+end
+
 local function clip_tag(clip)
     if not clip then return '' end
     return string.format('\\clip(%.1f,%.1f,%.1f,%.1f)',
@@ -654,9 +684,9 @@ local function draw_rect(ass, x, y, w, h, o)
     -- o: {fill, a, radius, bc, bw, clip, blur}
     ass:new_event()
     ass:append('{\\pos(0,0)\\an7\\bord0\\shad0')
-    -- blur softens the border into a halo (the themed selection glow); the
-    -- caller must leave the clip off, or the container's viewport chops the
-    -- blur back into a hard edge.
+    -- blur softens the border into a halo (the themed selection glow); pass
+    -- such a caller's clip through spill_clip, or the container's viewport
+    -- chops the blur back into a hard edge.
     if o.blur then ass:append(string.format('\\blur%.1f', o.blur)) end
     if o.fill then
         ass:append('\\1c' .. ass_color(o.fill))
@@ -2009,11 +2039,13 @@ render = function()
                 if hs and hs.bc then
                     if state.glow then
                         -- Themed selection: a soft accent halo instead of a
-                        -- hard box. No clip — the row viewport would chop the
-                        -- blur back into the box this replaces.
+                        -- hard box. Clipped to the page rather than to the
+                        -- row — the row viewport would chop the blur back
+                        -- into the box this replaces (see spill_clip).
                         draw_rect(ass, ex - 3, ey - 3,
                             node.w + 6, node.h + 6, {
                                 bc = hs.bc, bw = 3, radius = 14, blur = 16,
+                                clip = spill_clip(clip, 3 + 3 + 16),
                             })
                     else
                         draw_rect(ass, ex - 2, ey - 2,
@@ -2036,12 +2068,14 @@ render = function()
                 if state.glow and hs and hs.glow then
                     -- Soft accent halo behind a hovered box (themed chrome:
                     -- hover={"glow": true}). Drawn first so the box sits on
-                    -- top of it, and unclipped — a clip would chop the blur
-                    -- back into a hard edge.
+                    -- top of it, and clipped to the page rather than to its
+                    -- own container — the latter chops the blur back into a
+                    -- hard edge (see spill_clip).
                     draw_rect(ass, ex - 2, ey - 2,
                         node.w + 4, node.h + 4, {
                             bc = hs.bc or node.bc or state.accent, bw = 2,
                             radius = (node.radius or 0) + 2, blur = 10,
+                            clip = spill_clip(clip, 2 + 2 + 10),
                         })
                 end
                 draw_rect(ass, ex, ey, node.w, node.h, {

--- a/jellyfin_mpv_shim/mpvtk/renderer.lua
+++ b/jellyfin_mpv_shim/mpvtk/renderer.lua
@@ -743,7 +743,11 @@ local function draw_text(ass, node, ex, ey, clip, text, color, extra,
         glow = '\\bord1.4\\blur2\\3c&H000000&\\3a&H40&'
     end
     ass:append(string.format(
-        '{\\q2\\an%d\\pos(%.1f,%.1f)\\fs%d\\bord0\\shad0' ..
+        -- %.2f, not %d: a font size arrives already scaled and is NOT rounded
+        -- (mpvtk/scaling.py _EXACT_KEYS). Truncating it here would put the
+        -- rounding error straight back, and it is the whole reason a wrapped
+        -- paragraph used to overrun its column on a fractional UI scale.
+        '{\\q2\\an%d\\pos(%.1f,%.1f)\\fs%.2f\\bord0\\shad0' ..
         '\\1c%s\\1a&H00&%s%s%s%s%s}',
         an, px, ey + node.h / 2, node.size,
         ass_color(color), glow, node.bold and '\\b1' or '',
@@ -2225,7 +2229,7 @@ render = function()
         -- box: the background is what softens against the picture, and
         -- fading the text with it would cost legibility on bright frames.
         ass:append(string.format(
-            '{\\q2\\an5\\pos(%.1f,%.1f)\\fs%d\\bord0\\shad0\\1c%s' ..
+            '{\\q2\\an5\\pos(%.1f,%.1f)\\fs%.2f\\bord0\\shad0\\1c%s' ..
             '\\1a&H00&\\b0%s}',
             x1 + bw / 2, y1 + bh / 2, fs, ass_color(PHUD_SKIP_FG),
             ui_font and ('\\fn' .. ui_font) or ''))

--- a/jellyfin_mpv_shim/mpvtk/scaling.py
+++ b/jellyfin_mpv_shim/mpvtk/scaling.py
@@ -89,8 +89,22 @@ def _round(v):
 
 # Pixel geometry, uniform across every node type (audited against
 # layout.py's emission and renderer.lua's reads).
-_PX_KEYS = ("x", "y", "w", "h", "size", "radius", "bw", "pw", "cw", "ch",
+_PX_KEYS = ("x", "y", "w", "h", "radius", "bw", "pw", "cw", "ch",
             "rh", "snap", "snap_off", "off0")
+
+# Scaled but NOT rounded. A font size is not a box: nothing is rasterized at
+# it, no stride depends on it, and libass takes a fractional `\fs` happily.
+# What does depend on it is that the text comes out the width layout wrapped
+# and ellipsized it to -- and px()'s rounding broke exactly that. At 0.75x,
+# an 18px run is drawn at px(18) = 14, which is 18.67 logical: every line
+# renders 3.7% wider than the width it was fitted to, so a full-width
+# paragraph overruns its column by tens of pixels and disappears under the
+# scrollbar. The error is worst at the fractional scales (0 at 1x and 2x),
+# which is why this only ever showed up on a scaled display.
+#
+# Rounding here bought nothing. The one thing that must round exactly like
+# every other rasterizer is the LINE BOX (h/rh), and that still does.
+_EXACT_KEYS = ("size",)
 
 # Pixel geometry that arrives as a LIST of numbers (scaled elementwise).
 _PX_LIST_KEYS = ("snaps",)
@@ -121,6 +135,10 @@ def scale_scene(nodes):
             v = node.get(key)
             if v is not None:
                 node[key] = px(v)
+        for key in _EXACT_KEYS:
+            v = node.get(key)
+            if v is not None:
+                node[key] = v * _scale
         for key in _PX_LIST_KEYS:
             v = node.get(key)
             if v is not None:

--- a/jellyfin_mpv_shim/mpvtk_browser/app.py
+++ b/jellyfin_mpv_shim/mpvtk_browser/app.py
@@ -1620,7 +1620,28 @@ class MpvtkBrowser(DialogsMixin, LiveTvDialogsMixin, AuthMixin, SettingsMixin,
         except Exception:
             log.exception("controller.%s failed", name)
 
+    def _park_on_leaving_browse(self):
+        """Park the scroll offsets on the way out of the browser.
+
+        Yielding to playback pushes an EMPTY scene, and the renderer drops
+        the state of every container that left the scene. Unlike a
+        navigation, coming back is a rebuild of the *same* route — nothing
+        pushes or pops — so ``navigate``'s park never runs and there was
+        nothing left for ``Page.parked_scroll`` to restore. Press play on
+        something near the end of a library and the library came back at the
+        top; whether it came back *blank* on the way depended on whether the
+        live read still had the old offsets when the window was built.
+
+        Guarded on ``_browsing``: a video start parks here and then reaches
+        ``_yield`` once playback reports in, by which time the container has
+        already left the scene — and ``park`` treats an empty snapshot as
+        "nothing was scrolled" and drops the key.
+        """
+        if self._browsing:
+            self._park_scroll()
+
     def _yield(self):
+        self._park_on_leaving_browse()
         self._browsing = False
         self._tell_controller("on_browse_leave")
         if self.hud.available():
@@ -1653,6 +1674,12 @@ class MpvtkBrowser(DialogsMixin, LiveTvDialogsMixin, AuthMixin, SettingsMixin,
             # _browsing first, then begin(): begin() arms the spinner timer,
             # and the original armed it last. Keeping that order means the
             # timer can never observe a half-applied start.
+            #
+            # Parked here rather than only in _yield: the loading screen
+            # replaces the content as soon as the spinner is due, so the
+            # scroll container can leave the scene well before playback
+            # reports in and the yield happens.
+            self._park_on_leaving_browse()
             self._browsing = False
             self.load.begin(title)
             self.invalidate()
@@ -1779,6 +1806,7 @@ class MpvtkBrowser(DialogsMixin, LiveTvDialogsMixin, AuthMixin, SettingsMixin,
         a cast target. This is the player's "playback_abort yes, force_window
         no" state; there is no separate window to hide, so minimizing *is*
         dropping force_window with nothing playing."""
+        self._park_on_leaving_browse()
         self._minimized = True
         self._browsing = False
         self.hud.shown = False
@@ -2115,8 +2143,11 @@ class MpvtkBrowser(DialogsMixin, LiveTvDialogsMixin, AuthMixin, SettingsMixin,
         w, h = size
         self._size = size
         # One synchronous read per frame: the renderer's live scroll offsets,
-        # which virtualization windows against (see _offset).
-        self._scroll.refresh(self.app)
+        # which virtualization windows against (see _offset). The route goes
+        # with it for the offsets parked on it — on the frame a screen comes
+        # back, those are what its containers are about to be restored to,
+        # and so what its window has to be built around.
+        self._scroll.refresh(self.app, self.route)
         # Load feedback outranks everything, including the yield to video:
         # that yield is exactly what left a blank window during a load, and a
         # failed start has no video to show through.

--- a/jellyfin_mpv_shim/mpvtk_browser/components/banner.py
+++ b/jellyfin_mpv_shim/mpvtk_browser/components/banner.py
@@ -75,7 +75,13 @@ def compose_banner(image, box, title=None, meta=None, context=None):
     if meta:
         f = pil_font(int(size * 0.6), text=meta)
         asc, desc = f.getmetrics()
-        draw.text((margin, y - asc - desc), meta, font=f,
+        # Ellipsized to the width, like the context line below and unlike
+        # what this used to do: the meta line ends in the genres, and a film
+        # carrying five of them drew straight off the right edge of the
+        # backdrop. Nothing clips a baked bitmap back -- the text IS the
+        # picture by the time the compositor sees it.
+        line = wrap_pil(draw, meta, f, avail, max_lines=1)[0]
+        draw.text((margin, y - asc - desc), line, font=f,
                   fill=(200, 200, 200, 255))
         y -= asc + desc + px(6)
     f = pil_font(size, bold=True, text=title)

--- a/jellyfin_mpv_shim/mpvtk_browser/components/chrome.py
+++ b/jellyfin_mpv_shim/mpvtk_browser/components/chrome.py
@@ -49,6 +49,56 @@ def error(msg):
                pad=24, flex=1, align="start", direction="row")
 
 
+def wrap_row(items, avail, gap=8, align="center", row_gap=None):
+    """``items`` in a Row, broken onto further rows when one will not fit.
+
+    A Row does not wrap: it lays its children out end to end and lets the
+    tail run off the window. That is invisible at 1x on a wide window and
+    routine at 200%, where a 1280px window is a 640px page (see
+    ``mpvtk/scaling.py`` -- view code is logical, so the UI scale is a width
+    problem). It is equally reachable at 100% by making the window small,
+    and by translation: "Servers & Users" is "Server und Benutzer" in German.
+
+    Measured rather than switched on a width constant, for the same reason
+    ``GridPage._fit_bar`` is: what fits depends on these particular items.
+
+    Returns the plain Row when everything fits on one, so the common case
+    produces the same tree it always did.
+    """
+    from ...mpvtk.layout import measure
+
+    one_row = Row(items, gap=gap, align=align)
+    if not items or avail <= 0:
+        return one_row
+    # A flexible Spacer is "push these apart", which is what pins a trailing
+    # group to the right edge -- and so is what puts those particular buttons
+    # off the window. It has nothing left to say once the row is full, so it
+    # is dropped on the way to wrapping (and only then: a row that fits keeps
+    # the tree it always had).
+    packable = [i for i in items
+                if not (isinstance(i, Spacer) and getattr(i, "flex", 0))]
+    try:
+        widths = [measure(i)[0] for i in packable]
+    except Exception:
+        # Never fail a render over a decoration: an unmeasurable item keeps
+        # the old behaviour, which is one row that may be too wide.
+        return one_row
+    rows, cur, used = [], [], 0.0
+    for item, iw in zip(packable, widths):
+        need = iw if not cur else used + gap + iw
+        if cur and need > avail:
+            rows.append(cur)
+            cur, used = [item], iw
+        else:
+            cur.append(item)
+            used = need
+    rows.append(cur)
+    if len(rows) == 1:
+        return one_row
+    return Column([Row(r, gap=gap, align=align) for r in rows],
+                  gap=gap if row_gap is None else row_gap, align="start")
+
+
 def body_width(w, pad=CONTENT_PAD):
     """Usable text width inside a padded, scrollable content column.
 

--- a/jellyfin_mpv_shim/mpvtk_browser/components/detail.py
+++ b/jellyfin_mpv_shim/mpvtk_browser/components/detail.py
@@ -44,7 +44,13 @@ def meta_line(item):
     # Genres are already fetched (repository asks for them); Tk showed up
     # to three here and dropping them lost the quickest read on what a
     # thing actually is.
-    genres = ", ".join(item.get("Genres") or [])
+    #
+    # Three, as Tk had it and as the Live TV cards do -- this is the quick
+    # read, not the full list, and a film tagged with eight of them pushed
+    # everything else off the line. The banner ellipsizes past its width
+    # anyway, but that backstop should be rare rather than routine: the
+    # genres are last, so they are what the ellipsis eats.
+    genres = ", ".join((item.get("Genres") or [])[:3])
     if genres:
         parts.append(genres)
     return "   ·   ".join(parts)

--- a/jellyfin_mpv_shim/mpvtk_browser/dialogs.py
+++ b/jellyfin_mpv_shim/mpvtk_browser/dialogs.py
@@ -615,6 +615,18 @@ class DialogsMixin:
         # Fetch groups off-thread, then show the dialog on the loop.
         self.run_async(work, done, ep)
 
+    def _may_create_sync_group(self, server):
+        """Fails open; see user_policy."""
+        from ..user_policy import CREATE_AND_JOIN
+
+        ask = getattr(self.source, "syncplay_access", None)
+        if ask is None or server is None:
+            return True
+        try:
+            return ask(server) == CREATE_AND_JOIN
+        except Exception:
+            return True
+
     def _show_syncplay(self, server, groups, state=None):
         joined = (state or {}).get("group_id")
         multi = len({g.get("server_uuid") for g in groups}) > 1
@@ -655,10 +667,14 @@ class DialogsMixin:
             else:
                 rows.append(Text(_("No active groups."), size=15,
                                  color=theme.SUBTLE_FG))
-            buttons = [
-                Button(_("New Group"), id="sp-new",
-                       on_click=lambda: self._sync_new(server)),
-            ]
+            buttons = []
+            # SyncPlayAccess is three-valued: `JoinGroups` may join a group
+            # somebody else made and may not make one. Treating it as a
+            # boolean either hides a dialog that works or offers a button
+            # that 403s. See user_policy.
+            if self._may_create_sync_group(server):
+                buttons.append(Button(_("New Group"), id="sp-new",
+                                      on_click=lambda: self._sync_new(server)))
             if joined is not None:
                 # Only when there is something to leave. It used to render
                 # unconditionally, so the one control that changes state was

--- a/jellyfin_mpv_shim/mpvtk_browser/item_actions.py
+++ b/jellyfin_mpv_shim/mpvtk_browser/item_actions.py
@@ -387,12 +387,23 @@ class ItemActions:
 
     # -- capability --------------------------------------------------------
 
-    def can_record(self):
+    def can_record(self, server=None):
         """Whether the Record affordances should be offered.
 
-        Fails OPEN, exactly as ``can_edit`` does and for the same reason:
-        only a probe that positively answers False hides them. The API call
-        is the real check.
+        Two independent questions, and both have to say yes:
+
+        1. Can this *apiclient* schedule a recording at all — the version
+           probe ``live_tv_apis``, cached because it is a question about
+           imported code and cannot change while we run.
+        2. May this *user*, on this server. ``EnableLiveTvManagement`` is a
+           third Live TV permission, separate from the access one the
+           browse gate reads, and without it every Record button answers
+           403 with a generic failure. Not cached here: it is per server
+           and the answer already is cached, on the client.
+
+        Fails OPEN in both, exactly as ``can_edit`` does and for the same
+        reason: only a probe that positively answers False hides them. The
+        API call is the real check.
         """
         if self._record_ok is None:
             try:
@@ -400,7 +411,16 @@ class ItemActions:
             except Exception:
                 answer = None
             self._record_ok = answer is not False
-        return self._record_ok
+        if not self._record_ok:
+            return False
+        source = getattr(self.services, "source", None)
+        ask = getattr(source, "can_manage_live_tv", None)
+        if ask is None or server is None:
+            return True
+        try:
+            return bool(ask(server))
+        except Exception:
+            return True
 
     def can_edit(self):
         """Whether the apiclient can edit playlists/collections.

--- a/jellyfin_mpv_shim/mpvtk_browser/livetv_dialogs.py
+++ b/jellyfin_mpv_shim/mpvtk_browser/livetv_dialogs.py
@@ -90,7 +90,11 @@ class LiveTvDialogsMixin:
         self._timer_dlg = {"server": server, "id": timer_id,
                            "series": series, "timer": None,
                            "on_change": on_change, "error": None,
-                           "fields": {}}
+                           "fields": {},
+                           # Asked once, at open: whether this is an editor
+                           # or a read-only look at what is scheduled. See
+                           # _timer_editable.
+                           "editable": self._timer_editable(server)}
         ep = self._epoch
         source = self.source
 
@@ -120,6 +124,27 @@ class LiveTvDialogsMixin:
 
         self.run_async(work, done, ep, on_error=failed)
         self._show_timer_editor()     # open immediately, in a loading state
+
+    def _timer_editable(self, server):
+        """May this user change the DVR on ``server``?
+
+        The Schedule and Series tabs are shown to everyone who can see Live
+        TV -- what is going to record is information, and the server serves
+        it to anyone (see ``LiveTvPage._tabs``). Only *changing* it needs
+        ``EnableLiveTvManagement``, so without it this dialog opens as a
+        read-only look at the rule: the form is disabled and Save, Cancel
+        Recording and Cancel Series are not offered at all.
+
+        ``can_record`` is the same question the Record buttons ask -- both
+        halves of it apply here too, since cancelling a timer needs the
+        apiclient's Live TV APIs just as much as creating one does. It fails
+        open, so an unanswered probe leaves the dialog editable and the API
+        call remains the real check.
+        """
+        try:
+            return bool(self._actions.can_record(server))
+        except Exception:
+            return True
 
     @staticmethod
     def _timer_fields(dto, series):
@@ -158,11 +183,16 @@ class LiveTvDialogsMixin:
             elif timer is None:
                 body = [Text(_("Loading…"), size=15, color=theme.SUBTLE_FG)]
             else:
-                body = self._timer_form(timer, fields, dlg["series"])
+                body = self._timer_form(timer, fields, dlg["series"],
+                                        editable=dlg.get("editable", True))
             title = _("Series Options") if dlg["series"] else _("Recording")
             buttons = [Button(_("Close"), id="tm-close",
                               on_click=self._close_timer_editor)]
-            if timer is not None and not dlg.get("error"):
+            # Not offered rather than disabled: a greyed Save invites the
+            # question "why", and the answer is a permission the user cannot
+            # do anything about from here. Close alone is a complete dialog.
+            if (timer is not None and not dlg.get("error")
+                    and dlg.get("editable", True)):
                 buttons.insert(0, Button(
                     _("Cancel Series") if dlg["series"]
                     else _("Cancel Recording"), id="tm-cancel",
@@ -188,7 +218,12 @@ class LiveTvDialogsMixin:
         """
         return 260 if dlg.get("series") else 120
 
-    def _timer_form(self, timer, fields, series):
+    def _timer_form(self, timer, fields, series, editable=True):
+        """The form. ``editable=False`` is the read-only look a user
+        without `EnableLiveTvManagement` gets: the same rows, showing the
+        same settings, with nothing that invites an edit the server would
+        refuse. The subtitle and the values are the point of opening it.
+        """
         rows = []
         when = live_tv.air_time_label(timer)
         channel = timer.get("ChannelName") or ""
@@ -204,12 +239,13 @@ class LiveTvDialogsMixin:
                 _p("series recording rule setting", "Record"), "tm-showtype",
                 [_("New episodes only"), _("All episodes")],
                 0 if fields["new_only"] else 1,
-                lambda i, v: self._timer_set("new_only", i == 0)))
+                lambda i, v: self._timer_set("new_only", i == 0), editable))
             rows.append(Checkbox(
                 _("Skip episodes already in my library"),
                 fields["skip_in_library"], id="tm-skip",
                 on_toggle=lambda: self._timer_set(
-                    "skip_in_library", not fields["skip_in_library"])))
+                    "skip_in_library", not fields["skip_in_library"]),
+                disabled=not editable))
             one_channel = (_("Only %s") % channel if channel
                            else _("One channel"))
             rows.append(self._picker(
@@ -218,27 +254,28 @@ class LiveTvDialogsMixin:
                 "tm-channels",
                 [one_channel, _("All channels")],
                 1 if fields["any_channel"] else 0,
-                lambda i, v: self._timer_set("any_channel", i == 1)))
+                lambda i, v: self._timer_set("any_channel", i == 1), editable))
             start = live_tv.parse_time(timer.get("StartDate"))
             rows.append(self._picker(
                 _("Air time"), "tm-airtime",
                 [(_("Around %s") % live_tv.fmt_time(start)) if start
                  else _("Original air time"), _("Any time")],
                 1 if fields["any_time"] else 0,
-                lambda i, v: self._timer_set("any_time", i == 1)))
+                lambda i, v: self._timer_set("any_time", i == 1), editable))
             keep = fields["keep_up_to"]
             choices = _keep_choices(keep)
             rows.append(self._picker(
                 _("Keep up to"), "tm-keep",
                 [self._keep_label(n) for n in choices],
                 choices.index(keep) if keep in choices else 0,
-                lambda i, v, c=choices: self._timer_set("keep_up_to", c[i])))
+                lambda i, v, c=choices: self._timer_set("keep_up_to", c[i]),
+                editable))
         rows.append(self._padding_row(
             _("Start early (minutes)"), "tm-pre", fields["pre"],
-            lambda s: self._timer_set("pre", s)))
+            lambda s: self._timer_set("pre", s), editable))
         rows.append(self._padding_row(
             _("Stop late (minutes)"), "tm-post", fields["post"],
-            lambda s: self._timer_set("post", s)))
+            lambda s: self._timer_set("post", s), editable))
         return rows
 
     @staticmethod
@@ -250,19 +287,21 @@ class LiveTvDialogsMixin:
         return _("%d episodes") % count
 
     @staticmethod
-    def _picker(label, node_id, items, selected, on_select):
+    def _picker(label, node_id, items, selected, on_select, editable=True):
         return Row([Text(label, w=170, size=16, color=theme.SUBTLE_FG),
                     Dropdown(node_id, items, selected=selected, w=280,
-                             size=16, on_select=on_select)],
+                             size=16, on_select=on_select,
+                             disabled=not editable)],
                    gap=8, align="center")
 
     @staticmethod
-    def _padding_row(label, node_id, value, on_change):
+    def _padding_row(label, node_id, value, on_change, editable=True):
         # on_commit as well as on_submit: a padding typed and then dismissed
         # with a click on Save (rather than ENTER) must still be read.
         return Row([Text(label, w=170, size=16, color=theme.SUBTLE_FG),
                     TextBox(node_id, value, size=16, w=90,
-                            on_submit=on_change, on_commit=on_change)],
+                            on_submit=on_change, on_commit=on_change,
+                            disabled=not editable)],
                    gap=8, align="center")
 
     def _timer_save(self):

--- a/jellyfin_mpv_shim/mpvtk_browser/pages/grid.py
+++ b/jellyfin_mpv_shim/mpvtk_browser/pages/grid.py
@@ -417,7 +417,7 @@ class GridPage(Page):
         ], gap=10, align="center")
         bar = self._fit_bar(bar, self._view_controls(), width)
         cur_letter = filters.get("letter")
-        letters = Row([
+        cells = [
             # flex + align="center" centres the glyph horizontally; a bare
             # Text is packed at the box's left edge (Box only centres on its
             # cross axis), which left every letter hugging its left border.
@@ -436,7 +436,14 @@ class GridPage(Page):
                        else theme.BUTTON_BG},
                 on_click=lambda c=ch: self._set_filter(
                     "letter", None if cur_letter == c else c))
-            for ch in _LETTERS], gap=2, align="center")
+            for ch in _LETTERS]
+        # 27 cells at 28px is 754px of row, which is wider than the page
+        # itself once the UI scale is up -- a 1280px window at 200% is a
+        # 640px page. Wrapped rather than shrunk: the cell is already only
+        # 26px, and the point of an A-Z bar is that every letter is one
+        # click away, which a horizontal scroll would take back.
+        letters = chrome.wrap_row(cells, width - 2 * chrome.CONTENT_PAD,
+                                  gap=2, row_gap=4)
         return Column([bar, letters], gap=8)
 
     def _paged_grid(self, size, header, geom, image_type="Primary",

--- a/jellyfin_mpv_shim/mpvtk_browser/pages/livetv.py
+++ b/jellyfin_mpv_shim/mpvtk_browser/pages/livetv.py
@@ -47,10 +47,45 @@ class LiveTvPage(Page):
 
     DEFAULT_TAB = "programs"
 
+    #: The two tabs that are *about* scheduling rather than about watching.
+    #: Recordings is not one of them -- a finished recording is something you
+    #: watch, and `EnableLiveTvManagement` does not gate watching.
+    MANAGEMENT_TABS = ("schedule", "series")
+
     # -- load --------------------------------------------------------------
 
-    def load(self, epoch):
+    def _tabs(self):
+        """The tabs this user can actually use.
+
+        Scheduling is `EnableLiveTvManagement`, which is granted separately
+        from the access that put Live TV in the sidebar at all -- so a user
+        can browse the guide perfectly well and have every timer they try to
+        set answered with a 403.
+        """
+        if self._may_manage():
+            return self.TABS
+        return tuple(t for t in self.TABS if t[0] not in self.MANAGEMENT_TABS)
+
+    def _may_manage(self):
+        ask = getattr(self.ctx.source, "can_manage_live_tv", None)
+        if ask is None:
+            return True                 # fails open; see user_policy
+        try:
+            return bool(ask(self._srv()))
+        except Exception:
+            return True
+
+    def _current_tab(self):
+        """The tab to draw. A tab this user may not have -- carried in on a
+        route, or left behind by a permission change -- falls back to the
+        default rather than rendering a screen with no way out of it."""
         tab = self.route.get("_tab") or self.DEFAULT_TAB
+        if tab not in [key for key, _label in self._tabs()]:
+            return self.DEFAULT_TAB
+        return tab
+
+    def load(self, epoch):
+        tab = self._current_tab()
         getattr(self, "_load_" + tab, self._load_programs)(epoch)
 
     def _put(self, key="_data"):
@@ -190,7 +225,7 @@ class LiveTvPage(Page):
     # -- render ------------------------------------------------------------
 
     def render(self, size):
-        tab = self.route.get("_tab") or self.DEFAULT_TAB
+        tab = self._current_tab()
         body = getattr(self, "_render_" + tab, self._render_programs)
         return Column([self._tab_bar(tab), body(size)], flex=1,
                       align="stretch")
@@ -198,7 +233,7 @@ class LiveTvPage(Page):
     def _tab_bar(self, current):
         tabs = [controls.tab_btn(label, "lttab-" + key, key == current,
                                  lambda k=key: self._set_tab(k))
-                for key, label in self.TABS]
+                for key, label in self._tabs()]
         return Row(tabs, gap=8, pad=12, align="center")
 
     def _scroll(self, children, scroll_id, gap=16):
@@ -819,7 +854,7 @@ class ProgramPage(Page):
                 "pg-watch",
                 lambda: actions.play_list([channel], server, 0),
                 primary=live_tv.is_airing(item), size=18))
-        if not actions.can_record():
+        if not actions.can_record(server):
             return Row(btns, gap=10)
         if single:
             btns.append(controls.action_btn(

--- a/jellyfin_mpv_shim/mpvtk_browser/pages/livetv.py
+++ b/jellyfin_mpv_shim/mpvtk_browser/pages/livetv.py
@@ -47,38 +47,32 @@ class LiveTvPage(Page):
 
     DEFAULT_TAB = "programs"
 
-    #: The two tabs that are *about* scheduling rather than about watching.
-    #: Recordings is not one of them -- a finished recording is something you
-    #: watch, and `EnableLiveTvManagement` does not gate watching.
-    MANAGEMENT_TABS = ("schedule", "series")
-
     # -- load --------------------------------------------------------------
 
     def _tabs(self):
-        """The tabs this user can actually use.
+        """Every tab, to every user who can see Live TV at all.
 
-        Scheduling is `EnableLiveTvManagement`, which is granted separately
-        from the access that put Live TV in the sidebar at all -- so a user
-        can browse the guide perfectly well and have every timer they try to
-        set answered with a 403.
+        `EnableLiveTvManagement` gates *changing* the DVR, not reading it.
+        Schedule and Series used to be hidden without it, which took away
+        information the user is entitled to: what is going to record, and
+        which series rules exist, are things a household member wants to know
+        whether or not they are allowed to change them -- and the server
+        agrees, answering `/LiveTv/Timers` and `/LiveTv/SeriesTimers` with 200
+        for an account that has no management permission (measured against a
+        real server; the 403 is on the writes).
+
+        jellyfin-web draws the same conclusion: its `getTabs` consults no
+        policy at all and it gates the mutating context-menu entries instead
+        (`itemContextMenu.js` -- Cancel Recording, Cancel Series). Actions are
+        gated here too: the Record buttons via `can_record`, and the timer
+        editor opens read-only (see `livetv_dialogs`).
         """
-        if self._may_manage():
-            return self.TABS
-        return tuple(t for t in self.TABS if t[0] not in self.MANAGEMENT_TABS)
-
-    def _may_manage(self):
-        ask = getattr(self.ctx.source, "can_manage_live_tv", None)
-        if ask is None:
-            return True                 # fails open; see user_policy
-        try:
-            return bool(ask(self._srv()))
-        except Exception:
-            return True
+        return self.TABS
 
     def _current_tab(self):
-        """The tab to draw. A tab this user may not have -- carried in on a
-        route, or left behind by a permission change -- falls back to the
-        default rather than rendering a screen with no way out of it."""
+        """The tab to draw. An unknown tab carried in on a route falls back
+        to the default rather than rendering a screen with no way out of
+        it."""
         tab = self.route.get("_tab") or self.DEFAULT_TAB
         if tab not in [key for key, _label in self._tabs()]:
             return self.DEFAULT_TAB

--- a/jellyfin_mpv_shim/mpvtk_browser/pages/music.py
+++ b/jellyfin_mpv_shim/mpvtk_browser/pages/music.py
@@ -16,6 +16,13 @@ from ..tile_renderer import GRID_GAP
 from .base import Page
 
 
+#: The cover beside an album's or artist's header, and the gap after it.
+#: Here rather than at the two call sites because ``header_text`` has to
+#: subtract exactly what they draw -- see its ``indent``.
+HEADER_ART = 132
+HEADER_GAP = 16
+
+
 class MusicPage(Page):
     """Shared furniture for the music screens. Not a route on its own."""
 
@@ -48,13 +55,22 @@ class MusicPage(Page):
                 lambda: actions.instant_mix(seed_id, server)))
         return Row(btns, gap=8, align="center")
 
-    def header_text(self, item, tracks, width):
+    def header_text(self, item, tracks, width, indent=0):
         """Title / metadata / overview for an album or artist page.
 
         Both were a bare title: no cover, no year or genre, no Overview, and
         on the artist page no heading over the album grid either. Tk showed
         all of it, and on a music library it is most of what tells one entry
-        from another."""
+        from another.
+
+        ``width`` is the WINDOW's; ``indent`` is whatever sits to the left of
+        this column inside it -- the cover and the gap after it. Both pages
+        put the text beside a 132px cover, and passing the window width alone
+        wrapped the overview to the full page: every line then started 148px
+        in and ran that far off the right edge. Not a scale bug, though the
+        scale matrix is what found it -- it was doing this at 1x on any
+        window narrower than the overview is long.
+        """
         out = [Text(item.get("Name") or self.route.get("title", ""), size=28,
                     bold=True)]
         meta = [x for x in (detail_components.meta_line(item),
@@ -66,7 +82,8 @@ class MusicPage(Page):
         overview = (item.get("Overview") or "").strip()
         if overview:
             out.append(chrome.paragraph(
-                overview, 15, self.ctx.art.tiles.body_w(width)))
+                overview, 15,
+                max(120, self.ctx.art.tiles.body_w(width) - indent)))
         return out
 
 

--- a/jellyfin_mpv_shim/mpvtk_browser/pages/music_detail.py
+++ b/jellyfin_mpv_shim/mpvtk_browser/pages/music_detail.py
@@ -9,7 +9,7 @@ from ...mpvtk.widgets import Column, Row, Spacer, Text, VScroll
 from .. import pagination
 from ..components import chrome
 from ..tile_renderer import GRID_GAP
-from .music import MusicPage
+from .music import HEADER_ART, HEADER_GAP, MusicPage
 
 
 class AlbumPage(MusicPage):
@@ -38,8 +38,9 @@ class AlbumPage(MusicPage):
         server = route.get("server") or self.ctx.server
         ids = [t.get("Id") for t in tracks]
         header = Row([
-            art.tiles.art_cell(item, size=132),
-            Column(self.header_text(item, tracks, size[0]) + [
+            art.tiles.art_cell(item, size=HEADER_ART),
+            Column(self.header_text(item, tracks, size[0],
+                                    indent=HEADER_ART + HEADER_GAP) + [
                 self.action_bar(server, ids, route["item_id"], "album",
                                 items=tracks),
             ], gap=8, flex=1, align="stretch"),
@@ -104,8 +105,10 @@ class ArtistPage(MusicPage):
         ids = [s.get("Id") for s in songs]
         item = data.get("item") or {}
         rows: list = [Row([
-            art.tiles.art_cell(item, size=132) if item else Spacer(w=0),
-            Column(self.header_text(item, songs, size[0]) + [
+            art.tiles.art_cell(item, size=HEADER_ART) if item else Spacer(w=0),
+            Column(self.header_text(item, songs, size[0],
+                                    indent=(HEADER_ART if item else 0)
+                                    + HEADER_GAP) + [
                 self.action_bar(server, ids, route["item_id"], "art",
                                 items=songs),
             ], gap=8, flex=1, align="stretch"),

--- a/jellyfin_mpv_shim/mpvtk_browser/pages/playlist.py
+++ b/jellyfin_mpv_shim/mpvtk_browser/pages/playlist.py
@@ -86,8 +86,28 @@ class PlaylistPage(Page):
             # the PLAYLIST from that point — going through the tile's normal
             # open meant Play on the detail page queued the item's series
             # instead, silently abandoning the playlist the user was in.
+            # Shaped by its own artwork, like every other grid in the app
+            # (and like jellyfin-web's cardBuilder). This was the one that
+            # was not: a playlist can hold anything, and a playlist of
+            # episodes -- whose art is 16:9 stills -- was drawn in 2:3
+            # poster tiles, so the server was asked to fill-crop every
+            # still into a portrait frame and most of each picture went.
+            # A playlist of films still comes out as posters; that is the
+            # same rule reaching a different answer.
+            geom, image_type = art.tiles.auto_geom(items)
             body = art.tiles.grid_of(
-                items, "pl", size, scroll_id="playlist", head_h=70,
+                items, "pl", size, geom=geom, image_type=image_type,
+                # inherit=False, for the reason the season listing gives:
+                # this is a list of *entries*, and each cell has to be the
+                # thing you would be playing. The Thumb chain otherwise
+                # borrows the series' thumb or backdrop for an episode that
+                # has no still of its own, so a playlist built out of one
+                # show draws the same series artwork in every cell and stops
+                # distinguishing anything. Borrowing is right for a Continue
+                # Watching card, which is a pointer back to the show; a
+                # playlist entry is not one.
+                inherit=False,
+                scroll_id="playlist", head_h=70,
                 on_click=lambda it: actions.play_list(
                     ids, server, items.index(it), audio=False, items=items))
         return VScroll(Column([header, Spacer(h=2)] + body,

--- a/jellyfin_mpv_shim/mpvtk_browser/pages/queue_edit.py
+++ b/jellyfin_mpv_shim/mpvtk_browser/pages/queue_edit.py
@@ -200,7 +200,7 @@ class QueuePage(SelectionPage):
         current = data.get("current_id")
         sel = self.selection()
         n = len(entries)
-        toolbar = Row([
+        toolbar = chrome.wrap_row([
             Text(_("Play Queue"), size=26, bold=True), Spacer(),
             Button(_("Top"), id="q-top", icon="vertical_align_top",
                    on_click=lambda: self._move("top")),
@@ -220,7 +220,7 @@ class QueuePage(SelectionPage):
                    on_click=lambda: self._to_playlist()),
             Button(_("Remove"), id="q-remove", icon="delete",
                    on_click=lambda: self._remove_selected()),
-        ], gap=8, align="center")
+        ], size[0] - 2 * chrome.CONTENT_PAD, gap=8)
         rows = [toolbar, Spacer(h=2)]
         if not entries:
             rows.append(Text(_("The queue is empty."), size=18,
@@ -343,7 +343,7 @@ class PlaylistEditPage(SelectionPage):
             return chrome.busy()
         sel = self.selection()
         n = len(items)
-        toolbar = Row([
+        toolbar = chrome.wrap_row([
             Button(_("Top"), id="pe-top", icon="vertical_align_top",
                    on_click=lambda: self._move("top")),
             Button(_("Up"), id="pe-up", icon="keyboard_arrow_up",
@@ -361,7 +361,7 @@ class PlaylistEditPage(SelectionPage):
                    on_click=lambda: self.set_selection(set())),
             Button(_("Remove"), id="pe-remove", icon="delete",
                    on_click=lambda: self._remove()),
-        ], gap=8, align="center")
+        ], size[0] - 2 * chrome.CONTENT_PAD, gap=8)
         rename_row = Row([
             TextBox("pe-name", text=route.get("title", ""), w=280,
                     on_change=lambda v: route.__setitem__("_newname", v),

--- a/jellyfin_mpv_shim/mpvtk_browser/repository.py
+++ b/jellyfin_mpv_shim/mpvtk_browser/repository.py
@@ -52,6 +52,14 @@ log = logging.getLogger("mpvtk_browser.repository")
 # why doing so was invisible; a stricter server would 400 the whole query.
 LIST_FIELDS = "PrimaryImageAspectRatio,Overview"
 
+#: An item's own artwork counts as landscape at or above this, which is what
+#: lets `backdrop_spec` use a home video's extracted still for its header and
+#: refuse a film's poster. Square is the boundary: anything taller is key art
+#: and a banner crop through the middle of it is worse than no banner at all.
+#: Same threshold as TileRenderer.SQUARE_RATIO, kept here because the source
+#: cannot import the renderer.
+_LANDSCAPE_ART = 0.8
+
 # Fields for a library GRID, which is the one place a hundred items arrive at
 # once. Overview is a third of that response body (154KB -> 108KB for a
 # hundred series here) and a tile draws a name, a year and a runtime -- none
@@ -2232,24 +2240,60 @@ class LibrarySource:
 
     @staticmethod
     def backdrop_spec(item):
-        """(owner_item_id, tag) identifying which backdrop image backdrop_url
-        would serve — the cache key must carry the real tag, or the same item
-        cached from another source/an older backdrop is served forever."""
+        """``(owner_item_id, image_type, tag)`` for the header banner, or
+        None when this item has nothing wide enough to draw one from.
+
+        The tag is part of the cache key, so it has to be the real one or the
+        same item cached from another source — or against an older backdrop —
+        is served forever. The *type* is in there too because the chain no
+        longer ends at Backdrop.
+
+        **The landscape fallbacks matter for video that is not a film.** A
+        home video, a clip, a recording — anything scanned out of a folder
+        rather than matched against a metadata provider — has no backdrop and
+        never will, and the header was a blank grey box for it. What it does
+        have is the still the server extracted, which is a frame of the thing
+        itself and exactly what belongs across the top of its page.
+
+        **A poster is not a fallback.** The banner is ~2.67:1; a 2:3 poster
+        cropped into it is a horizontal strip through the middle of the key
+        art, which is worse than the placeholder because it looks like a
+        rendering fault rather than like missing artwork. So the Primary step
+        is taken only when the item's own aspect ratio says it is landscape
+        (``_LANDSCAPE_ART``), which is what tells a home video's extracted
+        frame apart from a film's poster. Where that leaves nothing, the
+        caller still draws its heading as text — see ``backdrop_node``.
+        """
         tags = item.get("BackdropImageTags") or []
         if tags:
-            return item["Id"], tags[0]
+            return item["Id"], "Backdrop", tags[0]
         parent_tags = item.get("ParentBackdropImageTags") or []
         if parent_tags and item.get("ParentBackdropItemId"):
-            return item["ParentBackdropItemId"], parent_tags[0]
+            return item["ParentBackdropItemId"], "Backdrop", parent_tags[0]
+        image_tags = item.get("ImageTags") or {}
+        if image_tags.get("Thumb"):
+            return item["Id"], "Thumb", image_tags["Thumb"]
+        if item.get("ParentThumbImageTag") and item.get("ParentThumbItemId"):
+            return (item["ParentThumbItemId"], "Thumb",
+                    item["ParentThumbImageTag"])
+        ratio = item.get("PrimaryImageAspectRatio")
+        if (image_tags.get("Primary")
+                and isinstance(ratio, (int, float))
+                and ratio >= _LANDSCAPE_ART):
+            return item["Id"], "Primary", image_tags["Primary"]
         return None
 
     def backdrop_url(self, server_uuid, item, width=1280, height=None, fill=False):
         spec = self.backdrop_spec(item)
         if spec is None:
             return None
-        owner_id, tag = spec
-        return self.image_url(server_uuid, owner_id, "Backdrop", tag,
-                              width, height=height, fill=fill, index=0)
+        owner_id, image_type, tag = spec
+        # index=0 for a Backdrop only: backdrops are a numbered set and the
+        # indexed form is what matches the tag cached above, while a Thumb or
+        # a Primary is a single image and has no index at all.
+        return self.image_url(server_uuid, owner_id, image_type, tag,
+                              width, height=height, fill=fill,
+                              index=0 if image_type == "Backdrop" else None)
 
 
 class _OfflineSnapshot:
@@ -2922,8 +2966,13 @@ class OfflineLibrarySource:
     def backdrop_spec(item):
         """Cache-key spec matching LibrarySource.backdrop_spec. The "offline"
         sentinel keeps offline header art keyed apart from the online tags, so
-        source switches can't serve each other's cached bitmaps."""
-        return item.get("Id"), "offline"
+        source switches can't serve each other's cached bitmaps.
+
+        Three-tuple like the online one, and the middle element is the
+        sentinel rather than a type: a downloaded item has exactly one header
+        image on disk whatever it was online, so there is no chain here to
+        name a step of."""
+        return item.get("Id"), "offline", "offline"
 
     def backdrop_url(self, server_uuid, item, width=1280, height=None, fill=False):
         return self._art_path(item.get("Id"), "Backdrop")

--- a/jellyfin_mpv_shim/mpvtk_browser/repository.py
+++ b/jellyfin_mpv_shim/mpvtk_browser/repository.py
@@ -417,6 +417,31 @@ class LibrarySource:
         return (getattr(self, "_has_live_tv", None) or {}).get(
             server_uuid, False)
 
+    # -- what this user is allowed to do (see user_policy.py) --------------
+    #
+    # Thin, and deliberately so: the answer is cached on the client object,
+    # not here, because the player side reaches the same clients through
+    # clientManager and both have to get the same answer. These exist so the
+    # browser never has to reach for a client itself.
+
+    def syncplay_access(self, server_uuid):
+        from ..user_policy import syncplay_access
+
+        try:
+            return syncplay_access(self._conn(server_uuid).client)
+        except Exception:
+            from ..user_policy import CREATE_AND_JOIN
+
+            return CREATE_AND_JOIN      # fails open; see user_policy
+
+    def can_manage_live_tv(self, server_uuid):
+        from ..user_policy import may_manage_live_tv
+
+        try:
+            return may_manage_live_tv(self._conn(server_uuid).client)
+        except Exception:
+            return True                 # fails open; see user_policy
+
     # -- home screen layout (shared with jellyfin-web) ---------------------
 
     def _display_prefs_dto(self, api):
@@ -2524,6 +2549,16 @@ class OfflineLibrarySource:
         online one falls back TO, so a missing method here turns a degraded
         screen into an AttributeError on the fallback path.
         """
+        return False
+
+    def syncplay_access(self, server_uuid):
+        """Nobody to sync with, and no server to ask. Declared for the same
+        reason has_live_tv is."""
+        from ..user_policy import NO_SYNCPLAY
+
+        return NO_SYNCPLAY
+
+    def can_manage_live_tv(self, server_uuid):
         return False
 
     def get_genres(self, server_uuid, parent_id=None):

--- a/jellyfin_mpv_shim/mpvtk_browser/scroll_state.py
+++ b/jellyfin_mpv_shim/mpvtk_browser/scroll_state.py
@@ -27,6 +27,13 @@ Three pieces of state, and each exists for a different failure:
     comparing adjacent events lets a slow scroll drift a whole window without
     ever crossing the gap — and the virtualized rows fall out of the built
     window as blank spacers until some larger coalesced jump finally trips it.
+
+``_pending``
+    The offsets **this frame's scene is about to command** — the route's
+    parked offsets, which the pages pass as ``Scroll(offset=…)``. For a
+    container the renderer has not heard of yet, this outranks its silence:
+    the scene is telling it where to go, so that is where it will be by the
+    time anything is drawn.
 """
 
 
@@ -50,18 +57,24 @@ class ScrollState:
         self._recorded = {}
         self._rendered = {}
         self._live = None
+        self._pending = {}
 
     # -- per-frame ---------------------------------------------------------
 
-    def refresh(self, app):
+    def refresh(self, app, route=None):
         """Take the renderer's live offsets. Call once at the top of
         ``build()``.
 
         Cleared first, so a failed read degrades to the recorded fallback
         rather than silently reusing last frame's numbers against this
         frame's content.
+
+        ``route`` is the route about to be built, and it is read for one
+        thing: the offsets parked on it, which its page is about to pass as
+        ``Scroll(offset=…)``. See ``offset``.
         """
         self._live = None
+        self._pending = (route or {}).get(self.PARK_KEY) or {}
         if app is None or not hasattr(app, "scroll_offsets"):
             return
         try:
@@ -72,20 +85,38 @@ class ScrollState:
     def offset(self, scroll_id):
         """Where ``scroll_id`` is scrolled to, in logical pixels.
 
-        When the renderer answered at all, it is the only authority — an id
-        it does not list is at the top, not "unknown, use my copy". The
-        renderer drops the state of containers that left the scene, so
-        letting ``_recorded`` fill that gap re-armed an offset the container
-        no longer has: tick Paginated on a scrolled grid and untick it, or
-        change a sort (which drops to the busy screen and takes the scroll
-        container with it), and the returning grid was virtualized around
-        the old offset while the real one sat at 0 — a screenful of blank
-        spacers with no tiles in it.
+        Where the renderer has an answer, it is the only authority — its
+        copy is the one clamped to the current content. What it does *not*
+        answer for is a container that has only just entered the scene, and
+        there are two of those, which want opposite things:
+
+        * The container really is at the top. Tick Paginated on a scrolled
+          grid and untick it, or change a sort (which drops to the busy
+          screen and takes the scroll container with it): the renderer built
+          a fresh container at 0. Letting ``_recorded`` fill that gap re-armed
+          an offset the container no longer has, and windowed the returning
+          grid around it — a screenful of blank spacers with no tiles in it.
+          So ``_recorded`` is a whole-snapshot fallback for mpv < 0.36 and
+          never a per-id one.
+        * The container is being *restored*. Press Back onto a library you
+          had scrolled to the end of: the scene we are building carries
+          ``off0`` for exactly that, and the renderer applies it before it
+          draws anything. Windowing that frame from its silence built the
+          top of the list and then jumped to the bottom, so the screen came
+          back empty and stayed empty until a scroll rebuilt it.
+
+        ``_pending`` is what tells them apart, and it is not a memory of
+        where the container *was*: it is where this frame's scene is about to
+        *put* it. A container the user has since scrolled has a live entry,
+        which still wins — including when that entry is 0.
         """
         live = self._live
         if live is not None:
-            return float(live.get(scroll_id) or 0.0)
-        return float(self._recorded.get(scroll_id, 0.0))
+            if scroll_id in live:
+                return float(live[scroll_id] or 0.0)
+        elif scroll_id in self._recorded:
+            return float(self._recorded[scroll_id])
+        return float(self._pending.get(scroll_id) or 0.0)
 
     # -- events ------------------------------------------------------------
 

--- a/jellyfin_mpv_shim/mpvtk_browser/settings/__init__.py
+++ b/jellyfin_mpv_shim/mpvtk_browser/settings/__init__.py
@@ -27,7 +27,7 @@ from ...mpvtk.widgets import (
     Row,
 )
 from .. import theme
-from ..components import controls
+from ..components import chrome, controls
 
 from .base import SettingsBase
 from .display import DisplayTabMixin
@@ -97,7 +97,10 @@ class SettingsMixin(
                 lambda t=t: self._set_settings_tab(route, t),
                 style=tab_style)
 
-        tabs = Row([tab_button(t) for t in self.SETTINGS_TABS], gap=8)
+        # Wrapped: six translated labels do not fit a narrow page, and
+        # "Logs" -- the last one -- was drawn off the right edge at 200%.
+        tabs = chrome.wrap_row([tab_button(t) for t in self.SETTINGS_TABS],
+                               (size[0] if size else 0) - 2 * 12, gap=8)
         body = {
             "home": self._settings_home,
             "display": self._settings_display,

--- a/jellyfin_mpv_shim/mpvtk_browser/strips.py
+++ b/jellyfin_mpv_shim/mpvtk_browser/strips.py
@@ -166,8 +166,9 @@ WIDE_GEOM = LANDSCAPE_GEOM  # backwards-compatible alias
 class Tile:
     """One tile's data. ``key`` is the stable identity (usually the
     Jellyfin item id) — it becomes the hit-region id and part of the
-    cache key. ``poster`` is a decoded PIL image (any size; centered and
-    letterboxed into the tile) or None for a placeholder. ``poster_tag``
+    cache key. ``poster`` is a decoded PIL image (any size; cover-cropped to
+    fill the tile, unless ``contain`` or ``logo_plate`` says this artwork is a
+    mark rather than a photograph) or None for a placeholder. ``poster_tag``
     identifies the poster's content for cache keying ("" when absent, so
     the strip recomposites when the real poster lands). ``glyph`` is the
     placeholder character drawn when there's no poster (initial / ♪)."""
@@ -568,10 +569,13 @@ class StripStore:
     def _paint_poster(self, img, dr, x, t, g):
         from PIL import Image as PILImage, ImageDraw, ImageOps
 
-        # The card look is theme-driven: a "rounded" theme draws
-        # jellyfin-web-style rounded corners and cover-crops the art; the
-        # stock look is a square opaque card with the poster letterboxed into
-        # it, so an untouched install renders exactly as before.
+        # The card's SHAPE is theme-driven -- a "rounded" theme draws
+        # jellyfin-web-style rounded corners, the stock look is a square
+        # opaque card. What the artwork does inside that shape is not: every
+        # theme cover-crops, as jellyfin-web does in all of its. The two used
+        # to be one flag, which left no way to say "square cards, cropped
+        # art" and made a letterboxed tile look like a theme choice rather
+        # than the accident it was.
         rounded = bool((theme.active() or {}).get("rounded"))
         r = _px(14)
         box = [x, 0, x + g.tile_w - 1, g.tile_h - 1]
@@ -619,17 +623,21 @@ class StripStore:
             # `plate` is the PICTURE's: anything on a transparent background
             # is a mark rather than a photograph, which covers the channel
             # logos nothing declares a type for. Either is enough.
-            if rounded and plate is None and not t.contain:
+            if plate is None and not t.contain:
                 if poster.size != (g.tile_w, g.tile_h):
                     # Cover-crop, like CSS object-fit: cover — scale to FILL
                     # the tile and crop the overflow, so odd-aspect art fills
                     # the frame edge to edge instead of letterboxing.
                     poster = ImageOps.fit(poster, (g.tile_w, g.tile_h),
                                           lanczos, centering=(0.5, 0.5))
-                # Clip the art to the same rounded rect so its corners match.
-                mask = PILImage.new("L", (g.tile_w, g.tile_h), 0)
-                ImageDraw.Draw(mask).rounded_rectangle(
-                    [0, 0, g.tile_w - 1, g.tile_h - 1], radius=r, fill=255)
+                mask = None
+                if rounded:
+                    # Clip the art to the same rounded rect so its corners
+                    # match. A square card needs no clip: the art is now
+                    # exactly the card, edge to edge.
+                    mask = PILImage.new("L", (g.tile_w, g.tile_h), 0)
+                    ImageDraw.Draw(mask).rounded_rectangle(
+                        [0, 0, g.tile_w - 1, g.tile_h - 1], radius=r, fill=255)
                 if poster.mode == "RGBA":
                     # paste() takes ONE mask, so the art's own transparency has
                     # to be folded into the corner clip — passing the rounded
@@ -637,7 +645,9 @@ class StripStore:
                     # put the black back.
                     from PIL import ImageChops
 
-                    mask = ImageChops.multiply(mask, poster.getchannel("A"))
+                    alpha = poster.getchannel("A")
+                    mask = (alpha if mask is None
+                            else ImageChops.multiply(mask, alpha))
                 img.paste(poster, (x, 0), mask)
             else:
                 if poster.size != (g.tile_w, g.tile_h):

--- a/jellyfin_mpv_shim/mpvtk_browser/themes.py
+++ b/jellyfin_mpv_shim/mpvtk_browser/themes.py
@@ -63,7 +63,10 @@ DEFAULT = {
     },
     "browse_bg": "#141414",
     "glow": False,       # blurred accent halo behind titles + on card selection
-    "rounded": False,    # rounded cover cards + cover-crop (False = stock square/letterbox)
+    # Rounded jellyfin-web-style cards (False = stock square cards). Card
+    # SHAPE only: cover-cropping the artwork is unconditional, so this no
+    # longer decides whether a tile letterboxes. See strips._paint_poster.
+    "rounded": False,
     "accent_buttons": False,  # accent-bordered top-bar buttons
     # Where a carousel's page buttons live. "header" is jellyfin-web's design
     # and the default: a flat pair in the section heading, clear of the

--- a/jellyfin_mpv_shim/mpvtk_browser/tile_renderer.py
+++ b/jellyfin_mpv_shim/mpvtk_browser/tile_renderer.py
@@ -726,11 +726,11 @@ class TileRenderer:
         if self.art.server is not None:
             spec = self.art.source.backdrop_spec(item)
         if spec:
-            owner_id, tag = spec
+            owner_id, itype, tag = spec
             # box is logical (it came off the surface width); the bitmap and
             # everything baked into it are physical.
             pbox = raster(*box)
-            key = make_key(owner_id, "Backdrop", tag, pbox[0], pbox[1])
+            key = make_key(owner_id, itype, tag, pbox[0], pbox[1])
             if title:
                 key += "|" + make_key(title, meta or "", context or "",
                                       pbox[0], pbox[1])
@@ -749,7 +749,7 @@ class TileRenderer:
             # ~1.8x, in the commit whose point was making banners cheaper.
             fetch_w = self._banner_fetch_w(pbox[0])
             fetch_h = max(1, int(fetch_w * self.BANNER_RATIO))
-            fetch_key = make_key(owner_id, "Backdrop", tag, fetch_w, fetch_h)
+            fetch_key = make_key(owner_id, itype, tag, fetch_w, fetch_h)
             url = self.art.source.backdrop_url(self.art.server, item,
                                                width=fetch_w, height=fetch_h,
                                                fill=True)

--- a/jellyfin_mpv_shim/mpvtk_browser/tile_renderer.py
+++ b/jellyfin_mpv_shim/mpvtk_browser/tile_renderer.py
@@ -476,19 +476,66 @@ class TileRenderer:
             attempts,
             time.time() + self.IMG_RETRY_BACKOFF * (2 ** (attempts - 1)))
         self._requested.discard(key)
-    #: Artwork that must be shown WHOLE, by the type it resolved to and the
-    #: type that was asked for. Everything else is cover-cropped: a poster, a
-    #: still and a backdrop are all photographs of a frame, and a crop takes
-    #: scenery off the edges. A wordmark loses the name.
-    #:
-    #: A Logo never covers -- it is a wordmark on transparency and there is no
-    #: frame it was cut for. A Banner covers only its own strip: standing in
-    #: for a missing logo on a 16:9 card, cropping it to that card would trim
-    #: exactly the title it was borrowed for.
+    @classmethod
+    def _contains(cls, resolved, geom, item=None):
+        """Whether this artwork must be drawn WHOLE rather than filling the
+        tile. **Contain is the default; one pairing covers.**
+
+        The one is a POSTER GOING INTO A POSTER TILE. There, cropping is
+        free -- a few percent off the edge of a 2:3 key art loses nothing and
+        the grid comes out perfectly uniform, which is most of what a wall of
+        posters is for -- and it is the case where the two are close enough
+        that a contain would only add thin bars.
+
+        Everywhere else the tile and the artwork can disagree by a lot, and a
+        crop is destructive in proportion to the disagreement:
+
+        * A **Home Videos** library is arbitrary footage. 4:3, phone video
+          shot in portrait, and 16:9 all sit in one grid, so whatever shape
+          the row takes, most of what goes in it is the wrong shape for it.
+        * A **film in a playlist of episodes**. ``auto_geom`` shapes a row
+          from the MEDIAN aspect ratio, which is the right call for the row
+          and necessarily the wrong one for its minority: the row comes out
+          landscape and the one 2:3 poster in it gets its top and bottom
+          taken off.
+        * A **Logo** is a wordmark on transparency, with no frame it was cut
+          for; a **Banner** standing in for one would be cropped to exactly
+          the title it was borrowed for. Both used to be named here as
+          exceptions and are now simply covered by the default.
+
+        The per-row shape decision cannot fix any of that, because the
+        mismatch is per ITEM. This is the half that can.
+
+        Note this is nearly free where it changes nothing: when the artwork
+        and the tile already agree, contain and cover produce the same
+        picture. It only diverges where cover was destroying something.
+        """
+        if geom is None:
+            return True                      # unknown shape: the safe answer
+        if resolved != "Primary":
+            return True                      # Thumb, Backdrop, Logo, Banner…
+        if not cls._poster_shaped(geom.tile_w / float(geom.tile_h or 1)):
+            return True
+        return not cls._poster_shaped(cls._item_ratio(item))
+
+    @classmethod
+    def _poster_shaped(cls, ratio):
+        """Taller than square, or unmeasurable.
+
+        Unmeasurable counts as a poster ON PURPOSE, and only ever reaches
+        here about artwork already going into a poster tile: most library
+        items carry no ``PrimaryImageAspectRatio`` at all, and treating that
+        as "not a poster" would letterbox every ordinary film grid on the
+        strength of a missing field.
+        """
+        return ratio is None or ratio <= cls.SQUARE_RATIO
+
     @staticmethod
-    def _contains(resolved, requested):
-        return resolved == "Logo" or (resolved == "Banner"
-                                      and requested != "Banner")
+    def _item_ratio(item):
+        ratio = (item or {}).get("PrimaryImageAspectRatio")
+        if isinstance(ratio, (int, float)) and ratio > 0:
+            return float(ratio)
+        return None
 
     def poster_for(self, item, geom, image_type="Primary", inherit=True):
         """Return (PIL image or None, cache tag, contain). Requests the
@@ -512,14 +559,18 @@ class TileRenderer:
             # art is indexed, so it isn't addressable through image_spec.
             spec, url = item.get("_image_spec"), item.get("_image_url")
             if not spec or not url:
-                return None, "", False
+                return None, "", True
             key = make_key(spec[0], spec[1], spec[2], w, h)
-            return self._request_image(key, url, (w, h)), key, False
+            # Contained, like everything that is not a poster. The chapter
+            # tile is shaped from the video's own aspect, but only from two
+            # choices -- a 4:3 source lands in the 16:9 tile, and a crop
+            # there takes the sides off a frame of the film.
+            return self._request_image(key, url, (w, h)), key, True
         spec = self.art.source.image_spec(item, image_type, w, inherit=inherit)
         if not spec or self.art.server is None:
-            return None, "", False
+            return None, "", True
         item_id, itype, itag = spec
-        contain = self._contains(itype, image_type)
+        contain = self._contains(itype, geom, item)
         # In the key as well as in the request: fill and fit are two different
         # pictures of one source at one size, and the store caches them to
         # disk.

--- a/jellyfin_mpv_shim/mpvtk_browser/tiles.py
+++ b/jellyfin_mpv_shim/mpvtk_browser/tiles.py
@@ -187,7 +187,8 @@ class TilesMixin:
             return out
         if item.get("ChannelId"):
             out.append((_("Watch Channel"), "play_arrow", "play"))
-        if not self._actions.can_record():
+        if not self._actions.can_record(self.route.get("server")
+                                       or self.server):
             return out
         # single_timer_state, not timer_state: the two answer different
         # questions and a showing covered by a series rule answers yes to

--- a/jellyfin_mpv_shim/mpvtk_browser/window_chrome.py
+++ b/jellyfin_mpv_shim/mpvtk_browser/window_chrome.py
@@ -62,6 +62,28 @@ def toast_node(b, w, h):
         x=(w - tw) / 2, y=max(20, h - 140), w=tw)
 
 
+def _may_syncplay(b):
+    """Whether to offer this user SyncPlay at all, on the current server.
+
+    Fails open in every direction — a source without the method (the
+    offline one declares it, but a test double may not), no server yet, or
+    an error asking — because the cost of being wrong that way is the
+    button being there, which is where it was before.
+    """
+    from ..user_policy import NO_SYNCPLAY
+
+    source, server = getattr(b, "source", None), getattr(b, "server", None)
+    if source is None or server is None:
+        return True
+    ask = getattr(source, "syncplay_access", None)
+    if ask is None:
+        return True
+    try:
+        return ask(server) != NO_SYNCPLAY
+    except Exception:
+        return True
+
+
 def chrome(b, w):
     # Fit probe instead of a hardcoded breakpoint: the bar goes
     # icon-only exactly when the labelled version wouldn't leave
@@ -186,11 +208,16 @@ def chrome_bar(b, compact, probe=False, servers=None,
                tip=_("Search"),
                on_click=lambda: b._search(
                    b._search_box.get("term", "")), **accent_style),
-        nav_button(_("SyncPlay"), "nav-syncplay", "groups",
-                   b._open_syncplay),
         nav_button(_("Settings"), "nav-settings", "settings",
                    b._open_settings),
     ]
+    # A user whose SyncPlayAccess is None gets a dialog that can only fail,
+    # and "Could not join the SyncPlay group." is indistinguishable from a
+    # network problem. Inserted rather than appended so the order is
+    # unchanged for everyone who does have it.
+    if _may_syncplay(b):
+        right.insert(-1, nav_button(_("SyncPlay"), "nav-syncplay", "groups",
+                                    b._open_syncplay))
     middle = [Spacer(w=6), Text(title, size=22, bold=True), Spacer()]
     bar = Row(
         left + middle + right,

--- a/jellyfin_mpv_shim/osc_bridge.py
+++ b/jellyfin_mpv_shim/osc_bridge.py
@@ -256,6 +256,12 @@ class OscBridge:
         syncplay = self.playerManager.syncplay
         if syncplay is None:
             return None
+        # None here is what removes the HUD's SyncPlay button entirely (see
+        # hud.py: `if syncplay is not None`), which is the right shape for a
+        # user whose SyncPlayAccess is None -- the dialog behind it can only
+        # fail, with a message indistinguishable from a network problem.
+        if not self._may_syncplay():
+            return None
         enabled = syncplay.is_enabled()
         groups = []
         for group in self._syncplay_groups:
@@ -269,6 +275,27 @@ class OscBridge:
             "current": _("SyncPlay Enabled") if enabled else _("None (Disabled)"),
             "groups": groups,
         }
+
+    def _may_syncplay(self):
+        """Whether the current server grants this user SyncPlay.
+
+        Asked of the *player's* client rather than the browser's source: the
+        HUD and the OSD menu are up while something is playing, and what is
+        playing decides which server the question is about. Fails open --
+        see user_policy.
+        """
+        from .user_policy import may_use_syncplay
+
+        try:
+            client = self.playerManager.get_current_client()
+        except Exception:
+            return True
+        if client is None:
+            return True
+        try:
+            return may_use_syncplay(client)
+        except Exception:
+            return True
 
     # ----------------------------------------------------------- actions
 

--- a/jellyfin_mpv_shim/player.py
+++ b/jellyfin_mpv_shim/player.py
@@ -2278,10 +2278,22 @@ class PlayerManager(AudioMixin, ReportingMixin, WindowMixin):
             # showing the ended video paused.
             self.should_send_timeline = False
             self._video = None
-            try:
-                self._player.command("stop")
-            except _mpv_errors:
-                self._handle_mpv_disconnect()
+            # _mpv_alive first, and not merely the try/except. Closing the
+            # window makes mpv end the file AND shut down, so this callback
+            # (queued by end-file) runs on the action thread while
+            # _on_shutdown_event's terminate thread is inside
+            # player.terminate(). On the external backend the command is a
+            # socket write and the race surfaces as BrokenPipeError, which
+            # _mpv_errors catches; on in-process libmpv the handle has been
+            # freed underneath us and the command is a use-after-free, which
+            # is a SIGSEGV no except clause can see. _terminate_mpv clears
+            # this flag before it calls terminate(), so checking it is what
+            # closes the window. Found by tests/e2e/test_mpv_reopen.
+            if self._mpv_alive:
+                try:
+                    self._player.command("stop")
+                except _mpv_errors:
+                    self._handle_mpv_disconnect()
             # Before releasing the stream, not after: this is the browser's
             # cue to come back, and the release is a blocking round trip that
             # the library screen has no reason to wait behind.

--- a/jellyfin_mpv_shim/player.py
+++ b/jellyfin_mpv_shim/player.py
@@ -1856,7 +1856,12 @@ class PlayerManager(AudioMixin, ReportingMixin, WindowMixin):
         # A start that got this far succeeded; nothing is left to retry.
         self._failed_playback = None
         self._video = video
-        if getattr(video, "is_photo", False) and pause_stills and is_initial_play:
+        # Carried down to the set_paused() below, which is unconditional and
+        # would otherwise undo this a few dozen lines later.
+        hold_still = bool(
+            getattr(video, "is_photo", False) and pause_stills
+            and is_initial_play)
+        if hold_still:
             # A photo is a video that happens to be still: mpv holds it for
             # --image-display-duration and then advances, which is a
             # slideshow nobody asked for when they opened one picture. Paused
@@ -1928,7 +1933,13 @@ class PlayerManager(AudioMixin, ReportingMixin, WindowMixin):
             self.set_speed(1)
             self.syncplay.play_done()
         else:
-            self.set_paused(False, False)
+            # `hold_still`, not False: a photo opened on its own was paused
+            # above and this call undid it, so the picture the user asked to
+            # look at started a slideshow instead. The unpause predates the
+            # photo branch by five years, which is why it reads as unrelated.
+            # Still routed through set_paused rather than left to the earlier
+            # assignment, because this is also what pushes the playstate.
+            self.set_paused(hold_still, False)
 
         # Trickplay (scrubbing thumbnails) is video-only — skip the fetch for
         # audio so switching songs isn't slowed by a pointless request.

--- a/jellyfin_mpv_shim/user_policy.py
+++ b/jellyfin_mpv_shim/user_policy.py
@@ -1,0 +1,103 @@
+"""What this user is allowed to do on this server.
+
+Jellyfin grants SyncPlay and Live TV *recording* independently of everything
+else, and the shim offered both to everyone. A user who lacks them does not
+conclude they lack permission when the button fails — they conclude the
+client is broken, and they are half right. See ``docs/PERMISSION_GAPS.md``.
+
+Two things make this its own module rather than a method somewhere:
+
+**It is per client, not per app.** The answer differs between two servers
+signed in at once, and every consumer already has a client or a server uuid
+in hand — the browser's ``LibrarySource`` connections, the player's
+``clientManager`` ones. Caching on the client object means both reach the
+same answer without either owning it.
+
+**It fails open.** A policy that could not be fetched must not hide features
+that work: the current behaviour is to offer everything, and a transient
+error is not a reason to take a working button away. Only an answer the
+server actually gave can close a gate. This mirrors ``ItemActions.can_edit``
+and ``can_record``, which take the same line about capability probes and for
+the same reason.
+
+The fetch is ``GET /Users/Me``: the policy also arrives on the login
+response, but credentials are restored from ``cred.json`` on every run after
+the first, so there is no login response to read most of the time. One
+request per server per session, taken lazily and cached, so a user who never
+opens Live TV never pays for it.
+"""
+
+import logging
+
+log = logging.getLogger(__name__)
+
+#: Where the answer is parked on a client object. A private attribute on
+#: someone else's class, which is the price of not making every caller own a
+#: cache; the name is distinctive enough not to collide.
+_CACHE_ATTR = "_jms_user_policy"
+
+#: SyncPlayAccess is three-valued, not a boolean. `JoinGroups` may join an
+#: existing group but not create one, so a client that treats this as
+#: on/off either hides a feature that works or offers one that 403s.
+CREATE_AND_JOIN = "CreateAndJoinGroups"
+JOIN_ONLY = "JoinGroups"
+NO_SYNCPLAY = "None"
+
+
+def policy_for(client, refresh=False):
+    """This client's `UserPolicy`, cached on the client. ``{}`` if unknown.
+
+    An empty dict is the fail-open answer: every accessor below reads it as
+    "permitted", because that is what the app did before any of this existed.
+    """
+    if client is None:
+        return {}
+    if not refresh:
+        cached = getattr(client, _CACHE_ATTR, None)
+        if cached is not None:
+            return cached
+    policy = {}
+    try:
+        user = client.jellyfin.get_user() or {}
+        policy = user.get("Policy") or {}
+    except Exception:
+        # Not an error worth a user-facing message: the consequence is that
+        # a button stays visible, which is the status quo.
+        log.debug("could not read the user policy", exc_info=True)
+        return {}
+    try:
+        setattr(client, _CACHE_ATTR, policy)
+    except Exception:
+        pass
+    return policy
+
+
+def syncplay_access(client):
+    """``CreateAndJoinGroups`` / ``JoinGroups`` / ``None``.
+
+    Absent from the policy means an older server that has no such setting,
+    which is the fail-open case and must read as full access.
+    """
+    return (policy_for(client) or {}).get("SyncPlayAccess") or CREATE_AND_JOIN
+
+
+def may_use_syncplay(client):
+    return syncplay_access(client) != NO_SYNCPLAY
+
+
+def may_create_syncplay_group(client):
+    return syncplay_access(client) == CREATE_AND_JOIN
+
+
+def may_manage_live_tv(client):
+    """`EnableLiveTvManagement` — a *third* Live TV permission.
+
+    Separate from `EnableLiveTvAccess`: watching Live TV and managing
+    recordings are granted independently, and the browse gate
+    (``LibrarySource.has_live_tv``) answers only the first. Absent means an
+    answer we did not get, so: permitted.
+    """
+    policy = policy_for(client) or {}
+    if "EnableLiveTvManagement" not in policy:
+        return True
+    return bool(policy.get("EnableLiveTvManagement"))

--- a/tests/e2e/README.md
+++ b/tests/e2e/README.md
@@ -47,6 +47,7 @@ E1 and E2 exist so far:
 | `test_route_walk` | E1 | every screen loads and renders against the real library |
 | `test_paging` | E1 | virtual scrolling over ~1000 items at real totals (#617) |
 | `test_keyboard_nav` | E1 | reaching and activating the library by keyboard, online |
+| `test_large_queue` | E1 | a queue too big for one request line (the 414) |
 | `test_playback_advance` | E2 | an episode finishes and the next starts; the server agrees; resume position |
 | `test_playback_eof` | E2 | last-in-queue watched-marking, seek-to-end (#541), replaying a finished episode (#157/#323) |
 | `test_playback_failure` | E2 | truncated, zero-byte and single-frame media fail rather than hang |

--- a/tests/e2e/README.md
+++ b/tests/e2e/README.md
@@ -37,14 +37,21 @@ that "up" moves the error somewhere that explains nothing.
 | E2 playback | server + mpv + xvfb | the playback loop with the server *in* it |
 | E3 app | server + mpv + browser | route walk, scroll under real latency |
 
-Only E2 exists so far:
+E1 and E2 exist so far:
 
-| Module | Covers |
-| --- | --- |
-| `test_playback_advance` | an episode finishes and the next starts; the server agrees; resume position |
-| `test_playback_eof` | last-in-queue watched-marking, seek-to-end (#541), replaying a finished episode (#157/#323) |
-| `test_playback_failure` | truncated, zero-byte and single-frame media fail rather than hang |
-| `test_mpv_reopen` | closing mpv mid-playback then playing again (#458) — runs out of process |
+| Module | Tier | Covers |
+| --- | --- | --- |
+| `test_account_policy` | E1 | restricted libraries, Live TV access, no-password / disabled / hidden / one-session logins |
+| `test_source_conformance` | E1 | the fake `LibrarySource` still describes the real one |
+| `test_playback_advance` | E2 | an episode finishes and the next starts; the server agrees; resume position |
+| `test_playback_eof` | E2 | last-in-queue watched-marking, seek-to-end (#541), replaying a finished episode (#157/#323) |
+| `test_playback_failure` | E2 | truncated, zero-byte and single-frame media fail rather than hang |
+| `test_mpv_reopen` | E2 | closing mpv mid-playback then playing again (#458) — runs out of process |
+
+**E1 runs once, without a display**, because nothing in it imports
+`player.py`; the runner keeps it in its own tier and the whole of it is under
+two seconds. Only E2 pays for the backend matrix. Put a new test in E1 if it
+can answer its question without a player — it is thirty times cheaper.
 
 The plan doc has the ordered list of what comes next and which past bug each
 line would have caught, plus the two defects this suite has already found.
@@ -82,6 +89,15 @@ raises `BrokenPipeError: socket is closed`.
 **Playstate is the state these tests share.** Watched flags and resume
 positions persist on the server, so anything that dirties them registers
 `Session.reset_played` with `addCleanup`, both before and after.
+
+**Sessions and devices leak unless you log out.** `client.stop()` only closes
+the socket; the session stays registered and the server keeps a Device record
+per device id forever. So `Session` uses one deterministic device id per
+account (not a fresh uuid — that left 119 device records behind) and `stop()`
+POSTs `/Sessions/Logout`. It matters beyond tidiness: accumulated sessions
+exhaust `qa-onesession`'s cap, and its test then fails on the *first* login,
+which looks exactly like the cap working. That test purges the account's
+devices as admin in `setUp` for the same reason.
 
 **Both backends, always.** External mpv is the least-tested path in the app
 and one of the two largest open-bug clusters in the tracker. The runner makes

--- a/tests/e2e/README.md
+++ b/tests/e2e/README.md
@@ -48,12 +48,16 @@ E1 and E2 exist so far:
 | `test_paging` | E1 | virtual scrolling over ~1000 items at real totals (#617) |
 | `test_keyboard_nav` | E1 | reaching and activating the library by keyboard, online |
 | `test_large_queue` | E1 | a queue too big for one request line (the 414) |
+| `test_connection_loss` | E1 | the server stops answering: gone, token revoked, or a page-in that fails after a screenful drew |
 | `test_playback_advance` | E2 | an episode finishes and the next starts; the server agrees; resume position |
 | `test_playback_eof` | E2 | last-in-queue watched-marking, seek-to-end (#541), replaying a finished episode (#157/#323) |
 | `test_playback_failure` | E2 | truncated, zero-byte and single-frame media fail rather than hang |
 | `test_mpv_reopen` | E2 | closing mpv mid-playback then playing again (#458) — runs out of process |
 | `test_input_routing` | E2 | real keys through mpv's input layer across every UI transition |
 | `test_scroll_recovery` | E2 | wheel-scrolling 1000 items hard in a real window; tiles come back |
+| `test_track_selection` | E2 | Jellyfin's stream index vs mpv's track id, in both numbering schemes, and reported back |
+| `test_photos` | E2 | one still is held, an album is a slideshow, and neither inherits the browser's endless display duration |
+| `test_window_resize` | E2 | the window changes size under the UI, down to a size nobody could use |
 
 **E1 runs once, without a display**, because nothing in it imports
 `player.py`; the runner keeps it in its own tier and the whole of it is under

--- a/tests/e2e/README.md
+++ b/tests/e2e/README.md
@@ -46,6 +46,7 @@ E1 and E2 exist so far:
 | `test_live_tv` | E1 | channel line-up, guide window bounds, category flags, guide prefs, timers |
 | `test_route_walk` | E1 | every screen loads and renders against the real library |
 | `test_paging` | E1 | virtual scrolling over ~1000 items at real totals (#617) |
+| `test_keyboard_nav` | E1 | reaching and activating the library by keyboard, online |
 | `test_playback_advance` | E2 | an episode finishes and the next starts; the server agrees; resume position |
 | `test_playback_eof` | E2 | last-in-queue watched-marking, seek-to-end (#541), replaying a finished episode (#157/#323) |
 | `test_playback_failure` | E2 | truncated, zero-byte and single-frame media fail rather than hang |

--- a/tests/e2e/README.md
+++ b/tests/e2e/README.md
@@ -52,6 +52,7 @@ E1 and E2 exist so far:
 | `test_playback_failure` | E2 | truncated, zero-byte and single-frame media fail rather than hang |
 | `test_mpv_reopen` | E2 | closing mpv mid-playback then playing again (#458) — runs out of process |
 | `test_input_routing` | E2 | real keys through mpv's input layer across every UI transition |
+| `test_scroll_recovery` | E2 | wheel-scrolling 1000 items hard in a real window; tiles come back |
 
 **E1 runs once, without a display**, because nothing in it imports
 `player.py`; the runner keeps it in its own tier and the whole of it is under
@@ -145,6 +146,13 @@ the whole path runs (device selection, format negotiation, the AudioMixin
 settings), it just ends nowhere, so this suite can grow audio tests. With no
 `pactl` it falls back to mpv's own `null` device — quiet and contention-free,
 just less of the path exercised. Both paths are verified.
+
+**A wheel event goes to whatever is under the pointer, and under xvfb
+nothing has ever moved a mouse.** `mouse-pos` reports no hover and the
+coordinates sit at (-1, -1), so wheel events are delivered and discarded.
+Send `mouse <x> <y>` first and wait for `hover`. Without it a scroll test
+scrolls nothing — and reads as "the app stops scrolling two thirds of the way
+down" when it never started.
 
 **Input tests must press real keys.** `test_input_routing` exists because
 declaring a key binding and *enabling its section* are different calls, and

--- a/tests/e2e/README.md
+++ b/tests/e2e/README.md
@@ -100,12 +100,15 @@ exhaust `qa-onesession`'s cap, and its test then fails on the *first* login,
 which looks exactly like the cap working. That test purges the account's
 devices as admin in `setUp` for the same reason.
 
-**Live TV timers need a permission nobody has.** `EnableLiveTvManagement` is
-a third Live TV permission and stdjflib grants it to no account, not even
-`qa-admin`, so `POST /LiveTv/Timers` is 403 for everyone. `TimerTest` grants
-it in `setUpClass` and restores the original policy in `tearDownClass` — the
-only mutation of server *configuration* in the suite, and acceptable only
-because the server is disposable. See `docs/PERMISSION_GAPS.md`.
+**Live TV timers need a third permission.** `EnableLiveTvManagement` is
+separate from `EnableLiveTvAccess`, a newly created Jellyfin user does not get
+it, and there is no administrator bypass — so `POST /LiveTv/Timers` is 403
+until someone grants it. Current stdjflib grants it to `qa-admin` and
+`qa-user`, so `TimerTest` needs nothing; against a server provisioned before
+that fix it grants the permission as admin and restores the original policy
+afterwards. That fallback is the only place the suite writes server
+*configuration*. See `docs/PERMISSION_GAPS.md` for why the permission is off
+on a fresh server and on for anyone who upgraded into it.
 
 **Both backends, always.** External mpv is the least-tested path in the app
 and one of the two largest open-bug clusters in the tracker. The runner makes

--- a/tests/e2e/README.md
+++ b/tests/e2e/README.md
@@ -75,6 +75,12 @@ passed against the build check alone: `_route_async` catches a failing loader,
 records the error on the route and leaves it empty, and an empty route builds
 perfectly. Write the negative control before trusting a walk.
 
+**The interaction sweep is verified on one path only.** `test_route_walk`
+right-clicks, scrolls and hovers each screen, but a negative control that made
+`_open_tile_menu` raise is caught on the home rows and *not* on the grid,
+detail or music screens — they wire `on_context` elsewhere. Green there does
+not mean right-click is covered everywhere; see `_interact`.
+
 **Log traps go on the root logger.** The two that matter are named `mpvtk` and
 `mpvtk_browser.async_runner` — outside the package hierarchy, so a handler on
 `jellyfin_mpv_shim` sees neither.

--- a/tests/e2e/README.md
+++ b/tests/e2e/README.md
@@ -51,6 +51,7 @@ E1 and E2 exist so far:
 | `test_playback_eof` | E2 | last-in-queue watched-marking, seek-to-end (#541), replaying a finished episode (#157/#323) |
 | `test_playback_failure` | E2 | truncated, zero-byte and single-frame media fail rather than hang |
 | `test_mpv_reopen` | E2 | closing mpv mid-playback then playing again (#458) — runs out of process |
+| `test_input_routing` | E2 | real keys through mpv's input layer across every UI transition |
 
 **E1 runs once, without a display**, because nothing in it imports
 `player.py`; the runner keeps it in its own tier and the whole of it is under
@@ -138,6 +139,19 @@ the whole path runs (device selection, format negotiation, the AudioMixin
 settings), it just ends nowhere, so this suite can grow audio tests. With no
 `pactl` it falls back to mpv's own `null` device — quiet and contention-free,
 just less of the path exercised. Both paths are verified.
+
+**Input tests must press real keys.** `test_input_routing` exists because
+declaring a key binding and *enabling its section* are different calls, and
+only mpv holds the second — the fake's `enable_key_bindings` was a no-op, so
+the tests covering those commits could only assert which section a binding was
+DECLARED in. Three regressions in 48 hours got through that way. Anything
+asserting on input goes through `handle.command("keypress", ...)`, never a
+synthesised event, which reaches the handler whether or not its section is on.
+
+**mbtn_back does not page back in browse.** It fires ESC, and in plain browse
+ESC has no binding — the forced ones belong to an open menu and to the
+playback HUD. So it dismisses an overlay; open the tile menu first if you want
+something to observe.
 
 **Both backends, always.** External mpv is the least-tested path in the app
 and one of the two largest open-bug clusters in the tracker. The runner makes

--- a/tests/e2e/README.md
+++ b/tests/e2e/README.md
@@ -44,6 +44,7 @@ E1 and E2 exist so far:
 | `test_account_policy` | E1 | restricted libraries, Live TV access, no-password / disabled / hidden / one-session logins |
 | `test_source_conformance` | E1 | the fake `LibrarySource` still describes the real one |
 | `test_live_tv` | E1 | channel line-up, guide window bounds, category flags, guide prefs, timers |
+| `test_route_walk` | E1 | every screen loads and renders against the real library |
 | `test_playback_advance` | E2 | an episode finishes and the next starts; the server agrees; resume position |
 | `test_playback_eof` | E2 | last-in-queue watched-marking, seek-to-end (#541), replaying a finished episode (#157/#323) |
 | `test_playback_failure` | E2 | truncated, zero-byte and single-frame media fail rather than hang |
@@ -63,6 +64,17 @@ Episodes`, `Date Based Show`, `Double Episode Show`), so nothing here depends
 on execution order — and each resets its own playstate in `setUp` as well as
 on cleanup, so a run that died halfway cannot change what the next one
 measures. Keep that up: pick an unused series rather than sharing one.
+
+**A route walk needs three assertions, not one.** `test_route_walk` checks
+that the build does not raise, that `route["_error"]` is unset, and that
+nothing logged a failure. A negative control that reintroduced `b97dd523`
+passed against the build check alone: `_route_async` catches a failing loader,
+records the error on the route and leaves it empty, and an empty route builds
+perfectly. Write the negative control before trusting a walk.
+
+**Log traps go on the root logger.** The two that matter are named `mpvtk` and
+`mpvtk_browser.async_runner` — outside the package hierarchy, so a handler on
+`jellyfin_mpv_shim` sees neither.
 
 ## Things that are easy to get wrong
 

--- a/tests/e2e/README.md
+++ b/tests/e2e/README.md
@@ -43,6 +43,7 @@ E1 and E2 exist so far:
 | --- | --- | --- |
 | `test_account_policy` | E1 | restricted libraries, Live TV access, no-password / disabled / hidden / one-session logins |
 | `test_source_conformance` | E1 | the fake `LibrarySource` still describes the real one |
+| `test_live_tv` | E1 | channel line-up, guide window bounds, category flags, guide prefs, timers |
 | `test_playback_advance` | E2 | an episode finishes and the next starts; the server agrees; resume position |
 | `test_playback_eof` | E2 | last-in-queue watched-marking, seek-to-end (#541), replaying a finished episode (#157/#323) |
 | `test_playback_failure` | E2 | truncated, zero-byte and single-frame media fail rather than hang |
@@ -99,6 +100,13 @@ exhaust `qa-onesession`'s cap, and its test then fails on the *first* login,
 which looks exactly like the cap working. That test purges the account's
 devices as admin in `setUp` for the same reason.
 
+**Live TV timers need a permission nobody has.** `EnableLiveTvManagement` is
+a third Live TV permission and stdjflib grants it to no account, not even
+`qa-admin`, so `POST /LiveTv/Timers` is 403 for everyone. `TimerTest` grants
+it in `setUpClass` and restores the original policy in `tearDownClass` — the
+only mutation of server *configuration* in the suite, and acceptable only
+because the server is disposable. See `docs/PERMISSION_GAPS.md`.
+
 **Both backends, always.** External mpv is the least-tested path in the app
 and one of the two largest open-bug clusters in the tracker. The runner makes
 it a separate leg so a jsonipc-only regression is unmissable — and the first
@@ -110,6 +118,12 @@ runs, so a test built on a window close passes about a third of the time.
 Exercise the close for outcomes that do not depend on who won (does it
 re-open, does auto-advance survive); for the abort-report path, drive
 `send_timeline_stopped(finished=True)` directly.
+
+**Stop playback before the process ends.** Leaving a file decoding means the
+atexit teardown destroys the libmpv handle while it is still running, which
+races exactly as `finished_callback` did — a SIGSEGV *after* all the
+assertions passed, roughly one run in four. `_close_child.verdict` stops first
+for this reason. The real app stops before it terminates; so should a test.
 
 **A scenario that can crash belongs in a child process.** `_close_child.py`
 exists because a use-after-free on the mpv handle is a SIGSEGV, and a segfault

--- a/tests/e2e/README.md
+++ b/tests/e2e/README.md
@@ -1,0 +1,122 @@
+# End-to-end suite — a real server, real media, real mpv
+
+Everything else under `tests/` runs against a fake. That is why those suites
+are fast and deterministic, and it is also why a wrong request parameter, a
+DTO field we invented, or a reporting round trip that never closes are all
+invisible to them. `docs/E2E_PLAN.md` has the evidence and the roadmap; this
+file is how to run what exists.
+
+## Running it
+
+```sh
+# One shell: the server. Takes a few minutes the first time (it builds
+# Jellyfin from source and scans ~4,800 items).
+cd ~/Desktop/stdjflib && ./stdjflib.py serve ~/Desktop/std-jf-lib --live-tv
+
+# Another: the suite. Both mpv backends, under xvfb.
+JMS_E2E_SERVER=http://127.0.0.1:8096 python3 tests/e2e/run_e2e.py
+
+JMS_E2E_SERVER=... python3 tests/e2e/run_e2e.py --backend libmpv
+JMS_E2E_SERVER=... python3 -m unittest tests.e2e.test_playback_advance -v
+```
+
+`tests/e2e/` has **no `__init__.py`**, so `python3 -m unittest discover tests`
+never recurses into it and the fast suite still needs no server and no mpv.
+
+**With `JMS_E2E_SERVER` unset — or set and unreachable — every test skips and
+the runner exits 0.** A machine without a server is not a failure. The probe
+requires a parseable `/System/Info/Public`, not merely a socket that accepts:
+a server still shutting down on the same port accepts and closes, and calling
+that "up" moves the error somewhere that explains nothing.
+
+## What runs where
+
+| Tier | Needs | Covers |
+| --- | --- | --- |
+| E1 contract | server | the request the shim actually sends; DTO shape; per-account policy |
+| E2 playback | server + mpv + xvfb | the playback loop with the server *in* it |
+| E3 app | server + mpv + browser | route walk, scroll under real latency |
+
+Only E2 exists so far:
+
+| Module | Covers |
+| --- | --- |
+| `test_playback_advance` | an episode finishes and the next starts; the server agrees; resume position |
+| `test_playback_eof` | last-in-queue watched-marking, seek-to-end (#541), replaying a finished episode (#157/#323) |
+| `test_playback_failure` | truncated, zero-byte and single-frame media fail rather than hang |
+| `test_mpv_reopen` | closing mpv mid-playback then playing again (#458) — runs out of process |
+
+The plan doc has the ordered list of what comes next and which past bug each
+line would have caught, plus the two defects this suite has already found.
+
+**Test classes own disjoint fixtures.** One series each (`The Standard Show`,
+`Absolute Numbering Show`, `Flat Show No Season Folders`, `Show With Missing
+Episodes`, `Date Based Show`, `Double Episode Show`), so nothing here depends
+on execution order — and each resets its own playstate in `setUp` as well as
+on cleanup, so a run that died halfway cannot change what the next one
+measures. Keep that up: pick an unused series rather than sharing one.
+
+## Things that are easy to get wrong
+
+**Never bake an item id into a test.** Ids are assigned on scan and change on
+every reprovision. `Session.find` / `.episodes` look up by name.
+
+**`NameStartsWith` matches SortName, not Name.** SortName strips the leading
+article, so `NameStartsWith="The Standard Show"` returns *nothing* while
+`"Standard"` returns it. `Session.find` filters client-side for this reason —
+the harness is not allowed to contain the bug shape it is meant to catch.
+
+**A short item can never hold a resume position.** The server discards one
+below `MinResumeDurationSeconds` (300 by default) and clamps to
+`MinResumePct` 5% / `MaxResumePct` 90%. A resume test written against a
+10-second episode fails in a way that reads as a shim bug. Use `x-long`
+("Three hours").
+
+**The player is a process-wide singleton.** `playerManager` is shared by every
+test class in the interpreter, so it is built once and terminated at exit
+(`ensure_real_player`) — never in `tearDownClass`. Getting this wrong fails on
+one backend only: in-process libmpv quietly re-creates itself, while an
+external mpv is a separate process that is simply gone, and the next `play`
+raises `BrokenPipeError: socket is closed`.
+
+**Playstate is the state these tests share.** Watched flags and resume
+positions persist on the server, so anything that dirties them registers
+`Session.reset_played` with `addCleanup`, both before and after.
+
+**Both backends, always.** External mpv is the least-tested path in the app
+and one of the two largest open-bug clusters in the tracker. The runner makes
+it a separate leg so a jsonipc-only regression is unmissable — and the first
+defect this suite found ran the other way, crashing only on libmpv.
+
+**Closing mpv is a race; do not hang an assertion on it.** Whether
+`finished_callback` or the shutdown teardown wins decides which report path
+runs, so a test built on a window close passes about a third of the time.
+Exercise the close for outcomes that do not depend on who won (does it
+re-open, does auto-advance survive); for the abort-report path, drive
+`send_timeline_stopped(finished=True)` directly.
+
+**A scenario that can crash belongs in a child process.** `_close_child.py`
+exists because a use-after-free on the mpv handle is a SIGSEGV, and a segfault
+in-process loses the whole run instead of failing one test. Same reasoning as
+`tests/integration/_idle_reopen_child.py`.
+
+## Fixtures worth knowing about
+
+From `~/Desktop/std-jf-lib`, built by stdjflib and deterministic by design
+(every NFO carries `<lockdata>true</lockdata>`, dates derive from a fixed
+epoch, nothing depends on wall-clock time or `hash()`).
+
+| Item | Library | Why it exists |
+| --- | --- | --- |
+| `The Standard Show` | Shows | six 10s episodes per season — a queue that finishes in seconds |
+| `Three hours` | Test Media | resume points, seeking far from the start |
+| `Twelve chapters` | Test Media | chapter nav and boundaries |
+| `Six audio tracks` | Test Media | track selection, language preference, the default flag |
+| `Truncated file` | Test Media | must fail cleanly rather than hang |
+| `Zero-byte file` | Test Media | must be refused cleanly |
+| `One frame` | Test Media | duration rounds to zero; progress bars divide by it |
+| `Bulk *` | — | ~1000 items each: paging, virtual scroll, thumbnail pressure |
+
+Twelve test accounts (password `stdjflib`, except `qa-nopassword`) cover the
+policy paths — `qa-restricted`, `qa-nodownload`, `qa-noplayback`, `qa-kid`,
+`qa-onesession` and the rest. `./stdjflib.py accounts` explains each one.

--- a/tests/e2e/README.md
+++ b/tests/e2e/README.md
@@ -45,6 +45,7 @@ E1 and E2 exist so far:
 | `test_source_conformance` | E1 | the fake `LibrarySource` still describes the real one |
 | `test_live_tv` | E1 | channel line-up, guide window bounds, category flags, guide prefs, timers |
 | `test_route_walk` | E1 | every screen loads and renders against the real library |
+| `test_paging` | E1 | virtual scrolling over ~1000 items at real totals (#617) |
 | `test_playback_advance` | E2 | an episode finishes and the next starts; the server agrees; resume position |
 | `test_playback_eof` | E2 | last-in-queue watched-marking, seek-to-end (#541), replaying a finished episode (#157/#323) |
 | `test_playback_failure` | E2 | truncated, zero-byte and single-frame media fail rather than hang |
@@ -155,10 +156,29 @@ races exactly as `finished_callback` did — a SIGSEGV *after* all the
 assertions passed, roughly one run in four. `_close_child.verdict` stops first
 for this reason. The real app stops before it terminates; so should a test.
 
+**Tear the libmpv handle down explicitly at exit.**
+`PlayerManager.terminate` destroys the handle only for *external* mpv; on
+in-process libmpv it is left to CPython's finalization. Fine for the app — a
+desktop process exiting lets the OS reap it — and racy under a test runner,
+where it surfaced as a rare SIGSEGV *after* "OK" was printed and a leg the
+runner then called failed. `_terminate_player` does it explicitly.
+
 **A scenario that can crash belongs in a child process.** `_close_child.py`
 exists because a use-after-free on the mpv handle is a SIGSEGV, and a segfault
 in-process loses the whole run instead of failing one test. Same reasoning as
 `tests/integration/_idle_reopen_child.py`.
+
+**Bulk items all share a creation time.** They are built by one scan, so
+`DateCreated` ties and the server falls back to name order — "Date Added" and
+"Name" return the same first item, which makes a resort look like a refetch
+that never happened. Use "Release Date" to prove a reorder.
+
+**The grid's query is typed and recursive** from the collection type
+(`LIBRARY_ITEM_TYPES`). A hand-rolled comparison query that omits that
+describes a different set and lands on different indices — index 500 came back
+"Midnight Yard" untyped against the grid's "Midnight Zenith", which reads as
+an off-by-something in the shim and is not one. Compare through
+`source.get_library_items`.
 
 ## Fixtures worth knowing about
 

--- a/tests/e2e/README.md
+++ b/tests/e2e/README.md
@@ -110,6 +110,21 @@ afterwards. That fallback is the only place the suite writes server
 *configuration*. See `docs/PERMISSION_GAPS.md` for why the permission is off
 on a fresh server and on for anyone who upgraded into it.
 
+**Audio goes to a null sink, not your speakers.** The playback legs decode
+real media, so mpv opens a real output — audible, contending with whatever
+else is playing, and able to fail on a device another process holds (a run
+against the real device produced "Audio device underrun detected"). The runner
+loads one PipeWire/PulseAudio null sink for the whole matrix, exports it as
+`JMS_E2E_AUDIO_DEVICE`, and unloads it at the end; `quiet_settings` puts it in
+`settings.audio_device`. **The default sink is never changed** — nothing about
+your audio moves.
+
+A null sink rather than `ao=null` on purpose: mpv still opens an output and
+the whole path runs (device selection, format negotiation, the AudioMixin
+settings), it just ends nowhere, so this suite can grow audio tests. With no
+`pactl` it falls back to mpv's own `null` device — quiet and contention-free,
+just less of the path exercised. Both paths are verified.
+
 **Both backends, always.** External mpv is the least-tested path in the app
 and one of the two largest open-bug clusters in the tracker. The runner makes
 it a separate leg so a jsonipc-only regression is unmissable — and the first

--- a/tests/e2e/_close_child.py
+++ b/tests/e2e/_close_child.py
@@ -10,7 +10,7 @@ that as a normal failure with a useful message instead of losing the run.
 Same reasoning as `tests/integration/_idle_reopen_child.py`.
 
 Usage:  _close_child.py <mode>
-Modes:  reopen | abandon-long | abandon-short
+Modes:  reopen | abandon-long | abort-report-long | abort-report-short
 Prints: `RESULT: <PASS|FAIL> <detail>` and exits 0 on PASS.
 """
 
@@ -26,7 +26,25 @@ sys.path.insert(0, os.path.dirname(os.path.dirname(
 import _e2e  # noqa: E402
 
 
+#: The child's player, so `verdict` can stop it before the interpreter goes.
+_PM = None
+
+
 def verdict(ok, detail):
+    """Report, stop playback, exit.
+
+    The stop is not tidiness. Leaving a file decoding means the atexit
+    teardown destroys the libmpv handle while it is still running, and that
+    races the same way `finished_callback` did — a SIGSEGV *after* the verdict
+    was printed, which surfaces as "the child died on signal 11" on a run
+    whose assertions all passed. Roughly one run in four before this.
+    The real app stops before it terminates; so does this.
+    """
+    if _PM is not None:
+        try:
+            _PM.stop()
+        except Exception:
+            pass
     print("RESULT: %s %s" % ("PASS" if ok else "FAIL", detail), flush=True)
     sys.exit(0 if ok else 1)
 
@@ -49,10 +67,11 @@ def close_mpv(pm):
 
 
 def main():
+    global _PM
     mode = sys.argv[1]
     _e2e.isolate_config()
     player_module = _e2e.ensure_real_player()
-    pm = player_module.playerManager
+    pm = _PM = player_module.playerManager
     pm.action_trigger = threading.Event()
     pm.timeline_trigger = threading.Event()
 

--- a/tests/e2e/_close_child.py
+++ b/tests/e2e/_close_child.py
@@ -1,0 +1,165 @@
+"""Child process for the mpv-close scenarios. Run by `test_mpv_reopen`.
+
+These run out-of-process because **one of the outcomes under test is a
+segmentation fault**, which no amount of `assertRaises` survives: closing mpv
+mid-playback has `finished_callback` issue `self._player.command("stop")` on
+the same libmpv handle that `_terminate_mpv` is concurrently destroying, and a
+use-after-free takes the interpreter with it. A child lets the parent report
+that as a normal failure with a useful message instead of losing the run.
+
+Same reasoning as `tests/integration/_idle_reopen_child.py`.
+
+Usage:  _close_child.py <mode>
+Modes:  reopen | abandon-long | abandon-short
+Prints: `RESULT: <PASS|FAIL> <detail>` and exits 0 on PASS.
+"""
+
+import os
+import sys
+import threading
+import time
+
+sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+sys.path.insert(0, os.path.dirname(os.path.dirname(
+    os.path.dirname(os.path.abspath(__file__)))))
+
+import _e2e  # noqa: E402
+
+
+def verdict(ok, detail):
+    print("RESULT: %s %s" % ("PASS" if ok else "FAIL", detail), flush=True)
+    sys.exit(0 if ok else 1)
+
+
+def close_mpv(pm):
+    """Quit mpv out from under the shim, as closing the window does.
+
+    mpv's default CLOSE_WIN binding is `quit`, so this is the event the shim
+    sees when a user clicks the X — deliberately not `pm.stop()`, which is the
+    orderly path these bugs do not live on. The command may fail: the socket
+    can die between accepting and answering, which is the condition under
+    test, not an error.
+    """
+    try:
+        pm._player.command("quit")
+    except Exception:
+        pass
+    _e2e.pump_until(pm, lambda: pm._video is None or not pm._mpv_alive,
+                    timeout=20)
+
+
+def main():
+    mode = sys.argv[1]
+    _e2e.isolate_config()
+    player_module = _e2e.ensure_real_player()
+    pm = player_module.playerManager
+    pm.action_trigger = threading.Event()
+    pm.timeline_trigger = threading.Event()
+
+    session = _e2e.Session()
+
+    if mode == "reopen":
+        eps = session.episodes("Date Based Show", season=2019)
+        ids = [e["Id"] for e in eps[:2]]
+        session.reset_played(*ids)
+        try:
+            # 1) Playing normally.
+            pm.play(_e2e.build_media(session, ids).video, is_initial_play=True)
+            if not pm._player.duration:
+                verdict(False, "no duration before the close")
+            _e2e.pump_until(
+                pm, lambda: (pm._player.playback_time or 0) >= 1.0, timeout=20)
+
+            # 2) The window goes away mid-file.
+            close_mpv(pm)
+
+            # 3) "Cast again" — must build a fresh mpv, not talk to the dead one.
+            pm.play(_e2e.build_media(session, ids).video, is_initial_play=True)
+            if not (pm._player.duration and pm._player.duration > 0):
+                verdict(False, "the re-opened mpv never reported a duration")
+            if pm._video is None or pm._video.item_id != ids[0]:
+                verdict(False, "wrong video after the re-open")
+
+            # 4) What the bug was actually about: EOF still advances.
+            advanced = _e2e.pump_until(
+                pm, lambda: pm._video is not None
+                and pm._video.item_id == ids[1], timeout=45)
+            if not advanced:
+                verdict(False, "auto-advance is dead after close/re-open")
+            played = _e2e.wait_for(
+                lambda: session.user_data(ids[0]).get("Played"), timeout=20)
+            if not played:
+                verdict(False, "the episode that played out was not marked "
+                               "watched on the server")
+            verdict(True, "re-opened and auto-advanced")
+        finally:
+            session.reset_played(*ids)
+
+    elif mode in ("abort-report-long", "abort-report-short"):
+        # Drive the abort-report path directly. The realistic trigger is a
+        # window close, but that is a race between finished_callback and the
+        # shutdown teardown — either can win, so a test built on it passes
+        # about a third of the time. send_timeline_stopped(finished=True) is
+        # the seam the close path reaches, minus the race.
+        if mode == "abort-report-long":
+            item = session.find("Three hours", library="Test Media")
+        else:
+            item = session.episodes("Double Episode Show", season=1)[0]
+        item_id = item["Id"]
+        runtime = (item.get("RunTimeTicks") or 0) / 1e7
+        session.reset_played(item_id)
+        try:
+            pm.play(_e2e.build_media(session, [item_id]).video,
+                    is_initial_play=True)
+            if not pm._player.duration:
+                verdict(False, "no duration")
+            if not _e2e.pump_until(
+                    pm, lambda: (pm._player.playback_time or 0) >= 2.5,
+                    timeout=25):
+                verdict(False, "never reached the 2.5s mark")
+            position = pm._player.playback_time
+            pm.send_timeline_stopped(True)
+            _e2e.wait_for(lambda: session.user_data(item_id).get("PlayCount"),
+                          timeout=10)
+            time.sleep(1.0)
+            played = session.user_data(item_id).get("Played")
+            verdict(not played, "runtime=%.1fs aborted_at=%.1fs played=%s"
+                    % (runtime, position or -1, played))
+        finally:
+            session.reset_played(item_id)
+
+    elif mode == "abandon-long":
+        item = session.find("Three hours", library="Test Media")
+        item_id = item["Id"]
+        runtime = (item.get("RunTimeTicks") or 0) / 1e7
+        session.reset_played(item_id)
+        try:
+            pm.play(_e2e.build_media(session, [item_id]).video,
+                    is_initial_play=True)
+            if not pm._player.duration:
+                verdict(False, "no duration")
+            got = _e2e.pump_until(
+                pm, lambda: (pm._player.playback_time or 0) >= 2.5, timeout=25)
+            if not got:
+                verdict(False, "never reached the 2.5s mark")
+            position = pm._player.playback_time
+
+            close_mpv(pm)
+
+            # Let the stop report land before believing the answer.
+            _e2e.wait_for(lambda: session.user_data(item_id).get("PlayCount"),
+                          timeout=10)
+            time.sleep(1.0)
+            played = session.user_data(item_id).get("Played")
+            detail = ("runtime=%.1fs abandoned_at=%.1fs played=%s"
+                      % (runtime, position or -1, played))
+            verdict(not played, detail)
+        finally:
+            session.reset_played(item_id)
+
+    else:
+        verdict(False, "unknown mode %r" % mode)
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/e2e/_e2e.py
+++ b/tests/e2e/_e2e.py
@@ -22,8 +22,11 @@ Not named `test_*` so unittest discovery ignores it. `tests/e2e/` has no
 `__init__.py`, so `python3 -m unittest discover tests` never recurses in.
 """
 
+import atexit
 import json
 import os
+import shutil
+import subprocess
 import sys
 import tempfile
 import time
@@ -134,6 +137,89 @@ def require_server_and_mpv(obj):
 # Settings + the player module
 # --------------------------------------------------------------------------
 
+_SINK_MODULE = None
+SINK_NAME = "jms-e2e-sink"
+
+
+def dummy_audio_device():
+    """An mpv `audio-device` that makes noise nowhere. Created on first use.
+
+    The playback tests decode real media, so mpv opens a real audio output —
+    which on a developer's box means the suite is audible, fights whatever
+    else is playing, and can fail on a device another process holds. (A run
+    against the real device already produced "Audio device underrun
+    detected".)
+
+    A PipeWire/PulseAudio **null sink** is better than `ao=null` here: mpv
+    genuinely opens an output and the whole audio path runs — device
+    selection, format negotiation, the AudioMixin settings — it just ends
+    nowhere. `ao=null` would skip all of that, and audio behaviour is
+    something this suite should be able to grow tests for.
+
+    The sink is created explicitly and addressed explicitly; **the default
+    sink is never changed**, so nothing about the developer's audio moves.
+    Unloaded at exit.
+
+    Returns None when there is no `pactl` or the sink cannot be made, in
+    which case the caller falls back to mpv's own null device — quiet, and
+    still no contention, just less of the path exercised.
+    """
+    global _SINK_MODULE
+    if _SINK_MODULE is not None:
+        return "pulse/" + SINK_NAME
+    # The runner makes one sink for the whole matrix and names it here, so the
+    # eleven legs (and the children they spawn) share it instead of each
+    # loading a module — eleven sinks with one requested name is eleven
+    # deduplicated names, and any leg that dies takes its unload with it.
+    from_runner = os.environ.get("JMS_E2E_AUDIO_DEVICE")
+    if from_runner:
+        return from_runner
+    if not shutil.which("pactl"):
+        return None
+    if _sink_exists():
+        # Left by a crashed run, or a sibling process. Reuse it and do not
+        # register an unload: this process did not create it and unloading
+        # someone else's sink mid-run would pull the device out from under
+        # them. A stray null sink is harmless and gets reused next time.
+        return "pulse/" + SINK_NAME
+    try:
+        out = subprocess.run(
+            ["pactl", "load-module", "module-null-sink",
+             "sink_name=" + SINK_NAME,
+             "sink_properties=device.description=" + SINK_NAME],
+            capture_output=True, text=True, timeout=20)
+    except (OSError, subprocess.SubprocessError):
+        return None
+    module_id = (out.stdout or "").strip()
+    if out.returncode != 0 or not module_id.isdigit():
+        return None
+    _SINK_MODULE = module_id
+    atexit.register(_unload_sink)
+    return "pulse/" + SINK_NAME
+
+
+def _sink_exists():
+    try:
+        out = subprocess.run(["pactl", "list", "short", "sinks"],
+                             capture_output=True, text=True, timeout=20)
+    except (OSError, subprocess.SubprocessError):
+        return False
+    return any(line.split("\t")[1:2] == [SINK_NAME]
+               for line in (out.stdout or "").splitlines())
+
+
+def _unload_sink():
+    global _SINK_MODULE
+    if _SINK_MODULE is None:
+        return
+    module_id, _SINK_MODULE = _SINK_MODULE, None
+    try:
+        subprocess.run(["pactl", "unload-module", module_id],
+                       capture_output=True, timeout=20)
+    except (OSError, subprocess.SubprocessError):
+        pass
+
+
 def quiet_settings():
     """Turn off everything that is not under test, and pin the backend.
 
@@ -142,6 +228,10 @@ def quiet_settings():
     """
     from jellyfin_mpv_shim.conf import settings
     h.prime_args()
+    # "null" rather than leaving it unset: mpv's own null device is the
+    # fallback when there is no sound server to make a sink in, and it is
+    # still better than opening whatever the box's default output is.
+    settings.audio_device = dummy_audio_device() or "null"
     settings.thumbnail_enable = False
     settings.shader_pack_enable = False
     settings.menu_mouse = False

--- a/tests/e2e/_e2e.py
+++ b/tests/e2e/_e2e.py
@@ -292,15 +292,33 @@ class Session:
         except Exception:
             pass
 
-    def _request(self, path, method="GET"):
+    def _request(self, path, method="GET", body=None):
         """A raw authenticated call, for the handful of endpoints the
-        apiclient does not expose (logout, the Devices admin API)."""
-        req = urllib.request.Request(
-            SERVER + path, method=method,
-            headers={"Authorization": 'MediaBrowser Token="%s"' % self.token})
+        apiclient does not expose (logout, the Devices and Policy admin
+        APIs)."""
+        headers = {"Authorization": 'MediaBrowser Token="%s"' % self.token}
+        data = None
+        if body is not None:
+            data = json.dumps(body).encode()
+            headers["Content-Type"] = "application/json"
+        req = urllib.request.Request(SERVER + path, method=method,
+                                     data=data, headers=headers)
         with urllib.request.urlopen(req, timeout=15) as resp:
-            body = resp.read()
-            return json.loads(body) if body else None
+            payload = resp.read()
+            return json.loads(payload) if payload else None
+
+    def policy(self):
+        return (self.api.get_user() or {}).get("Policy") or {}
+
+    def set_policy(self, policy):
+        """Replace this user's policy. Admin only.
+
+        Used by the Live TV timer tests, which cannot run at all without
+        `EnableLiveTvManagement` — stdjflib grants it to nobody, not even
+        qa-admin. They grant it, run, and put the original back.
+        """
+        self._request("/Users/%s/Policy" % self.user_id, method="POST",
+                      body=policy)
 
     def purge_devices(self, account):
         """Delete every Device record belonging to `account`. Admin only.

--- a/tests/e2e/_e2e.py
+++ b/tests/e2e/_e2e.py
@@ -140,6 +140,12 @@ def require_server_and_mpv(obj):
 _SINK_MODULE = None
 SINK_NAME = "jms-e2e-sink"
 
+#: Every device id this suite registers starts with this, and `purge_devices`
+#: will not delete one that does not. The QA server is a machine a developer
+#: also points a real client at, and a device record is a live session: a
+#: purge that matched on the account alone signed that client out mid-run.
+DEVICE_PREFIX = "jms-e2e-"
+
 
 def dummy_audio_device():
     """An mpv `audio-device` that makes noise nowhere. Created on first use.
@@ -364,7 +370,15 @@ class Session:
         # which is junk on the server and makes `/Sessions` lookups
         # ambiguous. Tests that genuinely need to look like a second device
         # — qa-onesession — pass `device_id` explicitly.
-        self.device_id = device_id or ("jms-e2e-" + account)
+        # DEVICE_PREFIX, not a literal: `purge_devices` will not delete a
+        # device whose id does not carry it, so an id built any other way
+        # becomes litter this suite can no longer clear up after itself.
+        self.device_id = device_id or (DEVICE_PREFIX + account)
+        if not self.device_id.startswith(DEVICE_PREFIX):
+            raise AssertionError(
+                "device_id %r does not start with %r, so purge_devices "
+                "cannot clean it up and it becomes permanent litter on the "
+                "server" % (self.device_id, DEVICE_PREFIX))
         self.account = account
 
         client = JellyfinClient(allow_multiple_clients=True)
@@ -443,18 +457,33 @@ class Session:
         raise AssertionError("no user named %r" % name)
 
     def purge_devices(self, account):
-        """Delete every Device record belonging to `account`. Admin only.
+        """Delete THIS SUITE's Device records for `account`. Admin only.
 
         For `qa-onesession`, whose cap counts what the server still believes
         is connected: a session left behind by a crashed run refuses the next
         one, and the failure looks like the cap working rather than like
         litter. Called from `setUp` so the test starts from a known state
         however the last run ended.
+
+        **Ours only.** A Device record is a live session, and deleting one
+        signs that client out. This matched on the account alone, which meant
+        a run against the QA server signed out whatever real client a
+        developer had pointed at it under the same login -- observed exactly
+        once, with a client on `qa-nosyncplay` while `RevokedSessionTest`
+        purged that account. The litter this exists to clear is always ours,
+        and ours always carries `DEVICE_PREFIX`, so there is nothing to
+        trade off: `qa-onesession`'s own ids are `jms-e2e-1session-a/b`.
+
+        A foreign device holding the cap is a real possibility and is
+        deliberately left to fail loudly -- deleting somebody's session to
+        make a test pass is the wrong way round.
         """
         devices = self._request("/Devices") or {}
         items = devices.get("Items", devices if isinstance(devices, list) else [])
         for device in items:
             if device.get("LastUserName") != account:
+                continue
+            if not str(device.get("Id") or "").startswith(DEVICE_PREFIX):
                 continue
             try:
                 self._request("/Devices?id=" + urllib.parse.quote(device["Id"]),

--- a/tests/e2e/_e2e.py
+++ b/tests/e2e/_e2e.py
@@ -310,15 +310,24 @@ class Session:
     def policy(self):
         return (self.api.get_user() or {}).get("Policy") or {}
 
-    def set_policy(self, policy):
-        """Replace this user's policy. Admin only.
+    def set_policy(self, policy, user_id=None):
+        """Replace a user's policy (this user's by default). Admin only.
 
-        Used by the Live TV timer tests, which cannot run at all without
-        `EnableLiveTvManagement` — stdjflib grants it to nobody, not even
-        qa-admin. They grant it, run, and put the original back.
+        A fallback for the Live TV timer tests. Current stdjflib grants
+        `EnableLiveTvManagement` to `qa-user`, so they need no mutation at
+        all — but an older server, or one provisioned before that fix, has it
+        on nobody, and there the tests grant it and put the original back
+        rather than skipping the whole DVR surface.
         """
-        self._request("/Users/%s/Policy" % self.user_id, method="POST",
-                      body=policy)
+        self._request("/Users/%s/Policy" % (user_id or self.user_id),
+                      method="POST", body=policy)
+
+    def user_by_name(self, name):
+        """A user record by name. Admin only."""
+        for user in self._request("/Users") or []:
+            if user.get("Name") == name:
+                return user
+        raise AssertionError("no user named %r" % name)
 
     def purge_devices(self, account):
         """Delete every Device record belonging to `account`. Admin only.

--- a/tests/e2e/_e2e.py
+++ b/tests/e2e/_e2e.py
@@ -284,11 +284,34 @@ def ensure_real_player():
 
 
 def _terminate_player():
+    """Shut the player down while the interpreter is still healthy.
+
+    `PlayerManager.terminate` tears the handle down only for **external** mpv
+    (`if is_using_ext_mpv: self._player.terminate()`); in-process libmpv is
+    left for CPython's finalization. That is fine for the app — a desktop
+    process exiting lets the OS reap it — and racy under a test runner, where
+    finalization runs with atexit handlers and daemon threads still in play.
+    It showed up as a rare SIGSEGV *after* "OK" was printed, which the runner
+    then reported as a failed leg on a run whose assertions all passed:
+    roughly one in five to eight, libmpv only.
+
+    So terminate the handle here too, explicitly, before the interpreter
+    starts pulling itself apart. Harness-only — nothing about the app's own
+    exit path changes.
+    """
+    if _PLAYER is None:
+        return
+    manager = _PLAYER.playerManager
+    handle = getattr(manager, "_player", None)
     try:
-        if _PLAYER is not None:
-            _PLAYER.playerManager.terminate()
+        manager.terminate()
     except Exception:
         pass
+    if not getattr(_PLAYER, "is_using_ext_mpv", False) and handle is not None:
+        try:
+            handle.terminate()
+        except Exception:
+            pass
 
 
 def import_real_player():

--- a/tests/e2e/_e2e.py
+++ b/tests/e2e/_e2e.py
@@ -29,8 +29,8 @@ import tempfile
 import time
 import unittest
 import urllib.error
+import urllib.parse
 import urllib.request
-import uuid
 
 # The integration harness already probes mpv/ffmpeg/display, primes the arg
 # parser and knows how to tell a FakeMPV-bound player module from a real one.
@@ -43,9 +43,50 @@ import _harness as h  # noqa: E402
 SERVER = (os.environ.get("JMS_E2E_SERVER") or "").rstrip("/")
 BACKEND = h.BACKEND
 
+# Done at import, before any test module can pull a shim module in. Two traps,
+# both of which bite whichever module imports first rather than the one at
+# fault:
+#   * the app parses sys.argv the first time anything resolves the config dir,
+#     and under a test runner argv carries tokens its argparse rejects — it
+#     exits with a usage message, which reads as a broken test file.
+#   * without an isolated config dir the suite reads and writes the
+#     developer's real one.
+_CONFIG_DIR = tempfile.mkdtemp(prefix="jms-e2e-config-")
+os.environ["XDG_CONFIG_HOME"] = _CONFIG_DIR
+h.prime_args()
+
 # stdjflib's fixed accounts. Password is the same for all of them except
 # qa-nopassword, whose whole point is not having one.
 PASSWORD = "stdjflib"
+
+# The server uuid a LibrarySource built by `Session.library_source` answers to.
+SOURCE_UUID = "e2e"
+
+
+def public_users():
+    """`/Users/Public` — the login list a client offers without credentials.
+
+    Deliberately raw rather than through the apiclient: this endpoint is what
+    an unauthenticated client sees, so asking it with a token would be asking
+    a different question.
+    """
+    with urllib.request.urlopen(SERVER + "/Users/Public", timeout=10) as resp:
+        return [u.get("Name") for u in json.loads(resp.read())]
+
+
+def login_refused(account, password=PASSWORD, device_id=None):
+    """True when the server refuses this login.
+
+    Returns rather than raises so a test can say what it means. `Session`
+    raises on a refusal because every other test wants that; here the refusal
+    *is* the assertion.
+    """
+    try:
+        session = Session(account, password, device_id=device_id)
+    except AssertionError:
+        return True
+    session.stop()
+    return False
 
 
 # --------------------------------------------------------------------------
@@ -203,9 +244,14 @@ class Session:
             CLIENT_VERSION, USER_APP_NAME, USER_AGENT,
         )
 
-        # Unique per Session: two of these must look like two devices to the
-        # server, or a test that logs in twice (qa-onesession) evicts itself.
-        self.device_id = device_id or ("jms-e2e-" + uuid.uuid4().hex[:12])
+        # Deterministic, one per account, and NOT a fresh uuid per Session.
+        # A real client has one persistent device id, and the server keeps a
+        # Device record per id forever: a random one leaked a device per
+        # Session ever constructed (119 of them before this was noticed),
+        # which is junk on the server and makes `/Sessions` lookups
+        # ambiguous. Tests that genuinely need to look like a second device
+        # — qa-onesession — pass `device_id` explicitly.
+        self.device_id = device_id or ("jms-e2e-" + account)
         self.account = account
 
         client = JellyfinClient(allow_multiple_clients=True)
@@ -230,10 +276,65 @@ class Session:
         self.api = client.jellyfin
 
     def stop(self):
+        """Revoke the token, then close the HTTP session.
+
+        `client.stop()` alone only closes the socket — the session stays
+        registered on the server, which is how a suite that logs in freely
+        exhausts `qa-onesession`'s cap with its own leftovers. Logging out is
+        also what keeps `/Sessions` readable for the tests that consult it.
+        """
+        try:
+            self._request("/Sessions/Logout", method="POST")
+        except Exception:
+            pass
         try:
             self.client.stop()
         except Exception:
             pass
+
+    def _request(self, path, method="GET"):
+        """A raw authenticated call, for the handful of endpoints the
+        apiclient does not expose (logout, the Devices admin API)."""
+        req = urllib.request.Request(
+            SERVER + path, method=method,
+            headers={"Authorization": 'MediaBrowser Token="%s"' % self.token})
+        with urllib.request.urlopen(req, timeout=15) as resp:
+            body = resp.read()
+            return json.loads(body) if body else None
+
+    def purge_devices(self, account):
+        """Delete every Device record belonging to `account`. Admin only.
+
+        For `qa-onesession`, whose cap counts what the server still believes
+        is connected: a session left behind by a crashed run refuses the next
+        one, and the failure looks like the cap working rather than like
+        litter. Called from `setUp` so the test starts from a known state
+        however the last run ended.
+        """
+        devices = self._request("/Devices") or {}
+        items = devices.get("Items", devices if isinstance(devices, list) else [])
+        for device in items:
+            if device.get("LastUserName") != account:
+                continue
+            try:
+                self._request("/Devices?id=" + urllib.parse.quote(device["Id"]),
+                              method="DELETE")
+            except Exception:
+                pass
+
+    def library_source(self):
+        """A real `LibrarySource` over this session's credentials.
+
+        The browser is handed one of these and does everything through it, so
+        it is the seam the contract tests belong at — above the apiclient,
+        below the UI.
+        """
+        from jellyfin_mpv_shim.mpvtk_browser.repository import LibrarySource
+        source = LibrarySource(
+            [{"uuid": SOURCE_UUID, "name": "e2e", "address": SERVER,
+              "user_id": self.user_id, "token": self.token}],
+            self.device_id, "jms-e2e", False)
+        return source
 
     # -- lookup ------------------------------------------------------------
     #

--- a/tests/e2e/_e2e.py
+++ b/tests/e2e/_e2e.py
@@ -1,0 +1,419 @@
+"""Fixtures for the end-to-end suite: a real Jellyfin server, a real mpv.
+
+Everything else in `tests/` runs against a fake. That is deliberate and it is
+why those suites are fast and deterministic — but it also means the request
+the shim actually sends is never validated by anything, and the DTOs it
+reasons about are hand-written by us. `docs/E2E_PLAN.md` has the evidence:
+`enable_images=False` to a method with no such argument, `is_movies` for
+`IsMovie` (with a unit test asserting the wrong spelling, which is why it was
+green), a SyncPlay ping sent as a float against a `long`. None of those are
+reachable without a server on the other end.
+
+The server is stdjflib's:
+
+    ./stdjflib.py serve ~/Desktop/std-jf-lib --live-tv
+    JMS_E2E_SERVER=http://127.0.0.1:8096 python3 tests/e2e/run_e2e.py
+
+With `JMS_E2E_SERVER` unset — or set and unreachable — every test here skips,
+the same discipline as the integration suite's capability gating. A bare
+machine exits clean.
+
+Not named `test_*` so unittest discovery ignores it. `tests/e2e/` has no
+`__init__.py`, so `python3 -m unittest discover tests` never recurses in.
+"""
+
+import json
+import os
+import sys
+import tempfile
+import time
+import unittest
+import urllib.error
+import urllib.request
+import uuid
+
+# The integration harness already probes mpv/ffmpeg/display, primes the arg
+# parser and knows how to tell a FakeMPV-bound player module from a real one.
+# Importing it beats a second copy that drifts: these are the same questions,
+# and the answers have to stay the same.
+sys.path.insert(0, os.path.join(os.path.dirname(os.path.dirname(
+    os.path.abspath(__file__))), "integration"))
+import _harness as h  # noqa: E402
+
+SERVER = (os.environ.get("JMS_E2E_SERVER") or "").rstrip("/")
+BACKEND = h.BACKEND
+
+# stdjflib's fixed accounts. Password is the same for all of them except
+# qa-nopassword, whose whole point is not having one.
+PASSWORD = "stdjflib"
+
+
+# --------------------------------------------------------------------------
+# Capability gate
+# --------------------------------------------------------------------------
+
+_reachable = None
+
+
+def server_reachable():
+    """Is there a Jellyfin on the other end? Probed once, cached.
+
+    Requires a parseable payload, not merely a socket that accepts: a server
+    still shutting down on the same port accepts and closes, and treating that
+    as "up" makes the next call fail with a connection error pointing nowhere
+    near the cause. (stdjflib's own `wait_until_up` learned this the same way.)
+    """
+    global _reachable
+    if _reachable is not None:
+        return _reachable
+    _reachable = False
+    if SERVER:
+        try:
+            with urllib.request.urlopen(
+                    SERVER + "/System/Info/Public", timeout=5) as resp:
+                _reachable = bool(json.loads(resp.read()).get("Id"))
+        except (urllib.error.URLError, OSError, ValueError, TypeError):
+            _reachable = False
+    return _reachable
+
+
+def require_server(obj):
+    return unittest.skipUnless(
+        server_reachable(),
+        "no server: set JMS_E2E_SERVER to a running Jellyfin "
+        "(see docs/E2E_PLAN.md)",
+    )(obj)
+
+
+def require_server_and_mpv(obj):
+    return require_server(h.require_real_mpv(obj))
+
+
+# --------------------------------------------------------------------------
+# Settings + the player module
+# --------------------------------------------------------------------------
+
+def quiet_settings():
+    """Turn off everything that is not under test, and pin the backend.
+
+    **Must run before `jellyfin_mpv_shim.player` is imported** — player.py
+    picks its mpv backend at import time and builds its singleton there.
+    """
+    from jellyfin_mpv_shim.conf import settings
+    h.prime_args()
+    settings.thumbnail_enable = False
+    settings.shader_pack_enable = False
+    settings.menu_mouse = False
+    settings.svp_enable = False
+    settings.discord_presence = False
+    settings.check_updates = False
+    # "none" keeps the OSC lua out of in-process libmpv (its teardown at
+    # interpreter exit goes racy with a script loaded) and suppresses mpv's
+    # own OSC — same reasoning as test_realmpv_smoke.
+    settings.osc_style = "none"
+    settings.fullscreen = False
+    settings.auto_play = True
+    settings.mpv_ext = (BACKEND == "jsonipc")
+    settings.mpv_ext_start = True
+    return settings
+
+
+def isolate_config():
+    """Point the config dir at a throwaway.
+
+    The suite writes credentials and playstate; a developer running it must
+    not find their real `cred.json` rewritten. Called before any shim import.
+    """
+    path = tempfile.mkdtemp(prefix="jms-e2e-config-")
+    os.environ["XDG_CONFIG_HOME"] = path
+    return path
+
+
+_PLAYER = None
+
+
+def ensure_real_player():
+    """The process's one real player, built on first use and torn down at exit.
+
+    `playerManager` is a **module-level singleton**, so it is shared by every
+    test class in the interpreter — which makes per-class teardown wrong.
+    Terminating it in `tearDownClass` leaves the next class holding a dead
+    player, and the two backends do not fail the same way: in-process libmpv
+    quietly re-creates itself and the run looks fine, while external mpv is a
+    separate process that is simply gone, and the next `play` dies with
+    `BrokenPipeError: socket is closed`. Exactly the kind of one-backend
+    divergence the matrix exists to surface — it caught this on its first run.
+    """
+    global _PLAYER
+    if _PLAYER is None:
+        _PLAYER = import_real_player()
+        import atexit
+        atexit.register(_terminate_player)
+    return _PLAYER
+
+
+def _terminate_player():
+    try:
+        if _PLAYER is not None:
+            _PLAYER.playerManager.terminate()
+    except Exception:
+        pass
+
+
+def import_real_player():
+    """Import `jellyfin_mpv_shim.player` bound to a REAL mpv backend.
+
+    In a full-suite run the fake-mpv legs may already have imported player
+    against `FakeMPV`, and player.py caches its singleton at import time — a
+    plain import would hand that back and this suite would silently smoke-test
+    the fake. Ask the *player module* what it is bound to rather than
+    `sys.modules`, which the integration harness deliberately restores.
+    """
+    quiet_settings()
+    player_mod = sys.modules.get("jellyfin_mpv_shim.player")
+    if player_mod is not None and _is_fake(getattr(player_mod, "mpv", None)):
+        sys.modules.pop("jellyfin_mpv_shim.player")
+    for name in ("mpv", "python_mpv_jsonipc"):
+        if _is_fake(sys.modules.get(name)):
+            del sys.modules[name]
+    import jellyfin_mpv_shim.player as player_module
+    assert not _is_fake(player_module.mpv), "e2e suite is bound to FakeMPV"
+    return player_module
+
+
+def _is_fake(mod):
+    return mod is not None and getattr(mod, "MPV", None) is h.FakeMPV
+
+
+# --------------------------------------------------------------------------
+# A logged-in connection
+# --------------------------------------------------------------------------
+
+class Session:
+    """One authenticated connection, built the way the app builds one.
+
+    The token half is `clients.ClientManager.login`; the "we already hold a
+    token, just bring the HTTP session up" half is `repository.ServerConn`.
+    Between them that is every way the app reaches a server.
+    """
+
+    def __init__(self, account="qa-user", password=PASSWORD, device_id=None):
+        from jellyfin_apiclient_python import JellyfinClient
+        from jellyfin_mpv_shim.constants import (
+            CLIENT_VERSION, USER_APP_NAME, USER_AGENT,
+        )
+
+        # Unique per Session: two of these must look like two devices to the
+        # server, or a test that logs in twice (qa-onesession) evicts itself.
+        self.device_id = device_id or ("jms-e2e-" + uuid.uuid4().hex[:12])
+        self.account = account
+
+        client = JellyfinClient(allow_multiple_clients=True)
+        client.config.data["app.default"] = True
+        client.config.app(USER_APP_NAME, CLIENT_VERSION, "jms-e2e", self.device_id)
+        client.config.data["http.user_agent"] = USER_AGENT
+        client.config.data["auth.ssl"] = False
+
+        client.auth.connect_to_address(SERVER)
+        result = client.auth.login(SERVER, account, password or "")
+        if "AccessToken" not in result:
+            raise AssertionError(
+                "login failed for %s: %r" % (account, result))
+        self.token = result["AccessToken"]
+        self.user_id = result["User"]["Id"]
+
+        client.config.auth(SERVER, self.user_id, self.token, False)
+        client.logged_in = True
+        client.start(websocket=False)
+
+        self.client = client
+        self.api = client.jellyfin
+
+    def stop(self):
+        try:
+            self.client.stop()
+        except Exception:
+            pass
+
+    # -- lookup ------------------------------------------------------------
+    #
+    # Always by NAME, never by id. Ids are assigned by the server on scan and
+    # change on every reprovision; a baked-in GUID is a test that passes once.
+
+    def view(self, name):
+        for item in self.api.get_views()["Items"]:
+            if item["Name"] == name:
+                return item
+        raise AssertionError("no library named %r (have: %s)" % (
+            name, [i["Name"] for i in self.api.get_views()["Items"]]))
+
+    def find(self, name, library=None, item_type=None, fields=None):
+        """One item by exact `Name`, optionally within a library.
+
+        Filtered client-side on purpose. **`NameStartsWith` matches SortName,
+        not Name**, and SortName has the leading article stripped — measured
+        against this server: `NameStartsWith="The Standard Show"` returns
+        nothing at all, `"Standard"` returns it, and the item's SortName is
+        `"standard show"`. Narrowing the query with the name you can see is a
+        filter that silently matches nothing, which is the exact shape of bug
+        this suite exists to catch, so it does not get to live in the harness.
+        """
+        items = self.find_all(library=library, item_type=item_type,
+                              fields=fields)
+        exact = [i for i in items if i["Name"] == name]
+        if not exact:
+            raise AssertionError("no %s named %r in %r (saw %d items: %s)" % (
+                item_type or "item", name, library, len(items),
+                [i["Name"] for i in items[:10]]))
+        return exact[0]
+
+    def find_all(self, library=None, item_type=None, fields=None,
+                 parent_id=None, **params):
+        query = {"Recursive": True}
+        if parent_id is not None:
+            query["ParentId"] = parent_id
+        elif library is not None:
+            query["ParentId"] = self.view(library)["Id"]
+        if item_type:
+            query["IncludeItemTypes"] = item_type
+        if fields:
+            query["Fields"] = fields
+        query.update(params)
+        return self.api.user_items(params=query)["Items"]
+
+    def episodes(self, series_name, season=None, library="Shows"):
+        """A series' episodes in broadcast order."""
+        series = self.find(series_name, library=library, item_type="Series")
+        eps = self.find_all(parent_id=series["Id"], item_type="Episode",
+                            SortBy="ParentIndexNumber,IndexNumber",
+                            SortOrder="Ascending")
+        if season is not None:
+            eps = [e for e in eps if e.get("ParentIndexNumber") == season]
+        return eps
+
+    # -- state -------------------------------------------------------------
+
+    def user_data(self, item_id):
+        return self.api.get_item(item_id).get("UserData") or {}
+
+    def reset_played(self, *item_ids):
+        """Clear watched state and resume position so a run is repeatable.
+
+        Registered with `addCleanup` by the tests that dirty it. Playstate is
+        the one piece of server state these tests mutate that another test can
+        actually see.
+        """
+        for item_id in item_ids:
+            try:
+                self.api.item_played(item_id, False)
+            except Exception:
+                pass
+
+    def my_session(self):
+        """This device's entry in the server's session list, if it has one.
+
+        The server's own view of what we are playing — the half of the
+        reporting loop `test_realmpv_smoke` fakes.
+        """
+        try:
+            for sess in self.api.sessions():
+                if sess.get("DeviceId") == self.device_id:
+                    return sess
+        except Exception:
+            pass
+        return None
+
+
+# --------------------------------------------------------------------------
+# Driving the player
+# --------------------------------------------------------------------------
+
+def build_media(session, item_ids, seq=0):
+    """A real `Media` over real server DTOs — the app's own play path.
+
+    `event_handler.play_media` builds exactly this before handing
+    `media.video` to the player; going through `Media` rather than a stand-in
+    Video is the point of the suite, since it is what fetches PlaybackInfo and
+    resolves the stream URL against the server.
+    """
+    from jellyfin_mpv_shim.media import Media
+    return Media(session.client, list(item_ids), seq=seq,
+                 user_id=session.user_id)
+
+
+def pump_until(pm, predicate, timeout=45, interval=0.05):
+    """Drive the action queue by hand until `predicate` holds.
+
+    The real `ActionThread` pumps `playerManager.update()`; doing it here
+    instead keeps the timing under the test's control, exactly as the
+    integration suite does. Returns the predicate's final value.
+    """
+    deadline = time.time() + timeout
+    while time.time() < deadline:
+        pm.update()
+        try:
+            if predicate():
+                return True
+        except Exception:
+            pass
+        time.sleep(interval)
+    pm.update()
+    try:
+        return bool(predicate())
+    except Exception:
+        return False
+
+
+def wait_for(predicate, timeout=15, interval=0.25):
+    """Poll a server-side condition. Reporting is asynchronous — a progress
+    post lands on a background thread — so an assertion made the instant after
+    playback starts is a race the test loses, not a bug."""
+    deadline = time.time() + timeout
+    while time.time() < deadline:
+        try:
+            value = predicate()
+            if value:
+                return value
+        except Exception:
+            pass
+        time.sleep(interval)
+    try:
+        return predicate()
+    except Exception:
+        return None
+
+
+class E2ETestCase(unittest.TestCase):
+    """Base: an isolated config, a real player, one qa-user session."""
+
+    account = "qa-user"
+
+    @classmethod
+    def setUpClass(cls):
+        isolate_config()
+        cls.player_module = ensure_real_player()
+        cls.pm = cls.player_module.playerManager
+        # Own the pump rather than starting the real ActionThread singleton.
+        import threading
+        cls.pm.action_trigger = threading.Event()
+        cls.pm.timeline_trigger = threading.Event()
+
+    # No tearDownClass: the player is process-wide and outlives this class.
+    # See ensure_real_player.
+
+    def setUp(self):
+        self.session = Session(self.account)
+        self.addCleanup(self.session.stop)
+        # Never leave a player running into the next test: a live session keeps
+        # reporting and the next test's assertions read its progress.
+        self.addCleanup(self._safe_stop)
+
+    def _safe_stop(self):
+        try:
+            self.pm.stop()
+        except Exception:
+            pass
+
+    def pump_until(self, predicate, timeout=45):
+        """`pump_until` against this case's player."""
+        return pump_until(self.pm, predicate, timeout=timeout)

--- a/tests/e2e/run_e2e.py
+++ b/tests/e2e/run_e2e.py
@@ -35,25 +35,36 @@ import sys
 REPO_ROOT = os.path.dirname(os.path.dirname(os.path.dirname(
     os.path.abspath(__file__))))
 
-MODULES = [
+# Contract tier: never imports player.py, so the mpv backend is irrelevant and
+# these run ONCE and without a display. Seconds, not minutes.
+CONTRACT = [
+    "tests.e2e.test_account_policy",
+    "tests.e2e.test_source_conformance",
+]
+
+# Playback tier: a real mpv, so once per backend under xvfb.
+PER_BACKEND = [
     "tests.e2e.test_playback_advance",
     "tests.e2e.test_playback_eof",
     "tests.e2e.test_playback_failure",
     "tests.e2e.test_mpv_reopen",
 ]
 
+MODULES = CONTRACT + PER_BACKEND
+
 BACKENDS = ("libmpv", "jsonipc")
 
 
 def run_leg(module, backend, use_xvfb, verbosity):
     env = dict(os.environ)
-    env["JMS_TEST_BACKEND"] = backend
+    if backend:
+        env["JMS_TEST_BACKEND"] = backend
     cmd = [sys.executable, "-m", "unittest", module]
     if verbosity > 1:
         cmd.append("-v")
     if use_xvfb:
         cmd = ["xvfb-run", "-a"] + cmd
-    print("\n=== %s [%s] ===" % (module, backend), flush=True)
+    print("\n=== %s [%s] ===" % (module, backend or "contract"), flush=True)
     proc = subprocess.run(cmd, cwd=REPO_ROOT, env=env)
     return proc.returncode == 0
 
@@ -89,14 +100,19 @@ def main():
     modules = args.module or MODULES
 
     results = []
+    # Contract modules once, with no display: they never import player.py.
+    for module in [m for m in modules if m in CONTRACT]:
+        ok = run_leg(module, None, False, args.verbose)
+        results.append((module, "contract", ok))
+
     for backend in backends:
-        for module in modules:
+        for module in [m for m in modules if m not in CONTRACT]:
             ok = run_leg(module, backend, use_xvfb, args.verbose)
             results.append((module, backend, ok))
 
     print("\n" + "=" * 60)
     for module, backend, ok in results:
-        print("%-6s %-45s %s" % (backend, module, "PASS" if ok else "FAIL"))
+        print("%-8s %-45s %s" % (backend, module, "PASS" if ok else "FAIL"))
     failed = [r for r in results if not r[2]]
     print("=" * 60)
     print("%d/%d legs passed" % (len(results) - len(failed), len(results)))

--- a/tests/e2e/run_e2e.py
+++ b/tests/e2e/run_e2e.py
@@ -52,6 +52,7 @@ PER_BACKEND = [
     "tests.e2e.test_playback_advance",
     "tests.e2e.test_playback_eof",
     "tests.e2e.test_playback_failure",
+    "tests.e2e.test_track_selection",
     "tests.e2e.test_mpv_reopen",
     "tests.e2e.test_input_routing",
     "tests.e2e.test_scroll_recovery",

--- a/tests/e2e/run_e2e.py
+++ b/tests/e2e/run_e2e.py
@@ -53,6 +53,7 @@ PER_BACKEND = [
     "tests.e2e.test_playback_eof",
     "tests.e2e.test_playback_failure",
     "tests.e2e.test_track_selection",
+    "tests.e2e.test_photos",
     "tests.e2e.test_mpv_reopen",
     "tests.e2e.test_input_routing",
     "tests.e2e.test_scroll_recovery",

--- a/tests/e2e/run_e2e.py
+++ b/tests/e2e/run_e2e.py
@@ -45,6 +45,7 @@ CONTRACT = [
     "tests.e2e.test_paging",
     "tests.e2e.test_keyboard_nav",
     "tests.e2e.test_large_queue",
+    "tests.e2e.test_connection_loss",
 ]
 
 # Playback tier: a real mpv, so once per backend under xvfb.

--- a/tests/e2e/run_e2e.py
+++ b/tests/e2e/run_e2e.py
@@ -42,6 +42,7 @@ CONTRACT = [
     "tests.e2e.test_source_conformance",
     "tests.e2e.test_live_tv",
     "tests.e2e.test_route_walk",
+    "tests.e2e.test_paging",
 ]
 
 # Playback tier: a real mpv, so once per backend under xvfb.

--- a/tests/e2e/run_e2e.py
+++ b/tests/e2e/run_e2e.py
@@ -41,6 +41,7 @@ CONTRACT = [
     "tests.e2e.test_account_policy",
     "tests.e2e.test_source_conformance",
     "tests.e2e.test_live_tv",
+    "tests.e2e.test_route_walk",
 ]
 
 # Playback tier: a real mpv, so once per backend under xvfb.

--- a/tests/e2e/run_e2e.py
+++ b/tests/e2e/run_e2e.py
@@ -55,6 +55,46 @@ MODULES = CONTRACT + PER_BACKEND
 
 BACKENDS = ("libmpv", "jsonipc")
 
+SINK_NAME = "jms-e2e-sink"
+
+
+def make_dummy_sink():
+    """One null audio sink for the whole matrix. Returns (device, unload).
+
+    The playback legs decode real media, so mpv opens a real output — audible
+    on a developer's box, contending with whatever else is playing, and able
+    to fail on a device another process holds. A null sink keeps the entire
+    audio path live (device selection, format negotiation, the AudioMixin
+    settings) while ending nowhere.
+
+    Made here rather than per-leg so eleven processes share one sink instead
+    of loading eleven modules under one requested name, and so a leg that dies
+    does not leak its own. The **default sink is never changed** — this one is
+    addressed explicitly and nothing about the developer's audio moves.
+    """
+    if not shutil.which("pactl"):
+        return None, None
+    try:
+        out = subprocess.run(
+            ["pactl", "load-module", "module-null-sink",
+             "sink_name=" + SINK_NAME,
+             "sink_properties=device.description=" + SINK_NAME],
+            capture_output=True, text=True, timeout=20)
+    except (OSError, subprocess.SubprocessError):
+        return None, None
+    module_id = (out.stdout or "").strip()
+    if out.returncode != 0 or not module_id.isdigit():
+        return None, None
+
+    def unload():
+        try:
+            subprocess.run(["pactl", "unload-module", module_id],
+                           capture_output=True, timeout=20)
+        except (OSError, subprocess.SubprocessError):
+            pass
+
+    return "pulse/" + SINK_NAME, unload
+
 
 def run_leg(module, backend, use_xvfb, verbosity):
     env = dict(os.environ)
@@ -96,6 +136,15 @@ def main():
     else:
         print("server: %s" % server)
 
+    device, unload_sink = make_dummy_sink()
+    if device:
+        os.environ["JMS_E2E_AUDIO_DEVICE"] = device
+        print("audio:  %s (null sink; your default output is untouched)"
+              % device)
+    else:
+        print("audio:  no null sink available; mpv's own null device",
+              file=sys.stderr)
+
     use_xvfb = not args.no_xvfb and shutil.which("xvfb-run") is not None
     backends = [args.backend] if args.backend else list(BACKENDS)
     modules = args.module or MODULES
@@ -114,6 +163,8 @@ def main():
     print("\n" + "=" * 60)
     for module, backend, ok in results:
         print("%-8s %-45s %s" % (backend, module, "PASS" if ok else "FAIL"))
+    if unload_sink:
+        unload_sink()
     failed = [r for r in results if not r[2]]
     print("=" * 60)
     print("%d/%d legs passed" % (len(results) - len(failed), len(results)))

--- a/tests/e2e/run_e2e.py
+++ b/tests/e2e/run_e2e.py
@@ -44,6 +44,7 @@ CONTRACT = [
     "tests.e2e.test_route_walk",
     "tests.e2e.test_paging",
     "tests.e2e.test_keyboard_nav",
+    "tests.e2e.test_large_queue",
 ]
 
 # Playback tier: a real mpv, so once per backend under xvfb.

--- a/tests/e2e/run_e2e.py
+++ b/tests/e2e/run_e2e.py
@@ -43,6 +43,7 @@ CONTRACT = [
     "tests.e2e.test_live_tv",
     "tests.e2e.test_route_walk",
     "tests.e2e.test_paging",
+    "tests.e2e.test_keyboard_nav",
 ]
 
 # Playback tier: a real mpv, so once per backend under xvfb.

--- a/tests/e2e/run_e2e.py
+++ b/tests/e2e/run_e2e.py
@@ -1,0 +1,107 @@
+#!/usr/bin/env python3
+"""Runner for the end-to-end suite (real Jellyfin server + real mpv).
+
+Separate from both `python3 -m unittest discover tests` and the integration
+runner: `tests/e2e/` has no `__init__.py`, so the fast suite never recurses
+into it and never needs a server.
+
+    ./stdjflib.py serve ~/Desktop/std-jf-lib --live-tv     # in another shell
+
+    JMS_E2E_SERVER=http://127.0.0.1:8096 python3 tests/e2e/run_e2e.py
+    JMS_E2E_SERVER=... python3 tests/e2e/run_e2e.py --backend libmpv
+    python3 tests/e2e/run_e2e.py --list
+
+Every module runs once per mpv backend, in a fresh interpreter with
+`JMS_TEST_BACKEND` set — player.py picks its backend at import time and wires
+interdependent module-level singletons, so a subprocess is the only clean way
+to get a pristine import per backend. External mpv is the least-tested path in
+the app and one of the two largest open-bug clusters, which is exactly why it
+is not optional here.
+
+Legs run under `xvfb-run` when it is available, not merely when headless: a
+bare run throws real video windows onto the developer's desktop and steals
+their clicks. `--no-xvfb` to watch them.
+
+With `JMS_E2E_SERVER` unset the tests skip themselves and this exits 0 — the
+suite is not a reason for a machine without a server to fail.
+"""
+
+import argparse
+import os
+import shutil
+import subprocess
+import sys
+
+REPO_ROOT = os.path.dirname(os.path.dirname(os.path.dirname(
+    os.path.abspath(__file__))))
+
+MODULES = [
+    "tests.e2e.test_playback_advance",
+    "tests.e2e.test_playback_eof",
+    "tests.e2e.test_playback_failure",
+    "tests.e2e.test_mpv_reopen",
+]
+
+BACKENDS = ("libmpv", "jsonipc")
+
+
+def run_leg(module, backend, use_xvfb, verbosity):
+    env = dict(os.environ)
+    env["JMS_TEST_BACKEND"] = backend
+    cmd = [sys.executable, "-m", "unittest", module]
+    if verbosity > 1:
+        cmd.append("-v")
+    if use_xvfb:
+        cmd = ["xvfb-run", "-a"] + cmd
+    print("\n=== %s [%s] ===" % (module, backend), flush=True)
+    proc = subprocess.run(cmd, cwd=REPO_ROOT, env=env)
+    return proc.returncode == 0
+
+
+def main():
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--backend", choices=BACKENDS,
+                        help="run one backend instead of the matrix")
+    parser.add_argument("--module", action="append",
+                        help="run only this module (repeatable)")
+    parser.add_argument("--no-xvfb", action="store_true",
+                        help="show the real mpv windows")
+    parser.add_argument("--list", action="store_true")
+    parser.add_argument("-v", "--verbose", action="count", default=1)
+    args = parser.parse_args()
+
+    if args.list:
+        for module in MODULES:
+            print(module)
+        return 0
+
+    server = os.environ.get("JMS_E2E_SERVER")
+    if not server:
+        print("JMS_E2E_SERVER is not set — every test will skip.\n"
+              "Start one with:  ./stdjflib.py serve ~/Desktop/std-jf-lib "
+              "--live-tv\nthen re-run with "
+              "JMS_E2E_SERVER=http://127.0.0.1:8096", file=sys.stderr)
+    else:
+        print("server: %s" % server)
+
+    use_xvfb = not args.no_xvfb and shutil.which("xvfb-run") is not None
+    backends = [args.backend] if args.backend else list(BACKENDS)
+    modules = args.module or MODULES
+
+    results = []
+    for backend in backends:
+        for module in modules:
+            ok = run_leg(module, backend, use_xvfb, args.verbose)
+            results.append((module, backend, ok))
+
+    print("\n" + "=" * 60)
+    for module, backend, ok in results:
+        print("%-6s %-45s %s" % (backend, module, "PASS" if ok else "FAIL"))
+    failed = [r for r in results if not r[2]]
+    print("=" * 60)
+    print("%d/%d legs passed" % (len(results) - len(failed), len(results)))
+    return 1 if failed else 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/e2e/run_e2e.py
+++ b/tests/e2e/run_e2e.py
@@ -58,6 +58,7 @@ PER_BACKEND = [
     "tests.e2e.test_mpv_reopen",
     "tests.e2e.test_input_routing",
     "tests.e2e.test_scroll_recovery",
+    "tests.e2e.test_window_resize",
 ]
 
 MODULES = CONTRACT + PER_BACKEND

--- a/tests/e2e/run_e2e.py
+++ b/tests/e2e/run_e2e.py
@@ -40,6 +40,7 @@ REPO_ROOT = os.path.dirname(os.path.dirname(os.path.dirname(
 CONTRACT = [
     "tests.e2e.test_account_policy",
     "tests.e2e.test_source_conformance",
+    "tests.e2e.test_live_tv",
 ]
 
 # Playback tier: a real mpv, so once per backend under xvfb.

--- a/tests/e2e/run_e2e.py
+++ b/tests/e2e/run_e2e.py
@@ -52,6 +52,7 @@ PER_BACKEND = [
     "tests.e2e.test_playback_eof",
     "tests.e2e.test_playback_failure",
     "tests.e2e.test_mpv_reopen",
+    "tests.e2e.test_input_routing",
 ]
 
 MODULES = CONTRACT + PER_BACKEND

--- a/tests/e2e/run_e2e.py
+++ b/tests/e2e/run_e2e.py
@@ -53,6 +53,7 @@ PER_BACKEND = [
     "tests.e2e.test_playback_failure",
     "tests.e2e.test_mpv_reopen",
     "tests.e2e.test_input_routing",
+    "tests.e2e.test_scroll_recovery",
 ]
 
 MODULES = CONTRACT + PER_BACKEND

--- a/tests/e2e/test_account_policy.py
+++ b/tests/e2e/test_account_policy.py
@@ -11,16 +11,17 @@ path above it.
 `EnableMediaPlayback` or `SyncPlayAccess`, and the only policy-derived
 behaviour is Live TV, which comes from whether the server put a Live TV view
 in `/Views` (`repository.get_libraries`). So Download, Play and SyncPlay are
-offered to accounts the server may refuse. That is a gap against jellyfin-web,
-which hides them — recorded in `docs/E2E_PLAN.md` rather than asserted here,
-because the tests below can only pin what the code actually promises.
+offered to accounts the server may refuse. The two that matter are written up
+as work items in `docs/PERMISSION_GAPS.md`; they are not asserted here,
+because these tests can only pin what the code actually promises today.
 
 Two things that are *not* tested here, because measurement said they are not
 true (both in `docs/E2E_PLAN.md`):
 
-* `qa-noplayback` can play. `EnableMediaPlayback: False` does not stop the
-  server serving a `static=true` direct-play URL, so there is no refusal for
-  the client to handle and no spinner for this account to find.
+* `qa-noplayback` can play, and no client can change that. Jellyfin's video
+  endpoints are `AllowAnonymous`, so the item id is effectively the
+  credential; `EnableMediaPlayback: False` does not stop the server serving a
+  `static=true` URL, and there is no refusal for the client to handle.
 * `qa-onesession` does not evict. The server refuses the *second* login with
   403 and leaves the first working, which is the opposite way round from the
   account's description.

--- a/tests/e2e/test_account_policy.py
+++ b/tests/e2e/test_account_policy.py
@@ -1,0 +1,199 @@
+"""What each kind of user account does to login and to the library.
+
+stdjflib ships twelve accounts, each one reaching "a client path that is
+otherwise tedious to set up by hand" — and the shim has never been run
+against any of them by anything automatic. These are contract tests: no mpv,
+no window, just the seam the browser is handed (`LibrarySource`) and the login
+path above it.
+
+**The shim reads no user policy fields.** Confirmed by grep: nothing in
+`jellyfin_mpv_shim/` consults `EnableContentDownloading`,
+`EnableMediaPlayback` or `SyncPlayAccess`, and the only policy-derived
+behaviour is Live TV, which comes from whether the server put a Live TV view
+in `/Views` (`repository.get_libraries`). So Download, Play and SyncPlay are
+offered to accounts the server may refuse. That is a gap against jellyfin-web,
+which hides them — recorded in `docs/E2E_PLAN.md` rather than asserted here,
+because the tests below can only pin what the code actually promises.
+
+Two things that are *not* tested here, because measurement said they are not
+true (both in `docs/E2E_PLAN.md`):
+
+* `qa-noplayback` can play. `EnableMediaPlayback: False` does not stop the
+  server serving a `static=true` direct-play URL, so there is no refusal for
+  the client to handle and no spinner for this account to find.
+* `qa-onesession` does not evict. The server refuses the *second* login with
+  403 and leaves the first working, which is the opposite way round from the
+  account's description.
+"""
+
+import os
+import sys
+import unittest
+
+sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+import _e2e  # noqa: E402
+
+
+@_e2e.require_server
+class RestrictedLibrariesTest(unittest.TestCase):
+    """`qa-restricted` — "the rest must be *absent*, not merely unplayable".
+
+    Absence is the whole point: a client that lists a library it cannot open
+    has failed this account even though nothing errored.
+    """
+
+    ALLOWED = {"Movies", "Shows"}
+
+    def setUp(self):
+        self.session = _e2e.Session("qa-restricted")
+        self.addCleanup(self.session.stop)
+        self.source = self.session.library_source()
+        self.addCleanup(self.source.stop)
+
+    def test_only_the_permitted_libraries_are_visible(self):
+        names = {lib["Name"] for lib in
+                 self.source.get_libraries(_e2e.SOURCE_UUID)}
+        # Live TV is a view rather than a library and is granted separately,
+        # so it is allowed to be here and is not the subject of this test.
+        names.discard("Live TV")
+        self.assertEqual(
+            names, self.ALLOWED,
+            "a restricted user sees libraries they have no access to")
+
+    def test_the_home_screen_offers_nothing_from_a_forbidden_library(self):
+        """The rows are built from the libraries, so this is the same rule one
+        layer up — and the layer a user actually looks at."""
+        allowed_ids = {lib["Id"] for lib
+                       in self.source.get_libraries(_e2e.SOURCE_UUID)}
+        rows = self.source.get_home_rows(_e2e.SOURCE_UUID)
+        self.assertTrue(rows, "a restricted user got no home rows at all")
+        for row in rows:
+            parent = row.get("parent_id")
+            if parent is not None:
+                self.assertIn(
+                    parent, allowed_ids,
+                    "home row %r is built from a library this user cannot "
+                    "see" % row.get("title"))
+
+    def test_a_full_user_sees_more(self):
+        """Guards the test above from passing because everything is empty."""
+        other = _e2e.Session("qa-user")
+        self.addCleanup(other.stop)
+        source = other.library_source()
+        self.addCleanup(source.stop)
+        self.assertGreater(
+            len(source.get_libraries(_e2e.SOURCE_UUID)),
+            len(self.source.get_libraries(_e2e.SOURCE_UUID)),
+            "qa-restricted sees as much as qa-user, so the restriction is "
+            "not in force and the assertions above prove nothing")
+
+
+@_e2e.require_server
+class LiveTvAccessTest(unittest.TestCase):
+    """`qa-kid` has Live TV revoked, which is the gate `has_live_tv` reads.
+
+    `repository.get_libraries` derives it from the presence of the Live TV
+    view rather than fetching the policy, on the reasoning that the server
+    adds that view only when the user may use Live TV *and* a tuner exists.
+    This is that reasoning, checked against a server where exactly one of two
+    users has the right.
+    """
+
+    def _source(self, account):
+        session = _e2e.Session(account)
+        self.addCleanup(session.stop)
+        source = session.library_source()
+        self.addCleanup(source.stop)
+        source.get_libraries(_e2e.SOURCE_UUID)      # what populates the flag
+        return source
+
+    def test_a_user_with_live_tv_is_offered_it(self):
+        self.assertTrue(
+            self._source("qa-user").has_live_tv(_e2e.SOURCE_UUID),
+            "Live TV is configured on this server but qa-user was not "
+            "offered it")
+
+    def test_a_user_without_live_tv_is_not_offered_it(self):
+        source = self._source("qa-kid")
+        self.assertFalse(
+            source.has_live_tv(_e2e.SOURCE_UUID),
+            "qa-kid has EnableLiveTvAccess False but was offered Live TV")
+        self.assertNotIn(
+            "Live TV",
+            {lib["Name"] for lib in source.get_libraries(_e2e.SOURCE_UUID)})
+
+
+@_e2e.require_server
+class LoginTest(unittest.TestCase):
+    """The login paths that are awkward to reach by hand."""
+
+    def test_an_account_with_no_password_can_sign_in(self):
+        """`qa-nopassword` — "a login flow that assumes a password field is
+        filled breaks here". Common in home setups."""
+        session = _e2e.Session("qa-nopassword", password="")
+        self.addCleanup(session.stop)
+        self.assertTrue(session.token)
+        self.assertTrue(session.api.get_views()["Items"],
+                        "signed in with no password but cannot browse")
+
+    def test_a_disabled_account_is_refused(self):
+        """`qa-disabled` — must fail cleanly rather than hang or land the
+        client half signed in. The server answers 403."""
+        self.assertTrue(_e2e.login_refused("qa-disabled"))
+
+    def test_a_wrong_password_is_refused(self):
+        self.assertTrue(_e2e.login_refused("qa-user", "not-the-password"))
+
+    def test_a_hidden_account_is_absent_from_the_list_but_can_sign_in(self):
+        """`qa-hidden` — "a client that only offers the public user list
+        cannot reach this account at all", which is why the shim asks for a
+        username rather than only offering the list."""
+        public = _e2e.public_users()
+        self.assertTrue(public, "no public users at all")
+        self.assertIn("qa-user", public,
+                      "the public list is empty of accounts that should be in "
+                      "it, so its absence proves nothing below")
+        self.assertNotIn("qa-hidden", public)
+
+        session = _e2e.Session("qa-hidden")
+        self.addCleanup(session.stop)
+        self.assertTrue(session.token,
+                        "a hidden account could not sign in by name")
+
+    def test_a_second_session_is_refused_and_the_first_survives(self):
+        """`qa-onesession` caps concurrent sessions at one.
+
+        The account's description says the second login must evict the first.
+        Measured, the server does the opposite: it refuses the newcomer with
+        403 and leaves the incumbent working. Either way the client must not
+        end up half signed in, which is what this pins.
+
+        The cap counts what the server still believes is connected, so this
+        starts by deleting the account's Device records as admin. Without
+        that, a session left behind by a crashed run refuses the *first*
+        login here and the failure looks like the cap working rather than
+        like litter — which is exactly how it first failed.
+        """
+        admin = _e2e.Session("qa-admin")
+        self.addCleanup(admin.stop)
+        admin.purge_devices("qa-onesession")
+        self.addCleanup(admin.purge_devices, "qa-onesession")
+
+        first = _e2e.Session("qa-onesession", device_id="jms-e2e-1session-a")
+        self.addCleanup(first.stop)
+        self.assertTrue(first.api.get_views()["Items"])
+
+        # A genuinely different device, which is the scenario the cap is about.
+        self.assertTrue(
+            _e2e.login_refused("qa-onesession",
+                               device_id="jms-e2e-1session-b"),
+            "a second concurrent session was allowed, so this server does "
+            "not cap them and the assertion below proves nothing")
+        self.assertTrue(
+            first.api.get_views()["Items"],
+            "the incumbent session stopped working when a second login was "
+            "refused")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/e2e/test_account_policy.py
+++ b/tests/e2e/test_account_policy.py
@@ -272,6 +272,25 @@ class LiveTvManagementPermissionTest(unittest.TestCase):
             "longer has an account without the permission and the gate is "
             "untested")
 
+    def test_it_may_still_READ_what_is_scheduled(self):
+        """The premise of showing Schedule and Series to everyone.
+
+        The permission gates writes. If the server ever starts refusing
+        these reads as well, hiding those two tabs becomes right again and
+        this is the test that says so — no unit test can, because the answer
+        is the server's and not ours.
+        """
+        source = self._source("qa-restricted")
+        for name in ("get_timers", "get_series_timers"):
+            with self.subTest(name):
+                # Not "returns rows": the QA server schedules nothing, so an
+                # empty list is the honest answer. What is being asserted is
+                # that asking is allowed at all -- a 403 raises.
+                self.assertIsNotNone(
+                    getattr(source, name)(_e2e.SOURCE_UUID),
+                    "%s was refused for an account without "
+                    "EnableLiveTvManagement" % name)
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/tests/e2e/test_account_policy.py
+++ b/tests/e2e/test_account_policy.py
@@ -6,14 +6,13 @@ against any of them by anything automatic. These are contract tests: no mpv,
 no window, just the seam the browser is handed (`LibrarySource`) and the login
 path above it.
 
-**The shim reads no user policy fields.** Confirmed by grep: nothing in
-`jellyfin_mpv_shim/` consults `EnableContentDownloading`,
-`EnableMediaPlayback` or `SyncPlayAccess`, and the only policy-derived
-behaviour is Live TV, which comes from whether the server put a Live TV view
-in `/Views` (`repository.get_libraries`). So Download, Play and SyncPlay are
-offered to accounts the server may refuse. The two that matter are written up
-as work items in `docs/PERMISSION_GAPS.md`; they are not asserted here,
-because these tests can only pin what the code actually promises today.
+**Two of the gaps these tests turned up are now closed** (`user_policy.py`)
+and asserted below: SyncPlay is not offered to a user the server refuses it
+to, and the Record affordances are not offered without
+`EnableLiveTvManagement`. `EnableContentDownloading` is still unread, and
+Live TV *browsing* was already gated by whether the server put a Live TV
+view in `/Views` (`repository.get_libraries`). See
+`docs/PERMISSION_GAPS.md`.
 
 Two things that are *not* tested here, because measurement said they are not
 true (both in `docs/E2E_PLAN.md`):
@@ -194,6 +193,84 @@ class LoginTest(unittest.TestCase):
             first.api.get_views()["Items"],
             "the incumbent session stopped working when a second login was "
             "refused")
+
+
+@_e2e.require_server
+class SyncPlayPermissionTest(unittest.TestCase):
+    """`qa-nosyncplay` — "SyncPlay refused, so the client's SyncPlay entry
+    points must go".
+
+    The policy is read from the server here, not fabricated: the point of
+    doing this end to end is that `SyncPlayAccess` really does come back on
+    `/Users/Me` for a real account, spelled the way the code expects. A unit
+    test with a hand-written policy dict proves the branch, not the field
+    name.
+    """
+
+    def _client(self, account):
+        session = _e2e.Session(account)
+        self.addCleanup(session.stop)
+        source = session.library_source()
+        self.addCleanup(source.stop)
+        return source
+
+    def test_the_refused_account_is_refused(self):
+        from jellyfin_mpv_shim import user_policy
+
+        source = self._client("qa-nosyncplay")
+        access = source.syncplay_access(_e2e.SOURCE_UUID)
+        self.assertEqual(
+            access, user_policy.NO_SYNCPLAY,
+            "qa-nosyncplay came back as %r — either the account no longer "
+            "has SyncPlay revoked, or the field is not where the client "
+            "looks for it" % access)
+
+    def test_an_ordinary_account_still_has_it(self):
+        """The control. Without this the test above passes just as well if
+        the client answers "no" to everybody."""
+        from jellyfin_mpv_shim import user_policy
+
+        source = self._client("qa-user")
+        self.assertEqual(source.syncplay_access(_e2e.SOURCE_UUID),
+                         user_policy.CREATE_AND_JOIN)
+
+
+@_e2e.require_server
+class LiveTvManagementPermissionTest(unittest.TestCase):
+    """`EnableLiveTvManagement` is a *third* Live TV permission, separate
+    from the access one — and the one that made this suite unable to
+    schedule a timer as any account on the server until stdjflib was fixed.
+
+    A user can therefore browse the guide perfectly well and have every
+    Record button answer 403.
+    """
+
+    def _source(self, account):
+        session = _e2e.Session(account)
+        self.addCleanup(session.stop)
+        source = session.library_source()
+        self.addCleanup(source.stop)
+        return source
+
+    def test_the_account_that_may_record_may(self):
+        self.assertTrue(
+            self._source("qa-user").can_manage_live_tv(_e2e.SOURCE_UUID),
+            "qa-user was granted EnableLiveTvManagement by stdjflib and the "
+            "client does not see it")
+
+    def test_an_account_without_it_is_refused(self):
+        """`qa-restricted` is an ordinary account that was never granted it.
+
+        Which is the default for every account created on a modern server:
+        `AddDefaultPermissions` leaves it False, and only an install
+        migrated from an older one has it on by default.
+        """
+        source = self._source("qa-restricted")
+        self.assertFalse(
+            source.can_manage_live_tv(_e2e.SOURCE_UUID),
+            "qa-restricted can manage Live TV recordings, so this server no "
+            "longer has an account without the permission and the gate is "
+            "untested")
 
 
 if __name__ == "__main__":

--- a/tests/e2e/test_connection_loss.py
+++ b/tests/e2e/test_connection_loss.py
@@ -1,0 +1,342 @@
+"""The server stops answering while you are looking at the library.
+
+Three ways it happens, and they are not the same failure: the box goes away
+(connection refused), the token stops being accepted (401), and — the one
+that matters most — it happens *after* a screenful has already drawn, while
+paging further in.
+
+That last case has a rule the other two do not, and it is the one worth
+holding on to: **a failure while paging must not take away what is already on
+screen.** The first page is real data the user is reading. Replacing it with
+an error panel because the *second* page failed loses a screenful to a
+problem that did not touch it. So `Paginator.window` raises a toast and
+leaves the items alone, while a load that has nothing at all to show sets
+`_error` and offers Retry.
+
+The other rule is a rate one. Windows are requested from **render**, because
+which items are visible is a question about geometry — so a page that
+re-requested on failure would issue one request per frame for as long as the
+server stayed down, and the toast it raises is itself a repaint. One attempt
+per page per scroll (`_win_tried`), cleared by `rewindow` when the user
+moves.
+
+None of this can be seen against a fake: a fake answers, so there is no
+failure to recover from, and the failure the app has to survive is a real
+socket error raised from inside a worker thread. The server here is real and
+the connection to it is genuinely broken — by pointing the client at a closed
+port, which is what a stopped server looks like, and by having an admin
+revoke the device's session, which is what a signed-out client looks like.
+"""
+
+import logging
+import os
+import sys
+import unittest
+
+sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+import _e2e  # noqa: E402
+
+REPO_ROOT = os.path.dirname(os.path.dirname(os.path.dirname(
+    os.path.abspath(__file__))))
+if REPO_ROOT not in sys.path:
+    sys.path.insert(0, REPO_ROOT)
+
+SIZE = (1280, 720)
+#: A port nothing listens on. Refused immediately, which is what a stopped
+#: server does; a blackholed address would instead time out, which is a
+#: different failure with a different (much slower) shape.
+DEAD = "http://127.0.0.1:1"
+
+#: Loggers that narrate a failed request. Both spellings of the apiclient's
+#: root are here on purpose: it uses `'JELLYFIN.' + __name__` in five modules
+#: and `'Jellyfin.' + __name__` in http.py, and logger names are
+#: case-sensitive, so silencing the shouted one alone leaves every connection
+#: error on the console.
+_NOISY = ("Jellyfin", "JELLYFIN", "mpvtk_browser.async_runner",
+          "mpvtk_browser.repository", "mpvtk_browser.app")
+
+BIG_LIBRARY = "Bulk Movies"
+SMALL_LIBRARY = "Movies"
+
+
+class _SyncPool:
+    def submit(self, fn, *a, **k):
+        fn(*a, **k)
+
+    def shutdown(self, *a, **k):
+        pass
+
+
+class _BrowserCase(unittest.TestCase):
+    """A real browser over a real source, with its worker pool made
+    synchronous so a load has finished by the time navigate() returns."""
+
+    account = "qa-user"
+
+    def setUp(self):
+        from jellyfin_mpv_shim.mpvtk_browser.app import MpvtkBrowser
+        from jellyfin_mpv_shim.mpvtk.layout import layout
+
+        self.layout = layout
+        self.session = _e2e.Session(self.account)
+        self.addCleanup(self._stop_session)
+        self.source = self.session.library_source()
+        self.addCleanup(self.source.stop)
+        self.libraries = {lib["Name"]: lib
+                          for lib in self.source.get_libraries(_e2e.SOURCE_UUID)}
+
+        self.browser = MpvtkBrowser(app=None, source=self.source,
+                                    server_uuid=_e2e.SOURCE_UUID)
+        self.browser._async._pool.shutdown(wait=True, cancel_futures=True)
+        self.browser._pool = _SyncPool()
+        self.addCleanup(self._shutdown)
+        self.conn = self.source._conn(_e2e.SOURCE_UUID)
+        self.address = self.conn.client.config.data["auth.server"]
+        self.addCleanup(self._revive)
+
+    def _stop_session(self):
+        try:
+            self.session.stop()
+        except Exception:
+            pass
+
+    def _shutdown(self):
+        try:
+            self.browser.shutdown()
+        except Exception:
+            pass
+
+    def _revive(self):
+        self.conn.client.config.data["auth.server"] = self.address
+
+    # -- driving -----------------------------------------------------------
+
+    def _kill(self):
+        """The server stops answering, mid-session.
+
+        Every failure below is deliberate, and both the apiclient and the
+        async runner log the whole traceback for one — three screens of it
+        per test, on a run where nothing is wrong. Silenced from here so
+        that a traceback appearing in this suite's output still means
+        something.
+        """
+        for name in _NOISY:
+            logger = logging.getLogger(name)
+            self.addCleanup(logger.setLevel, logger.level)
+            logger.setLevel(logging.CRITICAL)
+        self.conn.client.config.data["auth.server"] = DEAD
+
+    def _goto(self, name):
+        library = self.libraries.get(name)
+        if library is None:
+            self.skipTest("no %r library" % name)
+        self.browser.navigate({
+            "kind": "grid", "server": _e2e.SOURCE_UUID,
+            "parent_id": library["Id"], "title": name,
+            "collection_type": library.get("CollectionType")})
+        return library
+
+    def _render(self):
+        return self.layout(self.browser.build(SIZE), *SIZE)
+
+    def _loaded(self):
+        return sum(1 for x in (self.browser.route.get("_items") or [])
+                   if x is not None)
+
+    def _count_requests(self):
+        """Count HTTP calls to the server from here on. Returns a getter."""
+        http = self.conn.client.http
+        original = http.request
+        calls = []
+
+        def counted(*a, **k):
+            calls.append(1)
+            return original(*a, **k)
+
+        http.request = counted
+        self.addCleanup(setattr, http, "request", original)
+        return lambda: len(calls)
+
+
+@_e2e.require_server
+class ServerGoneTest(_BrowserCase):
+
+    def test_a_load_with_nothing_to_show_says_so_and_offers_a_retry(self):
+        """Without `_error` the route's data stays None and the view spins
+        forever, so an unreachable server reads as a hang."""
+        self._kill()
+        self._goto(SMALL_LIBRARY)
+        self.assertTrue(
+            self.browser.route.get("_error"),
+            "a grid that could not load anything set no error, so the screen "
+            "spins with no retry and no explanation")
+        _nodes, handlers = self._render()
+        self.assertIn(
+            "route-retry", handlers,
+            "no Retry button on a failed load — the only way out is Back")
+
+    def test_retry_recovers_once_the_server_is_back(self):
+        """The button has to actually re-issue the load, not just clear the
+        error and leave an empty screen."""
+        self._kill()
+        self._goto(SMALL_LIBRARY)
+        _nodes, handlers = self._render()
+        self.assertIn("route-retry", handlers)
+
+        self._revive()
+        handlers["route-retry"]["click"]()
+        self.assertIsNone(self.browser.route.get("_error"),
+                          "the error survived a successful retry")
+        self.assertGreater(
+            self._loaded(), 0,
+            "Retry cleared the error but loaded nothing, so the library is "
+            "blank rather than broken — which is worse")
+
+    def test_navigating_on_while_down_does_not_crash_the_browser(self):
+        """A dead server must not make the shell unusable. Every route the
+        user can reach from a failed one still has to build."""
+        self._kill()
+        self._goto(SMALL_LIBRARY)
+        for route in ({"kind": "home", "server": _e2e.SOURCE_UUID},
+                      {"kind": "search", "server": _e2e.SOURCE_UUID,
+                       "query": "standard"},
+                      {"kind": "settings", "server": _e2e.SOURCE_UUID}):
+            with self.subTest(kind=route["kind"]):
+                self.browser.navigate(dict(route))
+                self._render()      # must not raise
+        self.browser.go_back()
+        self._render()
+
+
+@_e2e.require_server
+class PagingWhileDownTest(_BrowserCase):
+    """The case with the extra rule: it broke *after* something drew."""
+
+    def setUp(self):
+        super().setUp()
+        self._goto(BIG_LIBRARY)
+        self._render()
+        self.first_page = self._loaded()
+        if self.first_page < 50 or (self.browser.route.get("_total") or 0) < 500:
+            self.skipTest("need a library big enough to page through; got "
+                          "%d of %r loaded" % (self.first_page,
+                                               self.browser.route.get("_total")))
+        self.page = self.browser._page_for(self.browser.route)
+        self.assertIsNotNone(self.page, "the grid has no page object")
+
+    def _ask_for_a_far_window(self, first=400, last=460):
+        """What the view does when the user scrolls to items it has not got.
+
+        Called directly rather than by faking a scroll offset: the offset is
+        owned by the renderer's scroll state, and forging one tests the
+        forgery. This is the call render makes.
+        """
+        self.page._window(first, last)
+
+    def test_a_failed_page_in_keeps_what_is_already_on_screen(self):
+        self._kill()
+        self._ask_for_a_far_window()
+        self._render()
+        self.assertEqual(
+            self._loaded(), self.first_page,
+            "a failed page-in dropped items that had already loaded")
+        self.assertIsNone(
+            self.browser.route.get("_error"),
+            "a failed page-in set the route error, which replaces a "
+            "screenful of real data with an error panel")
+
+    def test_it_says_something_rather_than_failing_silently(self):
+        self._kill()
+        self.browser.set_status("")
+        self._ask_for_a_far_window()
+        self.assertTrue(
+            self.browser.status,
+            "paging failed with no message at all, so the grid simply stops "
+            "filling in and nothing says why")
+
+    def test_the_tiles_are_still_drawn(self):
+        """The point of keeping the items: the screen still works."""
+        self._kill()
+        self._ask_for_a_far_window()
+        _nodes, handlers = self._render()
+        self.assertNotIn(
+            "route-retry", handlers,
+            "the whole grid was replaced by the error panel because a page "
+            "further down failed")
+        self.assertTrue(
+            [i for i in handlers if "click" in handlers[i]],
+            "nothing on the grid is clickable any more")
+
+    def test_a_dead_server_is_not_re_asked_every_frame(self):
+        """Windows are requested from render, so a retry-on-failure here is
+        a request per frame for as long as the server stays down — and the
+        toast the failure raises is itself a repaint."""
+        self._kill()
+        count = self._count_requests()
+        for _frame in range(5):
+            self._ask_for_a_far_window()
+            self._render()
+        self.assertEqual(
+            count(), 1,
+            "five frames against a dead server issued %d requests; one "
+            "attempt per page per scroll is the rule, and render is what "
+            "drives this" % count())
+
+    def test_moving_again_retries_the_window_that_failed(self):
+        """`rewindow` is called on a scroll, which is the cadence: a window
+        that failed is retried when the user moves, and never while they hold
+        still. Without it the hole stays a hole for the rest of the session.
+        """
+        self._kill()
+        self._ask_for_a_far_window()
+        self._render()
+        self.assertEqual(self._loaded(), self.first_page)
+
+        self._revive()
+        self.browser._pages.rewindow(self.browser.route)   # a scroll
+        self._ask_for_a_far_window()
+        self.assertGreater(
+            self._loaded(), self.first_page,
+            "the window that failed while the server was down was never "
+            "asked for again, so those tiles stay blank forever")
+
+
+@_e2e.require_server
+class RevokedSessionTest(_BrowserCase):
+    """Signed out from elsewhere: the address answers, the token does not.
+
+    A different failure from an unreachable server and, until measured, an
+    open question — a 401 that came back as an empty result set would render
+    a perfectly calm, perfectly empty library, which is the worst of the
+    three outcomes because nothing looks wrong.
+    """
+
+    account = "qa-nosyncplay"
+
+    def test_a_revoked_token_reads_as_an_error_not_an_empty_library(self):
+        for name in _NOISY:
+            logger = logging.getLogger(name)
+            self.addCleanup(logger.setLevel, logger.level)
+            logger.setLevel(logging.CRITICAL)
+        admin = _e2e.Session("qa-admin")
+        self.addCleanup(admin.stop)
+        admin.purge_devices(self.account)
+
+        self._goto(SMALL_LIBRARY)
+        self.assertEqual(
+            self._loaded(), 0,
+            "items came back after the session was revoked")
+        # The message does not distinguish this from a network failure
+        # ("Failed to load. Check the connection."), which is worth
+        # improving; what matters here is that it is an error at all rather
+        # than a library that looks empty.
+        self.assertTrue(
+            self.browser.route.get("_error"),
+            "a revoked session rendered as an empty library with no error, "
+            "so the user sees a server that has lost their media")
+        _nodes, handlers = self._render()
+        self.assertIn("route-retry", handlers)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/e2e/test_input_routing.py
+++ b/tests/e2e/test_input_routing.py
@@ -1,0 +1,288 @@
+"""Real keys through mpv's input layer, across every UI transition.
+
+This is the surface with the worst recent record. **Three regressions in
+48 hours (2026-08-01/02), every one found by hand**, all the same shape: a
+key-binding section that was never re-enabled after a transition, so the
+library came back from playback with no keyboard at all.
+
+`f70ad1e7` says what the suite could see and what it could not:
+
+    The fake mpv's enable/disable_key_bindings were no-ops, which is why the
+    tests covering that commit could only assert which section a binding was
+    DECLARED in.
+
+Declaring a binding and *enabling its section* are different calls, and only
+mpv holds the second. So the tests were green while, in the reporter's words,
+"from the first video played, the library had no arrow, ENTER, TAB or MENU
+navigation for the rest of the session".
+
+The two paths that broke are both ordinary, and neither involves an error:
+
+* `set_active(False)` then `set_active(True)` — leaving a video.
+* a **summoned HUD**, which sets `active` itself, so the app's later "yes" is
+  a no-op and `ui_resume` never runs. `f70ad1e7` calls this "the common one —
+  clicking Back on a visible bar is how you leave a film."
+
+So nothing here asserts on which section a binding is declared in. Every test
+presses a real key and checks the UI moved.
+"""
+
+import os
+import sys
+import threading
+import time
+import unittest
+
+sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+import _e2e  # noqa: E402
+
+# _e2e puts tests/integration on the path; both of these live there.
+import _harness as h  # noqa: E402
+from test_mpvtk_browser import _spawn_handle  # noqa: E402
+
+
+@_e2e.require_server_and_mpv
+class InputRoutingTest(unittest.TestCase):
+    """A real browser on a real mpv, against the real library."""
+
+    def setUp(self):
+        from jellyfin_mpv_shim.mpvtk.app import MpvtkApp
+        from jellyfin_mpv_shim.mpvtk.rawimage import MemoryStore, cache_dir
+        from jellyfin_mpv_shim.mpvtk_browser.app import MpvtkBrowser
+        from jellyfin_mpv_shim.mpvtk_browser.strips import StripStore
+
+        self.session = _e2e.Session()
+        self.addCleanup(self.session.stop)
+        self.source = self.session.library_source()
+        self.addCleanup(self.source.stop)
+        self.libraries = self.source.get_libraries(_e2e.SOURCE_UUID)
+        self.assertTrue(self.libraries, "no libraries to navigate")
+
+        self.handle, ext = _spawn_handle()
+        self.app = MpvtkApp.attach(self.handle, ext=ext)
+        strips = (StripStore(mem_store=MemoryStore()) if self.app.in_process
+                  else StripStore(cache_dir=cache_dir("mpvtk-input-")))
+        self.browser = MpvtkBrowser(self.app, self.source,
+                                    server_uuid=_e2e.SOURCE_UUID, strips=strips)
+        self._thread = threading.Thread(
+            target=lambda: self.app.run(self.browser.build), daemon=True)
+        self._thread.start()
+        self.addCleanup(self._teardown)
+        self.assertTrue(self.app.ready.wait(20), "renderer never came up")
+        self._wait(lambda: (self._state().get("overlays") or 0) >= 1,
+                   "the browser never rendered a strip, so there is nothing "
+                   "to navigate")
+        # A window manager is free to ignore the requested geometry, and a
+        # squashed window has no rows to move between — which would fail as
+        # "the keyboard is dead" rather than as the environment problem it
+        # is. Same guard, and same reason, as test_mpvtk_browser.
+        state = self._state()
+        self.assertGreaterEqual(
+            state.get("h") or 0, 200,
+            "the window came back %sx%s — too short for a tile row, so "
+            "focus has nowhere to go. Run under xvfb."
+            % (state.get("w"), state.get("h")))
+
+    def _teardown(self):
+        try:
+            self.app.quit()
+            self._thread.join(timeout=5)
+        finally:
+            try:
+                self.browser.shutdown(free_bitmaps=False)
+            except Exception:
+                pass
+            try:
+                self.handle.terminate()
+            except Exception:
+                pass
+
+    # -- driving -----------------------------------------------------------
+
+    def _state(self):
+        return self.app.debug_state() or {}
+
+    def _keypress(self, key):
+        """A real key, through mpv's input layer — not a synthesised event.
+
+        Which is the entire point: a synthesised event reaches the handler
+        whether or not its section is enabled, so it cannot see these bugs.
+        """
+        self.handle.command("keypress", key)
+
+    def _click_key(self, key):
+        """Press AND release, for a binding that acts on the release.
+
+        `mpvtk_thumb` binds mbtn_back as a complex binding whose *third*
+        element runs on release (it fires ESC), so a plain `keypress` is not
+        guaranteed to deliver the edge that does the work.
+        """
+        self.handle.command("keydown", key)
+        time.sleep(0.1)
+        self.handle.command("keyup", key)
+
+    def _focus_a_content_tile(self):
+        """Arrow onto any tile in any home row and return its node id.
+
+        By steering rather than by parking a guessed id on `app.focus`: an id
+        has to be in the scene for a park to land, and which rows the home
+        screen has — and which of their tiles are materialised — depends on
+        the user's saved layout and on what the library holds. Any `row-`
+        tile navigates somewhere, which is all these tests need; insisting on
+        a *library* tile made them fail on a home screen whose Libraries row
+        the wander never reached.
+        """
+        seen = set()
+        for _ in range(40):
+            for key in ("DOWN", "RIGHT", "UP", "LEFT"):
+                self._keypress(key)
+                time.sleep(0.1)
+                nav = self._nav()
+                if nav and nav.startswith("row-"):
+                    return nav
+                if nav:
+                    seen.add(nav)
+        self.fail("never reached a content tile by arrowing; focus visited %r"
+                  % (sorted(seen)[:8],))
+
+    def _wait(self, pred, why, timeout=10.0):
+        deadline = time.time() + timeout
+        while time.time() < deadline:
+            if pred():
+                return True
+            time.sleep(0.15)
+        self.fail(why)
+
+    def _nav(self):
+        return self._state().get("nav")
+
+    def _nav_moves(self, keys=("DOWN", "RIGHT", "UP", "LEFT"), presses=6):
+        """Does *any* arrow key move focus? Returns the node it landed on.
+
+        Tries several directions because focus may already be against an edge
+        — a single DOWN at the bottom of a screen legitimately does nothing,
+        and reading that as "the keyboard is dead" would be a flaky test that
+        cried wolf about the exact bug it exists to find.
+        """
+        start = self._nav()
+        for _ in range(presses):
+            for key in keys:
+                self._keypress(key)
+                time.sleep(0.12)
+                now = self._nav()
+                if now and now != start:
+                    return now
+        return None
+
+    def _leave_and_return_to_browse(self):
+        """The plain round trip: browse -> playback -> browse."""
+        self.app.set_active(False)
+        time.sleep(0.4)
+        self.app.set_active(True)
+        time.sleep(0.4)
+
+    def _summoned_hud_and_back(self):
+        """The common one. A summoned HUD sets `active` itself, so the app's
+        later "yes" does not change it — and the early return below that used
+        to skip `ui_resume` entirely."""
+        self.app.set_active(False)
+        time.sleep(0.3)
+        self.app.set_hud(True)
+        time.sleep(0.3)
+        self.app.summon_hud()
+        time.sleep(0.3)
+        self.app.set_hud(False)
+        time.sleep(0.3)
+        self.app.set_active(True)
+        time.sleep(0.4)
+
+    # -- the tests ---------------------------------------------------------
+
+    def test_arrows_navigate_from_launch(self):
+        """#614's half: the keys were dead from launch and only started
+        working after a playback round trip happened to hide the bar."""
+        landed = self._nav_moves()
+        self.assertIsNotNone(
+            landed,
+            "no arrow key moved focus on a freshly started browser — the nav "
+            "section was never enabled at startup")
+
+    def test_arrows_still_navigate_after_a_playback_round_trip(self):
+        """`f70ad1e7`: `ui_suspend` drops the arrows for playback (there they
+        are mpv's seek keys) and only `ui_resume` puts them back."""
+        self.assertIsNotNone(self._nav_moves(),
+                             "focus did not move before playback, so this "
+                             "test could not tell the difference after")
+        self._leave_and_return_to_browse()
+        self.assertIsNotNone(
+            self._nav_moves(),
+            "arrow keys are dead after leaving playback — the library has no "
+            "keyboard for the rest of the session")
+
+    def test_arrows_still_navigate_after_a_summoned_hud(self):
+        """The path `f70ad1e7` calls the common one: clicking Back on a
+        visible bar is how you leave a film."""
+        self.assertIsNotNone(self._nav_moves())
+        self._summoned_hud_and_back()
+        self.assertIsNotNone(
+            self._nav_moves(),
+            "arrow keys are dead after browse resumed from a summoned HUD")
+
+    def test_enter_activates_after_a_playback_round_trip(self):
+        """Focus moving is not enough — ENTER has to still reach the node."""
+        self._leave_and_return_to_browse()
+        self._focus_a_content_tile()
+        before = self.browser.route.get("kind")
+        self._keypress("ENTER")
+        self._wait(lambda: self.browser.route.get("kind") != before,
+                   "ENTER did not activate the focused tile after a playback "
+                   "round trip")
+
+    def test_menu_opens_and_mouse_back_dismisses_after_a_round_trip(self):
+        """The MENU key and the thumb section, together.
+
+        `#614` / `86f113e2`: "mouse Back did nothing in the library from
+        launch, and started working only after a playback round trip that hid
+        the bar first: intermittent." The thumb section is `mpvtk_thumb`, and
+        `ui_resume` is what re-enables it.
+
+        What mbtn_back *does* in browse is fire ESC, and in plain browse ESC
+        has no binding at all — the forced ones belong to an open menu
+        (`mpvtk_menu_esc`) and to the playback HUD (`mpvtk_phud_esc`). So it
+        dismisses an overlay rather than paging back, and a test that
+        expected it to navigate was asserting something the app has never
+        done. Open the tile menu first, and both keys have a real observable.
+        """
+        self._leave_and_return_to_browse()
+        self._focus_a_content_tile()
+
+        self._keypress("MENU")
+        self._wait(lambda: self._state().get("menu_open"),
+                   "the MENU key did not open the tile menu after a playback "
+                   "round trip")
+
+        self._click_key("MBTN_BACK")
+        self._wait(
+            lambda: not self._state().get("menu_open"),
+            "mouse Back did not dismiss the menu — the mpvtk_thumb section "
+            "is not enabled in browse")
+
+    def test_the_hud_does_not_leave_browse_holding_the_arrows(self):
+        """The other direction, and the reason `ui_resume` takes `no_nav`:
+        during plain playback the arrows are mpv's seek keys, so the UI must
+        NOT be holding them."""
+        self.assertIsNotNone(self._nav_moves(),
+                             "focus did not move in browse to begin with")
+        self.app.set_active(False)
+        time.sleep(0.5)
+        # In playback the renderer is idle; arrows belong to mpv. Focus must
+        # not move, or seeking is broken instead.
+        moved = self._nav_moves(presses=2)
+        self.assertIsNone(
+            moved,
+            "the UI still moves focus on arrow keys during playback, so the "
+            "arrows are not reaching mpv as seek keys (landed on %r)" % moved)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/e2e/test_keyboard_nav.py
+++ b/tests/e2e/test_keyboard_nav.py
@@ -1,0 +1,288 @@
+"""Reaching the library by keyboard, against a real server.
+
+Focus movement itself lives in `renderer.lua` and is covered by the Lua
+suite. What Python owns is the other half: the scene has to *offer* something
+to focus, every focusable thing needs a handler, and activating it has to go
+somewhere. Those are the parts real data can break.
+
+Three ways it breaks that fabricated data cannot show:
+
+* **A screen with no activatable content.** The chrome is always there, so a
+  screen whose content area produced no handlers still looks fine in a
+  snapshot and is simply unreachable without a mouse.
+* **Duplicate node ids.** `layout()` warns that "renderer state and events
+  will target only the last occurrence" — so a collision silently makes one
+  tile unreachable and misroutes the other. Node ids embed item ids, and a
+  real library has a thousand of them, unicode titles and near-duplicate
+  names; the fake has two dozen tidy ones.
+* **Actions that only exist for some item types.** The tile menu is the
+  keyboard route to everything per-item, and it is built per type — the
+  07-25 checklist walks it "on at least a movie, an episode, a series, an
+  album and a track" for that reason.
+
+Activation is `handlers[id]["click"]()`, which is what the renderer calls for
+the focused node when you press Enter — the same entry point a click uses, so
+this exercises the keyboard path without needing a window or a real keypress.
+"""
+
+import collections
+import logging
+import os
+import sys
+import unittest
+
+sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+import _e2e  # noqa: E402
+
+REPO_ROOT = os.path.dirname(os.path.dirname(os.path.dirname(
+    os.path.abspath(__file__))))
+if REPO_ROOT not in sys.path:
+    sys.path.insert(0, REPO_ROOT)
+
+SIZE = (1280, 720)
+
+#: Ids belonging to the window chrome rather than the screen's content. A
+#: screen is only reachable if something *other* than these is activatable.
+CHROME_PREFIXES = ("nav-", "chrome-", "topbar-", "bar-")
+
+
+class _SyncPool:
+    def submit(self, fn, *a, **k):
+        fn(*a, **k)
+
+    def shutdown(self, *a, **k):
+        pass
+
+
+@_e2e.require_server
+class KeyboardNavTest(unittest.TestCase):
+
+    @classmethod
+    def setUpClass(cls):
+        from jellyfin_mpv_shim.mpvtk_browser.app import MpvtkBrowser
+        from jellyfin_mpv_shim.mpvtk.layout import layout
+        cls.MpvtkBrowser = MpvtkBrowser
+        cls.layout = staticmethod(layout)
+        cls.session = _e2e.Session()
+        cls.source = cls.session.library_source()
+        cls.libraries = cls.source.get_libraries(_e2e.SOURCE_UUID)
+        cls.by_name = {lib["Name"]: lib for lib in cls.libraries}
+
+    @classmethod
+    def tearDownClass(cls):
+        try:
+            cls.source.stop()
+        finally:
+            cls.session.stop()
+
+    def setUp(self):
+        self.browser = self.MpvtkBrowser(
+            app=None, source=self.source, server_uuid=_e2e.SOURCE_UUID)
+        self.browser._async._pool.shutdown(wait=True, cancel_futures=True)
+        self.browser._pool = _SyncPool()
+        self.browser._load_route(self.browser.route)
+        self.addCleanup(self._shutdown)
+        self.nodes, self.handlers = self._render()
+
+    def _shutdown(self):
+        try:
+            self.browser.shutdown()
+        except Exception:
+            pass
+
+    def _render(self):
+        self.nodes, self.handlers = self.layout(
+            self.browser.build(SIZE), *SIZE)
+        return self.nodes, self.handlers
+
+    def _activate(self, node_id):
+        """Press Enter on `node_id`, then repaint.
+
+        The renderer calls the focused node's click handler on Enter, so this
+        is the keyboard path — no window and no real keypress needed.
+        """
+        self.assertIn(node_id, self.handlers,
+                      "%s has no handlers at all" % node_id)
+        self.assertIn("click", self.handlers[node_id],
+                      "%s cannot be activated" % node_id)
+        self.handlers[node_id]["click"]()
+        return self._render()
+
+    def _find(self, needle):
+        matches = [i for i in self.handlers if needle in i]
+        self.assertTrue(matches, "no node id containing %r" % needle)
+        return matches[0]
+
+    def _content_ids(self):
+        return [i for i, h in self.handlers.items()
+                if "click" in h
+                and not any(i.startswith(p) for p in CHROME_PREFIXES)]
+
+    def _goto_library(self, name):
+        library = self.by_name.get(name)
+        if library is None:
+            self.skipTest("no %r library" % name)
+        self._activate(self._find(library["Id"]))
+        return library
+
+    # -- the flows ---------------------------------------------------------
+
+    def test_home_to_library_to_item_and_back(self):
+        """The core flow, entirely by activation: a library tile, then an
+        item, then back out the way you came."""
+        self.assertEqual(self.browser.route["kind"], "home")
+        self._goto_library("Movies")
+        self.assertEqual(self.browser.route["kind"], "grid")
+        self.assertEqual(self.browser.route.get("title"), "Movies")
+
+        item = next((i for i in (self.browser.route.get("_items") or []) if i),
+                    None)
+        self.assertIsNotNone(item, "the grid loaded no items to open")
+        self._activate(self._find(item["Id"]))
+        self.assertEqual(self.browser.route["kind"], "detail")
+        self.assertEqual(self.browser.route.get("title"), item["Name"])
+
+        self.browser.go_back()
+        self._render()
+        self.assertEqual(self.browser.route["kind"], "grid",
+                         "Back from an item did not return to the library")
+        self.browser.go_back()
+        self._render()
+        self.assertEqual(self.browser.route["kind"], "home",
+                         "Back from a library did not return home")
+
+    def test_every_screen_offers_something_to_activate(self):
+        """A screen whose content produced no handlers is mouse-only.
+
+        The chrome is always activatable, so it is excluded — otherwise every
+        screen passes, including one that drew no content at all.
+        """
+        screens = [("home", None)]
+        for name in ("Movies", "Shows", "Music", "Test Media"):
+            if name in self.by_name:
+                screens.append((name, self.by_name[name]))
+
+        for label, library in screens:
+            with self.subTest(screen=label):
+                if library is None:
+                    self.browser.navigate({"kind": "home",
+                                           "server": _e2e.SOURCE_UUID})
+                else:
+                    kind = ("music" if library.get("CollectionType") == "music"
+                            else "grid")
+                    self.browser.navigate({
+                        "kind": kind, "server": _e2e.SOURCE_UUID,
+                        "parent_id": library["Id"], "title": label,
+                        "collection_type": library.get("CollectionType")})
+                self._render()
+                self.assertTrue(
+                    self._content_ids(),
+                    "%s drew no activatable content, so it cannot be reached "
+                    "with a keyboard at all" % label)
+
+    def test_no_duplicate_node_ids_on_real_data(self):
+        """A collision makes one node unreachable and misroutes the other.
+
+        `layout()` only warns: "renderer state and events will target only
+        the last occurrence". Ids embed item ids, so this is a real-data
+        risk — a thousand items, unicode titles, near-duplicate names.
+        """
+        checks = [("home", {"kind": "home", "server": _e2e.SOURCE_UUID})]
+        for name in ("Movies", "Bulk Movies", "Shows"):
+            library = self.by_name.get(name)
+            if library:
+                checks.append((name, {
+                    "kind": "grid", "server": _e2e.SOURCE_UUID,
+                    "parent_id": library["Id"], "title": name,
+                    "collection_type": library.get("CollectionType")}))
+
+        for label, route in checks:
+            with self.subTest(screen=label):
+                self.browser.navigate(dict(route))
+                nodes, _handlers = self._render()
+                counts = collections.Counter(n["id"] for n in nodes)
+                dupes = sorted(i for i, c in counts.items() if c > 1)
+                self.assertEqual(
+                    dupes, [],
+                    "%s drew duplicate node ids, so events reach only the "
+                    "last of each: %s" % (label, dupes[:5]))
+
+    def test_a_tile_offers_its_menu_for_every_item_type(self):
+        """The tile menu is the keyboard route to per-item actions, and it is
+        built per type — the 07-25 checklist walks a movie, an episode, a
+        series, an album and a track for exactly that reason."""
+        cases = []
+        movie = self.session.find_all(library="Movies", item_type="Movie",
+                                      Limit=1)
+        series = self.session.find_all(library="Shows", item_type="Series",
+                                       Limit=1)
+        episode = self.session.find_all(library="Shows", item_type="Episode",
+                                        Limit=1)
+        album = self.session.find_all(library="Music", item_type="MusicAlbum",
+                                      Limit=1)
+        track = self.session.find_all(library="Music", item_type="Audio",
+                                      Limit=1)
+        for label, found in (("movie", movie), ("series", series),
+                             ("episode", episode), ("album", album),
+                             ("track", track)):
+            if found:
+                cases.append((label, found[0]))
+        self.assertTrue(cases, "no items of any type to test")
+
+        for label, item in cases:
+            with self.subTest(item_type=label):
+                entries = self.browser._tile_menu_entries(item)
+                self.assertTrue(
+                    entries,
+                    "a %s tile offers no menu, so its actions are "
+                    "unreachable by keyboard" % label)
+                for entry in entries:
+                    self.assertTrue(
+                        entry[0], "%s has a menu entry with no label" % label)
+                    self.assertTrue(
+                        entry[2], "%s has a menu entry with no action" % label)
+
+    def test_jumping_back_through_history_matches_pressing_back(self):
+        """`662d4b06` — the history menu's backward jump skipped what a Back
+        press reloads, so a jump past an editor showed stale membership while
+        the same number of Back presses refetched.
+
+        Same depth, two routes out, same destination.
+        """
+        self._goto_library("Movies")
+        item = next((i for i in (self.browser.route.get("_items") or []) if i),
+                    None)
+        self.assertIsNotNone(item)
+        self._activate(self._find(item["Id"]))
+        self.assertEqual(self.browser.route["kind"], "detail")
+        depth = len(self.browser.nav_stack)
+        self.assertGreaterEqual(depth, 3, "not deep enough to jump")
+
+        self.browser.go_back()
+        self.browser.go_back()
+        self._render()
+        by_back = (self.browser.route["kind"],
+                   self.browser.route.get("title"))
+
+        # Rebuild the same stack, then leave it in one jump instead.
+        self._goto_library("Movies")
+        self._activate(self._find(item["Id"]))
+        self.assertEqual(len(self.browser.nav_stack), depth)
+        # go_back_to, not the Navigator's rewind_to: the shell's half of a
+        # back press is decided by the page being LEFT (a playlist editor
+        # makes what is underneath stale), which is the whole of 662d4b06 —
+        # so a test that called the navigator directly would skip the
+        # reloading the bug was about. Depth is 1-based; 1 is the root.
+        self.browser.go_back_to(1)
+        self._render()
+        by_jump = (self.browser.route["kind"],
+                   self.browser.route.get("title"))
+
+        self.assertEqual(
+            by_jump, by_back,
+            "jumping back through history lands somewhere different from "
+            "pressing Back the same number of times")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/e2e/test_large_queue.py
+++ b/tests/e2e/test_large_queue.py
@@ -1,0 +1,148 @@
+"""A queue big enough to overflow the request line.
+
+Reported 2026-07-14: "one of my playlists does not show titles, artists, or
+runtimes in the queue. The other does... `HTTPException: (414, HTTPError('414
+Client Error: Request-URI Too Large'))` ... turns out the playlist is too big
+to request metadata for all at once."
+
+`get_items_by_ids` batches at `CHUNK = 100` because of it. Nothing executed
+that: the limit belongs to Kestrel and to whatever reverse proxy is in front
+of it, not to the client, so a fake accepts a URL of any length and the
+batching is decoration as far as the suite is concerned.
+
+Measured against this server, which is where the numbers below come from:
+100 ids fine, 200 ids fine, **400 ids `414 URI Too Long`**. So the control
+matters — `test_a_single_request_of_this_size_would_fail` is what stops every
+other test here passing just as well with the batching deleted.
+"""
+
+import logging
+import os
+import sys
+import unittest
+
+sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+import _e2e  # noqa: E402
+
+REPO_ROOT = os.path.dirname(os.path.dirname(os.path.dirname(
+    os.path.abspath(__file__))))
+if REPO_ROOT not in sys.path:
+    sys.path.insert(0, REPO_ROOT)
+
+#: Comfortably past the measured 414 threshold, and past three chunks.
+BIG = 400
+
+
+@_e2e.require_server
+class LargeQueueMetadataTest(unittest.TestCase):
+
+    @classmethod
+    def setUpClass(cls):
+        from jellyfin_mpv_shim.mpvtk_browser.repository import LibrarySource
+        cls.CHUNK = 100     # mirrors get_items_by_ids; asserted below
+        cls.session = _e2e.Session()
+        cls.source = cls.session.library_source()
+        libs = cls.source.get_libraries(_e2e.SOURCE_UUID)
+        music = [lib for lib in libs if lib["Name"] == "Bulk Music"]
+        if not music:
+            cls.source.stop()
+            cls.session.stop()
+            raise unittest.SkipTest(
+                "no Bulk Music library — this test is about a queue too big "
+                "for one request and there is nothing big enough")
+        cls.songs = cls.session.find_all(
+            parent_id=music[0]["Id"], item_type="Audio", Limit=BIG + 50)
+        cls.ids = [s["Id"] for s in cls.songs]
+        if len(cls.ids) < BIG:
+            cls.source.stop()
+            cls.session.stop()
+            raise unittest.SkipTest(
+                "only %d tracks; need %d to overflow the request line"
+                % (len(cls.ids), BIG))
+        cls.api = cls.source._conn(_e2e.SOURCE_UUID).api
+
+    @classmethod
+    def tearDownClass(cls):
+        try:
+            cls.source.stop()
+        finally:
+            cls.session.stop()
+
+    def test_a_single_request_of_this_size_would_fail(self):
+        """The control. Without it every test below passes with the batching
+        removed, and this file would be testing nothing at all."""
+        # The apiclient logs the whole rejected URL, which for 400 GUIDs is
+        # 30KB of console noise on a test that is *supposed* to fail.
+        http_log = logging.getLogger("JELLYFIN.jellyfin_apiclient_python.http")
+        previous = http_log.level
+        http_log.setLevel(logging.CRITICAL)
+        self.addCleanup(http_log.setLevel, previous)
+        with self.assertRaises(Exception) as caught:
+            self.api.get_items(self.ids[:BIG], fields="")
+        self.assertIn(
+            "414", str(caught.exception),
+            "a single request for %d ids did not fail with 414, so the "
+            "server's request-line limit is higher than it was when the "
+            "batching was written and these tests no longer prove it is "
+            "needed: %s" % (BIG, caught.exception))
+
+    def test_every_row_gets_its_metadata(self):
+        """The reported symptom: no titles, artists or runtimes in the queue."""
+        got = self.source.get_items_by_ids(_e2e.SOURCE_UUID, self.ids[:BIG])
+        self.assertEqual(
+            len(got), BIG,
+            "asked for %d rows and got %d — a failed batch leaves its rows "
+            "without metadata" % (BIG, len(got)))
+        nameless = [i for i, item in enumerate(got) if not item.get("Name")]
+        self.assertEqual(nameless, [],
+                         "%d rows came back without a Name" % len(nameless))
+        # The queue table's columns, which are what the reporter could not
+        # see. Runtime is the one that needs a real DTO rather than the id.
+        runtimeless = [i for i, item in enumerate(got)
+                       if not item.get("RunTimeTicks")]
+        self.assertEqual(
+            runtimeless, [],
+            "%d rows have no RunTimeTicks, so the queue would show a blank "
+            "duration column" % len(runtimeless))
+
+    def test_order_is_the_order_asked_for(self):
+        """`Ids=` does not preserve order server-side, so the queue would be
+        shuffled against the playlist it came from."""
+        want = self.ids[:BIG]
+        got = [item.get("Id") for item
+               in self.source.get_items_by_ids(_e2e.SOURCE_UUID, want)]
+        self.assertEqual(got, want)
+
+    def test_the_chunk_boundary(self):
+        """One under, exactly on, one over. Off-by-one here drops a row or
+        sends an empty final batch."""
+        for size in (self.CHUNK - 1, self.CHUNK, self.CHUNK + 1,
+                     self.CHUNK * 2, self.CHUNK * 2 + 1):
+            with self.subTest(size=size):
+                want = self.ids[:size]
+                got = self.source.get_items_by_ids(_e2e.SOURCE_UUID, want)
+                self.assertEqual(
+                    [i.get("Id") for i in got], want,
+                    "%d ids did not round-trip intact" % size)
+
+    def test_a_repeated_id_gets_a_row_each_time(self):
+        """A queue can hold the same track twice, and both rows have to draw.
+
+        The batch is de-duplicated before it is sent — asking for the same
+        GUID twice in one `Ids=` wastes the very budget this is rationing —
+        so the mapping back has to expand it again.
+        """
+        want = [self.ids[0], self.ids[1], self.ids[0], self.ids[0]]
+        got = self.source.get_items_by_ids(_e2e.SOURCE_UUID, want)
+        self.assertEqual([i.get("Id") for i in got], want)
+
+    def test_an_unknown_id_is_dropped_rather_than_faked(self):
+        """A stale playlist entry must not become a blank row with no id."""
+        want = [self.ids[0], "0" * 32, self.ids[1]]
+        got = self.source.get_items_by_ids(_e2e.SOURCE_UUID, want)
+        self.assertEqual([i.get("Id") for i in got],
+                         [self.ids[0], self.ids[1]])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/e2e/test_large_queue.py
+++ b/tests/e2e/test_large_queue.py
@@ -73,7 +73,12 @@ class LargeQueueMetadataTest(unittest.TestCase):
         removed, and this file would be testing nothing at all."""
         # The apiclient logs the whole rejected URL, which for 400 GUIDs is
         # 30KB of console noise on a test that is *supposed* to fail.
-        http_log = logging.getLogger("JELLYFIN.jellyfin_apiclient_python.http")
+        #
+        # `Jellyfin.`, not `JELLYFIN.`: http.py is the one module in the
+        # apiclient that spells its logger root in mixed case, and logger
+        # names are case-sensitive -- so the shouted spelling silenced a
+        # logger that does not exist and the dump came out anyway.
+        http_log = logging.getLogger("Jellyfin.jellyfin_apiclient_python.http")
         previous = http_log.level
         http_log.setLevel(logging.CRITICAL)
         self.addCleanup(http_log.setLevel, previous)

--- a/tests/e2e/test_live_tv.py
+++ b/tests/e2e/test_live_tv.py
@@ -354,49 +354,59 @@ class TimerTest(_LiveTvCase):
     Timers are the one thing in this file that writes to the server, so every
     one created is registered for cancellation the moment it exists.
 
-    **This class grants itself a permission and gives it back.** Scheduling a
-    recording needs `EnableLiveTvManagement`, which is a *third* Live TV
-    permission distinct from `EnableLiveTvAccess` — and stdjflib grants it to
-    nobody, not even `qa-admin`, so without this every DVR path is
-    unreachable and `POST /LiveTv/Timers` answers 403 for every account on the
-    server. Rather than leave the whole surface untested, the class runs as
-    `qa-admin`, turns the flag on in `setUpClass` and restores whatever it
-    found in `tearDownClass`. The server is disposable by design; that is the
-    only reason this is acceptable, and it is why the restore is not
-    conditional on the tests passing.
+    Scheduling needs `EnableLiveTvManagement`, a *third* Live TV permission
+    distinct from `EnableLiveTvAccess`. A freshly created Jellyfin user does
+    not get it — `AddDefaultPermissions` stores `false` and there is no
+    administrator bypass — so on an unfixed server `POST /LiveTv/Timers`
+    answers 403 for everyone and this whole surface is unreachable. stdjflib
+    grants it to `qa-admin` and `qa-user` now; against a server provisioned
+    before that, `setUpClass` grants it as admin and `tearDownClass` puts the
+    original policy back, so the tests run either way rather than skipping.
+    That fallback is the only place the suite writes server *configuration*,
+    and it is a no-op on a current server.
     """
 
-    ACCOUNT = "qa-admin"
+    ACCOUNT = "qa-user"
 
     @classmethod
     def setUpClass(cls):
         super().setUpClass()
         cls._original_policy = None
-        policy = cls.session.policy()
-        if not policy.get("EnableLiveTvManagement"):
-            cls._original_policy = dict(policy)
-            granted = dict(policy)
-            granted["EnableLiveTvManagement"] = True
-            try:
-                cls.session.set_policy(granted)
-            except Exception as exc:
-                cls._original_policy = None
-                raise unittest.SkipTest(
-                    "cannot grant EnableLiveTvManagement, so no DVR path is "
-                    "reachable: %s" % exc)
-            # The token's cached policy is stale now; a fresh session sees it.
-            cls.session.stop()
-            cls.session = _e2e.Session(cls.ACCOUNT)
-            cls.source = cls.session.library_source()
-            cls.source.get_libraries(_e2e.SOURCE_UUID)
+        cls._admin = None
+        if cls.session.policy().get("EnableLiveTvManagement"):
+            return                      # a current stdjflib server: nothing to do
+
+        cls._admin = _e2e.Session("qa-admin")
+        target = cls._admin.user_by_name(cls.ACCOUNT)
+        cls._original_policy = dict(target.get("Policy") or {})
+        granted = dict(cls._original_policy)
+        granted["EnableLiveTvManagement"] = True
+        try:
+            cls._admin.set_policy(granted, user_id=target["Id"])
+        except Exception as exc:
+            cls._original_policy = None
+            cls._admin.stop()
+            raise unittest.SkipTest(
+                "cannot grant EnableLiveTvManagement, so no DVR path is "
+                "reachable: %s" % exc)
+        # The session's cached policy is stale now; a fresh one sees it.
+        cls.session.stop()
+        cls.session = _e2e.Session(cls.ACCOUNT)
+        cls.source = cls.session.library_source()
+        cls.source.get_libraries(_e2e.SOURCE_UUID)
 
     @classmethod
     def tearDownClass(cls):
         try:
             if cls._original_policy is not None:
-                cls.session.set_policy(cls._original_policy)
+                target = cls._admin.user_by_name(cls.ACCOUNT)
+                cls._admin.set_policy(cls._original_policy,
+                                      user_id=target["Id"])
         except Exception:
             pass
+        finally:
+            if cls._admin is not None:
+                cls._admin.stop()
         super().tearDownClass()
 
     def setUp(self):

--- a/tests/e2e/test_live_tv.py
+++ b/tests/e2e/test_live_tv.py
@@ -1,0 +1,512 @@
+"""Live TV against a real tuner and a real guide.
+
+`tests/test_live_tv.py` is 110k of tests against fabricated data, and it was
+green while `4bc952c1` shipped: category flags derived as `"is_" + name`, so
+`"movies"` became `is_movies` and every filtered fetch raised `TypeError`
+before reaching the server — **the unit test asserted the wrong spelling,
+which is why it passed**. That is the case for doing this against a server,
+and it is not a hypothetical: Live TV is where the shim makes the most claims
+about server behaviour, and `CLAUDE.md` records a dozen of them as prose that
+nothing executes.
+
+The claims pinned here, each of which failed silently when it was wrong:
+
+* Category flags reach the server without raising, and go to the **channel**
+  query only.
+* Guide bounds are UTC with the `Z`; the server accepts an offset-less bound
+  *without shifting it* and then answers for the wrong window, so getting this
+  wrong returns plausible data for a time you did not ask about.
+* Times come back with seven fractional digits, which most parsers accept and
+  silently mis-zone.
+* Guide preferences live in jellyfin-web's DisplayPreferences document, under
+  its client id, written as the **strings** `"true"`/`"false"` — and saving
+  them must not take the home layout with them.
+
+The tuner is faketvsource (`stdjflib serve --live-tv`): six channels, ~970
+programmes, generated against the clock. So every assertion here is relative
+— "something is on now", "this window excludes that one" — and never against
+an absolute time.
+"""
+
+import datetime
+import os
+import sys
+import unittest
+
+sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+import _e2e  # noqa: E402
+
+REPO_ROOT = os.path.dirname(os.path.dirname(os.path.dirname(
+    os.path.abspath(__file__))))
+if REPO_ROOT not in sys.path:
+    sys.path.insert(0, REPO_ROOT)
+
+
+def utcnow():
+    return datetime.datetime.now(datetime.timezone.utc)
+
+
+class _LiveTvCase(unittest.TestCase):
+    """A session with Live TV, skipping if the server has no tuner."""
+
+    ACCOUNT = "qa-user"
+
+    @classmethod
+    def setUpClass(cls):
+        from jellyfin_mpv_shim.mpvtk_browser import live_tv
+        cls.live_tv = live_tv
+        cls.session = _e2e.Session(cls.ACCOUNT)
+        cls.source = cls.session.library_source()
+        cls.source.get_libraries(_e2e.SOURCE_UUID)   # populates has_live_tv
+        if not cls.source.has_live_tv(_e2e.SOURCE_UUID):
+            cls.source.stop()
+            cls.session.stop()
+            raise unittest.SkipTest(
+                "no Live TV on this server — start it with "
+                "`stdjflib serve <library> --live-tv`")
+
+    @classmethod
+    def tearDownClass(cls):
+        try:
+            cls.source.stop()
+        finally:
+            cls.session.stop()
+
+    @property
+    def uuid(self):
+        return _e2e.SOURCE_UUID
+
+
+@_e2e.require_server
+class ChannelsTest(_LiveTvCase):
+
+    def test_the_line_up_comes_back_with_what_a_tile_needs(self):
+        channels, total = self.source.get_channels(self.uuid)
+        self.assertTrue(channels, "no channels from a server with a tuner")
+        self.assertGreaterEqual(total, len(channels))
+        for channel in channels:
+            self.assertEqual(channel.get("Type"), "TvChannel")
+            self.assertTrue(channel.get("Name"))
+            # The tile draws the number, and the channel logo is the whole
+            # artwork fallback for guide data that carries none of its own.
+            self.assertTrue(channel.get("ChannelNumber"))
+
+
+@_e2e.require_server
+class GuideWindowTest(_LiveTvCase):
+    """The window bounds, which are the easiest thing here to get wrong in a
+    way that still returns data."""
+
+    def _guide(self, start, end):
+        channels = self.source.get_channels(self.uuid)[0]
+        ids = [c["Id"] for c in channels]
+        return self.source.get_guide(self.uuid, ids, start, end)
+
+    def test_every_entry_overlaps_the_window_asked_for(self):
+        start = utcnow()
+        end = start + datetime.timedelta(hours=2)
+        entries = self._guide(start, end)
+        self.assertTrue(entries, "an empty guide for the next two hours")
+        for entry in entries:
+            entry_start = self.live_tv.parse_time(entry["StartDate"])
+            entry_end = self.live_tv.parse_time(entry["EndDate"])
+            self.assertTrue(
+                entry_start < end and entry_end > start,
+                "%r runs %s..%s, outside the window %s..%s — the bounds were "
+                "sent in a form the server read as a different time"
+                % (entry.get("Name"), entry_start, entry_end, start, end))
+
+    def test_a_later_window_answers_about_later(self):
+        """The sharp one.
+
+        An offset-less bound is accepted and *not* shifted, so a client in a
+        non-UTC zone gets a plausible guide for a window hours from the one it
+        asked about. Comparing two windows catches that where checking one
+        cannot: this box is UTC-4, so a dropped offset moves the answer by
+        four hours and these two sets stop disagreeing the way they should.
+        """
+        now = utcnow()
+        soon = self._guide(now, now + datetime.timedelta(minutes=30))
+        later_start = now + datetime.timedelta(hours=6)
+        later = self._guide(later_start,
+                            later_start + datetime.timedelta(minutes=30))
+        self.assertTrue(soon, "nothing on in the next half hour")
+        self.assertTrue(later, "nothing on in half an hour, six hours out")
+
+        for entry in later:
+            self.assertGreater(
+                self.live_tv.parse_time(entry["EndDate"]), later_start,
+                "a window six hours out returned something that had already "
+                "finished — the bound was not read as the time we sent")
+
+    def test_times_carry_seven_fractional_digits_and_parse_to_utc(self):
+        """`parse_time` exists because every shorter way of reading these
+        yields a plausible datetime that is out by the UTC offset."""
+        entries = self._guide(utcnow(), utcnow() + datetime.timedelta(hours=2))
+        raw = entries[0]["StartDate"]
+        self.assertTrue(
+            raw.endswith("Z"),
+            "the server stopped sending UTC-marked times: %r" % raw)
+        parsed = self.live_tv.parse_time(raw)
+        self.assertIsNotNone(parsed.tzinfo,
+                             "parse_time returned a naive datetime, which is "
+                             "how an offset silently goes missing")
+        # Same instant, whatever local zone the box is in.
+        self.assertEqual(
+            parsed.astimezone(datetime.timezone.utc).strftime(
+                "%Y-%m-%dT%H:%M:%S"),
+            raw.split(".")[0])
+
+
+@_e2e.require_server
+class CategoryFilterTest(_LiveTvCase):
+    """`4bc952c1` — the flags must reach the server, and only on channels.
+
+    What this can assert is narrow on purpose. The *results* are a server
+    wart: `IsMovie` is a column predicate while `IsSports`/`IsNews`/`IsKids`
+    become a tag filter, so several categories legitimately return nothing
+    here and two together return nothing at all. jellyfin-web behaves
+    identically. Asserting on the counts would be asserting the wart, so what
+    is asserted is that the call is well-formed and completes — which is
+    exactly what was broken.
+    """
+
+    def test_every_category_reaches_the_server_without_raising(self):
+        for category in ("movies", "sports", "kids", "news"):
+            with self.subTest(category=category):
+                kwargs = self.live_tv.category_kwargs([category])
+                self.assertTrue(kwargs, "no flag produced for %r" % category)
+                # The regression: "movies" -> is_movie, not is_movies.
+                channels, _total = self.source.get_channels(
+                    self.uuid, categories=(category,))
+                self.assertIsInstance(channels, list)
+
+    def test_two_categories_at_once_still_completes(self):
+        channels, _total = self.source.get_channels(
+            self.uuid, categories=("movies", "sports"))
+        self.assertIsInstance(channels, list)
+
+    def test_a_column_predicate_category_actually_filters(self):
+        """`movies` is the one of the four the server answers properly, so it
+        is the one that can show the filter is applied rather than ignored."""
+        everything = self.source.get_channels(self.uuid)[0]
+        movies = self.source.get_channels(
+            self.uuid, categories=("movies",))[0]
+        self.assertTrue(everything, "no channels at all")
+        self.assertLess(
+            len(movies), len(everything),
+            "the movies filter returned the whole line-up, so it was not "
+            "applied")
+
+    def test_no_categories_means_no_filter(self):
+        self.assertEqual(self.live_tv.category_kwargs([]), {})
+        self.assertEqual(
+            self.live_tv.category_kwargs(["movies", "sports", "kids", "news"]),
+            {},
+            "all four must mean 'no filter', not four ANDed flags that match "
+            "nothing")
+
+
+@_e2e.require_server
+class GuidePrefsTest(_LiveTvCase):
+    """Guide preferences are jellyfin-web's, in jellyfin-web's document.
+
+    Two things are load-bearing and neither is visible without a server: the
+    booleans are stored as the *strings* `"true"`/`"false"` (jellyfin-web
+    compares with `=== 'true'`, so a JSON boolean reads as false there and the
+    setting appears to revert whenever the web client is opened), and saving
+    is a read-modify-write of the whole DTO — there is no partial update, so
+    writing only our keys drops the home layout that shares the document.
+    """
+
+    def setUp(self):
+        self.original = dict(self.source.get_live_tv_prefs(
+            self.uuid, refresh=True))
+        self.addCleanup(self._restore)
+
+    def _restore(self):
+        try:
+            self.source.save_live_tv_prefs(self.uuid, self.original)
+        except Exception:
+            pass
+
+    def test_preferences_round_trip(self):
+        changed = dict(self.original)
+        changed["color_coded"] = not self.original.get("color_coded")
+        changed["favorites_first"] = not self.original.get("favorites_first")
+        indicators = dict(self.original.get("indicators") or {})
+        indicators["hd"] = not indicators.get("hd")
+        changed["indicators"] = indicators
+
+        self.source.save_live_tv_prefs(self.uuid, changed)
+        read_back = self.source.get_live_tv_prefs(self.uuid, refresh=True)
+
+        self.assertEqual(read_back.get("color_coded"),
+                         changed["color_coded"])
+        self.assertEqual(read_back.get("favorites_first"),
+                         changed["favorites_first"])
+        self.assertEqual((read_back.get("indicators") or {}).get("hd"),
+                         indicators["hd"])
+
+    def _stored_document(self):
+        """The DisplayPreferences document as the *server* holds it.
+
+        Read back raw rather than through the source, so this asserts what is
+        on the wire instead of what our own parser made of it — and so it also
+        pins the client id. `usersettings` under client `emby` is
+        jellyfin-web's legacy namespace, and any other client string reads a
+        different, empty preference set: get that wrong and everything still
+        "works" while sharing nothing with the web client, which is the entire
+        purpose of storing it here.
+        """
+        from jellyfin_mpv_shim.mpvtk_browser import home_sections
+        return self.session._request(
+            "/DisplayPreferences/usersettings?userId=%s&client=%s"
+            % (self.session.user_id, home_sections.DISPLAY_PREFS_CLIENT))
+
+    def test_booleans_are_stored_as_strings(self):
+        changed = dict(self.original)
+        changed["color_coded"] = True
+        self.source.save_live_tv_prefs(self.uuid, changed)
+
+        custom = (self._stored_document() or {}).get("CustomPrefs") or {}
+        self.assertTrue(custom, "no CustomPrefs on the server after a save")
+        stored = custom.get("guide-colorcodedbackgrounds")
+        self.assertEqual(
+            stored, "true",
+            "guide booleans must be the strings jellyfin-web compares with "
+            "=== 'true'; a JSON boolean reads as false there and the setting "
+            "appears to revert whenever the web client is opened. Got %r"
+            % (stored,))
+
+    def test_the_document_is_the_one_jellyfin_web_reads(self):
+        """`usersettings` / client `emby`, which is what makes these settings
+        shared rather than private to this app."""
+        from jellyfin_mpv_shim.mpvtk_browser import home_sections
+        self.assertEqual(home_sections.DISPLAY_PREFS_CLIENT, "emby")
+        document = self._stored_document()
+        self.assertTrue(
+            document, "no DisplayPreferences document under client 'emby'")
+        self.assertIn("CustomPrefs", document)
+
+    def test_saving_guide_prefs_keeps_the_home_layout(self):
+        """The same DisplayPreferences document holds both. A partial write
+        here is a home screen quietly reset to defaults."""
+        layout_before, _excludes = self.source.get_home_prefs(
+            self.uuid, refresh=True)
+        self.assertTrue(layout_before, "no home layout to preserve")
+
+        changed = dict(self.original)
+        changed["color_coded"] = not self.original.get("color_coded")
+        self.source.save_live_tv_prefs(self.uuid, changed)
+
+        layout_after, _after = self.source.get_home_prefs(
+            self.uuid, refresh=True)
+        self.assertEqual(
+            layout_after, layout_before,
+            "saving guide preferences rewrote the home screen layout")
+
+
+@_e2e.require_server
+class ProgramSectionsTest(_LiveTvCase):
+    """The Programs screen's rows, which are six independent guide queries."""
+
+    def test_every_row_comes_back(self):
+        sections = self.source.get_program_sections(self.uuid, limit=6)
+        self.assertTrue(sections, "the Programs screen has no rows at all")
+        titles = [s.get("title") for s in sections]
+        self.assertEqual(len(titles), len(set(titles)),
+                         "duplicate rows: %s" % titles)
+        # One failed row costs only that row, by design — so an all-empty
+        # result is the failure mode worth catching.
+        self.assertTrue(
+            any(s.get("items") for s in sections),
+            "every Programs row came back empty")
+
+    def test_on_now_is_actually_on_now(self):
+        sections = self.source.get_program_sections(self.uuid, limit=6)
+        on_now = [s for s in sections if s.get("key") == "onnow"]
+        if not on_now:
+            self.skipTest("no On Now row on this server")
+        items = on_now[0].get("items") or []
+        self.assertTrue(items, "On Now is empty while the tuner has channels")
+        now = utcnow()
+        for item in items:
+            start = self.live_tv.parse_time(item["StartDate"])
+            end = self.live_tv.parse_time(item["EndDate"])
+            self.assertTrue(
+                start <= now <= end,
+                "%r is in On Now but runs %s..%s" % (item.get("Name"),
+                                                     start, end))
+
+
+@_e2e.require_server
+class TimerTest(_LiveTvCase):
+    """Scheduling a recording, and the two questions about it.
+
+    `timer_state` answers *which icon* and `single_timer_state` answers *what
+    the Record button should do*; `4bc952c1` drove the button off the former,
+    so every episode of a series being recorded offered "Record" again — a
+    second timer for a programme that already had one, with no way to skip a
+    single showing. The two only diverge once a real series rule exists on the
+    server, which is why this is worth doing here.
+
+    Timers are the one thing in this file that writes to the server, so every
+    one created is registered for cancellation the moment it exists.
+
+    **This class grants itself a permission and gives it back.** Scheduling a
+    recording needs `EnableLiveTvManagement`, which is a *third* Live TV
+    permission distinct from `EnableLiveTvAccess` — and stdjflib grants it to
+    nobody, not even `qa-admin`, so without this every DVR path is
+    unreachable and `POST /LiveTv/Timers` answers 403 for every account on the
+    server. Rather than leave the whole surface untested, the class runs as
+    `qa-admin`, turns the flag on in `setUpClass` and restores whatever it
+    found in `tearDownClass`. The server is disposable by design; that is the
+    only reason this is acceptable, and it is why the restore is not
+    conditional on the tests passing.
+    """
+
+    ACCOUNT = "qa-admin"
+
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+        cls._original_policy = None
+        policy = cls.session.policy()
+        if not policy.get("EnableLiveTvManagement"):
+            cls._original_policy = dict(policy)
+            granted = dict(policy)
+            granted["EnableLiveTvManagement"] = True
+            try:
+                cls.session.set_policy(granted)
+            except Exception as exc:
+                cls._original_policy = None
+                raise unittest.SkipTest(
+                    "cannot grant EnableLiveTvManagement, so no DVR path is "
+                    "reachable: %s" % exc)
+            # The token's cached policy is stale now; a fresh session sees it.
+            cls.session.stop()
+            cls.session = _e2e.Session(cls.ACCOUNT)
+            cls.source = cls.session.library_source()
+            cls.source.get_libraries(_e2e.SOURCE_UUID)
+
+    @classmethod
+    def tearDownClass(cls):
+        try:
+            if cls._original_policy is not None:
+                cls.session.set_policy(cls._original_policy)
+        except Exception:
+            pass
+        super().tearDownClass()
+
+    def setUp(self):
+        self.api = self.session.api
+        self._cancelled = set()
+        channels = self.source.get_channels(self.uuid)[0]
+        ids = [c["Id"] for c in channels]
+        start = utcnow() + datetime.timedelta(minutes=20)
+        entries = self.source.get_guide(
+            self.uuid, ids, start, start + datetime.timedelta(hours=3))
+        future = [e for e in entries
+                  if self.live_tv.parse_time(e["StartDate"]) > utcnow()]
+        if not future:
+            self.skipTest("no future programme to record")
+        self.program = future[0]
+
+    def _create_timer(self):
+        defaults = self.api.get_new_timer_defaults(
+            program_id=self.program["Id"])
+        self.api.create_live_tv_timer(defaults)
+        timer = self._find_timer()
+        self.assertIsNotNone(timer, "the timer was created but is not listed")
+        self.addCleanup(self._cancel, timer["Id"])
+        return timer
+
+    def _find_timer(self):
+        for timer in self.source.get_timers(self.uuid):
+            if timer.get("ProgramId") == self.program["Id"]:
+                return timer
+        return None
+
+    def _cancel(self, timer_id):
+        # Idempotent: the happy path cancels explicitly and the cleanup fires
+        # too, and a second DELETE logs a 404 that reads like a failure.
+        if timer_id in self._cancelled:
+            return
+        self._cancelled.add(timer_id)
+        try:
+            self.api.cancel_live_tv_timer(timer_id)
+        except Exception:
+            pass
+
+    def _reload_program(self):
+        return self.source.get_live_program(self.uuid, self.program["Id"])
+
+    def test_a_timer_can_be_scheduled_and_cancelled(self):
+        before = self._reload_program()
+        self.assertIsNone(
+            self.live_tv.single_timer_state(before),
+            "this programme already had a timer, so the test starts dirty")
+
+        timer = self._create_timer()
+
+        after = self._reload_program()
+        self.assertTrue(
+            after.get("TimerId"),
+            "the programme carries no TimerId after scheduling a recording")
+        self.assertEqual(
+            self.live_tv.single_timer_state(after), "timer",
+            "the Record button would still offer to record a programme that "
+            "already has a timer")
+        self.assertEqual(self.live_tv.timer_state(after), "timer")
+
+        self._cancel(timer["Id"])
+        self.assertIsNone(self._find_timer(),
+                          "the timer is still listed after cancelling")
+        self.assertIsNone(
+            self.live_tv.single_timer_state(self._reload_program()),
+            "the programme still reports a timer after cancelling")
+
+    def test_a_series_rule_and_an_own_timer_are_different_questions(self):
+        """The `4bc952c1` distinction, against a real series rule.
+
+        Under a series rule `timer_state` says "series" — the icon — while
+        `single_timer_state` reports only whether *this showing* has a timer
+        of its own. Driving the button off the first is what broke.
+        """
+        defaults = self.api.get_new_timer_defaults(
+            program_id=self.program["Id"])
+        try:
+            self.api.create_live_tv_series_timer(defaults)
+        except Exception as exc:
+            self.skipTest("this programme takes no series rule: %s" % exc)
+
+        series = self.source.get_series_timers(self.uuid)
+        if not series:
+            self.skipTest("the series rule was not created")
+        self.addCleanup(self._cancel_series, series[0]["Id"])
+
+        covered = self._reload_program()
+        if not covered.get("SeriesTimerId"):
+            self.skipTest("the server did not attach the rule to this showing")
+
+        self.assertEqual(
+            self.live_tv.timer_state(covered), "series",
+            "a showing covered by a series rule must draw the series icon")
+        # The button's question is answered independently: whatever the icon
+        # says, this is about whether the showing has a timer of its own.
+        self.assertEqual(
+            self.live_tv.single_timer_state(covered),
+            "timer" if covered.get("TimerId") else None,
+            "single_timer_state must read TimerId alone and never consult "
+            "SeriesTimerId")
+
+    def _cancel_series(self, timer_id):
+        try:
+            self.api.cancel_live_tv_series_timer(timer_id)
+        except Exception:
+            pass
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/e2e/test_mpv_reopen.py
+++ b/tests/e2e/test_mpv_reopen.py
@@ -1,0 +1,148 @@
+"""Closing mpv mid-playback, then playing again.
+
+`docs/REGRESSION_CHECKLIST_2026-07-25.md` calls this "the historic stale-queue
+bug; the highest-value single item on this page", and it is the flagship of
+the tracker's largest cluster (#458, 18 comments).
+
+The mechanism, from the integration suite's write-up: when mpv goes away, its
+dying observers have already queued `_handle_mpv_shutdown` — and that task
+nulls `self._video`. Run against the *new* session after a re-open, the
+re-opened player's `eof-reached` then sees no video and does nothing, so
+**auto-advance silently stops**. Nothing crashes; the queue just never moves
+again, which is why it took eighteen comments to pin down. So the assertion
+that matters is not "it re-opened" but "the episode after the one you
+restarted actually plays" — which needs a genuine EOF, which needs real media.
+
+Everything here runs **out of process** (`_close_child.py`). One of the
+outcomes under test is a segfault, and a child is what turns that into a
+readable failure instead of a lost run. See `_close_child` for why.
+"""
+
+import os
+import subprocess
+import sys
+import unittest
+
+sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+import _e2e  # noqa: E402
+
+CHILD = os.path.join(os.path.dirname(os.path.abspath(__file__)),
+                     "_close_child.py")
+REPO_ROOT = os.path.dirname(os.path.dirname(os.path.dirname(
+    os.path.abspath(__file__))))
+
+
+def run_child(mode, timeout=180):
+    env = dict(os.environ)
+    env["JMS_TEST_BACKEND"] = _e2e.BACKEND
+    proc = subprocess.run(
+        [sys.executable, CHILD, mode], cwd=REPO_ROOT, env=env,
+        capture_output=True, text=True, timeout=timeout)
+    result = ""
+    for line in (proc.stdout or "").splitlines():
+        if line.startswith("RESULT:"):
+            result = line
+    return proc, result
+
+
+class _ChildCase(_e2e.E2ETestCase):
+    """Drives the child; never builds a player of its own."""
+
+    @classmethod
+    def setUpClass(cls):
+        pass            # no in-process player: the child owns one
+
+    def setUp(self):
+        pass            # and no session either
+
+    def check(self, mode, timeout=180):
+        proc, result = run_child(mode, timeout=timeout)
+        if proc.returncode < 0:
+            self.fail(
+                "the child died on signal %d (segfault = a use-after-free on "
+                "the mpv handle).\nstdout:\n%s\nstderr tail:\n%s" % (
+                    -proc.returncode, proc.stdout,
+                    "\n".join((proc.stderr or "").splitlines()[-25:])))
+        self.assertTrue(result, "child printed no RESULT line.\nstdout:\n%s\n"
+                                "stderr tail:\n%s" % (
+                                    proc.stdout,
+                                    "\n".join((proc.stderr or "")
+                                              .splitlines()[-25:])))
+        return proc, result
+
+
+@_e2e.require_server_and_mpv
+class MpvReopenTest(_ChildCase):
+
+    def test_closing_mpv_then_playing_again_still_auto_advances(self):
+        proc, result = self.check("reopen")
+        self.assertEqual(proc.returncode, 0, result)
+
+
+@_e2e.require_server_and_mpv
+class AbandonedItemTest(_ChildCase):
+    """The #458 caveat, recorded in `docs/ISSUES_TO_VERIFY.md`:
+
+        a later comment describes a residual X-button freeze that also
+        *marks the item watched* via `get_timeline_options`. Verify that
+        specific path before closing.
+
+    It was never verified, so these two tests do it. They differ only in the
+    length of the item, and that turns out to be the whole story.
+    """
+
+    def test_a_long_item_abandoned_early_is_not_marked_watched(self):
+        """Three hours, abandoned at ~3 seconds. The unambiguous case."""
+        proc, result = self.check("abandon-long")
+        self.assertEqual(proc.returncode, 0, result)
+
+
+@_e2e.require_server_and_mpv
+class AbortReportedPositionTest(_ChildCase):
+    """An abort must be reported where it aborted, whatever the runtime.
+
+    These two are the same action against two items, and they disagree — which
+    is the diagnosis. `_finished_at_eof` (player.py) decides whether the end
+    that just happened was genuine:
+
+        return position >= duration * 0.95 or duration - position <= 10
+
+    The second clause is an *absolute* ten-second margin, there to absorb the
+    timeline tick interval and metadata duration drift. It has no lower bound
+    relative to the runtime, so for anything shorter than ten seconds it is
+    true at **every** position including zero, and for anything under about
+    twenty it is true across most of the file. The abort is then reported at
+    full duration and the server records the item as watched.
+
+    Measured against this server: a 10.0s episode aborted at 2.58s was
+    reported with `session_stop` at 10.02s and came back `Played=True`; the
+    same on the 3h item reported 0.33s and came back `Played=False`. Both
+    backends.
+
+    Driven through `send_timeline_stopped(finished=True)` rather than through
+    a window close: the close is the realistic trigger, but it is a race
+    between `finished_callback` and the shutdown teardown and either can win,
+    so a test built on it passes about a third of the time. This is the same
+    seam without the coin toss.
+    """
+
+    def test_a_long_item_aborted_early_is_not_marked_watched(self):
+        proc, result = self.check("abort-report-long")
+        self.assertEqual(proc.returncode, 0, result)
+
+    @unittest.expectedFailure
+    def test_a_short_item_aborted_early_is_not_marked_watched(self):
+        """**Currently fails** — pinned, not skipped, so it becomes a hard
+        failure the moment the margin is bounded. Same instrument the
+        integration suite uses for `_rearm_sync`.
+
+        The arithmetic itself would be cheaper to pin as a unit test on
+        `_finished_at_eof`; this exists to show the server-visible
+        consequence, which is an item you watched three seconds of appearing
+        as watched."""
+        proc, result = self.check("abort-report-short")
+        self.assertEqual(proc.returncode, 0, result)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/e2e/test_paging.py
+++ b/tests/e2e/test_paging.py
@@ -1,0 +1,273 @@
+"""Virtual scrolling over a thousand items, at real totals.
+
+`#617` replaced append-on-approach with a true virtual scroll, and its own
+hand-testing checklist says why this wants a real server:
+
+    The tests use a synchronous pool, so pages arrive instantly and in order.
+    Neither is true against a real server.
+
+and, under **Least confident**:
+
+    The thumbnail-request pressure from free scrollbar dragging ... only
+    misbehaves at scale. If there is time for two things, those.
+
+stdjflib's `Bulk *` libraries are ~1000 items each and exist for exactly this.
+What they buy over the fake is a real `_total`: the fake's grids are dozens of
+items, so a windowed list and a fully-loaded one look identical and the
+arithmetic that separates them is never exercised.
+
+The sharpest test here is `test_the_item_at_an_index_is_that_index`. A
+windowed list is `_total` long and mostly holes, and an item's position in it
+**is** its position in the library — that is what lets the scrollbar be the
+right length before anything is fetched. Nothing in a fake-based test can
+check that mapping is true, because the fake decides both sides of it. Asking
+for `start_index=N, limit=1` and comparing can.
+
+One fixture property worth knowing before writing anything here: **every bulk
+item is created by the same scan**, so their `DateCreated` values tie and the
+server falls back to name order. "Date Added" and "Name" return the identical
+first item, which makes a resort look like a refetch that never happened.
+"Release Date" genuinely reorders.
+"""
+
+import logging
+import os
+import sys
+import unittest
+
+sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+import _e2e  # noqa: E402
+
+REPO_ROOT = os.path.dirname(os.path.dirname(os.path.dirname(
+    os.path.abspath(__file__))))
+if REPO_ROOT not in sys.path:
+    sys.path.insert(0, REPO_ROOT)
+
+SIZE = (1280, 720)
+LIBRARY = "Bulk Movies"
+
+
+class _SyncPool:
+    def submit(self, fn, *a, **k):
+        fn(*a, **k)
+
+    def shutdown(self, *a, **k):
+        pass
+
+
+@_e2e.require_server
+class WindowedGridTest(unittest.TestCase):
+
+    @classmethod
+    def setUpClass(cls):
+        from jellyfin_mpv_shim.mpvtk_browser.app import MpvtkBrowser
+        from jellyfin_mpv_shim.mpvtk_browser.pagination import Paginator
+        from jellyfin_mpv_shim.mpvtk.layout import layout
+        cls.MpvtkBrowser = MpvtkBrowser
+        cls.Paginator = Paginator
+        cls.layout = staticmethod(layout)
+        cls.session = _e2e.Session()
+        cls.source = cls.session.library_source()
+        libs = cls.source.get_libraries(_e2e.SOURCE_UUID)
+        match = [lib for lib in libs if lib["Name"] == LIBRARY]
+        if not match:
+            cls.source.stop()
+            cls.session.stop()
+            raise unittest.SkipTest(
+                "%r is not on this server — build the library with the bulk "
+                "tiers, or these tests are about nothing" % LIBRARY)
+        cls.library = match[0]
+
+    @classmethod
+    def tearDownClass(cls):
+        try:
+            cls.source.stop()
+        finally:
+            cls.session.stop()
+
+    def setUp(self):
+        self.browser = self.MpvtkBrowser(
+            app=None, source=self.source, server_uuid=_e2e.SOURCE_UUID)
+        # See test_route_walk: __init__ starts the home load on the real
+        # threaded pool, so drain it before making everything inline.
+        self.browser._async._pool.shutdown(wait=True, cancel_futures=True)
+        self.browser._pool = _SyncPool()
+        self.browser._load_route(self.browser.route)
+        self.addCleanup(self._shutdown)
+        self.browser.navigate({
+            "kind": "grid", "server": _e2e.SOURCE_UUID,
+            "parent_id": self.library["Id"], "title": LIBRARY,
+            "collection_type": self.library.get("CollectionType")})
+        self.route = self.browser.route
+        self._render()
+
+    def _shutdown(self):
+        try:
+            self.browser.shutdown()
+        except Exception:
+            pass
+
+    def _render(self):
+        nodes, _handlers = self.layout(self.browser.build(SIZE), *SIZE)
+        return nodes
+
+    def _scroll_to(self, offset, maximum):
+        """Move the scroller and let the render ask for what that brings in.
+
+        The same two steps the view's own on_scroll does — rewindow, then
+        render, because the render is what computes the visible range from
+        the geometry it is about to composite.
+        """
+        self.Paginator.rewindow(self.route)
+        self.browser._scroll.on_scroll("grid", offset, maximum)
+        return self._render()
+
+    def _items(self):
+        return self.route.get("_items") or []
+
+    def _filled(self):
+        return [i for i, item in enumerate(self._items()) if item is not None]
+
+    # -- the tests ---------------------------------------------------------
+
+    def test_the_total_is_the_servers_not_what_is_loaded(self):
+        """`f18088aa` — the scrollbar is full length from the first frame.
+
+        A list sized by what has loaded grows as pages land, so the thumb
+        shrinks and jumps under the cursor while you drag it.
+        """
+        total = self.route.get("_total")
+        self.assertTrue(total, "the grid recorded no total")
+        self.assertGreater(
+            total, 500,
+            "%r has only %s items, which is too few for windowing to differ "
+            "from loading everything — these tests need the bulk library"
+            % (LIBRARY, total))
+        self.assertEqual(
+            len(self._items()), total,
+            "the item list is not the library's length, so the scrollbar "
+            "cannot be the right size before everything is fetched")
+        self.assertLess(
+            len(self._filled()), total,
+            "the whole library was loaded up front, which is the thing "
+            "windowing exists to avoid")
+
+    def test_jumping_to_the_middle_does_not_walk_from_the_top(self):
+        """#617's core promise, and the drag the checklist calls the one to
+        watch: parts of the library are reachable without loading everything
+        in between."""
+        total = self.route.get("_total")
+        before = len(self._filled())
+        self._scroll_to(20000, 40000)
+        filled = self._filled()
+
+        self.assertGreater(len(filled), before,
+                           "scrolling to the middle loaded nothing new")
+        self.assertGreater(
+            max(filled), total // 4,
+            "nothing from the middle of the library was fetched")
+        # The point: far fewer items are loaded than the index reached. A
+        # walk from the top would have filled every slot up to it.
+        self.assertLess(
+            len(filled), max(filled),
+            "every slot up to the furthest one is loaded, so this walked the "
+            "library from the top instead of windowing to the target")
+
+    def test_the_item_at_an_index_is_that_index(self):
+        """The mapping the whole design rests on, checked against the server.
+
+        An item's position in `_items` is its position in the library. A fake
+        cannot test this — it decides both sides. The server can be asked
+        independently, with the same sort the grid requests.
+        """
+        self._scroll_to(20000, 40000)
+        filled = self._filled()
+        middle = [i for i in filled if i > 200]
+        if not middle:
+            self.skipTest("nothing beyond index 200 was fetched")
+        index = middle[len(middle) // 2]
+
+        got = self._items()[index]
+        # Through the source's own query, deliberately. The grid's fetch is
+        # typed and recursive from the collection type
+        # (LIBRARY_ITEM_TYPES), and a hand-rolled query that omits that
+        # describes a DIFFERENT set — index 500 came back "Midnight Yard"
+        # untyped against the grid's "Midnight Zenith", which reads as an
+        # off-by-something in the shim and is not one. What is under test
+        # here is the window *placement*: slot N must hold what the same
+        # query returns at start_index=N. Query construction is a separate
+        # concern, covered by test_source_conformance.
+        expected, _total = self.source.get_library_items(
+            _e2e.SOURCE_UUID, self.library["Id"], start_index=index, limit=1,
+            collection_type=self.library.get("CollectionType"))
+        self.assertTrue(expected, "the server has no item at index %d" % index)
+        self.assertEqual(
+            got.get("Id"), expected[0].get("Id"),
+            "slot %d holds %r but the library's item %d is %r — the window "
+            "was placed at the wrong offset, which draws the right number of "
+            "tiles with the wrong things in them"
+            % (index, got.get("Name"), index, expected[0].get("Name")))
+
+    def test_scrolling_back_does_not_lose_what_was_loaded(self):
+        """Repeated drags are the checklist's "fast repeated drags" case.
+
+        Each new window asks for a screenful or three of artwork, and the
+        worry is thrash: a window that discards what it already had makes
+        every drag a fresh round trip.
+        """
+        self._scroll_to(20000, 40000)
+        far = set(self._filled())
+        self._scroll_to(0, 40000)
+        back = set(self._filled())
+        self.assertTrue(
+            far <= back,
+            "scrolling back dropped %d slots that were already loaded, so "
+            "coming back re-fetches them" % len(far - back))
+
+    def test_a_resort_starts_over_rather_than_mixing_two_orders(self):
+        """`4b0e3afd`'s neighbour: a refetch must drop the loaded list.
+
+        Keeping it would leave slots filled from the previous sort — the
+        right number of tiles, in two different orders, with no way to tell.
+        """
+        self._scroll_to(20000, 40000)
+        self.assertGreater(len(self._filled()), 100)
+
+        first_id = next((i.get("Id") for i in self._items() if i is not None),
+                        None)
+
+        # A route stores its sort as an INDEX into the page's SORTS table,
+        # not as sort_by/sort_order keys — passing those to navigate() does
+        # nothing at all and the grid comes back in the same order, which
+        # looks like the refetch failing to take.
+        # PremiereDate, not DateCreated. Every bulk item is created by the
+        # same scan, so their DateCreated values tie and the server falls
+        # back to name order — "Date Added" returns the identical first item
+        # as "Name" and the test reads as a refetch that did not take.
+        # Measured: SortName/Asc and DateCreated/Desc both start with
+        # "!Exclamation First 00295"; PremiereDate/Desc starts with
+        # "Ålesund Nordic 00369".
+        from jellyfin_mpv_shim.mpvtk_browser.pages.grid import SORTS
+        by_release = next(i for i, (_l, by, _o) in enumerate(SORTS)
+                          if by == "PremiereDate")
+        self.route["_sort"] = by_release
+        for key in ("_items", "_total", "_win_tried", "_win_load"):
+            self.route.pop(key, None)
+        self.browser._load_route(self.route)
+        self._render()
+
+        items = self._items()
+        self.assertTrue(items, "the resorted grid has no items")
+        new_first = next((i for i in items if i is not None), None)
+        self.assertIsNotNone(new_first, "nothing loaded after the resort")
+        self.assertNotEqual(
+            new_first.get("Id"), first_id,
+            "the first item is unchanged after switching from Name to "
+            "Release Date, so the grid is still showing the previous order")
+        self.assertLess(
+            len(self._filled()), len(items),
+            "the resorted grid came back fully loaded rather than windowed")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/e2e/test_photos.py
+++ b/tests/e2e/test_photos.py
@@ -1,0 +1,172 @@
+"""One picture is a picture; an album is a slideshow.
+
+A photo is a video that happens to be still, which makes the whole feature a
+matter of two mpv properties agreeing with two decisions the shim makes:
+
+* `image_display_duration` — how long mpv holds a still before it reaches
+  end-of-file. The in-window browser parks it at **inf** while it owns the
+  window (`set_browse_window`), and `browse_yield` deliberately does not undo
+  that, so a photo opened out of the library inherited "inf" and displayed
+  forever. The queue was waiting on an EOF mpv had been told never to send:
+  that is the whole of "photo auto-advance is broken".
+* `pause` — a photo opened on its own is held, and one reached by Play All or
+  by the queue advancing is not.
+
+Neither is visible without a real mpv. `image_display_duration` is a property
+of the demuxer, and a fake accepts "inf" as cheerfully as it accepts 5;
+`tests/test_photos.py` covers the pause decision as a truth table over an
+**excerpt** of `_play_media`, and an excerpt cannot see that the same method
+went on to unpause it seventy lines later — which it did, for the whole life
+of the feature, until this suite ran (`02d3329e`).
+
+The fixtures are the `orientation-*` JPEGs. Deliberately not `format-gif`:
+an animated GIF is a video as far as mpv is concerned, with a real duration
+and no `image_display_duration` at all, so a slideshow test written on it
+would pass whatever these properties said.
+"""
+
+import os
+import sys
+import unittest
+
+sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+import _e2e  # noqa: E402
+
+LIBRARY = "Photos"
+#: Short enough that a slideshow test is quick, and >= mpv's own floor of 1.
+DISPLAY_SECS = 2
+
+
+@_e2e.require_server_and_mpv
+class PhotoTest(_e2e.E2ETestCase):
+
+    def setUp(self):
+        super().setUp()
+        from jellyfin_mpv_shim.conf import settings
+
+        photos = [p for p in self.session.find_all(
+            library=LIBRARY, item_type="Photo", Limit=50)
+            if p["Name"].startswith("orientation-")]
+        if len(photos) < 3:
+            self.skipTest("need three still photos in %r; found %d"
+                          % (LIBRARY, len(photos)))
+        self.photos = sorted(photos, key=lambda p: p["Name"])[:3]
+        self.ids = [p["Id"] for p in self.photos]
+
+        self.settings = settings
+        self._was = settings.photo_display_secs
+        settings.photo_display_secs = DISPLAY_SECS
+        self.addCleanup(setattr, settings, "photo_display_secs", self._was)
+        # The library owns the window before anything is played, and that is
+        # where the "inf" comes from. Entering it here is not scene-setting:
+        # it is the precondition the auto-advance bug needed.
+        self.pm.set_browse_window(True)
+        self.addCleanup(self.pm.set_browse_window, False)
+
+    def _play(self, pause_stills):
+        media = _e2e.build_media(self.session, self.ids)
+        video = media.video
+        self.assertTrue(video.is_photo,
+                        "%r did not come back as a Photo"
+                        % self.photos[0]["Name"])
+        self.pm.play(video, is_initial_play=True, pause_stills=pause_stills)
+        self.assertIs(self.pm._video, video, "the photo never started")
+        return video
+
+    def _current_id(self):
+        return self.pm._video.item_id if self.pm._video else None
+
+    def _display_duration(self):
+        """`image_display_duration`, as a number, on either backend.
+
+        The two disagree about its type: libmpv hands back a float and
+        jsonipc the string mpv printed, so an endless still is `inf` on one
+        and `'inf'` on the other. Comparing the raw value passed on libmpv
+        and failed on jsonipc for a reason that had nothing to do with the
+        app — which is what the backend matrix is for.
+        """
+        return float(self.pm._player.image_display_duration)
+
+    # -- the tests ---------------------------------------------------------
+
+    def test_the_browsers_endless_still_does_not_survive_into_a_photo(self):
+        """`set_browse_window` parks the duration at inf and `browse_yield`
+        leaves it there, so the value has to be re-set on the way into
+        playback. Inherit it and the picture never reaches end-of-file, and
+        the queue behind it never moves."""
+        self.assertEqual(
+            self._display_duration(), float("inf"),
+            "the browser no longer parks image_display_duration at inf, so "
+            "this test is no longer staging the condition it exists for")
+        self._play(pause_stills=False)
+        self.assertEqual(
+            self._display_duration(), float(DISPLAY_SECS),
+            "the photo inherited the browser's endless display duration, so "
+            "mpv will never send the EOF the queue is waiting for")
+
+    def test_one_photo_opened_on_its_own_is_held(self):
+        """Clicking a picture means "show me this". It must not run on."""
+        self._play(pause_stills=True)
+        self.assertTrue(self.pm._player.pause,
+                        "the photo started playing instead of being held")
+        moved = self.pump_until(
+            lambda: self._current_id() != self.ids[0],
+            timeout=DISPLAY_SECS * 3 + 4)
+        self.assertFalse(
+            moved,
+            "a photo opened on its own advanced to the next one after about "
+            "%d seconds — the viewer turned into a slideshow" % DISPLAY_SECS)
+        self.assertEqual(self._current_id(), self.ids[0])
+
+    def test_play_all_runs_the_slideshow(self):
+        """The other half of the same decision: Play All on an album must
+        not pause on frame one, or the queue never starts."""
+        self._play(pause_stills=False)
+        self.assertFalse(self.pm._player.pause,
+                         "Play All paused on the first picture")
+        advanced = self.pump_until(
+            lambda: self._current_id() == self.ids[1],
+            timeout=DISPLAY_SECS * 4 + 10)
+        self.assertTrue(
+            advanced,
+            "the slideshow never advanced past the first picture (still on "
+            "%r after %d seconds)" % (self._current_id(), DISPLAY_SECS * 4))
+
+    def test_the_slideshow_does_not_stop_after_one_frame(self):
+        """The regression `is_initial_play` exists for. Pausing on every
+        load meant the queue advanced onto the second picture and paused
+        there too, so the slideshow moved exactly one frame and stopped —
+        which looks far more like "auto-advance is broken" than like a
+        deliberate pause."""
+        self._play(pause_stills=False)
+        self.assertTrue(
+            self.pump_until(lambda: self._current_id() == self.ids[1],
+                            timeout=DISPLAY_SECS * 4 + 10),
+            "never reached the second picture")
+        self.assertFalse(
+            self.pm._player.pause,
+            "the slideshow paused on the picture it advanced onto")
+        self.assertTrue(
+            self.pump_until(lambda: self._current_id() == self.ids[2],
+                            timeout=DISPLAY_SECS * 4 + 10),
+            "the slideshow advanced one frame and stopped")
+
+    def test_a_photo_needs_no_playback_session(self):
+        """Photos do not go through PlaybackInfo — that endpoint answers
+        about MediaSources and a Photo has none. Asking anyway yields no
+        source to negotiate and, worse, a play-session id that the reporting
+        path would then carry for an item the server has no session for."""
+        video = self._play(pause_stills=True)
+        self.assertIsNone(video.playback_info,
+                          "a photo went through PlaybackInfo")
+        self.assertIsNone(video.media_source)
+        url = video.get_playback_url()
+        host = _e2e.SERVER.split("//")[-1].split("/")[0]
+        self.assertIn(host, url)
+        self.assertIn("/Items/", url,
+                      "a photo is fetched from the item endpoint, not from a "
+                      "video stream url: %s" % url)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/e2e/test_playback_advance.py
+++ b/tests/e2e/test_playback_advance.py
@@ -1,0 +1,157 @@
+"""The queue advances, and the server agrees that it did.
+
+This is the suite's proof-of-concept and its most valuable single test. The
+integration suite's `test_realmpv_smoke` already plays a real clip through a
+real mpv and watches a genuine EOF auto-advance — but it plays a local file
+and the Jellyfin *session* is a recording fake, deliberately (see
+`tests/integration/README.md`). So the shim's half of the loop is asserted and
+the round trip is not.
+
+Here the episode comes from a real library, over a real HTTP stream URL the
+server resolved, through a real `Media` built from real DTOs, and the
+watched-marking is read back off the server rather than off a fake we wrote.
+Auto-advance and watched-marking are one of the two largest open-bug clusters
+in the tracker (#157, #323, #458, #541); every one of those reproduced only
+against a server.
+
+stdjflib's episodes are 10 seconds, which is what makes playing one to its end
+a reasonable thing for a test to do.
+"""
+
+import os
+import sys
+import unittest
+
+sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+import _e2e  # noqa: E402
+
+SHOW = "The Standard Show"
+SERVER_HOST = (_e2e.SERVER.split("//")[-1].split("/")[0]
+               if _e2e.SERVER else "")
+
+
+@_e2e.require_server_and_mpv
+class QueueAdvanceTest(_e2e.E2ETestCase):
+
+    def setUp(self):
+        super().setUp()
+        eps = self.session.episodes(SHOW, season=1)
+        self.assertGreaterEqual(
+            len(eps), 2, "need two episodes to test an advance")
+        self.first, self.second = eps[0], eps[1]
+        ids = (self.first["Id"], self.second["Id"])
+        # Watched state persists on the server, so a second run would start
+        # dirty. Clear it both ways round.
+        self.session.reset_played(*ids)
+        self.addCleanup(self.session.reset_played, *ids)
+
+    def test_an_episode_plays_out_and_the_next_one_starts(self):
+        media = _e2e.build_media(self.session, [self.first["Id"],
+                                                self.second["Id"]])
+        video = media.video
+        self.assertIsNotNone(video, "Media built no video for a live server")
+
+        # The stream URL is the server's answer, not ours. A direct-play URL
+        # here is also the assertion that this library needs no transcode —
+        # if that ever changes the timings below stop being reliable and we
+        # want to know from this line rather than from a flaky EOF.
+        url = video.get_playback_url()
+        self.assertIn(SERVER_HOST, url,
+                      "playback URL does not point at the server under test")
+        self.assertFalse(video.is_transcode,
+                         "expected direct play for a generated H.264 episode")
+
+        self.pm.play(video, is_initial_play=True)
+        self.assertIs(self.pm._video, video)
+        self.assertTrue(
+            self.pm._player.duration and self.pm._player.duration > 0,
+            "real mpv never reported a duration for the stream")
+
+        # 1) The server is told we started, and what we started.
+        self.pm.send_timeline()
+        playing = _e2e.wait_for(
+            lambda: (self.session.my_session() or {}).get("NowPlayingItem"))
+        self.assertTrue(playing, "the server never saw this device playing")
+        self.assertEqual(playing["Id"], self.first["Id"],
+                         "the server thinks we are playing something else")
+
+        # 2) A genuine end-of-file advances the queue. Ten seconds of media,
+        #    so the timeout is slack rather than a guess.
+        advanced = self.pump_until(
+            lambda: self.pm._video is not None
+            and self.pm._video.item_id == self.second["Id"],
+            timeout=45)
+        self.assertTrue(advanced, "the queue did not advance on EOF")
+
+        # 3) The finished episode is watched *on the server*. This is the
+        #    assertion the fake session cannot make, and the one that has
+        #    regressed repeatedly.
+        self.pm.send_timeline()
+        played = _e2e.wait_for(
+            lambda: self.session.user_data(self.first["Id"]).get("Played"))
+        self.assertTrue(played,
+                        "the finished episode was not marked watched on the "
+                        "server")
+
+        # 4) ...and the one that replaced it is not, which is what separates a
+        #    real advance from the whole queue being marked off.
+        self.assertFalse(
+            self.session.user_data(self.second["Id"]).get("Played"),
+            "the episode we advanced INTO was marked watched")
+
+
+@_e2e.require_server_and_mpv
+class ResumePositionTest(_e2e.E2ETestCase):
+    """The other direction of the same reporting loop: a progress post that
+    carries a position rather than a completion.
+
+    **This needs a long item, and that is the server's rule, not a choice.**
+    Jellyfin discards a resume position for anything shorter than
+    `MinResumeDurationSeconds` (300 by default, confirmed against this
+    server's `/System/Configuration`), and additionally clamps to
+    `MinResumePct` 5% / `MaxResumePct` 90%. A 10-second episode can therefore
+    never hold one, so writing this test against the show it seems to belong
+    with produces a failure that reads as a shim bug and is not. `x-long`
+    exists in stdjflib for exactly this — "resume points, seek accuracy far
+    from the start".
+    """
+
+    ITEM = "Three hours"
+    SEEK_TO = 1200.0        # 20 min: past the 5% floor (540s), far from 90%
+
+    def setUp(self):
+        super().setUp()
+        self.item = self.session.find(self.ITEM, library="Test Media")
+        self.session.reset_played(self.item["Id"])
+        self.addCleanup(self.session.reset_played, self.item["Id"])
+
+    def test_stopping_midway_leaves_a_resume_position(self):
+        media = _e2e.build_media(self.session, [self.item["Id"]])
+        video = media.video
+        self.pm.play(video, is_initial_play=True)
+        self.assertTrue(self.pm._player.duration)
+
+        self.pm.seek(self.SEEK_TO, absolute=True, exact=True)
+        arrived = self.pump_until(
+            lambda: (self.pm._player.playback_time or 0) >= self.SEEK_TO - 5,
+            timeout=30)
+        self.assertTrue(arrived, "mpv never reached the seek target")
+        self.pm.send_timeline()
+        self.pm.stop()
+
+        ticks = _e2e.wait_for(
+            lambda: self.session.user_data(self.item["Id"])
+            .get("PlaybackPositionTicks"))
+        self.assertTrue(ticks, "no resume position was recorded")
+        seconds = ticks / 10_000_000
+        self.assertGreater(seconds, self.SEEK_TO - 60,
+                           "resume position is well short of where we stopped")
+        self.assertLess(seconds, self.SEEK_TO + 60,
+                        "resume position is well past where we stopped")
+        self.assertFalse(
+            self.session.user_data(self.item["Id"]).get("Played"),
+            "an item stopped 20 minutes into three hours was marked watched")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/e2e/test_playback_eof.py
+++ b/tests/e2e/test_playback_eof.py
@@ -1,0 +1,190 @@
+"""End-of-file edges, against a real server.
+
+The three historically worst of them, each with an issue behind it and each
+reproducible only with a server on the other end:
+
+* the **last** item in a queue, which ends via `playback-abort` rather than
+  `eof-reached` because there is no next file for `keep_open` to hold on —
+  the path that decides whether finishing a series marks the finale watched;
+* a **seek to the very end** (#541), where the historic complaint is that the
+  end-of-file notification never arrives at all when you skip into it rather
+  than play into it;
+* **replaying something already finished** (#157, closed #323), which used to
+  start at EOF, mark itself watched again and skip straight past.
+
+Each class owns its own series, so nothing here depends on execution order —
+and each resets that series' playstate in `setUp` as well as on cleanup, so a
+previous run that died halfway cannot change the outcome either.
+"""
+
+import os
+import sys
+import unittest
+from unittest import mock
+
+sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+import _e2e  # noqa: E402
+
+
+class _ShowCase(_e2e.E2ETestCase):
+    """A case that owns one series. Subclasses set `SHOW` (and `SEASON`)."""
+
+    SHOW = None
+    SEASON = 1
+    NEEDED = 2
+
+    def setUp(self):
+        super().setUp()
+        self.eps = self.session.episodes(self.SHOW, season=self.SEASON)
+        self.assertGreaterEqual(
+            len(self.eps), self.NEEDED,
+            "%s needs %d episodes" % (self.SHOW, self.NEEDED))
+        self.ep_ids = [e["Id"] for e in self.eps]
+        # Reset in setUp, not only on cleanup: a run that died halfway would
+        # otherwise leave this series watched and change what the next run
+        # measures. This is what makes the suite order-independent.
+        self.session.reset_played(*self.ep_ids)
+        self.addCleanup(self.session.reset_played, *self.ep_ids)
+
+    def play_queue(self, ids, seq=0):
+        media = _e2e.build_media(self.session, ids, seq=seq)
+        video = media.video
+        self.assertIsNotNone(video, "Media built no video")
+        self.pm.play(video, is_initial_play=True)
+        self.assertTrue(self.pm._player.duration,
+                        "real mpv never reported a duration")
+        return video
+
+    def assert_played(self, item_id, msg, timeout=20):
+        got = _e2e.wait_for(
+            lambda: self.session.user_data(item_id).get("Played"),
+            timeout=timeout)
+        self.assertTrue(got, msg)
+
+
+@_e2e.require_server_and_mpv
+class EndOfQueueTest(_ShowCase):
+    """The last item in a queue still gets marked watched.
+
+    It ends differently from every other item: with no next file, mpv reports
+    `playback-abort` rather than `eof-reached`, and the 07-25 checklist calls
+    this out specifically. Run under both `force_set_played` values because
+    they reach the same outcome by different routes — the setting makes the
+    shim mark it, and without it the server infers it from a stop report past
+    `MaxResumePct` (90%). A user cares that the finale is watched; which of
+    the two did it is the implementation detail.
+    """
+
+    SHOW = "Absolute Numbering Show"
+    NEEDED = 1
+
+    def _play_single_to_end(self):
+        last = self.eps[0]
+        self.play_queue([last["Id"]])
+        finished = self.pump_until(lambda: self.pm._video is None
+                                   or (self.pm._player.playback_time or 0) >= 9.0,
+                                   timeout=45)
+        self.assertTrue(finished, "the single item never reached its end")
+        self.pm.send_timeline()
+        return last
+
+    def test_the_last_item_is_marked_watched_with_force_set_played(self):
+        with mock.patch.object(self.player_module.settings,
+                               "force_set_played", True):
+            last = self._play_single_to_end()
+        self.assert_played(
+            last["Id"],
+            "the last item in a queue was not marked watched "
+            "(force_set_played on)")
+
+    def test_the_last_item_is_marked_watched_without_force_set_played(self):
+        with mock.patch.object(self.player_module.settings,
+                               "force_set_played", False):
+            last = self._play_single_to_end()
+        self.assert_played(
+            last["Id"],
+            "the last item in a queue was not marked watched "
+            "(force_set_played off — the server should infer it from the "
+            "stop report past MaxResumePct)")
+
+
+@_e2e.require_server_and_mpv
+class SeekToEndTest(_ShowCase):
+    """#541 — skipping to the end must fire EOF, not park there.
+
+    The reported symptom is a queue that stops instead of advancing. The
+    integration suite covers this against a local clip; the point of doing it
+    again here is that the bytes now arrive over HTTP from the server, which
+    is where the reporters were.
+    """
+
+    SHOW = "Flat Show No Season Folders"
+
+    def test_seeking_to_the_end_advances_the_queue(self):
+        self.play_queue(self.ep_ids[:2])
+        duration = self.pm._player.duration
+        self.assertTrue(duration and duration > 1)
+
+        self.pm.seek(max(duration - 0.3, 0), absolute=True, exact=True)
+
+        advanced = self.pump_until(
+            lambda: self.pm._video is not None
+            and self.pm._video.item_id == self.ep_ids[1],
+            timeout=45)
+        self.assertTrue(
+            advanced, "a seek to the end did not fire EOF / advance the queue")
+        self.assert_played(
+            self.ep_ids[0],
+            "the episode we seeked to the end of was not marked watched")
+
+
+@_e2e.require_server_and_mpv
+class ReplayFinishedTest(_ShowCase):
+    """#157 / #323 — replaying a finished episode starts at the start.
+
+    The failure was that it resumed at EOF, remarked itself watched and
+    skipped straight to the next one, so choosing to rewatch something played
+    the episode after it. Reported external-mpv-only, which is why this runs
+    on both legs.
+    """
+
+    SHOW = "Show With Missing Episodes"
+
+    def test_replaying_a_watched_episode_does_not_skip_it(self):
+        # 1) Finish it for real, so the replay starts from the state the
+        #    reporters were in rather than from a flag we set by hand.
+        self.play_queue([self.ep_ids[0]])
+        self.pump_until(lambda: self.pm._video is None
+                        or (self.pm._player.playback_time or 0) >= 9.0,
+                        timeout=45)
+        self.pm.send_timeline()
+        self.pm.stop()
+        self.assert_played(self.ep_ids[0],
+                           "the episode never became watched, so the replay "
+                           "below would not be testing anything")
+
+        # 2) Play it again, with a next episode queued behind it — the bug
+        #    needs somewhere to skip *to* in order to be visible.
+        video = self.play_queue(self.ep_ids[:2])
+        self.assertEqual(video.item_id, self.ep_ids[0])
+
+        started_near_zero = _e2e.wait_for(
+            lambda: (self.pm._player.playback_time or 0) < 3.0, timeout=10)
+        self.assertTrue(started_near_zero,
+                        "the replay did not start near the beginning")
+
+        # 3) It must still be on the same episode a few seconds later. A skip
+        #    was instant, so this does not need the full runtime to catch it.
+        self.pump_until(lambda: False, timeout=4)
+        self.assertIsNotNone(self.pm._video, "playback stopped during a replay")
+        self.assertEqual(
+            self.pm._video.item_id, self.ep_ids[0],
+            "replaying a watched episode skipped to the next one")
+        self.assertLess(
+            self.pm._player.playback_time or 0, 9.0,
+            "the replay is sitting at the end of the file rather than "
+            "playing it")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/e2e/test_playback_failure.py
+++ b/tests/e2e/test_playback_failure.py
@@ -1,0 +1,99 @@
+"""Media that cannot play must fail, not hang — and must not count as watched.
+
+stdjflib builds three hostile files for this and says what each is for: a
+truncated one ("playback should fail cleanly and report an error, not hang"),
+a zero-byte one ("rejected at scan, and if it is not, it must fail gracefully
+at playback") and a single-frame one ("duration rounds to zero in a lot of
+arithmetic, and progress bars divide by it").
+
+The failure mode these guard against is the one `qa-notranscode` exists to
+find in the account list — "anything that cannot direct play must fail with a
+clear message rather than spinning". A spinner is not an exception, so no unit
+test sees it; what a test can see is that the call returns, that no video is
+left behind, and that the server was not told you watched something you could
+not play.
+"""
+
+import os
+import sys
+import time
+import unittest
+
+sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+import _e2e  # noqa: E402
+
+LIBRARY = "Test Media"
+
+
+@_e2e.require_server_and_mpv
+class BrokenMediaTest(_e2e.E2ETestCase):
+
+    def _item(self, name):
+        item = self.session.find(name, library=LIBRARY)
+        self.session.reset_played(item["Id"])
+        self.addCleanup(self.session.reset_played, item["Id"])
+        return item
+
+    def _play(self, item):
+        """Play, and bound how long that is allowed to take.
+
+        `play()` is synchronous and gates on the file loading, so a hang here
+        is the reported symptom rather than something we have to infer.
+        """
+        video = _e2e.build_media(self.session, [item["Id"]]).video
+        self.assertIsNotNone(video, "Media built no video")
+        started = time.time()
+        self.pm.play(video, is_initial_play=True)
+        return time.time() - started
+
+    def test_a_truncated_file_fails_and_is_not_marked_watched(self):
+        item = self._item("Truncated file")
+        elapsed = self._play(item)
+        self.assertLess(elapsed, 90, "play() hung on a truncated file")
+
+        # It aborts partway. What matters is that it stops on its own and
+        # leaves nothing behind claiming to be playing.
+        ended = self.pump_until(lambda: self.pm._video is None, timeout=60)
+        self.assertTrue(ended, "a truncated file never ended playback")
+
+        _e2e.wait_for(lambda: self.session.user_data(item["Id"])
+                      .get("PlayCount"), timeout=10)
+        self.assertFalse(
+            self.session.user_data(item["Id"]).get("Played"),
+            "a file that failed mid-stream was recorded as watched")
+
+    def test_a_zero_byte_file_is_refused_cleanly(self):
+        item = self._item("Zero-byte file")
+        elapsed = self._play(item)
+        self.assertLess(elapsed, 90, "play() hung on a zero-byte file")
+
+        # Nothing to decode: the load fails and no session should survive it.
+        self.assertIsNone(
+            self.pm._video,
+            "a zero-byte file left a video attached to the player")
+        time.sleep(1.0)
+        self.assertFalse(
+            self.session.user_data(item["Id"]).get("Played"),
+            "an unplayable file was recorded as watched")
+
+    def test_a_single_frame_file_does_not_break_the_progress_arithmetic(self):
+        """One frame, ~1s. The point is that nothing divides by zero.
+
+        Its runtime is short enough that finishing it legitimately marks it
+        watched — that is correct and is not what this asserts. What it
+        asserts is that playing it start to finish raises nothing and leaves
+        the player in a clean state.
+        """
+        item = self._item("One frame")
+        elapsed = self._play(item)
+        self.assertLess(elapsed, 90, "play() hung on a single-frame file")
+
+        ended = self.pump_until(lambda: self.pm._video is None, timeout=60)
+        self.assertTrue(ended, "a single-frame file never ended playback")
+        # Still usable afterwards: a divide-by-zero deep in the reporting path
+        # would have taken the action pump down rather than raised here.
+        self.pm.update()
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/e2e/test_route_walk.py
+++ b/tests/e2e/test_route_walk.py
@@ -1,0 +1,379 @@
+"""Every screen, loaded and rendered against a real library.
+
+This replaces a manual step. `docs/REGRESSION_CHECKLIST_2026-07-25.md` §1 is:
+
+    Walk each route once: home, library grid, person, detail, series, season,
+    search, playlists, playlist editor, queue editor, music library (all five
+    tabs), album, artist, genre, downloads, settings, cast screen.
+    **Then grep `log.txt` for `scene build failed`.** This is the important
+    half.
+
+It is the important half because `strict_builds` is off in production: a build
+exception keeps the last good frame, so a broken route does not look like a
+crash — it looks like a UI that ignored the click. `b97dd523` is what that
+costs. `get_channel_listing` passed `enable_images=False` to a client method
+with no such argument, so opening a Live TV channel raised `TypeError` before
+the fetch, and nothing found it until a human opened that screen.
+
+Every route here is driven the way production drives it — `navigate()` through
+the real `Navigator`, the real page `load()` against real DTOs, then a real
+`build()` and `layout()`. What is *not* here is mpv: the failures this catches
+live in load and build, and dropping the window makes it a contract-tier test
+that runs once in about a second instead of a windowed one per backend. The
+real-window rendering path already has coverage in
+`tests/integration/test_mpvtk_browser.py`.
+
+Three things are checked per screen, and the order they were added is the
+lesson. **(1)** the build does not raise — `app=None` means `build()` is
+called directly rather than through the app's guarded wrapper, so nothing
+swallows it. **(2)** `route["_error"]` is unset. **(3)** nothing logged a
+failure. A negative control that reintroduced `b97dd523` passed against (1)
+alone, because `_route_async` catches a failing loader, records the error on
+the route and leaves it empty — and an empty route builds perfectly. (2) is
+what caught it. (3) is the belt, and it hangs off the **root** logger: the two
+loggers that matter are named `mpvtk` and `mpvtk_browser.async_runner`,
+outside the package hierarchy, so a handler on `jellyfin_mpv_shim` sees
+neither — which is how the first version of the trap collected nothing while
+the failure printed to the console beside it.
+"""
+
+import logging
+import os
+import sys
+import unittest
+
+sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+import _e2e  # noqa: E402
+
+REPO_ROOT = os.path.dirname(os.path.dirname(os.path.dirname(
+    os.path.abspath(__file__))))
+if REPO_ROOT not in sys.path:
+    sys.path.insert(0, REPO_ROOT)
+
+SIZE = (1280, 720)
+
+
+#: A route whose loader raised carries this, set by `_route_async`. The
+#: primary signal, because it depends on no logging configuration and names
+#: the route that broke.
+ROUTE_ERROR_KEY = "_error"
+
+
+#: The log lines that mean a screen broke. This is the automated form of the
+#: checklist's "then grep `log.txt` for `scene build failed`", widened by what
+#: a negative control showed: reintroducing `b97dd523` (a TypeError in the
+#: channel page's fetch) did NOT fail a walk that only watched `build()`,
+#: because `AsyncRunner` catches a failing loader, logs it, and leaves the
+#: route empty — and an empty route builds perfectly. The load is where these
+#: bugs actually land, and the log is the only place it is recorded.
+FAILURE_LOGS = (
+    "async work failed",
+    "async on_error failed",
+    "scene build failed",
+)
+
+
+class _LogTrap(logging.Handler):
+    """Collect the failure lines above while a route is walked."""
+
+    def __init__(self):
+        super().__init__(level=logging.DEBUG)
+        self.records = []
+
+    def emit(self, record):
+        try:
+            message = record.getMessage()
+        except Exception:
+            return
+        if any(message.startswith(sig) for sig in FAILURE_LOGS):
+            self.records.append(record)
+
+    def drain(self):
+        found, self.records = self.records, []
+        return found
+
+    def describe(self):
+        out = []
+        for record in self.records:
+            text = record.getMessage()
+            if record.exc_info:
+                text += ": %s" % (record.exc_info[1],)
+            out.append(text)
+        return out
+
+
+class _SyncPool:
+    """Run route loaders inline, so a fetch completes before the render.
+
+    The real pool is threaded and the shell tests substitute this to make
+    ordering deterministic. Here the work it runs inline is a *real* request,
+    which is the point: `navigate()` fetches, then `build()` draws what came
+    back.
+    """
+
+    def submit(self, fn, *a, **k):
+        fn(*a, **k)
+
+    def shutdown(self, *a, **k):
+        pass
+
+
+@_e2e.require_server
+class RouteWalkTest(unittest.TestCase):
+
+    @classmethod
+    def setUpClass(cls):
+        from jellyfin_mpv_shim.mpvtk_browser.app import MpvtkBrowser, PAGES
+        cls.PAGES = PAGES
+        cls.session = _e2e.Session()
+        cls.source = cls.session.library_source()
+        cls.libraries = cls.source.get_libraries(_e2e.SOURCE_UUID)
+        cls.by_name = {lib["Name"]: lib for lib in cls.libraries}
+        cls._browser_cls = MpvtkBrowser
+
+    @classmethod
+    def tearDownClass(cls):
+        try:
+            cls.source.stop()
+        finally:
+            cls.session.stop()
+
+    def setUp(self):
+        # ROOT, not the `jellyfin_mpv_shim` logger. The two that matter are
+        # named `mpvtk` and `mpvtk_browser.async_runner` — outside the package
+        # hierarchy, so a handler on the package name sees neither. That is
+        # exactly how the first version of this trap caught nothing while the
+        # failure printed to the console beside it.
+        self.trap = _LogTrap()
+        root = logging.getLogger()
+        root.addHandler(self.trap)
+        self.addCleanup(root.removeHandler, self.trap)
+        self.browser = self._browser_cls(
+            app=None, source=self.source, server_uuid=_e2e.SOURCE_UUID)
+        # `__init__` already kicked the home load onto the runner's real
+        # threaded pool (app.py:408), so swapping the pool afterwards does not
+        # catch it. Drain that one first — otherwise it lands *after*
+        # tearDownClass has logged the session out, which shows up as a
+        # cascade of 401s and a render that asserted against a spinner.
+        self.browser._async._pool.shutdown(wait=True, cancel_futures=True)
+        self.browser._pool = _SyncPool()
+        # Now redo it inline, so the route holds real data before anything
+        # renders.
+        self.browser._load_route(self.browser.route)
+        self.assertEqual(
+            self.trap.describe(), [],
+            "the home screen failed to load before the walk even started")
+        self.trap.drain()
+        self.addCleanup(self._shutdown_browser)
+
+    def _shutdown_browser(self):
+        try:
+            self.browser.shutdown()
+        except Exception:
+            pass
+
+    # -- the walk ----------------------------------------------------------
+
+    def _render(self, label):
+        """Build and lay the current route out, as a frame would.
+
+        `app=None` means there is no `MpvtkApp` to carry `strict_builds`, so
+        the exception surfaces here directly — `build()` is called rather than
+        the app's guarded wrapper, and anything the page raises comes straight
+        out with the route named.
+        """
+        from jellyfin_mpv_shim.mpvtk.layout import layout
+        try:
+            tree = self.browser.build(SIZE)
+            nodes, _handlers = layout(tree, *SIZE)
+        except Exception as exc:
+            raise AssertionError(
+                "%s raised while building its scene against real data: "
+                "%s: %s" % (label, type(exc).__name__, exc)) from exc
+        self.assertTrue(
+            nodes,
+            "%s built an empty scene — it drew nothing at all" % label)
+        # The half that actually catches things. A loader that raised was
+        # caught, recorded on the route, and left it empty; the scene above
+        # then built fine and proved nothing. A negative control that
+        # reintroduced b97dd523 passed until this was added.
+        self.assertIsNone(
+            self.browser.route.get(ROUTE_ERROR_KEY),
+            "%s failed to load against real data: %s"
+            % (label, self.browser.route.get(ROUTE_ERROR_KEY)))
+        broken = self.trap.describe()
+        self.trap.drain()
+        self.assertEqual(
+            broken, [],
+            "%s logged a failure while loading or building against real "
+            "data: %s" % (label, broken))
+        return nodes
+
+    def _walk(self, label, route):
+        self.browser.navigate(dict(route))
+        self.assertEqual(self.browser.route.get("kind"), route["kind"],
+                         "%s did not become the current route" % label)
+        # The loader runs inline, so anything still marked loading means the
+        # fetch never happened — and a screen rendered mid-load draws a
+        # spinner, which builds perfectly and proves nothing. Without this
+        # the whole walk passes against a server it never reached.
+        self.assertFalse(
+            self.browser.route.get("_loading"),
+            "%s is still loading after an inline fetch, so its scene would "
+            "be a spinner rather than the screen" % label)
+        return self._render(label)
+
+    def _item(self, library, item_type, fields=None):
+        items = self.session.find_all(library=library, item_type=item_type,
+                                      fields=fields, Limit=1)
+        if not items:
+            self.skipTest("no %s in %r" % (item_type, library))
+        return items[0]
+
+    def _base(self, item):
+        return {"server": _e2e.SOURCE_UUID, "item_id": item.get("Id"),
+                "title": item.get("Name", "")}
+
+    # -- the screens -------------------------------------------------------
+
+    def test_home(self):
+        nodes = self._render("home")
+        self.assertTrue(nodes)
+
+    def test_library_grids(self):
+        """Every library, not one: the grid classifies itself by collection
+        type, so a books or photos library takes a different path from movies.
+        """
+        for lib in self.libraries:
+            if lib.get("CollectionType") == "livetv":
+                continue                      # its own page kind, below
+            with self.subTest(library=lib["Name"]):
+                kind = "music" if lib.get("CollectionType") == "music" else "grid"
+                self._walk("grid:%s" % lib["Name"],
+                           {"kind": kind, "server": _e2e.SOURCE_UUID,
+                            "parent_id": lib["Id"], "title": lib["Name"],
+                            "collection_type": lib.get("CollectionType")})
+
+    def test_detail_series_and_season(self):
+        series = self._item("Shows", "Series")
+        self._walk("series", dict(self._base(series), kind="series"))
+
+        seasons = self.source.get_seasons(_e2e.SOURCE_UUID, series["Id"])
+        self.assertTrue(seasons, "the series has no seasons")
+        self._walk("season", dict(self._base(seasons[0]), kind="season",
+                                  series_id=series["Id"]))
+
+        episodes = self.source.get_episodes(
+            _e2e.SOURCE_UUID, series["Id"], seasons[0]["Id"])
+        self.assertTrue(episodes, "the season has no episodes")
+        self._walk("detail:episode",
+                   dict(self._base(episodes[0]), kind="detail"))
+
+        movie = self._item("Movies", "Movie")
+        self._walk("detail:movie", dict(self._base(movie), kind="detail"))
+
+    def test_music_screens(self):
+        music = self.by_name.get("Music")
+        if music is None:
+            self.skipTest("no Music library")
+        albums = self.source.get_music_albums(
+            _e2e.SOURCE_UUID, music["Id"], start_index=0, limit=1)[0]
+        self.assertTrue(albums, "no albums")
+        self._walk("album", dict(self._base(albums[0]), kind="album"))
+
+        artists = self.source.get_album_artists(
+            _e2e.SOURCE_UUID, music["Id"], start_index=0, limit=1)[0]
+        if artists:
+            self._walk("artist", dict(self._base(artists[0]), kind="artist"))
+
+        genres = self.source.get_music_genres(_e2e.SOURCE_UUID, music["Id"])
+        if genres:
+            self._walk("music_genre",
+                       dict(self._base(genres[0]), kind="music_genre",
+                            parent_id=music["Id"]))
+
+    def test_person(self):
+        movie = self._item("Movies", "Movie", fields="People")
+        people = (self.source.get_item(_e2e.SOURCE_UUID, movie["Id"])
+                  or {}).get("People") or []
+        if not people:
+            self.skipTest("no People on this item — nothing to open")
+        self._walk("person", dict(self._base(people[0]), kind="person",
+                                  person_id=people[0].get("Id")))
+
+    def test_search(self):
+        route = {"kind": "search", "server": _e2e.SOURCE_UUID, "query": "the"}
+        self._walk("search", route)
+
+    def test_favorites_and_genres(self):
+        self._walk("favorites",
+                   {"kind": "favorites", "server": _e2e.SOURCE_UUID})
+        movies = self.by_name.get("Movies")
+        if movies is not None:
+            self._walk("genres", {"kind": "genres",
+                                  "server": _e2e.SOURCE_UUID,
+                                  "parent_id": movies["Id"],
+                                  "title": "Genres"})
+
+    def test_playlists_and_queue(self):
+        playlists = self.source.get_playlists(_e2e.SOURCE_UUID)
+        if playlists:
+            self._walk("playlist",
+                       dict(self._base(playlists[0]), kind="playlist"))
+            self._walk("playlist_edit",
+                       dict(self._base(playlists[0]), kind="playlist_edit"))
+        self._walk("queue", {"kind": "queue", "server": _e2e.SOURCE_UUID})
+
+    def test_live_tv_screens(self):
+        """The screens `b97dd523` took down. The channel page is the one that
+        raised before it fetched anything."""
+        if not self.source.has_live_tv(_e2e.SOURCE_UUID):
+            self.skipTest("no Live TV on this server")
+        live = [l for l in self.libraries
+                if l.get("CollectionType") == "livetv"]
+        self.assertTrue(live, "has_live_tv but no Live TV view")
+        self._walk("livetv", {"kind": "livetv", "server": _e2e.SOURCE_UUID,
+                              "parent_id": live[0]["Id"],
+                              "title": live[0]["Name"]})
+
+        channels = self.source.get_channels(_e2e.SOURCE_UUID)[0]
+        self.assertTrue(channels, "no channels")
+        self._walk("channel", dict(self._base(channels[0]), kind="channel",
+                                   _seed=channels[0]))
+
+        import datetime
+        now = datetime.datetime.now(datetime.timezone.utc)
+        guide = self.source.get_guide(
+            _e2e.SOURCE_UUID, [c["Id"] for c in channels], now,
+            now + datetime.timedelta(hours=2))
+        self.assertTrue(guide, "no programmes in the next two hours")
+        self._walk("program", dict(self._base(guide[0]), kind="program",
+                                   channel_id=guide[0].get("ChannelId"),
+                                   _seed=guide[0]))
+
+    def test_every_page_kind_was_reached_or_is_excused(self):
+        """The catch-all, so a route added later is not silently unwalked.
+
+        `tests/test_mpvtk_headless.py` uses the same shape for the headless
+        door list, and for the same reason: an enumeration that has to be
+        updated by hand rots, so make forgetting it a failure.
+        """
+        walked = {
+            "home", "grid", "music", "series", "season", "detail", "album",
+            "artist", "music_genre", "person", "search", "favorites",
+            "genres", "playlist", "playlist_edit", "queue", "livetv",
+            "channel", "program",
+        }
+        # Reached by a Studio or Genre tile rather than by a library, and
+        # covered by `list` below; kept out of the walk because building one
+        # needs an ItemsByName id that this library may not have.
+        excused = {"byname", "list"}
+        unwalked = sorted(set(self.PAGES) - walked - excused)
+        self.assertEqual(
+            unwalked, [],
+            "these page kinds are never opened by the route walk, so a "
+            "failure on real data would go unnoticed: %s" % unwalked)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/e2e/test_route_walk.py
+++ b/tests/e2e/test_route_walk.py
@@ -52,6 +52,9 @@ if REPO_ROOT not in sys.path:
 
 SIZE = (1280, 720)
 
+#: Window chrome, excluded from the interaction sweep — see `_interact`.
+CHROME_PREFIXES = ("nav-", "chrome-", "topbar-", "bar-")
+
 
 #: A route whose loader raised carries this, set by `_route_async`. The
 #: primary signal, because it depends on no logging configuration and names
@@ -185,7 +188,8 @@ class RouteWalkTest(unittest.TestCase):
         from jellyfin_mpv_shim.mpvtk.layout import layout
         try:
             tree = self.browser.build(SIZE)
-            nodes, _handlers = layout(tree, *SIZE)
+            nodes, handlers = layout(tree, *SIZE)
+            self._handlers = handlers
         except Exception as exc:
             raise AssertionError(
                 "%s raised while building its scene against real data: "
@@ -208,6 +212,73 @@ class RouteWalkTest(unittest.TestCase):
             "%s logged a failure while loading or building against real "
             "data: %s" % (label, broken))
         return nodes
+
+    def _interact(self, label):
+        """Right-click, scroll and hover every content node, then repaint.
+
+        The route walk above only *loads and renders* each screen, and two
+        real crashes fired on interaction instead: an `AttributeError` deep
+        in `layout.py` from right-clicking, and a raster `ValueError` while
+        scrolling the library that logged "scene build failed; keeping the
+        previous frame" every frame. Both look like a UI that ignored the
+        gesture, because that is exactly what a kept frame is.
+
+        Best-effort by design — a screen with no tiles has nothing to
+        right-click and that is not a failure. What is asserted is that
+        nothing raised and nothing logged.
+
+        **Verified on the home rows only.** A negative control that made
+        `TilesMixin._open_tile_menu` raise is caught on `test_home` and NOT on
+        the grid, detail or music screens: they build the same
+        `TileRenderer.image_map` lambda but wire `on_context` to something
+        else, so that control never reaches them. So this sweep is known to
+        fire and known to propagate on one path, and unproven on the others —
+        do not read a green run here as "right-click is covered everywhere".
+        Closing that means finding each page's `on_context` and controlling
+        against it, or making the failure observable (the two real crashes
+        both surfaced as `scene build failed`, which the trap does catch).
+        """
+        for event in ("hover", "context", "scroll", "hover_end"):
+            # CONTENT nodes only. The chrome carries these events too, and
+            # firing e.g. nav-back's context first can navigate away — taking
+            # the tiles this is actually about out of the scene, so the sweep
+            # silently stopped testing anything. (It did: a negative control
+            # that made right-click raise was caught on the home screen and
+            # not on a grid.)
+            targets = [i for i, _h in self.handlers_for(event)
+                       if not any(i.startswith(p) for p in CHROME_PREFIXES)]
+            for node_id in targets[:3]:
+                if node_id not in self._handlers:
+                    continue        # the scene moved on; nothing to fire
+                handler = self._handlers[node_id].get(event)
+                if handler is None:
+                    continue
+                try:
+                    if event == "scroll":
+                        handler(240.0, 4000.0)
+                    elif event == "context":
+                        handler(400.0, 300.0)
+                    else:
+                        handler()
+                except TypeError:
+                    # Signatures differ per event; a mismatch here is the
+                    # test's problem, not the app's.
+                    continue
+                except Exception as exc:
+                    raise AssertionError(
+                        "%s raised on %s of %s against real data: %s: %s"
+                        % (label, event, node_id, type(exc).__name__, exc)
+                    ) from exc
+                # Repaint with the gesture's state applied — an open menu is
+                # where the layout crash lived, so the build MUST happen
+                # while it is still up.
+                self._render("%s after %s" % (label, event))
+            if event == "context":
+                self.browser._close_menu()
+                self._render("%s after dismissing the menu" % label)
+
+    def handlers_for(self, event):
+        return [(i, h) for i, h in self._handlers.items() if event in h]
 
     def _walk(self, label, route):
         self.browser.navigate(dict(route))
@@ -239,6 +310,7 @@ class RouteWalkTest(unittest.TestCase):
     def test_home(self):
         nodes = self._render("home")
         self.assertTrue(nodes)
+        self._interact("home")
 
     def test_library_grids(self):
         """Every library, not one: the grid classifies itself by collection

--- a/tests/e2e/test_scroll_recovery.py
+++ b/tests/e2e/test_scroll_recovery.py
@@ -1,0 +1,280 @@
+"""Scrolling a thousand-item library hard, in a real window.
+
+The most-repeated hand-test complaint in this repo's history — four rounds
+across two different UI implementations, always found by a human, never by a
+test:
+
+* 2026-06-27 (Tk): "about 2/3 through the scroll it stops scrolling despite
+  being visibly not at the end."
+* 2026-07-19 (mpvtk): "When scrolling far in infinite scroll, I get blank
+  tiles when scrolling back up."
+* 2026-07-23: "when I scroll down to the bottom and then scroll up about 3
+  detents per second I get missing tiles and I have to scroll up a few more
+  rows for it to recover" — alongside `mpv: main: Too many events queued`.
+* 2026-08-02: "we should look at pagination/virtual scroll since the last work
+  on that shipped a regression."
+
+`tests/e2e/test_paging.py` covers the loader's arithmetic — which slot holds
+which item — and passes. This is the other half and a different failure: the
+data is there and the *picture* is not. It is a rate bug in the compositing
+pipeline (mpv overlay churn, Pillow decode on a worker pool, image fetches
+over the wire), so it needs a real window, a real server and real wheel
+events at speed. None of the three fakes reproduce it: a synchronous pool
+delivers every page instantly and in order, and no fake composites anything.
+
+The assertion is the symptom as reported: **come back to a place you have
+already been and the tiles must be there.** Overlays composited at the top
+before the journey are the baseline; after scrolling to the bottom and
+racing back, the same place must composite at least as much. "I have to
+scroll up a few more rows for it to recover" is precisely a count that comes
+back short and then catches up, so the check happens after a bounded settle
+and not before.
+"""
+
+import os
+import sys
+import threading
+import time
+import unittest
+
+sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+import _e2e  # noqa: E402
+
+import _harness as h  # noqa: E402
+from test_mpvtk_browser import _spawn_handle  # noqa: E402
+
+LIBRARY = "Bulk Movies"
+GRID = "grid"
+
+
+@_e2e.require_server_and_mpv
+class ScrollRecoveryTest(unittest.TestCase):
+
+    def setUp(self):
+        from jellyfin_mpv_shim.mpvtk.app import MpvtkApp
+        from jellyfin_mpv_shim.mpvtk.rawimage import MemoryStore, cache_dir
+        from jellyfin_mpv_shim.mpvtk_browser.app import MpvtkBrowser
+        from jellyfin_mpv_shim.mpvtk_browser.strips import StripStore
+
+        self.session = _e2e.Session()
+        self.addCleanup(self.session.stop)
+        self.source = self.session.library_source()
+        self.addCleanup(self.source.stop)
+        libs = self.source.get_libraries(_e2e.SOURCE_UUID)
+        match = [lib for lib in libs if lib["Name"] == LIBRARY]
+        if not match:
+            self.skipTest("%r is not on this server — this test is about "
+                          "scale and there is none" % LIBRARY)
+        self.library = match[0]
+
+        self.handle, ext = _spawn_handle()
+        self.app = MpvtkApp.attach(self.handle, ext=ext)
+        strips = (StripStore(mem_store=MemoryStore()) if self.app.in_process
+                  else StripStore(cache_dir=cache_dir("mpvtk-scroll-")))
+        self.browser = MpvtkBrowser(self.app, self.source,
+                                    server_uuid=_e2e.SOURCE_UUID, strips=strips)
+        self._thread = threading.Thread(
+            target=lambda: self.app.run(self.browser.build), daemon=True)
+        self._thread.start()
+        self.addCleanup(self._teardown)
+        self.assertTrue(self.app.ready.wait(20), "renderer never came up")
+
+        self.browser.navigate({
+            "kind": GRID, "server": _e2e.SOURCE_UUID,
+            "parent_id": self.library["Id"], "title": LIBRARY,
+            "collection_type": self.library.get("CollectionType")})
+        self._settle("the grid never composited a tile")
+        self._point_at_the_grid()
+        state = self._state()
+        self.assertGreaterEqual(
+            state.get("h") or 0, 200,
+            "the window came back %sx%s — too short to scroll. Run under "
+            "xvfb." % (state.get("w"), state.get("h")))
+
+    def _teardown(self):
+        try:
+            self.app.quit()
+            self._thread.join(timeout=5)
+        finally:
+            try:
+                self.browser.shutdown(free_bitmaps=False)
+            except Exception:
+                pass
+            try:
+                self.handle.terminate()
+            except Exception:
+                pass
+
+    # -- driving -----------------------------------------------------------
+
+    def _state(self):
+        return self.app.debug_state() or {}
+
+    def _overlays(self):
+        return (self._state().get("overlays") or 0)
+
+    def _offset(self):
+        return ((self._state().get("scroll") or {}).get(GRID) or 0)
+
+    def _point_at_the_grid(self):
+        """Put the pointer over the grid before wheeling.
+
+        The renderer routes a wheel event to the container *under the
+        pointer*, and under xvfb nothing has ever moved a mouse — `mouse-pos`
+        reports no hover and the coordinates sit at (-1, -1), so every wheel
+        event is delivered and discarded. The first version of this test
+        scrolled nothing: one assertion passed because the "before" and
+        "after" were the same untouched frame, and the other failed as though
+        the app stopped scrolling two thirds of the way through when in fact
+        it had never started.
+        """
+        state = self._state()
+        width, height = state.get("w") or 0, state.get("h") or 0
+        self.assertTrue(width and height, "no render size to point at")
+        self.handle.command("mouse", int(width * 0.5), int(height * 0.6))
+        deadline = time.time() + 5
+        while time.time() < deadline:
+            if self._state().get("hover"):
+                return
+            time.sleep(0.2)
+        self.fail("the pointer never came to rest over a tile, so wheel "
+                  "events have nothing to scroll")
+
+    def _wheel(self, key, count, delay):
+        for _ in range(count):
+            self.handle.command("keypress", key)
+            if delay:
+                time.sleep(delay)
+
+    def _scroll_to_bottom(self, bursts=40, per_burst=25):
+        """Wheel down until the offset stops rising. Returns the offset."""
+        last = -1.0
+        for _ in range(bursts):
+            self._wheel("WHEEL_DOWN", per_burst, 0.015)
+            time.sleep(0.5)
+            now = self._offset()
+            if now <= last + 1.0:
+                return now
+            last = now
+        return self._offset()
+
+    def _race_to_top(self, bursts=40, per_burst=60):
+        """Wheel up as fast as the input layer will take it, until the top.
+
+        Bounded by the offset rather than a wheel count: a thousand items is
+        a very tall container and a fixed number of detents stops somewhere
+        arbitrary in the middle, which is not the reported gesture and makes
+        the before/after comparison meaningless.
+
+        No delay inside a burst — the rate is the whole point. Every new
+        window asks the thumbnail workers for two or three screens of
+        artwork, and that churn is what produced "Too many events queued".
+        """
+        last = None
+        for _ in range(bursts):
+            self._wheel("WHEEL_UP", per_burst, 0.0)
+            time.sleep(0.35)
+            now = self._offset()
+            if now <= 5.0:
+                return now
+            if last is not None and now >= last - 1.0:
+                return now          # stopped moving; let the caller judge
+            last = now
+        return self._offset()
+
+    def _settle(self, why, timeout=25.0, quiet=1.2):
+        """Wait until compositing stops changing, then a beat more.
+
+        The reported bug recovers if you keep scrolling, so a check taken
+        mid-flight would pass for the wrong reason and one taken too early
+        would fail for it. Settle on a stable overlay count.
+        """
+        deadline = time.time() + timeout
+        last, stable_since = None, None
+        while time.time() < deadline:
+            now = self._overlays()
+            if now and now == last:
+                stable_since = stable_since or time.time()
+                if time.time() - stable_since >= quiet:
+                    return now
+            else:
+                stable_since = None
+            last = now
+            time.sleep(0.2)
+        if not self._overlays():
+            self.fail(why)
+        return self._overlays()
+
+    def _loaded_head(self, count=24):
+        items = self.browser.route.get("_items") or []
+        head = items[:count]
+        return sum(1 for i in head if i is not None), len(head)
+
+    # -- the tests ---------------------------------------------------------
+
+    def test_tiles_come_back_after_scrolling_to_the_bottom_and_racing_up(self):
+        """The 2026-07-23 report, as directly as it can be staged."""
+        baseline = self._settle("nothing composited at the top to begin with")
+        head_loaded, head_len = self._loaded_head()
+        self.assertEqual(
+            head_loaded, head_len,
+            "the first screenful was not fully loaded before scrolling, so "
+            "this test could not tell a regression from a slow start")
+
+        # Down to the bottom, unhurried.
+        bottom = self._scroll_to_bottom()
+        self.assertGreater(
+            bottom, 1000,
+            "the grid barely moved (offset %s), so nothing below was ever "
+            "visited and racing back up proves nothing" % bottom)
+        self._settle("nothing composited at the bottom")
+
+        # And back up as fast as the input layer will take it. This is the
+        # part that breaks: every new window asks the thumbnail workers for
+        # two or three screens of artwork, and the overlay churn is what
+        # produced "Too many events queued".
+        self._race_to_top()
+
+        after = self._settle("nothing composited after racing back to the top")
+        self.assertLessEqual(
+            self._offset(), 5.0,
+            "the scroll did not return to the top, so the comparison below "
+            "is against a different part of the library (offset %s)"
+            % self._offset())
+        self.assertGreaterEqual(
+            after, baseline,
+            "back at the top after a fast scroll up, %d strips are "
+            "composited where %d were before — these are the blank tiles, "
+            "and they are what 'I have to scroll up a few more rows for it "
+            "to recover' looks like" % (after, baseline))
+
+        loaded, total = self._loaded_head()
+        self.assertEqual(
+            loaded, total,
+            "%d of the first %d slots are empty after scrolling back, so the "
+            "window dropped items it had already fetched" % (total - loaded,
+                                                             total))
+
+    def test_scrolling_reaches_the_end_of_a_thousand_items(self):
+        """The 2026-06-27 report: "about 2/3 through the scroll it stops
+        scrolling despite being visibly not at the end."
+
+        Different UI, and the kind of thing that comes back. Keep wheeling
+        and the offset must keep rising until it genuinely runs out.
+        """
+        total = self.browser.route.get("_total") or 0
+        self.assertGreater(total, 500, "not a big enough library to matter")
+
+        self._scroll_to_bottom()
+        loaded = [i for i, x in enumerate(self.browser.route.get("_items") or [])
+                  if x is not None]
+        self.assertTrue(loaded, "nothing loaded at all")
+        self.assertGreater(
+            max(loaded), total * 0.75,
+            "scrolling stopped %d items into %d and would not go further — "
+            "the reported symptom is that it stops about two thirds through "
+            "while visibly not at the end" % (max(loaded), total))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/e2e/test_source_conformance.py
+++ b/tests/e2e/test_source_conformance.py
@@ -1,0 +1,224 @@
+"""Does the fake `LibrarySource` still describe the real one?
+
+~2900 unit tests run against `tests/_shell_harness.FakeSource`. That fake is
+the only description of the server those tests have, and nothing checks it
+against a server — so every one of them is sound exactly as far as the fake is
+honest. Two ways it can stop being:
+
+**A method the real source no longer has, or no longer takes.** A test calling
+it stays green while production raises. This is the shape of `b97dd523`:
+`enable_images=False` passed to a client method with no such argument, which
+took down the Live TV channel page and which nothing found until someone
+opened that screen. `tests/test_source_invariants.py` closed that at the
+apiclient boundary by walking the AST; this closes the same gap one layer up,
+at the boundary the browser actually uses.
+
+**A DTO field the fake invents.** Production code grows a dependency on a key
+the server does not send. Every historic instance ran this way round — the
+offline Series DTO with no `PrimaryImageAspectRatio` (squares instead of
+posters, `8a946e39`), the offline Season with no `SeriesId` (empty seasons,
+`5847cd20`), the `.strm` whose `RunTimeTicks` is on the MediaSource and not
+the Item (`8589cc4c`). The fake being *poorer* than the server is not
+symmetrical: it makes tests stricter than reality, which is safe, so only the
+one direction is asserted.
+
+This suite currently finds nothing, which is the point of writing it down now:
+it is a ratchet, not a diagnosis.
+"""
+
+import inspect
+import os
+import sys
+import unittest
+
+sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+import _e2e  # noqa: E402
+
+REPO_ROOT = os.path.dirname(os.path.dirname(os.path.dirname(
+    os.path.abspath(__file__))))
+if REPO_ROOT not in sys.path:
+    sys.path.insert(0, REPO_ROOT)
+
+# Methods on the fake with no counterpart on LibrarySource, and why that is
+# allowed. Keep this list short and argued — every entry is a screen whose
+# tests are describing something the browser cannot actually ask for.
+SURFACE_ALLOWLIST = {
+    # Test-only seam, not part of the source contract.
+    "_program",
+}
+
+
+def _public_methods(obj):
+    return {name for name in dir(obj)
+            if not name.startswith("__")
+            and callable(getattr(obj, name, None))}
+
+
+def _params(func):
+    """Parameter names, minus the receiver.
+
+    `self`/`cls` are dropped because one side being a `@staticmethod` is not a
+    divergence a caller can see: `backdrop_spec` is a staticmethod on
+    `LibrarySource` and a plain method on the fake, and `source.backdrop_spec(
+    item)` is correct against either.
+    """
+    try:
+        sig = inspect.signature(func)
+    except (TypeError, ValueError):
+        return None, False
+    names, star = set(), False
+    for param in sig.parameters.values():
+        if param.kind in (param.VAR_KEYWORD, param.VAR_POSITIONAL):
+            star = True
+        elif param.name not in ("self", "cls"):
+            names.add(param.name)
+    return names, star
+
+
+@_e2e.require_server
+class SourceSurfaceTest(unittest.TestCase):
+    """The fake's methods must exist on the real source, and take what the
+    fake lets a test pass. No server data needed — only the two classes."""
+
+    @classmethod
+    def setUpClass(cls):
+        from tests._shell_harness import FakeSource
+        from jellyfin_mpv_shim.mpvtk_browser.repository import LibrarySource
+        cls.fake_cls = FakeSource
+        cls.real_cls = LibrarySource
+
+    def test_every_fake_method_exists_on_the_real_source(self):
+        fake = _public_methods(self.fake_cls) - SURFACE_ALLOWLIST
+        real = _public_methods(self.real_cls)
+        missing = sorted(m for m in fake - real if not m.startswith("_"))
+        self.assertEqual(
+            missing, [],
+            "the fake source answers methods LibrarySource does not have, so "
+            "tests exercising them are describing a server that cannot be "
+            "asked: %s" % missing)
+
+    def test_the_real_source_accepts_what_the_fake_accepts(self):
+        """A parameter a test can pass to the fake must be one the real
+        source takes. The reverse is fine — the real source may have grown
+        options no test uses yet."""
+        problems = []
+        for name in sorted(_public_methods(self.fake_cls) - SURFACE_ALLOWLIST):
+            if name.startswith("_"):
+                continue
+            real_attr = getattr(self.real_cls, name, None)
+            if real_attr is None:
+                continue                        # the test above owns this
+            fake_params, _ = _params(getattr(self.fake_cls, name))
+            real_params, real_star = _params(real_attr)
+            if fake_params is None or real_params is None or real_star:
+                continue
+            extra = sorted(fake_params - real_params)
+            if extra:
+                problems.append("%s(%s)" % (name, ", ".join(extra)))
+        self.assertEqual(
+            problems, [],
+            "the fake accepts arguments LibrarySource does not, so a test can "
+            "make a call production would raise on: %s" % problems)
+
+
+@_e2e.require_server
+class DtoConformanceTest(unittest.TestCase):
+    """The fake must not invent DTO fields the server does not send."""
+
+    @classmethod
+    def setUpClass(cls):
+        from tests._shell_harness import FakeSource
+        cls.session = _e2e.Session()
+        cls.source = cls.session.library_source()
+        cls.fake = FakeSource()
+        U = _e2e.SOURCE_UUID
+        cls.libs = cls.source.get_libraries(U)
+        cls.by_name = {lib["Name"]: lib for lib in cls.libs}
+        cls.fake_libs = cls.fake.get_libraries("srv1")
+
+    @classmethod
+    def tearDownClass(cls):
+        try:
+            cls.source.stop()
+        finally:
+            cls.session.stop()
+
+    def _keys(self, items):
+        keys = set()
+        for item in items or []:
+            if isinstance(item, dict):
+                keys |= set(item)
+        return keys
+
+    def assert_no_invented_keys(self, label, real_items, fake_items):
+        # Both sides must have produced something, or the comparison is
+        # vacuously true and would stay green through any amount of drift.
+        self.assertTrue(real_items, "%s: the server returned nothing, so this "
+                                    "comparison proves nothing" % label)
+        self.assertTrue(fake_items, "%s: the fake returned nothing, so this "
+                                    "comparison proves nothing" % label)
+        invented = sorted(self._keys(fake_items) - self._keys(real_items))
+        self.assertEqual(
+            invented, [],
+            "%s: the fake promises fields the server does not send, so code "
+            "may come to depend on them: %s" % (label, invented))
+
+    def test_libraries(self):
+        self.assert_no_invented_keys("get_libraries", self.libs,
+                                     self.fake_libs)
+
+    def test_library_items(self):
+        real = self.source.get_library_items(
+            _e2e.SOURCE_UUID, self.by_name["Movies"]["Id"],
+            start_index=0, limit=8)[0]
+        fake = self.fake.get_library_items(
+            "srv1", self.fake_libs[0]["Id"], start_index=0)[0]
+        self.assert_no_invented_keys("get_library_items", real, fake)
+
+    def test_seasons_and_episodes(self):
+        series = self.source.get_library_items(
+            _e2e.SOURCE_UUID, self.by_name["Shows"]["Id"],
+            start_index=0, limit=1)[0][0]
+        seasons = self.source.get_seasons(_e2e.SOURCE_UUID, series["Id"])
+        self.assert_no_invented_keys(
+            "get_seasons", seasons, self.fake.get_seasons("srv1", "series1"))
+
+        episodes = self.source.get_episodes(
+            _e2e.SOURCE_UUID, series["Id"], seasons[0]["Id"])
+        self.assert_no_invented_keys(
+            "get_episodes", episodes,
+            self.fake.get_episodes("srv1", "series1", "season1"))
+
+    def test_music(self):
+        albums = self.source.get_music_albums(
+            _e2e.SOURCE_UUID, self.by_name["Music"]["Id"],
+            start_index=0, limit=4)[0]
+        self.assert_no_invented_keys(
+            "get_music_albums", albums,
+            self.fake.get_music_albums("srv1", "lib-music", start_index=0)[0])
+
+        tracks = self.source.get_album_tracks(_e2e.SOURCE_UUID,
+                                              albums[0]["Id"])
+        self.assert_no_invented_keys(
+            "get_album_tracks", tracks,
+            self.fake.get_album_tracks("srv1", "album1"))
+
+    def test_home_rows(self):
+        def flatten(rows):
+            return [item for row in rows or [] for item in row.get("items") or []]
+
+        self.assert_no_invented_keys(
+            "get_home_rows",
+            flatten(self.source.get_home_rows(_e2e.SOURCE_UUID)),
+            flatten(self.fake.get_home_rows("srv1")))
+
+    def test_live_tv_channels(self):
+        if not self.source.has_live_tv(_e2e.SOURCE_UUID):
+            self.skipTest("this server has no Live TV configured")
+        self.assert_no_invented_keys(
+            "get_channels", self.source.get_channels(_e2e.SOURCE_UUID),
+            self.fake.get_channels("srv1"))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/e2e/test_track_selection.py
+++ b/tests/e2e/test_track_selection.py
@@ -1,0 +1,339 @@
+"""Picking an audio or subtitle track, all the way down to mpv and back up.
+
+`media.map_streams` translates between two numbering schemes that only look
+alike: Jellyfin's `MediaStream.Index`, which counts **every** stream in the
+file including video and every external sidecar, and mpv's per-type track id,
+which counts from 1 within each type and skips nothing it did not load. The
+translation is a hand-rolled counter over position-within-type — the index is
+never passed through — and getting it wrong reads as "the wrong language
+plays" rather than as an error.
+
+Nothing before this exercised it against a real file. A fake source fabricates
+`MediaStreams`, so the mapping is checked against the very list that invented
+it and comes out right by construction. The numbers only disagree when the
+list is ffprobe's:
+
+* **Nine subtitle languages** — the subtitle streams are Jellyfin indices
+  2..10 (0 is video, 1 is audio) and mpv sub ids 1..9. Use the index as the
+  sid and every track is off by one; nine languages is enough that the
+  off-by-one lands on a real track every time rather than failing loudly.
+* **External sidecars, four formats** — the four sidecars come back as indices
+  **0..3** and the file's own audio as **5**, which mpv calls aid 1. Pass the
+  index through and there is no such track.
+
+Both were confirmed by mutation: index-as-id in the audio map fails
+`test_the_audio_index_is_not_the_mpv_track_id`, and in the subtitle map fails
+nine of the nine language subtests.
+
+So every assertion here is on what mpv **actually selected** — the track's own
+language and title, read back off `track-list` — rather than on the number
+that was sent. And two of them go the other way: the server has to be told
+which track is playing, or every other client shows the wrong one.
+
+**Not covered:** the counter's "do not advance for an external stream" rule.
+It only bites on a file that mixes external and embedded streams *of the same
+type*, and no fixture here has one — the sidecar file's subtitles are all
+external, so the embedded map stays empty either way, and the audio loop never
+sees an external stream at all. Mutating that branch away leaves this file
+green. It wants a fixture with an embedded subtitle *and* a sidecar.
+"""
+
+import os
+import sys
+import time
+import unittest
+
+sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+import _e2e  # noqa: E402
+
+LIBRARY = "Test Media"
+#: How long to let mpv apply a track change before reading `track-list`.
+SETTLE = 0.6
+
+
+class _TrackTest(_e2e.E2ETestCase):
+    """A single item from Test Media, playing, with helpers to read mpv."""
+
+    ITEM = None
+
+    def setUp(self):
+        super().setUp()
+        self.item = self.session.find(self.ITEM, library=LIBRARY)
+        media = _e2e.build_media(self.session, [self.item["Id"]])
+        self.video = media.video
+        self.video.get_playback_url()
+        self.assertFalse(
+            self.video.is_transcode,
+            "%r came back as a transcode, so mpv's track ids are the "
+            "*transcoder's* and this test is measuring something else"
+            % self.ITEM)
+        self.pm.play(self.video, is_initial_play=True)
+        self.assertTrue(
+            _e2e.wait_for(lambda: self.pm._player.duration),
+            "mpv never opened %r" % self.ITEM)
+
+    # -- reading mpv -------------------------------------------------------
+
+    def _mpv_tracks(self, kind):
+        return {t["id"]: t for t in self.pm._player.track_list
+                if t["type"] == kind}
+
+    def _streams(self, kind):
+        return {s["Index"]: s for s in self.video.media_source["MediaStreams"]
+                if s["Type"] == kind}
+
+    def _selected(self, kind):
+        """The track mpv is actually playing, as mpv describes it."""
+        track_id = self.pm._player.aid if kind == "audio" else self.pm._player.sid
+        if track_id in (False, None, "no"):
+            return None
+        return self._mpv_tracks(kind).get(track_id)
+
+
+@_e2e.require_server_and_mpv
+class AudioTrackTest(_TrackTest):
+    """Six audio tracks, five languages, one of them undetermined."""
+
+    ITEM = "Six audio tracks"
+
+    def test_every_audio_track_selects_the_one_it_names(self):
+        streams = self._streams("Audio")
+        self.assertGreaterEqual(len(streams), 6,
+                                "this fixture is meant to have six audio "
+                                "tracks; got %d" % len(streams))
+        for uid, stream in sorted(streams.items()):
+            with self.subTest(index=uid, title=stream.get("Title")):
+                self.pm.set_streams(uid, None)
+                time.sleep(SETTLE)
+                track = self._selected("audio")
+                self.assertIsNotNone(
+                    track, "selecting audio stream %d left mpv playing no "
+                    "audio at all" % uid)
+                # Language and title together: language alone would let the
+                # two English tracks (5.1 and commentary) pass for each other,
+                # which is precisely the off-by-one this exists to catch.
+                self.assertEqual(
+                    (track.get("lang"), track.get("title")),
+                    (stream.get("Language"), stream.get("Title")),
+                    "asked for Jellyfin audio index %d (%s / %s) and mpv is "
+                    "playing %s / %s" % (
+                        uid, stream.get("Language"), stream.get("Title"),
+                        track.get("lang"), track.get("title")))
+
+    def test_the_servers_default_track_is_the_one_that_starts(self):
+        """`DefaultAudioStreamIndex` is where the user's choice in another
+        client lives. Ignoring it plays the wrong language from the first
+        frame, with nothing on screen to explain why."""
+        default = self.video.media_source.get("DefaultAudioStreamIndex")
+        if default is None:
+            self.skipTest("the server named no default audio stream")
+        self.assertEqual(
+            self.video.aid, default,
+            "playback started on audio index %s, not the server's default %s"
+            % (self.video.aid, default))
+        track = self._selected("audio")
+        stream = self._streams("Audio")[default]
+        self.assertEqual((track.get("lang"), track.get("title")),
+                         (stream.get("Language"), stream.get("Title")))
+
+    def test_the_server_is_told_which_track_is_playing(self):
+        """The round trip. Other clients read `AudioStreamIndex` off the
+        session to show what is playing, and the resume path reads it back —
+        so a track change that never reaches the server is invisible outside
+        this window."""
+        streams = sorted(self._streams("Audio"))
+        pick = streams[-1]
+        self.pm.set_streams(pick, None)
+        self.pm.send_timeline()
+        reported = _e2e.wait_for(
+            lambda: ((self.session.my_session() or {}).get("PlayState") or {})
+            .get("AudioStreamIndex") == pick)
+        self.assertTrue(
+            reported,
+            "after switching to audio index %d the server still reports %r"
+            % (pick, ((self.session.my_session() or {}).get("PlayState")
+                      or {}).get("AudioStreamIndex")))
+
+
+@_e2e.require_server_and_mpv
+class EmbeddedSubtitleTest(_TrackTest):
+    """Nine embedded subtitle languages — where the numbering diverges."""
+
+    ITEM = "Nine subtitle languages"
+
+    def test_the_index_offset_is_real(self):
+        """A guard on the premise. If the fixture ever grows a stream layout
+        where index and sid happen to coincide, every assertion below would
+        pass with the mapping deleted and this file would be decorative."""
+        subs = sorted(self._streams("Subtitle"))
+        self.assertTrue(subs, "no subtitle streams")
+        self.assertNotEqual(
+            subs, sorted(self._mpv_tracks("sub")),
+            "Jellyfin's subtitle indices %s are the same numbers as mpv's sub "
+            "ids, so this fixture can no longer tell a correct mapping from "
+            "no mapping at all" % subs)
+
+    def test_every_subtitle_selects_the_language_it_names(self):
+        streams = self._streams("Subtitle")
+        self.assertGreaterEqual(len(streams), 9,
+                                "expected nine subtitle languages, got %d"
+                                % len(streams))
+        for uid, stream in sorted(streams.items()):
+            with self.subTest(index=uid, lang=stream.get("Language")):
+                self.pm.set_streams(None, uid)
+                time.sleep(SETTLE)
+                track = self._selected("sub")
+                self.assertIsNotNone(
+                    track, "selecting subtitle stream %d turned subtitles off"
+                    % uid)
+                self.assertEqual(
+                    track.get("lang"), stream.get("Language"),
+                    "asked for Jellyfin subtitle index %d (%s) and mpv is "
+                    "showing %s" % (uid, stream.get("Language"),
+                                    track.get("lang")))
+
+    def test_minus_one_turns_subtitles_off(self):
+        """-1 is Jellyfin's "no subtitle", and it is not an index — reaching
+        the map with it would either KeyError or select track -1."""
+        first = sorted(self._streams("Subtitle"))[0]
+        self.pm.set_streams(None, first)
+        time.sleep(SETTLE)
+        self.assertIsNotNone(self._selected("sub"))
+        self.pm.set_streams(None, -1)
+        time.sleep(SETTLE)
+        self.assertIsNone(self._selected("sub"),
+                          "subtitles are still on after selecting 'none'")
+
+
+@_e2e.require_server_and_mpv
+class ExternalSubtitleTest(_TrackTest):
+    """Four sidecars in four formats, which mpv has to be *given*.
+
+    An external subtitle is not in the file, so there is no track to select
+    until `sub_add` fetches one from the server. That makes three things
+    testable that embedded subtitles cannot show: the fetch happens, it is
+    remembered so that returning to a track does not fetch it again, and the
+    URL it fetches is one that carries our access token — which is why
+    `foreign_subtitle_hosts` exists.
+    """
+
+    ITEM = "External sidecars, four formats"
+
+    def test_the_audio_index_is_not_the_mpv_track_id(self):
+        """The clearest case of the two schemes disagreeing.
+
+        The sidecars occupy Jellyfin indices 0..3 and the video is 4, so the
+        file's single audio track is index **5** — while mpv, which knows
+        nothing of the sidecars, calls that same track aid 1. Pass the index
+        through and mpv is asked for a track that does not exist.
+        """
+        audio = self._streams("Audio")
+        self.assertEqual(len(audio), 1, "expected a single audio track")
+        uid = next(iter(audio))
+        self.assertGreater(
+            uid, 1, "the fixture's audio stream is index %d, so index and "
+            "track id coincide and this file no longer tells a correct "
+            "mapping from no mapping at all" % uid)
+        self.pm.set_streams(uid, None)
+        time.sleep(SETTLE)
+        track = self._selected("audio")
+        self.assertIsNotNone(
+            track, "Jellyfin audio index %d selected no mpv track — the "
+            "index was passed through as a track id" % uid)
+        self.assertEqual(track.get("lang"), audio[uid].get("Language"))
+
+    def test_each_sidecar_is_fetched_and_shown(self):
+        streams = self._streams("Subtitle")
+        self.assertGreaterEqual(len(streams), 4,
+                                "expected four sidecars, got %d" % len(streams))
+        for uid, stream in sorted(streams.items()):
+            with self.subTest(index=uid, codec=stream.get("Codec")):
+                self.assertEqual(
+                    stream.get("DeliveryMethod"), "External",
+                    "this fixture's subtitle %d is no longer delivered as an "
+                    "external file" % uid)
+                self.pm.set_streams(None, uid)
+                time.sleep(SETTLE)
+                track = self._selected("sub")
+                self.assertIsNotNone(
+                    track, "sidecar %d (%s) was never loaded into mpv"
+                    % (uid, stream.get("Codec")))
+                self.assertTrue(
+                    track.get("external"),
+                    "sidecar %d selected an embedded track instead" % uid)
+                self.assertIn(
+                    uid, self.pm.external_subtitles,
+                    "sidecar %d is shown but not remembered, so returning to "
+                    "it would fetch it again" % uid)
+
+    def test_returning_to_a_sidecar_does_not_fetch_it_twice(self):
+        """`external_subtitles` exists for this. Without it every visit adds
+        another copy of the same track to mpv's list, and the subtitle menu
+        grows a duplicate each time you switch back."""
+        uids = sorted(self._streams("Subtitle"))
+        first, second = uids[0], uids[1]
+        self.pm.set_streams(None, first)
+        time.sleep(SETTLE)
+        was = self.pm._player.sid
+        self.pm.set_streams(None, second)
+        time.sleep(SETTLE)
+        before = len(self._mpv_tracks("sub"))
+        self.pm.set_streams(None, first)
+        time.sleep(SETTLE)
+        self.assertEqual(
+            len(self._mpv_tracks("sub")), before,
+            "going back to a sidecar added another copy of it to mpv")
+        self.assertEqual(self.pm._player.sid, was,
+                         "going back to a sidecar landed on a different track")
+
+    def test_the_sidecar_urls_are_ours(self):
+        """`--http-header-fields` is global to mpv, so a sidecar hosted
+        elsewhere would receive our access token. The pre-check is on the
+        item, before PlaybackInfo, because the header is set before the
+        stream URL exists."""
+        self.assertEqual(
+            self.video.foreign_subtitle_hosts(), set(),
+            "this fixture is meant to host all four sidecars on the server "
+            "under test")
+        host = _e2e.SERVER.split("//")[-1].split("/")[0]
+        for uid, url in self.video.subtitle_url.items():
+            with self.subTest(index=uid):
+                self.assertIn(
+                    host, url,
+                    "sidecar %d would be fetched from somewhere other than "
+                    "the server: %s" % (uid, url))
+
+    def test_the_server_is_told_which_subtitle_is_showing(self):
+        pick = sorted(self._streams("Subtitle"))[-1]
+        self.pm.set_streams(None, pick)
+        self.pm.send_timeline()
+        reported = _e2e.wait_for(
+            lambda: ((self.session.my_session() or {}).get("PlayState") or {})
+            .get("SubtitleStreamIndex") == pick)
+        self.assertTrue(
+            reported,
+            "after switching to subtitle index %d the server still reports %r"
+            % (pick, ((self.session.my_session() or {}).get("PlayState")
+                      or {}).get("SubtitleStreamIndex")))
+
+
+@_e2e.require_server_and_mpv
+class NoAudioTrackTest(_TrackTest):
+    """A video with no audio at all: the maps are empty and nothing may
+    assume otherwise. `configure_streams` indexes `audio_seq[audio_uid]`
+    directly, so a stale aid carried in from the previous item is a KeyError
+    rather than a shrug."""
+
+    ITEM = "Video with no audio track"
+
+    def test_playing_a_silent_file_selects_no_audio(self):
+        self.assertEqual(self._streams("Audio"), {},
+                         "this fixture is supposed to have no audio track")
+        self.assertEqual(self.video.audio_seq, {})
+        self.assertIsNone(self._selected("audio"))
+        # And it is genuinely playing, rather than having failed to open.
+        self.assertTrue(self.pm._player.duration)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/e2e/test_window_resize.py
+++ b/tests/e2e/test_window_resize.py
@@ -1,0 +1,234 @@
+"""The window changes size under the UI.
+
+The browser draws *inside the player's mpv window*, so its layout is a
+function of a size mpv owns and a window manager can change at any moment —
+a tiling WM does it the instant the window appears, and the developer whose
+i3 kept reshaping these windows is why the rest of this suite runs under
+xvfb.
+
+Everything downstream of that size is recomputed on a resize: how many tiles
+fit a row, the pitch a scroll offset is measured against, and every
+composited strip (a strip is baked at one tile size, so a resize invalidates
+the lot). The failures are the ones you would expect from that list and none
+of them raise — the UI keeps drawing at the old size, or it redraws and
+throws away where you were.
+
+A fake cannot show any of it. `layout()` is pure and will happily lay out any
+size you hand it, so a test against a fake asserts that a number it chose was
+used. The question here is whether the renderer *notices*, which needs a real
+window that really changed.
+
+**What is pinned, and what is not.** These assert that the renderer notices
+the new size, keeps drawing, keeps focus and stays usable across it — the
+four ways a resize has broken. They do *not* verify that every strip was
+re-baked at the new tile size; an overlay count cannot tell a fresh bitmap
+from a stale one, and the tile geometry is not in `debug_state`. A strip
+drawn at the old size would still be counted here.
+
+This is also the one module that deliberately makes the window small. The
+rest of the suite guards `h >= 200` and calls a squashed window an
+environment problem, because for them it is; here a window nobody can use is
+the case under test.
+"""
+
+import os
+import sys
+import threading
+import time
+import unittest
+
+sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+import _e2e  # noqa: E402
+
+import _harness as h  # noqa: E402,F401
+from test_mpvtk_browser import _spawn_handle  # noqa: E402
+
+LIBRARY = "Movies"
+GRID = "grid"
+
+
+@_e2e.require_server_and_mpv
+class WindowResizeTest(unittest.TestCase):
+
+    def setUp(self):
+        from jellyfin_mpv_shim.mpvtk.app import MpvtkApp
+        from jellyfin_mpv_shim.mpvtk.rawimage import MemoryStore, cache_dir
+        from jellyfin_mpv_shim.mpvtk_browser.app import MpvtkBrowser
+        from jellyfin_mpv_shim.mpvtk_browser.strips import StripStore
+
+        self.session = _e2e.Session()
+        self.addCleanup(self.session.stop)
+        self.source = self.session.library_source()
+        self.addCleanup(self.source.stop)
+        libs = self.source.get_libraries(_e2e.SOURCE_UUID)
+        match = [lib for lib in libs if lib["Name"] == LIBRARY]
+        if not match:
+            self.skipTest("no %r library" % LIBRARY)
+        self.library = match[0]
+
+        self.handle, ext = _spawn_handle()
+        self.app = MpvtkApp.attach(self.handle, ext=ext)
+        strips = (StripStore(mem_store=MemoryStore()) if self.app.in_process
+                  else StripStore(cache_dir=cache_dir("mpvtk-resize-")))
+        self.browser = MpvtkBrowser(self.app, self.source,
+                                    server_uuid=_e2e.SOURCE_UUID, strips=strips)
+        self._thread = threading.Thread(
+            target=lambda: self.app.run(self.browser.build), daemon=True)
+        self._thread.start()
+        self.addCleanup(self._teardown)
+        self.assertTrue(self.app.ready.wait(20), "renderer never came up")
+
+        self.browser.navigate({
+            "kind": GRID, "server": _e2e.SOURCE_UUID,
+            "parent_id": self.library["Id"], "title": LIBRARY,
+            "collection_type": self.library.get("CollectionType")})
+        self.assertTrue(
+            self._settle(), "the grid never composited anything to resize")
+        self.start = (self._state().get("w"), self._state().get("h"))
+        self.assertTrue(
+            all(self.start) and self.start[1] >= 200,
+            "the window came back %sx%s, so there is nothing to shrink from. "
+            "Run under xvfb." % self.start)
+
+    def _teardown(self):
+        try:
+            self.app.quit()
+            self._thread.join(timeout=5)
+        finally:
+            try:
+                self.browser.shutdown(free_bitmaps=False)
+            except Exception:
+                pass
+            try:
+                self.handle.terminate()
+            except Exception:
+                pass
+
+    # -- driving -----------------------------------------------------------
+
+    def _state(self):
+        return self.app.debug_state() or {}
+
+    def _settle(self, timeout=25.0, quiet=1.0):
+        """Wait for compositing to stop changing. Returns the overlay count."""
+        deadline = time.time() + timeout
+        last, since = None, None
+        while time.time() < deadline:
+            now = self._state().get("overlays") or 0
+            if now and now == last:
+                since = since or time.time()
+                if time.time() - since >= quiet:
+                    return now
+            else:
+                since = None
+            last = now
+            time.sleep(0.2)
+        return self._state().get("overlays") or 0
+
+    def _resize(self, width, height, timeout=15.0):
+        """Change the window's size and wait for the renderer to agree.
+
+        `geometry` rather than a WM call: there is no window manager under
+        xvfb, which is the point — this isolates "the renderer noticed the
+        size changed" from "a WM did something", and the app has to survive
+        both.
+        """
+        self.handle.command("set", "geometry", "%dx%d" % (width, height))
+        deadline = time.time() + timeout
+        while time.time() < deadline:
+            state = self._state()
+            if (state.get("w"), state.get("h")) == (width, height):
+                return True
+            time.sleep(0.2)
+        state = self._state()
+        self.fail("asked for %dx%d and the renderer is still drawing at %sx%s "
+                  "— the UI is laid out for a window that no longer exists"
+                  % (width, height, state.get("w"), state.get("h")))
+
+    # -- the tests ---------------------------------------------------------
+
+    def test_the_scene_follows_the_window_both_ways(self):
+        """Growing and shrinking are not symmetric — a layout that caches a
+        width can be right on the way up and stale on the way down."""
+        for size in ((980, 560), (1500, 940), (760, 430)):
+            with self.subTest(size=size):
+                self._resize(*size)
+                self.assertGreater(
+                    self._settle(), 0,
+                    "nothing is composited at %dx%d, so the window is blank "
+                    "after a resize" % size)
+
+    def test_a_resize_does_not_blank_the_library(self):
+        """The failure that reads as a crash: the strips are all invalidated
+        by the new tile size and nothing replaces them."""
+        before = self._settle()
+        self.assertGreater(before, 0)
+        self._resize(1500, 940)
+        after = self._settle()
+        self.assertGreater(
+            after, 0,
+            "the library went blank after a resize (%d strips before, %d "
+            "after)" % (before, after))
+
+    def test_focus_survives_a_resize(self):
+        """A resize re-lays out the whole scene. Node ids are built from item
+        ids so they should be stable across it, and if they are not the
+        focused node is gone and the keyboard lands nowhere."""
+        for key in ("DOWN", "RIGHT"):
+            self.handle.command("keypress", key)
+            time.sleep(0.2)
+        focused = self._state().get("nav")
+        if not focused:
+            self.skipTest("could not put focus on anything to begin with")
+        self._resize(1500, 940)
+        self._settle()
+        self.assertEqual(
+            self._state().get("nav"), focused,
+            "focus moved from %r to %r across a resize" % (
+                focused, self._state().get("nav")))
+
+    def test_a_window_too_small_to_use_does_not_crash_it(self):
+        """A WM is free to make the window any size it likes, including one
+        with no room for a tile row. It has to come out the other side.
+
+        Deliberately below the guard every other module in this suite treats
+        as an environment failure — for them a squashed window means the
+        assertions cannot be trusted; here it is the case under test.
+        """
+        self._resize(320, 200)
+        time.sleep(1.5)
+        self.assertTrue(self._thread.is_alive(),
+                        "the render loop died on a tiny window")
+        # And it comes back: a layout that divided by an available width
+        # could leave permanent damage rather than merely drawing nothing.
+        self._resize(*self.start)
+        self.assertGreater(
+            self._settle(), 0,
+            "the library never came back after the window was squashed and "
+            "restored")
+
+    def test_navigation_still_works_at_the_new_size(self):
+        """Not just pixels: the handlers are rebuilt too, and a scene that
+        redrew without them is a picture of a library rather than one."""
+        self._resize(1500, 940)
+        self._settle()
+        before = self._state().get("nav")
+        moved = None
+        for _attempt in range(6):
+            for key in ("DOWN", "RIGHT", "UP", "LEFT"):
+                self.handle.command("keypress", key)
+                time.sleep(0.12)
+                now = self._state().get("nav")
+                if now and now != before:
+                    moved = now
+                    break
+            if moved:
+                break
+        self.assertIsNotNone(
+            moved,
+            "no arrow key moved focus after a resize — the scene redrew but "
+            "nothing in it is reachable")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/lua/fake_mp.lua
+++ b/tests/lua/fake_mp.lua
@@ -294,9 +294,16 @@ local shapes = {}
 local pending = {}      -- \-tags appended since the last new_event
 
 --- Rectangles drawn since the last :reset_draw(), as
---- {x, y, w, h, radius, fill = "rrggbb" or nil, alpha = 0-255}.
+--- {x, y, w, h, radius, fill = "rrggbb" or nil, alpha = 0-255,
+---  blur = number or nil, clip = {x1, y1, x2, y2} or nil}.
 --- `fill` is decoded back out of the ASS \1c tag, so a test names the
 --- colour the way the theme does rather than in ASS's reversed hex.
+---
+--- `blur` and `clip` are here for the themed glow, whose whole bug surface
+--- is the pair: it is blurred, so it must reach outside the box it decorates,
+--- and it is clipped, so it must not reach outside the page. Neither is
+--- observable anywhere else -- an unclipped halo is a correct rectangle
+--- drawn over the header.
 function M.shapes() return shapes end
 
 function M.reset_draw()
@@ -315,14 +322,24 @@ local function tags()
     local blob = table.concat(pending)
     local fill = blob:match("\\1c(&H%x+&)")
     local alpha = blob:match("\\1a&H(%x%x)&")
+    local clip
+    local cx1, cy1, cx2, cy2 = blob:match(
+        "\\clip%(([%d%.%-]+),([%d%.%-]+),([%d%.%-]+),([%d%.%-]+)%)")
+    if cx1 then
+        clip = { x1 = tonumber(cx1), y1 = tonumber(cy1),
+                 x2 = tonumber(cx2), y2 = tonumber(cy2) }
+    end
     return un_ass_color(fill or ""),
-           alpha and (255 - tonumber(alpha, 16)) or 255
+           alpha and (255 - tonumber(alpha, 16)) or 255,
+           tonumber(blob:match("\\blur([%d%.]+)") or ""),
+           clip
 end
 
 local function rect(_s, x1, y1, x2, y2, radius)
-    local fill, alpha = tags()
+    local fill, alpha, blur, clip = tags()
     shapes[#shapes + 1] = { x = x1, y = y1, w = x2 - x1, h = y2 - y1,
-                            radius = radius, fill = fill, alpha = alpha }
+                            radius = radius, fill = fill, alpha = alpha,
+                            blur = blur, clip = clip }
 end
 
 local Ass = {}

--- a/tests/lua/test_renderer.lua
+++ b/tests/lua/test_renderer.lua
@@ -1782,6 +1782,80 @@ ok(at1x and at2x and at2x > at1x * 1.5,
                  tostring(at2x)))
 fake.send("mpvtk-scale", fake.token({ s = 1 }))
 
+-- ============================================= the themed glow's clip
+--
+-- The glow is the one decoration that is meant to draw OUTSIDE the box it
+-- decorates: a card fills its row's viewport, so a halo clipped to that
+-- viewport is chopped back into the hard rectangle the glow exists to
+-- replace. It used to buy that by passing no clip at all -- and chrome is
+-- drawn BEFORE content (app.build stacks header, then the page), so a card
+-- near the top of the page had its halo painted over the header. ASS has no
+-- z-order beyond scene order, so nothing downstream could put it back.
+--
+-- The rule now: out of your own viewport, never out of the page.
+
+local HDR_H = 60
+
+--- A header, a page below it, a carousel inside that, and a tile in the
+--- carousel -- the arrangement every library screen has.
+local function glow_scene(tile)
+    return {
+        { id = "hdr", t = "rect", x = 0, y = 0, w = 1280, h = HDR_H,
+          fill = "202020" },
+        { id = "page", t = "scroll", axis = "y", x = 0, y = HDR_H,
+          w = 1280, h = 720 - HDR_H, cw = 1280, ch = 2000 },
+        { id = "row", t = "scroll", axis = "x", sc = "page",
+          x = 0, y = 70, w = 1280, h = 220, cw = 4000, ch = 220 },
+        tile,
+    }
+end
+
+--- The blurred rectangle, ie. the glow. Nothing else in a scene is blurred.
+local function blurred(shapes)
+    for _, s in ipairs(shapes) do
+        if s.blur then return s end
+    end
+    return nil
+end
+
+fake.send("mpvtk-theme", fake.token({ glow = true }))
+
+local TILE = { id = "tile", t = "rect", sc = "row", x = 10, y = 70,
+               w = 140, h = 210, ring = true,
+               hover = { bc = "a855f7", bw = 3 } }
+
+local ring = blurred(painted(glow_scene(TILE), function()
+    fake.mouse(80, 150)      -- onto the tile
+end))
+ok(ring ~= nil, "a hovered tile draws a blurred halo under a glow theme")
+ok(ring and ring.clip, "the halo is clipped at all",
+   "an unclipped halo is what painted over the header")
+ok(ring and ring.clip and ring.clip.y1 >= HDR_H,
+   "the halo stops at the header",
+   ring and ring.clip and ("clip starts at y=" .. tostring(ring.clip.y1)))
+ok(ring and ring.clip and ring.clip.y1 < 70,
+   "...but still escapes its own row, or it is the box it replaces",
+   ring and ring.clip and ("clip starts at y=" .. tostring(ring.clip.y1)))
+
+-- A box glow (themed chrome: hover={glow=true}) sitting DIRECTLY in the page
+-- has no inner viewport to escape, so the page is the whole answer.
+local BTN = { id = "btn", t = "rect", sc = "page", x = 40, y = 70,
+              w = 200, h = 40, fill = "2a1656", radius = 6,
+              hover = { fill = "3d2170", glow = true } }
+local box = blurred(painted({
+    { id = "hdr", t = "rect", x = 0, y = 0, w = 1280, h = HDR_H,
+      fill = "202020" },
+    { id = "page", t = "scroll", axis = "y", x = 0, y = HDR_H,
+      w = 1280, h = 720 - HDR_H, cw = 1280, ch = 2000 },
+    BTN,
+}, function() fake.mouse(100, 90) end))
+ok(box ~= nil, "a hovered themed box draws its halo")
+ok(box and box.clip and box.clip.y1 >= HDR_H,
+   "the box halo stops at the header too",
+   box and box.clip and ("clip starts at y=" .. tostring(box.clip.y1)))
+
+fake.send("mpvtk-theme", fake.token({ glow = false }))
+
 -- ========================================================== teardown
 
 scene({})

--- a/tests/test_carousel_paging.py
+++ b/tests/test_carousel_paging.py
@@ -152,5 +152,58 @@ class EndStopRepaintTest(unittest.TestCase):
         self.assertEqual(len(self.hits), 1)
 
 
+class OffsetPrecedenceTest(unittest.TestCase):
+    """Who answers "where is this container", and in what order.
+
+    Three sources, and the order between them is the whole of two separate
+    blank-screen bugs — see ``ScrollState.offset``.
+    """
+
+    class _App:
+        def __init__(self, offsets):
+            self.offsets = offsets
+
+        def scroll_offsets(self):
+            return self.offsets
+
+    def _state(self, live=None, route=None):
+        st = ScrollState(lambda: None)
+        st.refresh(self._App(live) if live is not None else None, route)
+        return st
+
+    def _parked(self, **offsets):
+        return {ScrollState.PARK_KEY: dict(offsets)}
+
+    def test_the_renderer_is_the_authority(self):
+        st = self._state(live={"grid": 900}, route=self._parked(grid=1500))
+        self.assertEqual(st.offset("grid"), 900)
+
+    def test_a_live_zero_still_outranks_a_parked_offset(self):
+        """The container is on screen and at the top because the user put it
+        there. Preferring the parked value here is the Paginated-toggle bug
+        wearing a new hat: a window built around an offset nothing has."""
+        st = self._state(live={"grid": 0}, route=self._parked(grid=1500))
+        self.assertEqual(st.offset("grid"), 0)
+
+    def test_a_container_the_renderer_has_not_met_takes_the_parked_offset(self):
+        """It has just entered the scene, and the scene carries off0 to put
+        it back — so that is where it is about to be."""
+        st = self._state(live={"detail": 40}, route=self._parked(grid=1500))
+        self.assertEqual(st.offset("grid"), 1500)
+
+    def test_a_container_with_nothing_parked_is_at_the_top(self):
+        st = self._state(live={}, route={})
+        self.assertEqual(st.offset("grid"), 0)
+
+    def test_the_recorded_copy_is_still_a_whole_snapshot_fallback(self):
+        """mpv < 0.36 has no live snapshot at all. It does NOT get consulted
+        per-id to fill gaps in one that answered."""
+        st = self._state(live={"other": 5}, route={})
+        st._recorded["grid"] = 1500
+        self.assertEqual(st.offset("grid"), 0)
+        st.refresh(None, {})                  # no live snapshot at all
+        self.assertEqual(st.offset("grid"), 1500)
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_dpi_matrix.py
+++ b/tests/test_dpi_matrix.py
@@ -1,0 +1,399 @@
+"""Text has to fit the window at every scale, not only at 1x.
+
+Everything in view code is logical (see ``mpvtk/scaling.py``), so a screen is
+laid out against ``physical / ui_scale``. That makes the UI scale a *width*
+problem rather than a font problem: at 200% a 1280px window is a 640px page,
+and every label, button row and heading has to survive it. Nothing in the
+suite was checking that, because everything is developed and tested at 1x
+where the logical size and the window are the same number.
+
+So: build the representative screens across a matrix of scales and window
+sizes, and assert that no text run is drawn outside the window.
+
+Two things this deliberately does not flag:
+
+* **Anything inside a horizontal scroll container.** A carousel's content is
+  meant to extend past the window — that is what scrolling it means.
+* **Ellipsis.** ``layout`` truncates a label to its assigned box, so a
+  cramped screen degrades to "Continue Watchi…" rather than to overflow.
+  That is the intended behaviour, and it is why the check below measures the
+  *drawn* run rather than the node's box: an over-wide box that ellipsizes is
+  fine, an over-wide box whose text reaches past the window is not.
+
+The matrix is (scale, window) pairs, not a cross product of everything: the
+combinations below are the ones a user can actually produce. ``ui_scale``
+offers 100/125/150/200% (config.py), and "Follow display" can hand back
+anything the compositor reports.
+
+Four things it found on the way in, none of them scale-specific once you
+look — every one is a Row or a paragraph that assumed a wide page, and every
+one is equally reachable at 100% on a small window:
+
+* the settings tab bar, whose last tab ("Logs") drew off the right edge;
+* the grid's A-Z filter bar, 754px of fixed cells;
+* the album and artist headers, whose overview wrapped to the *page* width
+  while being drawn in a column that starts 148px in;
+* the play queue's and playlist editor's toolbars.
+"""
+
+import sys
+import unittest
+
+sys.argv = [sys.argv[0]]      # importing the shim reaches args.get_args()
+
+from tests._scene_snapshot import frozen_clock                # noqa: E402
+from tests._shell_harness import FakeSource                   # noqa: E402
+
+from jellyfin_mpv_shim.mpvtk import scaling                   # noqa: E402
+from jellyfin_mpv_shim.mpvtk.layout import (                  # noqa: E402
+    SCROLLBAR_W, layout, text_width)
+from jellyfin_mpv_shim.mpvtk_browser.app import MpvtkBrowser  # noqa: E402
+
+
+class WordySource(FakeSource):
+    """The fake library, with the text a real one has.
+
+    The stock fixture's overview is one repeated sentence and its items have
+    no genres, so the paragraph and meta-line paths — the ones with the most
+    room to get a width wrong — were laid out against text too tame to reach
+    an edge. A matrix that measures short strings measures very little.
+    """
+
+    OVERVIEW = (
+        "When an ordinary man is drawn into a conspiracy he does not "
+        "understand, he has to decide how much of himself he is willing to "
+        "lose to see it through. Shot over four years on three continents, "
+        "it is a film about the cost of certainty.\n\n"
+        "Restored in 4K from the original camera negative."
+    )
+
+    def get_item(self, server_uuid, item_id, **kw):
+        item = super().get_item(server_uuid, item_id, **kw)
+        if not item:
+            return item
+        item = dict(item)
+        # Replaced, not defaulted: the fixture's own overview is one short
+        # sentence repeated, with no paragraph break and no long word in it.
+        item["Overview"] = self.OVERVIEW
+        item.setdefault("Genres", ["Drama", "Thriller", "Science Fiction",
+                                   "Mystery", "Adventure"])
+        return item
+
+
+#: The scales Settings offers, plus the ones "Follow display" and ``--scale``
+#: can produce — the compositor reports whatever it likes and is under no
+#: obligation to pick one of ours, and sub-1x is a real setting on a small
+#: high-density panel.
+#:
+#: The fractional ones are the interesting half, and **the sub-1x ones are
+#: the sharpest**: they are where ``px()``'s rounding disagreed most with the
+#: width layout fitted the text to. At 0.75x an 18px run was drawn at 14px,
+#: i.e. 18.67 logical — 3.7% wide, which on a full-width paragraph is tens of
+#: pixels out and under the scrollbar. See ``scaling._EXACT_KEYS``.
+SCALES = (0.75, 0.8, 1.0, 1.25, 1.5, 1.75, 2.0)
+
+#: Physical window sizes. The small end is a windowed player on a laptop; the
+#: large end is what a 4K display hands back before scaling.
+WINDOWS = ((1024, 576), (1280, 720), (1600, 900), (1920, 1080), (2560, 1440),
+           (3840, 2160))
+
+#: Logical widths below this are not a supported configuration — 200% on a
+#: 1024px window is a 512px page, which is narrower than the chrome's own
+#: buttons. Skipping them keeps the matrix honest instead of pinning failures
+#: nobody can hit.
+MIN_LOGICAL_W = 640
+
+#: The screens, by route. The scene snapshots' set (distinct layout shapes)
+#: plus the ones carrying dense chrome, which is where a row of controls runs
+#: out of page: tab bars, filter bars, track tables and the queue's toolbar.
+#:
+#: ``favorites``, ``genres`` and ``byname`` are deliberately absent: the fake
+#: source has no data for them, so they render an empty state that would pass
+#: this at any width and any scale. ``_walk`` pins that they are not quietly
+#: joined by a screen that has *become* empty.
+SCREENS = {
+    "home": {"kind": "home", "server": "s1"},
+    "grid": {"kind": "grid", "parent_id": "lib1", "server": "s1",
+             "title": "Movies"},
+    "list": {"kind": "list", "parent_id": "lib1", "server": "s1",
+             "title": "Movies"},
+    "search": {"kind": "search", "server": "s1", "term": "a"},
+    "settings": {"kind": "settings", "server": "s1"},
+    "detail": {"kind": "detail", "item_id": "m1", "server": "s1"},
+    "series": {"kind": "series", "item_id": "sh1", "server": "s1"},
+    "season": {"kind": "season", "item_id": "se1", "series_id": "sh1",
+               "server": "s1"},
+    "music": {"kind": "music", "parent_id": "lib2", "server": "s1",
+              "collection_type": "music"},
+    "album": {"kind": "album", "item_id": "al1", "server": "s1"},
+    "artist": {"kind": "artist", "item_id": "ar1", "server": "s1"},
+    "livetv": {"kind": "livetv", "server": "s1"},
+    "queue": {"kind": "queue", "server": "s1"},
+}
+
+#: A screen with fewer drawn labels than this is a spinner or an error state,
+#: which fits every window there has ever been. The threshold is a smoke
+#: alarm, not a measurement -- the thinnest real screen here draws four.
+MIN_TEXTS = 4
+
+#: One pixel. Everything here is measured on the physical scene, where each
+#: box edge has been through ``px()`` once — so half a pixel of rounding on
+#: the position is expected and means nothing. What this file is looking for
+#: is tens of pixels.
+SLOP = 1.0
+
+
+def _loaded(route):
+    """A browser with ``route`` loaded and its async work settled.
+
+    Rendering before the pool drains snapshots a spinner, and a spinner fits
+    every window there has ever been.
+    """
+    browser = MpvtkBrowser(app=None, source=WordySource())
+    browser.nav_stack = [dict(route)]
+    browser._load_route(browser.route)
+    browser._pool.shutdown(wait=True)
+    return browser
+
+
+def _x_scrolled(nodes):
+    """``id -> bool``: is this scroll container, or any container above it,
+    scrolled horizontally? Content inside one is *meant* to run past the
+    window."""
+    axis = {n["id"]: n.get("axis") for n in nodes if n.get("t") == "scroll"}
+    up = {n["id"]: n.get("sc") for n in nodes if n.get("t") == "scroll"}
+
+    def walk(sc):
+        seen = set()
+        while sc and sc not in seen:
+            seen.add(sc)
+            if axis.get(sc) == "x":
+                return True
+            sc = up.get(sc)
+        return False
+
+    return walk
+
+
+def right_limit(node, scrolls, win_w):
+    """How far right this run may reach.
+
+    The window, except inside a vertical scroll container that reserves a
+    scrollbar — there the limit is the viewport's inner edge, because the
+    scrollbar is drawn *over* the content and text run under it is text you
+    cannot read. ``chrome.body_width`` exists to keep wrapped text inside
+    exactly this line; the whole point of checking it here is that any
+    caller can forget to use it, or use it against the wrong width.
+    """
+    sc = scrolls.get(node.get("sc"))
+    if sc is None or sc.get("axis") != "y":
+        return float(win_w)
+    bar = scaling.px(SCROLLBAR_W) if sc.get("bar") else 0
+    return min(float(win_w), float(sc["x"] + sc["w"] - bar))
+
+
+def text_span(node):
+    """(left, right) of the run as libass will draw it.
+
+    ``layout`` has already ellipsized the string to the node's box, so this
+    is the real ink extent and not the box's.
+    """
+    tw = text_width(node["text"], node["size"], node.get("bold", False))
+    align = node.get("align") or "left"
+    if align == "center":
+        left = node["x"] + node["w"] / 2.0 - tw / 2.0
+    elif align == "right":
+        left = node["x"] + node["w"] - tw
+    else:
+        left = node["x"]
+    return left, left + tw
+
+
+def overflows(nodes, win_w):
+    """Text runs that escape the space they are allowed."""
+    scrolled = _x_scrolled(nodes)
+    scrolls = {n["id"]: n for n in nodes if n.get("t") == "scroll"}
+    out = []
+    for node in nodes:
+        if node.get("t") != "text" or not node.get("text"):
+            continue
+        if scrolled(node.get("sc")):
+            continue
+        left, right = text_span(node)
+        limit = right_limit(node, scrolls, win_w)
+        if left < -SLOP or right > limit + SLOP:
+            out.append((node.get("id"), node["text"], round(left, 1),
+                        round(right, 1), round(limit, 1)))
+    return out
+
+
+def _cases():
+    """(scale, (w, h)) pairs worth building."""
+    for scale in SCALES:
+        for win in WINDOWS:
+            if win[0] / scale >= MIN_LOGICAL_W:
+                yield scale, win
+
+
+class DpiMatrixTest(unittest.TestCase):
+    """One test per screen; every (scale, window) is a subTest, so a failure
+    names the exact configuration rather than "the matrix failed"."""
+
+    def tearDown(self):
+        scaling.set_scale(1.0)
+
+    def _walk(self, name, check):
+        with frozen_clock():
+            for scale in SCALES:
+                # BEFORE the browser exists, and one browser per scale.
+                # Production resolves the scale once at startup (app.py's
+                # ready event) and never moves it; a strip composited at one
+                # scale and drawn at another is caught by widgets._check_raster
+                # long before it is a layout question.
+                scaling.set_scale(scale)
+                browser = _loaded(SCREENS[name])
+                for win in WINDOWS:
+                    lsize = scaling.logical_size(win)
+                    if lsize[0] < MIN_LOGICAL_W:
+                        continue
+                    with self.subTest(scale=scale, window="%dx%d" % win):
+                        nodes, _h = layout(browser.build(lsize), *lsize)
+                        texts = [n for n in nodes if n.get("t") == "text"]
+                        self.assertGreaterEqual(
+                            len(texts), MIN_TEXTS,
+                            "%s drew %d labels -- a spinner or an error "
+                            "state passes this file trivially"
+                            % (name, len(texts)))
+                        # Measured on the PHYSICAL scene, exactly as pushed
+                        # to the renderer. Checking the logical one compares
+                        # layout against itself and can only ever agree — it
+                        # is blind to the whole class of bug where the size
+                        # the text is *drawn* at is not the size it was
+                        # fitted at.
+                        scaling.scale_scene(nodes)
+                        check(nodes, win)
+
+    def _no_overflow(self, name):
+        def check(nodes, lsize):
+            bad = overflows(nodes, lsize[0])
+            self.assertEqual(
+                bad, [],
+                "text drawn outside the space it has, on a %.0f-wide page:\n%s"
+                % (lsize[0], "\n".join(
+                    "  %s %r spans %s..%s, limit %s" % b for b in bad)))
+        self._walk(name, check)
+
+    def test_home(self):
+        self._no_overflow("home")
+
+    def test_grid(self):
+        self._no_overflow("grid")
+
+    def test_list(self):
+        self._no_overflow("list")
+
+    def test_search(self):
+        self._no_overflow("search")
+
+    def test_settings(self):
+        self._no_overflow("settings")
+
+    def test_detail(self):
+        self._no_overflow("detail")
+
+    def test_series(self):
+        self._no_overflow("series")
+
+    def test_season(self):
+        self._no_overflow("season")
+
+    def test_music(self):
+        self._no_overflow("music")
+
+    def test_album(self):
+        self._no_overflow("album")
+
+    def test_artist(self):
+        self._no_overflow("artist")
+
+    def test_livetv(self):
+        self._no_overflow("livetv")
+
+    def test_queue(self):
+        self._no_overflow("queue")
+
+    def test_every_screen_has_a_test(self):
+        """A SCREENS entry with no test above is a screen nobody checks."""
+        covered = {name[len("test_"):] for name in dir(self)
+                   if name.startswith("test_")}
+        self.assertEqual(sorted(set(SCREENS) - covered), [])
+
+    def test_the_matrix_is_not_empty(self):
+        """A guard on the guards: a bad MIN_LOGICAL_W would silently reduce
+        every test above to nothing."""
+        cases = list(_cases())
+        self.assertGreater(len(cases), 20)
+        self.assertIn((2.0, (3840, 2160)), cases)
+        self.assertIn((1.0, (1024, 576)), cases)
+
+
+class OverflowCheckTest(unittest.TestCase):
+    """The measurement itself.
+
+    A matrix whose check is wrong is worse than no matrix: it is a green
+    light nobody looks at again. These are synthetic scenes with the answer
+    known in advance.
+    """
+
+    WIN = 1000
+
+    def _scene(self, ends_at, axis="y", bar=True):
+        """A scroll container and one text run whose ink ends exactly at
+        ``ends_at``."""
+        text = "overflow " * 4
+        tw = text_width(text, 15, False)
+        return [
+            {"t": "scroll", "id": "page", "axis": axis, "x": 0, "y": 0,
+             "w": self.WIN, "h": 700, "cw": self.WIN, "ch": 3000,
+             **({"bar": True} if bar else {})},
+            {"t": "text", "id": "t", "sc": "page", "x": ends_at - tw,
+             "y": 10, "w": tw, "h": 20, "size": 15, "text": text},
+        ]
+
+    def test_text_stopping_at_the_scrollbar_is_clean(self):
+        self.assertEqual(overflows(self._scene(self.WIN - SCROLLBAR_W),
+                                   self.WIN), [])
+
+    def test_text_running_under_the_scrollbar_is_caught(self):
+        """Inside the window, and still unreadable: the scrollbar is drawn
+        over the content. This is the check the window-edge test misses."""
+        bad = overflows(self._scene(self.WIN - SCROLLBAR_W + 2), self.WIN)
+        self.assertEqual(len(bad), 1, bad)
+        self.assertEqual(bad[0][-1], float(self.WIN - SCROLLBAR_W))
+
+    def test_a_container_with_no_scrollbar_gets_the_whole_width(self):
+        self.assertEqual(
+            overflows(self._scene(self.WIN, bar=False), self.WIN), [])
+
+    def test_a_horizontal_scroller_is_never_flagged(self):
+        """Its content is meant to run past the window — that is scrolling."""
+        self.assertEqual(
+            overflows(self._scene(self.WIN * 3, axis="x", bar=False),
+                      self.WIN), [])
+
+    def test_text_off_the_left_edge_is_caught_too(self):
+        bad = overflows(self._scene(-5, bar=False), self.WIN)
+        self.assertEqual(len(bad), 1, bad)
+
+    def test_the_real_detail_page_is_measured_against_the_scrollbar(self):
+        """Not synthetic: the screen this was reported on must actually be
+        reaching the stricter limit, or the check above is inert here."""
+        browser = _loaded(SCREENS["detail"])
+        with frozen_clock():
+            nodes, _h = layout(browser.build((1280, 720)), 1280, 720)
+        scrolls = {n["id"]: n for n in nodes if n.get("t") == "scroll"}
+        para = [n for n in nodes if n.get("t") == "text"
+                and "conspiracy" in n.get("text", "")]
+        self.assertTrue(para, "the overview did not reach the scene")
+        self.assertEqual(right_limit(para[0], scrolls, 1280),
+                         1280 - SCROLLBAR_W)

--- a/tests/test_grid_artwork.py
+++ b/tests/test_grid_artwork.py
@@ -12,6 +12,7 @@ import unittest
 
 sys.argv = ["test"]
 
+from jellyfin_mpv_shim.mpvtk_browser.strips import TileGeom  # noqa: E402
 from jellyfin_mpv_shim.mpvtk_browser.app import MpvtkBrowser  # noqa: E402
 from jellyfin_mpv_shim.mpvtk_browser.repository import (  # noqa: E402
     LibrarySource, browse_image_types)
@@ -138,35 +139,79 @@ class SpecTest(unittest.TestCase):
 
 
 class CoverOrContainTest(unittest.TestCase):
-    """A poster, a still and a backdrop are photographs of a frame: cropping
-    one takes scenery off the edges. A wordmark loses the name."""
+    """**Contain is the default. One pairing covers: a poster into a poster
+    tile.**
 
-    def _contains(self, resolved, requested):
+    Cropping is only free where the artwork and the tile already agree, and
+    the one place they reliably do is 2:3 key art in a 2:3 card. Everywhere
+    else the crop is destructive in proportion to the disagreement, and the
+    disagreement is per ITEM -- which is why ``auto_geom``'s per-row shape
+    cannot be the whole answer.
+    """
+
+    POSTER = TileGeom(tile_w=150, tile_h=225)
+    WIDE = TileGeom(tile_w=240, tile_h=135)
+    SQUARE = TileGeom(tile_w=180, tile_h=180)
+
+    def _contains(self, resolved, geom, ratio=None):
         from jellyfin_mpv_shim.mpvtk_browser.tile_renderer import TileRenderer
-        return TileRenderer._contains(resolved, requested)
+        item = {"Id": "i"}
+        if ratio is not None:
+            item["PrimaryImageAspectRatio"] = ratio
+        return TileRenderer._contains(resolved, geom, item)
 
-    def test_a_banner_fills_its_own_strip(self):
-        """Asked for and delivered: the artwork was cut for this shape, and
-        the user asked for it to cover rather than letterbox."""
-        self.assertFalse(self._contains("Banner", "Banner"))
+    # -- the one that covers ------------------------------------------------
 
-    def test_a_poster_standing_in_still_fills_the_strip(self):
-        self.assertFalse(self._contains("Primary", "Banner"))
+    def test_a_poster_in_a_poster_tile_covers(self):
+        self.assertFalse(self._contains("Primary", self.POSTER, 2 / 3))
 
-    def test_a_borrowed_banner_is_drawn_whole(self):
-        """On a 16:9 logo card, cropping the banner would trim exactly the
-        title it was borrowed for."""
-        self.assertTrue(self._contains("Banner", "Logo"))
+    def test_artwork_with_no_measured_ratio_still_covers_in_a_poster_tile(self):
+        """Most library items carry no ``PrimaryImageAspectRatio``. Reading
+        that absence as "not a poster" would letterbox every ordinary film
+        grid on the strength of a missing field."""
+        self.assertFalse(self._contains("Primary", self.POSTER))
 
-    def test_a_logo_is_never_cropped(self):
-        for requested in ("Logo", "Banner", "Primary", "Thumb"):
-            with self.subTest(requested):
-                self.assertTrue(self._contains("Logo", requested))
+    # -- the cases this rule exists for -------------------------------------
 
-    def test_photographs_are_untouched(self):
-        for resolved in ("Primary", "Thumb", "Backdrop", "Disc"):
-            with self.subTest(resolved):
-                self.assertFalse(self._contains(resolved, "Primary"))
+    def test_a_film_in_a_row_of_episodes_is_drawn_whole(self):
+        """``auto_geom`` shapes a row from the MEDIAN ratio, so a playlist
+        that is mostly episodes comes out landscape — and the one film in it
+        had the top and bottom taken off its poster."""
+        self.assertTrue(self._contains("Primary", self.WIDE, 2 / 3))
+
+    def test_home_video_footage_is_drawn_whole(self):
+        """Arbitrary footage: 4:3, 16:9 and portrait phone video in one
+        grid. Whatever shape the row takes, most of it is the wrong shape
+        for what goes in it."""
+        for ratio in (4 / 3, 9 / 16, 1.0, 2.35):
+            with self.subTest(ratio=round(ratio, 2)):
+                self.assertTrue(self._contains("Primary", self.WIDE, ratio))
+
+    def test_a_still_in_a_poster_tile_is_drawn_whole(self):
+        """The mismatch the other way round."""
+        self.assertTrue(self._contains("Primary", self.POSTER, 16 / 9))
+
+    # -- everything that is not a Primary -----------------------------------
+
+    def test_nothing_but_a_primary_ever_covers(self):
+        """A Thumb, a Backdrop, a Disc, a Logo and a Banner are all drawn
+        whole now — the first three because they are never the shape of a
+        poster tile, and the last two because they never were cropped."""
+        for resolved in ("Thumb", "Backdrop", "Disc", "Logo", "Banner"):
+            for geom in (self.POSTER, self.WIDE, self.SQUARE):
+                with self.subTest(resolved=resolved, w=geom.tile_w):
+                    self.assertTrue(self._contains(resolved, geom, 2 / 3))
+
+    def test_a_square_tile_never_covers(self):
+        """Album art is square and the tile is square, so contain and cover
+        are the same picture — and where they are not, the artwork is not a
+        poster and must not be cropped to look like one."""
+        for ratio in (1.0, 2 / 3, 16 / 9, None):
+            with self.subTest(ratio=ratio):
+                self.assertTrue(self._contains("Primary", self.SQUARE, ratio))
+
+    def test_an_unknown_tile_shape_is_the_safe_answer(self):
+        self.assertTrue(self._contains("Primary", None, 2 / 3))
 
     def test_the_two_crops_are_cached_apart(self):
         """Fill and fit are different pictures of one source at one size,

--- a/tests/test_mpvtk_strips.py
+++ b/tests/test_mpvtk_strips.py
@@ -10,9 +10,10 @@ import tempfile
 import threading
 import unittest
 
-from PIL import Image
+from PIL import Image, ImageDraw
 
 from jellyfin_mpv_shim.mpvtk.rawimage import MemoryStore
+from jellyfin_mpv_shim.mpvtk_browser import theme
 from jellyfin_mpv_shim.mpvtk_browser.strips import StripStore, Tile, TileGeom
 
 
@@ -179,6 +180,70 @@ class TestStripStore(unittest.TestCase):
         out = s.strip([Tile(key="a", poster=_poster(size=(240, 135)))])
         self.assertEqual(out["iw"], 240)
         self.assertEqual(out["ih"], 135 + 44)
+
+
+class TestCoverCrop(unittest.TestCase):
+    """Artwork fills its tile in EVERY theme, not just the rounded ones.
+
+    The crop used to ride on the theme's ``rounded`` flag, so the stock look
+    letterboxed whatever the server had not already cropped for us -- offline
+    artwork (a local file, no server-side resize) and chapter thumbnails
+    (fetched by max width, so they keep the video's aspect). ``rounded`` now
+    decides the card's SHAPE and nothing about the picture inside it.
+
+    Painted with a wide poster in a portrait tile: whether it was cropped or
+    letterboxed is the colour of the bands above and below it.
+    """
+
+    def _paint(self, rounded=False, **tile):
+        g = TileGeom().physical()
+        img = Image.new("RGBA", (g.tile_w, g.strip_h), (0, 0, 0, 0))
+        store = StripStore(cache_dir=None, mem_store=None)
+        orig = theme.active
+        if rounded:
+            theme.active = lambda: dict(orig() or {}, rounded=True)
+        try:
+            store._paint_poster(
+                img, ImageDraw.Draw(img), 0,
+                Tile(key="k", title="T", poster=_poster(size=(400, 100)),
+                     **tile),
+                g)
+        finally:
+            theme.active = orig
+        return img, g
+
+    def _bands(self, img, g):
+        """The strips the letterbox would put above and below the art. Taken
+        mid-width, which is inside a rounded card's silhouette as well as a
+        square one's."""
+        return [img.getpixel((g.tile_w // 2, 3))[:3],
+                img.getpixel((g.tile_w // 2, g.tile_h - 4))[:3]]
+
+    def test_the_stock_theme_crops_rather_than_letterboxing(self):
+        img, g = self._paint()
+        for got in self._bands(img, g):
+            self.assertEqual(got, (120, 30, 30))
+        # Square card, so the art reaches the corners too.
+        self.assertEqual(img.getpixel((3, 3))[:3], (120, 30, 30))
+
+    def test_the_rounded_theme_still_crops(self):
+        img, g = self._paint(rounded=True)
+        for got in self._bands(img, g):
+            self.assertEqual(got, (120, 30, 30))
+
+    def test_a_rounded_card_still_clips_the_art_to_its_corners(self):
+        """Cropping the art to the tile and then pasting it square would fill
+        the corner pixels the silhouette leaves transparent."""
+        img, _g = self._paint(rounded=True)
+        self.assertEqual(img.getpixel((1, 1))[3], 0)
+
+    def test_contain_still_draws_the_artwork_whole(self):
+        """A wordmark standing in for missing artwork: cropping it takes the
+        name off both ends, and that is the caller's call, not the theme's."""
+        img, g = self._paint(contain=True)
+        card = theme.rgb(theme.CARD_BG)[:3]
+        for got in self._bands(img, g):
+            self.assertEqual(got, card)
 
 
 class TestBitmapConcurrentMiss(unittest.TestCase):

--- a/tests/test_photos.py
+++ b/tests/test_photos.py
@@ -735,7 +735,12 @@ class PhotoPauseRuleTest(unittest.TestCase):
     def _paused(self, is_photo=True, is_initial_play=True, pause_stills=True):
         player = self._P()
         video = type("V", (), {"is_photo": is_photo})()
-        # The excerpt of _play_media under test.
+        # An EXCERPT of _play_media, which is why the three-way truth table
+        # below could be right while the feature did not work at all: the
+        # real method goes on to call `set_paused` unconditionally, and for
+        # its whole life that call undid this one. Nothing that reimplements
+        # a fragment can see what the rest of the method does to it -- see
+        # test_the_unpause_further_down_respects_it, and `tests/e2e`.
         if (getattr(video, "is_photo", False) and pause_stills
                 and is_initial_play):
             player.pause = True
@@ -756,6 +761,27 @@ class PhotoPauseRuleTest(unittest.TestCase):
 
     def test_a_video_is_never_paused(self):
         self.assertFalse(self._paused(is_photo=False))
+
+    def test_the_unpause_further_down_respects_it(self):
+        """`_play_media` pauses the still early and then, seventy lines
+        later, calls `set_paused` to push the initial playstate. That call
+        passed a literal False -- it predates the photo branch by five years
+        -- so opening one picture started a slideshow. Found end to end
+        against a real mpv, because every unit test here works on an excerpt.
+
+        Asserted on the source rather than by driving the method: doing it
+        properly needs a real window, which is what `tests/e2e/test_photos`
+        does. This is the cheap guard that keeps the two lines coupled.
+        """
+        import inspect
+
+        from jellyfin_mpv_shim.player import PlayerManager
+
+        source = inspect.getsource(PlayerManager._play_media)
+        self.assertIn(
+            "self.set_paused(hold_still, False)", source,
+            "the initial unpause in _play_media no longer consults the "
+            "hold-the-still decision, so opening a photo starts a slideshow")
 
     def test_the_player_takes_the_flag_and_defaults_to_pausing(self):
         """Default True: every existing caller means "open this", and a

--- a/tests/test_shell_chrome.py
+++ b/tests/test_shell_chrome.py
@@ -394,6 +394,136 @@ class TestBanner(unittest.TestCase):
         self.assertEqual(titled.size, (600, 225))
         self.assertNotEqual(plain.tobytes(), titled.tobytes())
 
+    #: Everything compose_banner draws sits inside this much margin.
+    def _margin(self, w):
+        from jellyfin_mpv_shim.mpvtk.scaling import px
+        return max(px(18), w // 40)
+
+    def _ink_columns(self, img, x_from):
+        """Columns at or right of ``x_from`` carrying anything brighter than
+        the backdrop. The art is black and the gradient only darkens it, so
+        every bright pixel in a banner is text."""
+        w, h = img.size
+        return [x for x in range(x_from, w)
+                if any(max(img.getpixel((x, y))[:3]) > 100
+                       for y in range(h))]
+
+    def test_a_long_meta_line_stays_inside_the_backdrop(self):
+        """The meta line ends in the genres, and it used to be drawn with a
+        raw draw.text -- no wrap, no ellipsis. A film carrying a handful of
+        them ran off the right edge of the artwork, cut mid-letter by the
+        canvas. Nothing downstream can clip a baked bitmap back."""
+        from PIL import Image as PILImage
+        art = PILImage.new("RGB", (800, 800), (0, 0, 0))
+        meta = ("1998   ·   2:22:15   ·   R   ·   ★ 8.1   ·   "
+                "Drama, Romance, Thriller, Science Fiction, Adventure, "
+                "Mystery, Crime, Fantasy")
+        img = components.compose_banner(art, (600, 225), title="The Film",
+                                        meta=meta)
+        spill = self._ink_columns(img, 600 - self._margin(600))
+        self.assertEqual(spill, [], "text drawn into the right margin")
+
+    def test_a_long_title_and_context_stay_inside_too(self):
+        """The other two lines wrap and ellipsize already — pinned so the
+        margin is a property of the banner rather than of one line."""
+        from PIL import Image as PILImage
+        art = PILImage.new("RGB", (800, 800), (0, 0, 0))
+        img = components.compose_banner(
+            art, (600, 225),
+            title="A Deliberately Overlong Episode Title That Cannot Fit",
+            meta="2020",
+            context="Some Series With A Long Name · S01E01 · Pilot Episode")
+        spill = self._ink_columns(img, 600 - self._margin(600))
+        self.assertEqual(spill, [], "text drawn into the right margin")
+
+
+class TestWrapRow(unittest.TestCase):
+    """``chrome.wrap_row``: a Row that breaks onto more lines rather than
+    running off the window. The screens that use it are checked end to end
+    by tests/test_dpi_matrix.py; this pins the contract."""
+
+    def _row(self, avail, n=6, **kw):
+        from jellyfin_mpv_shim.mpvtk.widgets import Button
+        from jellyfin_mpv_shim.mpvtk_browser.components import chrome
+        items = [Button("Button %d" % i, id="b%d" % i) for i in range(n)]
+        return chrome.wrap_row(items, avail, **kw), items
+
+    def test_a_row_that_fits_is_the_row_it_always_was(self):
+        """Returning a Column unconditionally would move every screen's
+        layout at every width; the snapshots would all need regenerating for
+        a change that is meant to be invisible until it is needed."""
+        from jellyfin_mpv_shim.mpvtk.widgets import Row
+        out, items = self._row(4000)
+        self.assertIsInstance(out, Row)
+        self.assertEqual(out.children, items)
+
+    def test_a_row_that_does_not_fit_is_broken_up(self):
+        from jellyfin_mpv_shim.mpvtk.widgets import Column, Row
+        out, items = self._row(260)
+        self.assertIsInstance(out, Column)
+        self.assertGreater(len(out.children), 1)
+        for row in out.children:
+            self.assertIsInstance(row, Row)
+        drawn = [c for row in out.children for c in row.children]
+        self.assertEqual(drawn, items, "wrapping dropped or reordered items")
+
+    def test_an_unmeasurable_width_leaves_it_alone(self):
+        """A page that does not know its width yet passes 0. One row is the
+        honest answer there — better than guessing at a break."""
+        from jellyfin_mpv_shim.mpvtk.widgets import Row
+        self.assertIsInstance(self._row(0)[0], Row)
+        self.assertIsInstance(self._row(-32)[0], Row)
+
+    def test_a_flexible_spacer_is_dropped_only_when_it_wraps(self):
+        """The Spacer means 'push these apart', which is what pins a
+        trailing group to the right edge — and so is what puts those buttons
+        off the window. It has nothing to say once the row is full."""
+        from jellyfin_mpv_shim.mpvtk.widgets import Button, Spacer
+        from jellyfin_mpv_shim.mpvtk_browser.components import chrome
+        items = [Button("One", id="b1"), Spacer(),
+                 Button("Two", id="b2"), Button("Three", id="b3")]
+        wide = chrome.wrap_row(items, 4000)
+        self.assertIn(items[1], wide.children)
+        narrow = chrome.wrap_row(items, 90)
+        drawn = [c for row in narrow.children for c in row.children]
+        self.assertNotIn(items[1], drawn)
+        self.assertEqual([c for c in drawn],
+                         [items[0], items[2], items[3]])
+
+    def test_an_item_wider_than_the_space_gets_its_own_line(self):
+        """Rather than an empty line before it, or an endless loop."""
+        from jellyfin_mpv_shim.mpvtk.widgets import Column
+        out, items = self._row(10, n=3)
+        self.assertIsInstance(out, Column)
+        self.assertEqual([len(r.children) for r in out.children], [1, 1, 1])
+
+
+class TestMetaLine(unittest.TestCase):
+    """``meta_line`` is the year · runtime · rating · genres line, shared by
+    the detail, series and music headers."""
+
+    def _line(self, **item):
+        from jellyfin_mpv_shim.mpvtk_browser.components import detail
+        return detail.meta_line(item)
+
+    def test_genres_are_capped_at_three(self):
+        """The quick read on what a thing is, not the full tag list. Eight
+        genres pushed the year and rating off the visible line."""
+        line = self._line(ProductionYear=1998,
+                          Genres=["Drama", "Romance", "Thriller",
+                                  "Science Fiction", "Adventure"])
+        self.assertIn("Drama, Romance, Thriller", line)
+        self.assertNotIn("Adventure", line)
+        self.assertNotIn("Science Fiction", line)
+
+    def test_a_short_genre_list_is_untouched(self):
+        line = self._line(Genres=["Drama", "Romance"])
+        self.assertEqual(line, "Drama, Romance")
+
+    def test_no_genres_leaves_no_empty_separator(self):
+        line = self._line(ProductionYear=1998, Genres=[])
+        self.assertEqual(line, "1998")
+
 class TestOneBlue(unittest.TestCase):
     """There is exactly one blue. A second, unrelated blue makes the UI look
     assembled from parts, so anything the app colours itself must come from

--- a/tests/test_shell_library.py
+++ b/tests/test_shell_library.py
@@ -1894,6 +1894,84 @@ class TestNoDeadButtons(unittest.TestCase):
         self.assertIn("pl-play", present)
         self.assertIn("pl-shuffle", present)
 
+    def _playlist_tiles(self, items):
+        """The tile geometry a playlist of ``items`` is drawn at."""
+        src = FakeSource()
+        src.get_playlist_items = lambda srv, pid: list(items)
+        b = self._browser(src)
+        b.navigate({"kind": "playlist", "server": "srv1", "item_id": "P",
+                    "title": "Mix"})
+        nodes, _h = build_scene(b)
+        return b, [n for n in nodes
+                   if str(n.get("id") or "").startswith("pl-")
+                   and n.get("t") == "rect" and n.get("ring")]
+
+    @staticmethod
+    def _video(i, ratio):
+        return {"Id": "v%d" % i, "Name": "Item %d" % i, "Type": "Episode",
+                "PrimaryImageAspectRatio": ratio,
+                "ImageTags": {"Primary": "t%d" % i}}
+
+    def test_a_playlist_of_stills_is_drawn_as_stills(self):
+        """A playlist can hold anything, and this was the one grid in the app
+        whose shape did not follow its artwork: 16:9 episode stills were
+        drawn in 2:3 poster tiles, so the fill crop threw most of each
+        picture away. jellyfin-web's cardBuilder shapes a row from the
+        median aspect ratio; so does every other grid here."""
+        b, tiles = self._playlist_tiles([self._video(i, 16 / 9)
+                                         for i in range(8)])
+        self.assertTrue(tiles, "no playlist tiles were drawn")
+        wide = b.tiles.art.geom_wide
+        # strip_h, not tile_h: a hit region spans the caption under the tile.
+        self.assertAlmostEqual(tiles[0]["w"], wide.tile_w, delta=1)
+        self.assertAlmostEqual(tiles[0]["h"], wide.strip_h, delta=1)
+
+    def test_a_playlist_of_posters_still_gets_posters(self):
+        """The same rule reaching the other answer — this must not become
+        "landscape always"."""
+        b, tiles = self._playlist_tiles([self._video(i, 2 / 3)
+                                         for i in range(8)])
+        self.assertTrue(tiles)
+        poster = b.tiles.art.geom
+        self.assertAlmostEqual(tiles[0]["w"], poster.tile_w, delta=1)
+        self.assertAlmostEqual(tiles[0]["h"], poster.strip_h, delta=1)
+
+    def test_a_playlist_entry_shows_its_own_art_not_the_series(self):
+        """Same exception the season listing takes. Once the row is shaped
+        for stills, the Thumb chain will borrow the SERIES' thumb or backdrop
+        for an episode with no still of its own — so a playlist built out of
+        one show drew the same series artwork in every cell and stopped
+        distinguishing anything. Borrowing is right for a Continue Watching
+        card, which is a pointer back to the show; a playlist entry is the
+        thing you are about to play."""
+        asked = []
+        src = FakeSource()
+        real = src.image_spec
+
+        def image_spec(item, image_type="Primary", width=280, inherit=True):
+            asked.append(inherit)
+            return real(item, image_type, width, inherit=inherit)
+
+        src.image_spec = image_spec
+        src.get_playlist_items = lambda srv, pid: [
+            self._video(i, 16 / 9) for i in range(6)]
+        b = self._browser(src)
+        b.navigate({"kind": "playlist", "server": "srv1", "item_id": "P",
+                    "title": "Mix"})
+        build_scene(b)
+        self.assertTrue(asked, "no artwork was resolved for the tiles")
+        self.assertNotIn(True, asked,
+                         "a playlist tile inherited its parent's artwork")
+
+    def test_artwork_with_no_ratio_keeps_the_poster_default(self):
+        """Nothing to measure: the shape it has always had, not a guess."""
+        b, tiles = self._playlist_tiles(
+            [{"Id": "v%d" % i, "Name": "N", "Type": "Video"}
+             for i in range(4)])
+        self.assertTrue(tiles)
+        self.assertAlmostEqual(tiles[0]["w"], b.tiles.art.geom.tile_w,
+                               delta=1)
+
     def test_the_artist_bar_drops_play_when_the_songs_failed_to_load(self):
         b = self._browser()
         bar = music_page(b, {"kind": "artist", "item_id": "art1"}) \

--- a/tests/test_shell_library.py
+++ b/tests/test_shell_library.py
@@ -111,7 +111,7 @@ class TestBannerFetchIsQuantised(unittest.TestCase):
         class _Source:
             @staticmethod
             def backdrop_spec(_item):
-                return ("m1", "tag9")
+                return ("m1", "Backdrop", "tag9")
 
             @staticmethod
             def backdrop_url(_server, _item, width=None, height=None,

--- a/tests/test_shell_paging.py
+++ b/tests/test_shell_paging.py
@@ -944,6 +944,25 @@ class _Albums(FakeSource):
         return albums[start:start + kw.get("limit", 300)], len(albums)
 
 
+class _BigLibrary(FakeSource):
+    """A library long enough to virtualize. The stock fixture's 30 items all
+    fit in one window, so nothing is ever a hole and no windowing bug can
+    show itself."""
+
+    def __init__(self):
+        super().__init__()
+        self.grid_items = [
+            {"Id": "g%d" % i, "Name": "Item %d" % i, "Type": "Movie",
+             "PrimaryImageAspectRatio": 2 / 3}
+            for i in range(600)
+        ]
+
+    def get_library_items(self, server_uuid, parent_id, start_index=0,
+                          limit=100, **kw):
+        return (self.grid_items[start_index:start_index + limit],
+                len(self.grid_items))
+
+
 class TestAReturningScrollContainerStartsAtTheTop(unittest.TestCase):
     """A virtualized grid that leaves the scene and comes back rendered
     blank: it was windowed around the offset it had before it left, while
@@ -1061,6 +1080,107 @@ class TestAReturningScrollContainerStartsAtTheTop(unittest.TestCase):
         self.assertEqual(grid.get("off0"), 1500,
                          "the grid came back at the top instead of where it "
                          "was left")
+
+    def test_back_navigation_windows_around_where_it_is_going(self):
+        """The other half of the restore, and the half that was missing.
+
+        Sending ``off0`` puts the container back at the bottom. Building its
+        virtualized window is a *separate* question, and it was answered
+        from the renderer's live offsets -- where the container has just
+        entered the scene and so is reported at 0. So the frame that jumped
+        to the bottom carried the tiles for the top, and the screen came
+        back empty and stayed empty until a scroll rebuilt the window.
+
+        Reported from a real session: scroll a library to the end, open
+        something, press Back, and there is nothing on screen until you
+        nudge the wheel.
+        """
+        b, app = self._browser(_BigLibrary())
+        b.navigate({"kind": "grid", "server": "srv1", "parent_id": "lib1",
+                    "title": "Movies"})
+        app.on_screen = {"grid"}
+        end = self._grid_node(b)["ch"] - self._grid_node(b)["h"]
+
+        # To the end, and let the window catch up (the items for a jump are
+        # asked for during the build that needs them, so they land in the
+        # next one -- see Paginator.window).
+        app.scroll["grid"] = end
+        b._on_scroll("grid", end, end)
+        self._grid_node(b)
+        drawn = self._drawn(b)
+        self.assertTrue(drawn, "test premise: the end of the grid has tiles")
+        self.assertGreater(drawn[-1], 500, "test premise: those are last ones")
+
+        b.navigate({"kind": "detail", "server": "srv1", "item_id": "g1"})
+        app.scroll.pop("grid")                 # the scroller left the scene
+        b.go_back()
+        app.on_screen = {"grid"}
+
+        back = self._drawn(b)
+        self.assertTrue(
+            back, "the grid came back with no tiles built at all")
+        self.assertGreater(
+            back[-1], 500,
+            "the grid came back windowed at the top (items %s..%s) while "
+            "off0 put it at the bottom -- a screenful of holes"
+            % (back[0], back[-1]))
+
+    def test_playing_something_and_coming_back_lands_where_you_left_it(self):
+        """The play overlay, which is not a navigation at all.
+
+        Pressing it yields the whole window to the video, and the empty
+        scene that goes with that makes every scroll container vanish — so
+        the renderer drops their offsets. Coming back is a rebuild of the
+        *same* route: nothing pushes, nothing pops, so ``navigate``'s park
+        never ran and there was nothing for ``parked_scroll`` to restore.
+        The library came back at the top, and (depending on whether the live
+        read had caught up when the window was built) came back blank.
+
+        Reported from a real session, one screen further in than the Back
+        case above: scroll to the end, press Play on a tile, come back.
+        """
+        b, app = self._browser(_BigLibrary())
+        b.navigate({"kind": "grid", "server": "srv1", "parent_id": "lib1",
+                    "title": "Movies"})
+        app.on_screen = {"grid"}
+        end = self._grid_node(b)["ch"] - self._grid_node(b)["h"]
+        app.scroll["grid"] = end
+        b._on_scroll("grid", end, end)
+        self._drawn(b)                       # let the window catch up
+        self.assertGreater(self._drawn(b)[-1], 500, "test premise")
+
+        b.on_playstate({"stopped": False, "is_audio": False, "id": "g1",
+                        "title": "Item 1", "position": 1, "duration": 100})
+        self.assertAlmostEqual(
+            (b.route.get("_scroll") or {}).get("grid", 0), end,
+            msg="the offsets were not parked on the way into playback")
+
+        app.scroll.pop("grid")               # the empty scene dropped it
+        app.on_screen = set()
+        b.enter_browse()
+        app.on_screen = {"grid"}
+
+        grid = self._grid_node(b)
+        self.assertAlmostEqual(grid.get("off0") or 0, end,
+                               msg="the library came back at the top")
+        self.assertGreater(
+            self._drawn(b)[-1], 500,
+            "the library came back windowed at the top while off0 put it at "
+            "the bottom -- a screenful of holes")
+
+    def _grid_node(self, b, size=(1280, 720)):
+        nodes, _h = layout(b.build(size), *size)
+        return next(n for n in nodes
+                    if n.get("id") == "grid" and n.get("t") == "scroll")
+
+    def _drawn(self, b, size=(1280, 720)):
+        """Indexes of the library items this build actually composited."""
+        import re
+
+        pat = re.compile(r"^grid-\d+-g(\d+)")
+        nodes, _h = layout(b.build(size), *size)
+        return sorted({int(m.group(1)) for n in nodes
+                       for m in [pat.match(n.get("id") or "")] if m})
 
     def test_a_first_visit_carries_no_offset(self):
         """Only *returning* restores. A route opened fresh must not inherit

--- a/tests/test_themes.py
+++ b/tests/test_themes.py
@@ -151,7 +151,7 @@ class DefaultThemeIsTheStockLookTest(unittest.TestCase):
     def test_the_default_theme_asks_for_no_extra_decoration(self):
         d = theme.apply("default")
         self.assertFalse(d["glow"])       # no blurred accent halo
-        self.assertFalse(d["rounded"])    # square cards, letterboxed art
+        self.assertFalse(d["rounded"])    # square cards (the art still crops)
         self.assertFalse(d["accent_buttons"])   # plain top-bar buttons
         self.assertEqual(d["poster_scale"], 1.0)
         self.assertEqual(d["heading_size"], 24)

--- a/tests/test_ui_review_fixes.py
+++ b/tests/test_ui_review_fixes.py
@@ -300,15 +300,59 @@ class ArtPathMemoTest(unittest.TestCase):
 
 
 class BackdropSpecTest(unittest.TestCase):
+    """The header banner's fallback chain: backdrop, parent backdrop, thumb,
+    parent thumb, then the item's own still IF it is landscape."""
+
     def test_own_backdrop_tag_wins(self):
         item = {"Id": "i", "BackdropImageTags": ["t1"],
-                "ParentBackdropImageTags": ["p1"], "ParentBackdropItemId": "P"}
-        self.assertEqual(LibrarySource.backdrop_spec(item), ("i", "t1"))
+                "ParentBackdropImageTags": ["p1"], "ParentBackdropItemId": "P",
+                "ImageTags": {"Thumb": "th"}}
+        self.assertEqual(LibrarySource.backdrop_spec(item),
+                         ("i", "Backdrop", "t1"))
 
     def test_parent_backdrop_fallback(self):
         item = {"Id": "i", "ParentBackdropImageTags": ["p1"],
                 "ParentBackdropItemId": "P"}
-        self.assertEqual(LibrarySource.backdrop_spec(item), ("P", "p1"))
+        self.assertEqual(LibrarySource.backdrop_spec(item),
+                         ("P", "Backdrop", "p1"))
+
+    def test_a_thumb_beats_having_nothing(self):
+        item = {"Id": "i", "ImageTags": {"Thumb": "th", "Primary": "p"}}
+        self.assertEqual(LibrarySource.backdrop_spec(item),
+                         ("i", "Thumb", "th"))
+
+    def test_a_parent_thumb_is_next(self):
+        item = {"Id": "i", "ParentThumbItemId": "P",
+                "ParentThumbImageTag": "pt"}
+        self.assertEqual(LibrarySource.backdrop_spec(item),
+                         ("P", "Thumb", "pt"))
+
+    def test_a_home_video_uses_its_own_still(self):
+        """The case this chain was extended for: video scanned out of a
+        folder has no backdrop and never will, and its header was a blank
+        grey box. The still the server extracted is a frame of the thing
+        itself."""
+        for ratio in (16 / 9, 4 / 3, 1.0):
+            with self.subTest(ratio=round(ratio, 2)):
+                item = {"Id": "i", "Type": "Video",
+                        "PrimaryImageAspectRatio": ratio,
+                        "ImageTags": {"Primary": "p"}}
+                self.assertEqual(LibrarySource.backdrop_spec(item),
+                                 ("i", "Primary", "p"))
+
+    def test_a_poster_is_not_a_banner(self):
+        """A 2:3 poster cropped into a 2.67:1 banner is a strip through the
+        middle of the key art -- worse than the placeholder, because it reads
+        as a rendering fault rather than as missing artwork."""
+        item = {"Id": "i", "Type": "Movie", "PrimaryImageAspectRatio": 2 / 3,
+                "ImageTags": {"Primary": "p"}}
+        self.assertIsNone(LibrarySource.backdrop_spec(item))
+
+    def test_an_unmeasured_primary_is_not_used_either(self):
+        """Unknown shape, and the downside is asymmetric: a wrong guess here
+        mutilates the header, while the placeholder is merely plain."""
+        item = {"Id": "i", "ImageTags": {"Primary": "p"}}
+        self.assertIsNone(LibrarySource.backdrop_spec(item))
 
     def test_no_backdrop(self):
         self.assertIsNone(LibrarySource.backdrop_spec({"Id": "i"}))
@@ -317,7 +361,7 @@ class BackdropSpecTest(unittest.TestCase):
         # The offline spec must never collide with a real server tag, so a
         # source switch can't serve the other source's cached bitmap.
         self.assertEqual(OfflineLibrarySource.backdrop_spec({"Id": "i"}),
-                         ("i", "offline"))
+                         ("i", "offline", "offline"))
 
 
 if __name__ == "__main__":

--- a/tests/test_ui_scale.py
+++ b/tests/test_ui_scale.py
@@ -395,5 +395,73 @@ class ScaleResolutionTest(unittest.TestCase):
         self.assertEqual(scaling.logical_size((2560, 1440)), (1280.0, 720.0))
 
 
+class FontSizeIsNotRoundedTest(unittest.TestCase):
+    """A font size scales exactly; a box rounds.
+
+    Text is fitted to a width by ``layout`` at the LOGICAL size and drawn by
+    libass at the physical one, so the two agree only if the physical size is
+    exactly ``logical * scale``. Rounding it made every run come out at a
+    slightly different size than it was measured at — and the error is a
+    *percentage*, so it lands hardest on the longest line on the screen.
+
+    Worst at fractional scales and worst of all below 1x: at 0.75, an 18px
+    paragraph was drawn at ``px(18) = 14``, i.e. 18.67 logical. 3.7% of a
+    1200px column is 44px, which is well past the scrollbar. Reported from a
+    real session as the description on a movie page overflowing, visible at
+    0.75x and at no other scale the reporter tried.
+    """
+
+    def tearDown(self):
+        scaling.set_scale(1.0)
+
+    def _text_node(self, scale, size=18):
+        scaling.set_scale(scale)
+        nodes, _ = layout(Column([Text("hello", size=size, id="t")]),
+                          800, 600)
+        node = next(n for n in nodes if n.get("id") == "t")
+        scaling.scale_scene(nodes)
+        return node
+
+    def test_the_size_is_scaled_exactly(self):
+        for scale in (0.75, 0.8, 1.25, 1.5, 1.75, 2.0):
+            with self.subTest(scale=scale):
+                self.assertAlmostEqual(
+                    self._text_node(scale)["size"], 18 * scale, places=6)
+
+    def test_a_size_that_would_have_rounded_no_longer_does(self):
+        """0.75 * 18 = 13.5, which px() rounds up to 14 — a 3.7% error."""
+        self.assertNotEqual(self._text_node(0.75)["size"],
+                            scaling.px(18))
+
+    def test_the_line_box_still_rounds_like_every_other_rasterizer(self):
+        """Only the glyph size is exempt. Geometry must keep going through
+        px(), or it stops agreeing with the bitmaps beside it."""
+        node = self._text_node(1.5)
+        for key in ("x", "y", "w", "h"):
+            self.assertEqual(node[key], int(node[key]),
+                             "%s came out fractional" % key)
+
+    def test_text_fitted_to_a_width_is_drawn_no_wider(self):
+        """The invariant the whole thing is for, end to end: what layout
+        ellipsized to a box must still be inside that box once both have been
+        scaled."""
+        from jellyfin_mpv_shim.mpvtk.layout import text_width
+
+        long_label = "A deliberately overlong label that will be ellipsized"
+        for scale in (0.75, 0.8, 1.25, 1.5, 1.75, 2.0):
+            with self.subTest(scale=scale):
+                scaling.set_scale(scale)
+                nodes, _ = layout(
+                    Column([Text(long_label, size=18, id="t", w=200)]),
+                    800, 600)
+                node = next(n for n in nodes if n.get("id") == "t")
+                scaling.scale_scene(nodes)
+                drawn = text_width(node["text"], node["size"], False)
+                self.assertLessEqual(
+                    drawn, node["w"] + 1.0,
+                    "%r is drawn %.1fpx wide in a %spx box"
+                    % (node["text"], drawn, node["w"]))
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_user_policy.py
+++ b/tests/test_user_policy.py
@@ -247,8 +247,15 @@ class TheNewGroupButton(unittest.TestCase):
 
 
 class TheLiveTvTabs(unittest.TestCase):
-    """Schedule and Series are about scheduling. Recordings is not — a
-    finished recording is something you watch."""
+    """Every tab, to everyone who can see Live TV at all.
+
+    `EnableLiveTvManagement` gates changing the DVR, not reading it. Schedule
+    and Series were hidden without it, which took away information the server
+    itself hands out: both endpoints answer 200 for an account with no
+    management permission (measured against a real server; the 403 is on the
+    writes). jellyfin-web's `getTabs` consults no policy either and gates the
+    mutating context-menu entries instead.
+    """
 
     def _tabs(self, may_manage):
         from tests.test_live_tv import browser, open_live_tv
@@ -261,10 +268,11 @@ class TheLiveTvTabs(unittest.TestCase):
     def test_all_six_with_management(self):
         self.assertEqual(len(self._tabs(True)), 6)
 
-    def test_the_scheduling_tabs_go_without_it(self):
-        tabs = self._tabs(False)
-        self.assertNotIn("schedule", tabs)
-        self.assertNotIn("series", tabs)
+    def test_all_six_without_it_as_well(self):
+        """What is going to record is worth knowing whether or not you may
+        change it. The actions are what go — see TheTimerEditor."""
+        self.assertEqual(sorted(self._tabs(False)),
+                         sorted(self._tabs(True)))
 
     def test_watching_recordings_survives(self):
         """The permission is about managing recordings, not about playing
@@ -273,14 +281,26 @@ class TheLiveTvTabs(unittest.TestCase):
         for key in ("programs", "guide", "channels", "recordings"):
             self.assertIn(key, tabs)
 
-    def test_a_hidden_tab_carried_in_on_a_route_falls_back(self):
-        """Otherwise the tab bar shows nothing selected and the body draws a
-        screen with no way out of it."""
+    def test_the_scheduling_tabs_are_reachable_by_route(self):
+        """The route carries `_tab`; a remote or a deep link can land on
+        Schedule directly, and it must not bounce to Programs."""
         from tests.test_live_tv import browser, open_live_tv
 
         b = browser()
         b.source.can_manage_live_tv = lambda _srv: False
-        page = open_live_tv(b, tab="schedule")
+        for tab in ("schedule", "series"):
+            with self.subTest(tab):
+                page = open_live_tv(b, tab=tab)
+                self.assertEqual(page._current_tab(), tab)
+
+    def test_an_unknown_tab_still_falls_back(self):
+        """The guard that outlived the permission it was added for: without
+        it the tab bar shows nothing selected and the body draws a screen
+        with no way out of it."""
+        from tests.test_live_tv import browser, open_live_tv
+
+        b = browser()
+        page = open_live_tv(b, tab="nonsense")
         self.assertEqual(page._current_tab(), page.DEFAULT_TAB)
 
     def test_a_source_that_cannot_answer_keeps_them(self):
@@ -291,6 +311,82 @@ class TheLiveTvTabs(unittest.TestCase):
             del b.source.can_manage_live_tv
         page = open_live_tv(b)
         self.assertEqual(len(page._tabs()), 6)
+
+
+class TheTimerEditor(unittest.TestCase):
+    """Opening a scheduled recording without permission to change it.
+
+    The dialog is where the information lives — channel, air time, padding,
+    which episodes a series rule keeps — so it still opens. What goes is
+    everything that would be answered with a 403.
+    """
+
+    def _dialog(self, may_manage, series=True):
+        from tests.test_live_tv import browser, open_live_tv
+        from jellyfin_mpv_shim.mpvtk.layout import layout
+
+        b = browser()
+        b.source.can_manage_live_tv = lambda _srv: may_manage
+        page = open_live_tv(b, "series" if series else "schedule")
+        if series:
+            page._open_series_timer({"Id": "st1"})
+        else:
+            page._open_timer({"Id": "tm1"})
+        nodes, _h = layout(b.build((1280, 720)), 1280, 720)
+        return {n.get("id"): n for n in nodes if n.get("id")}
+
+    def test_the_form_is_still_shown(self):
+        """Read-only, not withheld: the settings are the reason to open it."""
+        nodes = self._dialog(False)
+        for node_id in ("tm-showtype", "tm-channels", "tm-airtime",
+                        "tm-keep", "tm-pre", "tm-post"):
+            with self.subTest(node_id):
+                self.assertIn(node_id, nodes)
+
+    def test_nothing_that_would_be_refused_is_offered(self):
+        nodes = self._dialog(False)
+        self.assertNotIn("tm-save", nodes)
+        self.assertNotIn("tm-cancel", nodes)
+
+    def test_close_is_still_there(self):
+        """A dialog you cannot dismiss is worse than one you cannot use."""
+        self.assertIn("tm-close", self._dialog(False))
+
+    def test_the_controls_are_disabled(self):
+        """Left live, they would take an edit that Save is not there to
+        apply — a form that silently discards what you type."""
+        nodes = self._dialog(False)
+        for node_id in ("tm-showtype", "tm-channels", "tm-airtime",
+                        "tm-keep", "tm-pre", "tm-post"):
+            with self.subTest(node_id):
+                self.assertTrue(nodes[node_id].get("dis"),
+                                "%s is still editable" % node_id)
+
+    def test_with_permission_it_is_an_editor_again(self):
+        nodes = self._dialog(True)
+        self.assertIn("tm-save", nodes)
+        self.assertIn("tm-cancel", nodes)
+        self.assertFalse(nodes["tm-pre"].get("dis"))
+
+    def test_a_single_timer_is_read_only_too(self):
+        nodes = self._dialog(False, series=False)
+        self.assertIn("tm-pre", nodes)
+        self.assertTrue(nodes["tm-pre"].get("dis"))
+        self.assertNotIn("tm-cancel", nodes)
+
+    def test_it_fails_open(self):
+        """Same doctrine as everywhere else: only an answer the server gave
+        closes a gate. A source that cannot answer leaves it an editor."""
+        from tests.test_live_tv import browser, open_live_tv
+        from jellyfin_mpv_shim.mpvtk.layout import layout
+
+        b = browser()
+        if hasattr(b.source, "can_manage_live_tv"):
+            del b.source.can_manage_live_tv
+        page = open_live_tv(b, "series")
+        page._open_series_timer({"Id": "st1"})
+        nodes, _h = layout(b.build((1280, 720)), 1280, 720)
+        self.assertIn("tm-save", {n.get("id") for n in nodes})
 
 
 class TheRecordButtons(unittest.TestCase):

--- a/tests/test_user_policy.py
+++ b/tests/test_user_policy.py
@@ -1,0 +1,334 @@
+"""Permissions the server grants separately, and the UI that has to follow.
+
+SyncPlay and Live TV *recording* are granted independently of everything
+else, and the shim offered both to everyone — so a user without them got a
+button that could only fail, with a message ("Could not join the SyncPlay
+group.", a bare 403) indistinguishable from a network problem. See
+`docs/PERMISSION_GAPS.md`.
+
+Two rules run through all of it and both are asserted here as much as the
+hiding is:
+
+* **Fail open.** Only an answer the server actually gave closes a gate. A
+  policy that could not be fetched, a source that does not answer the
+  question, a test double without the method — all of those leave the
+  feature exactly where it was. Taking a working button away because a
+  request failed is a worse bug than the one being fixed.
+* **SyncPlayAccess is three-valued.** `JoinGroups` may join a group somebody
+  else made and may not make one, so the dialog is reachable and the New
+  Group button is not. Treating it as a boolean gets one of those wrong.
+"""
+
+import unittest
+
+from jellyfin_mpv_shim import user_policy
+
+
+class _Client:
+    """The shape `policy_for` needs: `client.jellyfin.get_user()`."""
+
+    def __init__(self, policy=None, raises=False):
+        self.calls = 0
+        self._policy = policy
+        self._raises = raises
+        outer = self
+
+        class _Api:
+            def get_user(self):
+                outer.calls += 1
+                if outer._raises:
+                    raise RuntimeError("server said no")
+                return {"Policy": outer._policy} if outer._policy is not None \
+                    else {}
+
+        self.jellyfin = _Api()
+
+
+class PolicyFetch(unittest.TestCase):
+
+    def test_it_is_read_once_and_cached_on_the_client(self):
+        """One request per server per session. The consumers ask on every
+        repaint — the top bar asks whenever it draws — so an uncached read
+        would be a request per frame."""
+        client = _Client({"SyncPlayAccess": "JoinGroups"})
+        for _ in range(5):
+            user_policy.policy_for(client)
+        self.assertEqual(client.calls, 1)
+
+    def test_refresh_asks_again(self):
+        client = _Client({"SyncPlayAccess": "JoinGroups"})
+        user_policy.policy_for(client)
+        user_policy.policy_for(client, refresh=True)
+        self.assertEqual(client.calls, 2)
+
+    def test_a_failed_fetch_is_not_cached_as_a_no(self):
+        """Caching an error would turn one bad moment into a session-long
+        loss of the feature."""
+        client = _Client(raises=True)
+        self.assertEqual(user_policy.policy_for(client), {})
+        self.assertTrue(user_policy.may_use_syncplay(client))
+        self.assertTrue(user_policy.may_manage_live_tv(client))
+
+    def test_no_client_at_all(self):
+        self.assertEqual(user_policy.policy_for(None), {})
+        self.assertTrue(user_policy.may_use_syncplay(None))
+
+
+class SyncPlayAccess(unittest.TestCase):
+
+    def _client(self, access):
+        return _Client({"SyncPlayAccess": access} if access else {})
+
+    def test_the_three_values(self):
+        cases = [
+            (user_policy.CREATE_AND_JOIN, True, True),
+            (user_policy.JOIN_ONLY, True, False),
+            (user_policy.NO_SYNCPLAY, False, False),
+        ]
+        for access, may_use, may_create in cases:
+            with self.subTest(access=access):
+                client = self._client(access)
+                self.assertIs(user_policy.may_use_syncplay(client), may_use)
+                self.assertIs(user_policy.may_create_syncplay_group(client),
+                              may_create)
+
+    def test_an_absent_setting_is_full_access(self):
+        """An older server has no such field, and must not lose the feature
+        to a client that reads its absence as a refusal."""
+        client = self._client(None)
+        self.assertEqual(user_policy.syncplay_access(client),
+                         user_policy.CREATE_AND_JOIN)
+        self.assertTrue(user_policy.may_create_syncplay_group(client))
+
+
+class LiveTvManagement(unittest.TestCase):
+
+    def test_the_flag_is_read(self):
+        self.assertFalse(user_policy.may_manage_live_tv(
+            _Client({"EnableLiveTvManagement": False})))
+        self.assertTrue(user_policy.may_manage_live_tv(
+            _Client({"EnableLiveTvManagement": True})))
+
+    def test_an_absent_flag_is_permitted(self):
+        """Absent means an answer we did not get — not a refusal. It is a
+        separate permission from `EnableLiveTvAccess`, so the presence of
+        that one says nothing either way."""
+        self.assertTrue(user_policy.may_manage_live_tv(
+            _Client({"EnableLiveTvAccess": True})))
+
+
+class TheOfflineSourceAnswers(unittest.TestCase):
+    """The offline source is what the online one falls back TO, so a missing
+    method turns a degraded screen into an AttributeError on the fallback
+    path — the same reasoning `has_live_tv` is declared there for."""
+
+    def test_it_declares_both(self):
+        from jellyfin_mpv_shim.mpvtk_browser.repository import OfflineLibrarySource
+
+        for name in ("syncplay_access", "can_manage_live_tv", "has_live_tv"):
+            with self.subTest(name=name):
+                self.assertTrue(callable(getattr(OfflineLibrarySource, name, None)))
+
+    def test_there_is_nobody_to_sync_with_offline(self):
+        from jellyfin_mpv_shim.mpvtk_browser.repository import OfflineLibrarySource
+
+        source = OfflineLibrarySource.__new__(OfflineLibrarySource)
+        self.assertEqual(source.syncplay_access("srv1"),
+                         user_policy.NO_SYNCPLAY)
+        self.assertFalse(source.can_manage_live_tv("srv1"))
+
+
+class TheTopBarButton(unittest.TestCase):
+    """`nav-syncplay` leads to a dialog whose join/create then 403s."""
+
+    def _bar(self, access):
+        from tests._shell_harness import build_scene, ids
+        from tests.test_live_tv import browser
+
+        b = browser()
+        if access is not None:
+            b.source.syncplay_access = lambda _srv, a=access: a
+        return ids(build_scene(b)[0])
+
+    def test_it_is_there_by_default(self):
+        self.assertIn("nav-syncplay", self._bar(None))
+
+    def test_full_access_keeps_it(self):
+        self.assertIn("nav-syncplay", self._bar(user_policy.CREATE_AND_JOIN))
+
+    def test_join_only_keeps_it(self):
+        """`JoinGroups` can use the dialog — only creating is refused."""
+        self.assertIn("nav-syncplay", self._bar(user_policy.JOIN_ONLY))
+
+    def test_a_refusal_removes_it(self):
+        self.assertNotIn("nav-syncplay", self._bar(user_policy.NO_SYNCPLAY))
+
+    def test_a_source_that_cannot_answer_keeps_it(self):
+        from tests._shell_harness import build_scene, ids
+        from tests.test_live_tv import browser
+
+        b = browser()
+
+        def boom(_srv):
+            raise RuntimeError("no")
+
+        b.source.syncplay_access = boom
+        self.assertIn("nav-syncplay", ids(build_scene(b)[0]))
+
+
+class ThePlayerSideButtons(unittest.TestCase):
+    """The HUD's SyncPlay button and the OSD menu's row.
+
+    Asked of the *player's* client rather than the browser's source: these
+    are up while something is playing, and what is playing decides which
+    server the question is about.
+    """
+
+    def _bridge(self, access):
+        from jellyfin_mpv_shim.osc_bridge import OscBridge
+        from tests.test_osc_bridge import FakePlayerManager, FakeVideo
+
+        pm = FakePlayerManager(FakeVideo())
+        pm.get_current_client = lambda: _Client({"SyncPlayAccess": access})
+        return OscBridge(pm), pm
+
+    def test_the_hud_button_goes(self):
+        """`None` from `_syncplay` is what removes the button entirely —
+        hud.py draws it only `if syncplay is not None`."""
+        bridge, _pm = self._bridge(user_policy.NO_SYNCPLAY)
+        self.assertNotIn("syncplay", bridge.build_state())
+
+    def test_the_hud_button_stays_for_join_only(self):
+        bridge, _pm = self._bridge(user_policy.JOIN_ONLY)
+        self.assertIn("syncplay", bridge.build_state())
+
+    def test_a_player_that_cannot_answer_keeps_it(self):
+        """`FakePlayerManager` has no `get_current_client` at all, which is
+        the inconclusive case: the button stays."""
+        from jellyfin_mpv_shim.osc_bridge import OscBridge
+        from tests.test_osc_bridge import FakePlayerManager, FakeVideo
+
+        bridge = OscBridge(FakePlayerManager(FakeVideo()))
+        self.assertIn("syncplay", bridge.build_state())
+
+    def test_the_osd_menu_asks_the_same_question(self):
+        """Two entry points to one dialog; they must not disagree about who
+        may reach it."""
+        import inspect
+
+        from jellyfin_mpv_shim.menu import OSDMenu
+
+        source = inspect.getsource(OSDMenu.show_menu)
+        self.assertIn("_may_syncplay()", source,
+                      "the OSD menu offers SyncPlay without consulting the "
+                      "permission the HUD button consults")
+
+
+class TheNewGroupButton(unittest.TestCase):
+    """The whole reason `SyncPlayAccess` is not a boolean."""
+
+    def _dialog(self, access):
+        from tests._shell_harness import build_scene, ids
+        from tests.test_live_tv import browser
+
+        b = browser()
+        b.source.syncplay_access = lambda _srv, a=access: a
+        b._show_syncplay("srv1", [], None)
+        return ids(build_scene(b)[0])
+
+    def test_full_access_can_create(self):
+        self.assertIn("sp-new", self._dialog(user_policy.CREATE_AND_JOIN))
+
+    def test_join_only_cannot(self):
+        found = self._dialog(user_policy.JOIN_ONLY)
+        self.assertNotIn("sp-new", found)
+        # ...but the dialog itself is still there and still usable.
+        self.assertIn("sp-close", found)
+
+
+class TheLiveTvTabs(unittest.TestCase):
+    """Schedule and Series are about scheduling. Recordings is not — a
+    finished recording is something you watch."""
+
+    def _tabs(self, may_manage):
+        from tests.test_live_tv import browser, open_live_tv
+
+        b = browser()
+        b.source.can_manage_live_tv = lambda _srv: may_manage
+        page = open_live_tv(b)
+        return [key for key, _label in page._tabs()]
+
+    def test_all_six_with_management(self):
+        self.assertEqual(len(self._tabs(True)), 6)
+
+    def test_the_scheduling_tabs_go_without_it(self):
+        tabs = self._tabs(False)
+        self.assertNotIn("schedule", tabs)
+        self.assertNotIn("series", tabs)
+
+    def test_watching_recordings_survives(self):
+        """The permission is about managing recordings, not about playing
+        the ones that exist."""
+        tabs = self._tabs(False)
+        for key in ("programs", "guide", "channels", "recordings"):
+            self.assertIn(key, tabs)
+
+    def test_a_hidden_tab_carried_in_on_a_route_falls_back(self):
+        """Otherwise the tab bar shows nothing selected and the body draws a
+        screen with no way out of it."""
+        from tests.test_live_tv import browser, open_live_tv
+
+        b = browser()
+        b.source.can_manage_live_tv = lambda _srv: False
+        page = open_live_tv(b, tab="schedule")
+        self.assertEqual(page._current_tab(), page.DEFAULT_TAB)
+
+    def test_a_source_that_cannot_answer_keeps_them(self):
+        from tests.test_live_tv import browser, open_live_tv
+
+        b = browser()
+        if hasattr(b.source, "can_manage_live_tv"):
+            del b.source.can_manage_live_tv
+        page = open_live_tv(b)
+        self.assertEqual(len(page._tabs()), 6)
+
+
+class TheRecordButtons(unittest.TestCase):
+    """`can_record` now answers two questions — can the apiclient, and may
+    this user — and both have to say yes."""
+
+    def test_it_still_fails_open(self):
+        from tests.test_live_tv import browser
+
+        self.assertTrue(browser()._actions.can_record("srv1"))
+
+    def test_the_permission_closes_it(self):
+        from tests.test_live_tv import browser
+
+        b = browser()
+        b.source.can_manage_live_tv = lambda _srv: False
+        self.assertFalse(b._actions.can_record("srv1"))
+
+    def test_the_apiclient_probe_still_closes_it(self):
+        """The older gate has to keep working: a user with every permission
+        on an apiclient that cannot schedule is still offered nothing."""
+        from tests.test_live_tv import FakeController, browser
+
+        controller = FakeController()
+        controller.live_tv_apis = lambda: False
+        b = browser(controller=controller)
+        b.source.can_manage_live_tv = lambda _srv: True
+        self.assertFalse(b._actions.can_record("srv1"))
+
+    def test_no_server_in_hand_fails_open(self):
+        """Callers that do not know which server they are asking about get
+        the old behaviour rather than a guess."""
+        from tests.test_live_tv import browser
+
+        b = browser()
+        b.source.can_manage_live_tv = lambda _srv: False
+        self.assertTrue(b._actions.can_record())
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
This adds real E2E tests against a live Jellyfin server created with [stdjflib](https://github.com/iwalton3/stdjflib).

It also includes a few fixes:
- Fix issue where text can overflow on certain DPI scaling settings.
- Fix issue where nebula selections outlines could overflow with the top UI bar.
- Use css-cover style placement for posters on all themes, not just nebula.
- Fix issue where playing via hover button and returning loses scroll position and blanks tile renderer.
- Prevent commands being sent to a terminated mpv instance.
- Hide syncplay and Live TV DVR when their respective permission checks fail.