### PR TITLE
Don't use /Download endpoint in photo viewer for users who are not allowed to download

### DIFF
--- a/docs/PERMISSION_GAPS.md
+++ b/docs/PERMISSION_GAPS.md
@@ -8,9 +8,9 @@ will refuse creates confusion and issue reports.** A user with SyncPlay
 revoked who is offered a SyncPlay button does not conclude they lack
 permission; they conclude the client is broken, and they are half right.
 
-**Items 1 and 3 are now fixed** (`jellyfin_mpv_shim/user_policy.py`); their
-sections below are kept as the record of what was wrong and why, with what
-shipped noted at the end of each. Item 2 is still open.
+**Items 1, 3 and 4 are now fixed** (`jellyfin_mpv_shim/user_policy.py`);
+their sections below are kept as the record of what was wrong and why, with
+what shipped noted at the end of each. Item 2 is still open.
 
 ## 1. SyncPlay is offered to users who do not have it  — FIXED
 
@@ -192,3 +192,47 @@ because `provision` skipped the account it authenticates as — and `qa-user`
 gets `EnableLiveTvManagement` as well, since its description already claimed
 everything a non-admin can have. The other ten accounts still lack it, which
 is the state this gap is about and is what makes it testable.
+
+## 4. A photo will not open for a user who may not download  — FIXED
+
+Found while researching what Jellyfin actually offers for books, which share
+the same endpoint. `qa-nodownload` is the account.
+
+`EnableContentDownloading` gates `GET /Items/{itemId}/Download`
+(`[Authorize(Policy = Policies.Download)]`, `LibraryController.cs:669`), and
+that endpoint is not only how a download is taken — it was the shim's
+ordinary path to a **photo's** bytes (`media.py:get_playback_url`, the
+`is_photo` branch). So for this account every picture in the library failed
+to open. Same family as the gaps above, but worse in one way: SyncPlay
+without permission gives a button that fails, which at least suggests
+something was refused. A photo that will not open looks like a broken client.
+
+It is also the only path to a **book's** bytes at all, since `Book` is not
+`IHasMediaSources` and so has no stream endpoint — worth knowing before book
+support is written, because there the permission is unavoidable and the
+answer has to be a clear message rather than a fallback.
+
+**What shipped.** `user_policy.may_download`, same module and the same
+fail-open rule: only an answer the server actually gave closes the gate,
+because closing it on a failed fetch would send every photo through the
+resizer for no reason. The photo branch already had an image-endpoint path
+for HEIC and raw — mpv's ffmpeg often cannot decode those, so the server
+converts them — and the permission now routes into the same place. One
+condition, one fallback, and the two roads are independent: a HEIC is
+unaffected either way.
+
+This is **parity, not a divergence**. jellyfin-web draws the same line in
+`src/components/slideshow/slideshow.js:getImgUrl`, which reaches for
+`getDownloadUrl` only when `user.Policy.EnableContentDownloading` is set and
+otherwise serves the same picture from the image endpoint. The download url
+is the original-quality *upgrade*, never the load-bearing path — which is
+why the fix is a fallback rather than dropping the download url for
+everybody.
+
+Pinned by `tests/test_user_policy.py` (the accessor), `tests/test_photos.py`
+(`PhotoDownloadPermissionTest`, the branch and the token rule) and
+`tests/e2e/test_account_policy.py:ContentDownloadingPermissionTest` — which
+is where the field spelling is checked, and where the *premise* is: that the
+server really answers 401/403 on the download for `qa-nodownload` and really
+serves 200 on the image endpoint. If it ever stops refusing, that test is
+what will say the fallback is unnecessary.

--- a/jellyfin_mpv_shim/media.py
+++ b/jellyfin_mpv_shim/media.py
@@ -10,6 +10,7 @@ from . import conf
 from .conf import settings
 from .language_config import apply as apply_language_config
 from .utils import is_local_domain, get_profile, get_seq
+from .user_policy import may_download
 from .i18n import _
 
 log = logging.getLogger("media")
@@ -646,12 +647,23 @@ class Video(object):
             # drops the token, so leaving them at the apiclient's default
             # sent both, and a photo was the one thing still putting a token
             # in a query string after all of the above.
+            #
+            # The image endpoint is also the fallback for a user who may not
+            # download. /Items/{id}/Download is permission-gated, so without
+            # EnableContentDownloading the original bytes are simply not
+            # reachable -- and a picture that will not open reads as a broken
+            # client, not as a permission. The same picture comes back from
+            # the image endpoint, which needs no permission, so the download
+            # url is the original-quality *upgrade* rather than the only way
+            # in. jellyfin-web draws exactly this line (slideshow.js:
+            # getImgUrl). Fails open: see user_policy.may_download.
             keep_token = not self.auth_via_header
             container = (self.item.get("Container") or "").lower()
             path = (self.item.get("Path") or "").lower()
-            if container in _SERVER_CONVERTED_IMAGES or any(
+            if (container in _SERVER_CONVERTED_IMAGES or any(
                     path.endswith("." + ext)
-                    for ext in _SERVER_CONVERTED_IMAGES):
+                    for ext in _SERVER_CONVERTED_IMAGES)
+                    or not may_download(self.client)):
                 return self.client.jellyfin.artwork(
                     self.item_id, "Primary", _PHOTO_MAX_WIDTH,
                     include_apikey=keep_token)

--- a/jellyfin_mpv_shim/user_policy.py
+++ b/jellyfin_mpv_shim/user_policy.py
@@ -101,3 +101,27 @@ def may_manage_live_tv(client):
     if "EnableLiveTvManagement" not in policy:
         return True
     return bool(policy.get("EnableLiveTvManagement"))
+
+
+def may_download(client):
+    """`EnableContentDownloading` — may this user use `/Items/{id}/Download`?
+
+    A *fourth* independently-granted permission, and the one with the widest
+    blast radius, because that endpoint is not only how a download is taken:
+    it is the only path to a Photo's original bytes, and the only path to a
+    Book's bytes at all. So a user without it does not merely lose the
+    Download button — a picture fails to open, with no hint as to why.
+
+    jellyfin-web takes exactly this line for photos: `slideshow.js:getImgUrl`
+    reaches for the download URL only when the policy allows, and otherwise
+    serves the same picture from the image endpoint, which needs no
+    permission. The download URL is the original-quality *upgrade*, never the
+    load-bearing path.
+
+    Absent means an answer we did not get, so: permitted. Closing this gate
+    on a failed fetch would send every photo through the resizer.
+    """
+    policy = policy_for(client) or {}
+    if "EnableContentDownloading" not in policy:
+        return True
+    return bool(policy.get("EnableContentDownloading"))

--- a/tests/e2e/test_account_policy.py
+++ b/tests/e2e/test_account_policy.py
@@ -9,10 +9,10 @@ path above it.
 **Two of the gaps these tests turned up are now closed** (`user_policy.py`)
 and asserted below: SyncPlay is not offered to a user the server refuses it
 to, and the Record affordances are not offered without
-`EnableLiveTvManagement`. `EnableContentDownloading` is still unread, and
-Live TV *browsing* was already gated by whether the server put a Live TV
-view in `/Views` (`repository.get_libraries`). See
-`docs/PERMISSION_GAPS.md`.
+`EnableLiveTvManagement`. `EnableContentDownloading` is now read too -- a photo falls
+back to the image endpoint rather than failing to open -- and Live TV
+*browsing* was already gated by whether the server put a Live TV view in
+`/Views` (`repository.get_libraries`). See `docs/PERMISSION_GAPS.md`.
 
 Two things that are *not* tested here, because measurement said they are not
 true (both in `docs/E2E_PLAN.md`):
@@ -294,3 +294,108 @@ class LiveTvManagementPermissionTest(unittest.TestCase):
 
 if __name__ == "__main__":
     unittest.main()
+
+
+@_e2e.require_server
+class ContentDownloadingPermissionTest(unittest.TestCase):
+    """`qa-nodownload` — a photo must still open.
+
+    `/Items/{id}/Download` is the shim's ordinary path to a photo's bytes and
+    it is permission-gated, so without `EnableContentDownloading` every
+    picture in the library failed to open. The fallback is the image
+    endpoint, which needs no permission.
+
+    End to end because a unit test cannot check the *spelling*: the branch is
+    provable with a hand-written dict, but that the server really returns
+    `EnableContentDownloading` on `/Users/Me`, and really refuses the
+    download for this account, are answers only the server has.
+    """
+
+    def _session(self, account):
+        session = _e2e.Session(account)
+        self.addCleanup(session.stop)
+        return session
+
+    def test_the_policy_field_is_spelled_the_way_the_client_reads_it(self):
+        from jellyfin_mpv_shim import user_policy
+
+        session = self._session("qa-nodownload")
+        self.assertFalse(
+            user_policy.may_download(session.client),
+            "qa-nodownload came back as permitted — either the account no "
+            "longer has downloading revoked, or the field is not where the "
+            "client looks for it")
+
+    def test_an_ordinary_account_still_may(self):
+        """The control. Without it the test above passes just as well if the
+        client answers "no" to everybody, which would send every photo
+        through the resizer."""
+        from jellyfin_mpv_shim import user_policy
+
+        self.assertTrue(user_policy.may_download(
+            self._session("qa-user").client))
+
+    def test_the_server_really_does_refuse_the_download(self):
+        """The premise. If this ever starts answering 200 the fallback is
+        unnecessary, and this test is what will say so."""
+        session = self._session("qa-nodownload")
+        item_id = _photo_id(session)
+        response = _raw_get(
+            session, "/Items/%s/Download" % item_id)
+        self.assertIn(response, (401, 403),
+                      "expected the download to be refused, got %s"
+                      % response)
+
+    def test_and_really_does_serve_the_same_photo_as_an_image(self):
+        """The fallback has to actually work for this account, not merely be
+        a different url."""
+        session = self._session("qa-nodownload")
+        item_id = _photo_id(session)
+        response = _raw_get(
+            session, "/Items/%s/Images/Primary" % item_id,
+            params={"MaxWidth": 3840, "format": "jpg"})
+        self.assertEqual(response, 200)
+
+    def test_the_url_the_client_builds_is_the_image_one(self):
+        """The whole path, not just the accessor: what `get_playback_url`
+        actually hands mpv for this account."""
+        from jellyfin_mpv_shim.media import Video
+
+        session = self._session("qa-nodownload")
+        item_id = _photo_id(session)
+
+        class _Parent:
+            is_local = True
+            client = session.client
+
+        url = Video(item_id, _Parent()).get_playback_url()
+        self.assertIn("/Images/Primary", url)
+        self.assertNotIn("/Download", url)
+
+
+def _photo_id(session):
+    """Any Photo on the server. stdjflib's Photos library is the source."""
+    result = session.client.jellyfin.user_items(params={
+        "IncludeItemTypes": "Photo",
+        "Recursive": True,
+        "Limit": 1,
+    }) or {}
+    items = result.get("Items") or []
+    if not items:
+        raise unittest.SkipTest(
+            "no Photo on the server — build stdjflib's Photos library")
+    return items[0]["Id"]
+
+
+def _raw_get(session, path, params=None):
+    """Status code only, with this session's token. The apiclient raises or
+    swallows depending on the failure, and the status is the whole point."""
+    import requests
+
+    return requests.get(
+        _e2e.SERVER + path,
+        params=params or {},
+        headers={"Authorization": 'MediaBrowser Token="%s"' % session.token},
+        timeout=30,
+        allow_redirects=False,
+    ).status_code

--- a/tests/test_photos.py
+++ b/tests/test_photos.py
@@ -25,13 +25,23 @@ from tests._shell_harness import (  # noqa: E402
 
 
 class _Jellyfin:
-    def __init__(self, item):
+    def __init__(self, item, policy=None):
         self._item = item
+        self._policy = policy
         self.calls = []
         self.apikeys = []
+        self.user_calls = 0
 
     def get_item(self, item_id):
         return dict(self._item, Id=item_id)
+
+    # Modelled because `may_download` reads it. A fake without it would send
+    # every photo down the fail-open path, so the permission branch would be
+    # unreachable while the suite reported a pass -- which is the exact
+    # failure `tools/audit_fake_contracts.py` exists to catch.
+    def get_user(self):
+        self.user_calls += 1
+        return {"Policy": self._policy} if self._policy is not None else {}
 
     # Both mirror the apiclient's own signature, ApiKey spelling and
     # include_apikey default. The default is the point: it is what made a
@@ -55,15 +65,15 @@ class _Jellyfin:
 
 
 class _Client:
-    def __init__(self, item):
-        self.jellyfin = _Jellyfin(item)
+    def __init__(self, item, policy=None):
+        self.jellyfin = _Jellyfin(item, policy)
 
 
 class _Parent:
     is_local = True
 
-    def __init__(self, item):
-        self.client = _Client(item)
+    def __init__(self, item, policy=None):
+        self.client = _Client(item, policy)
 
 
 class PhotoUrlTest(unittest.TestCase):
@@ -74,9 +84,9 @@ class PhotoUrlTest(unittest.TestCase):
     Confirmed against a live server: web fetches the file itself.
     """
 
-    def _video(self, **item):
+    def _video(self, policy=None, **item):
         item.setdefault("Type", PHOTO_TYPE)
-        parent = _Parent(item)
+        parent = _Parent(item, policy)
         v = Video("ph1", parent)
         return v, parent.client.jellyfin
 
@@ -115,6 +125,84 @@ class PhotoUrlTest(unittest.TestCase):
 
     def test_heic_is_in_the_converted_set(self):
         self.assertIn("heic", _SERVER_CONVERTED_IMAGES)
+
+
+class PhotoDownloadPermissionTest(unittest.TestCase):
+    """A photo must open for a user who may not download.
+
+    `/Items/{id}/Download` is `[Authorize(Policy = Policies.Download)]`, and
+    it is the shim's ordinary path to a photo's bytes -- so without
+    `EnableContentDownloading` every picture in the library failed to open,
+    which reads as a broken client rather than as a permission. The image
+    endpoint serves the same picture and needs no permission.
+
+    jellyfin-web draws the line in the same place (`slideshow.js:getImgUrl`),
+    so this is parity, not a divergence.
+    """
+
+    def _video(self, policy=None, **item):
+        item.setdefault("Type", PHOTO_TYPE)
+        item.setdefault("Container", "jpg")
+        item.setdefault("Path", "/pics/a.jpg")
+        parent = _Parent(item, policy)
+        return Video("ph1", parent), parent.client.jellyfin
+
+    def test_a_user_who_may_not_download_still_sees_the_photo(self):
+        v, jf = self._video({"EnableContentDownloading": False})
+        url = v.get_playback_url()
+        self.assertIn("/Images/Primary", url)
+        self.assertEqual(jf.calls[-1],
+                         ("artwork", "ph1", "Primary", _PHOTO_MAX_WIDTH))
+
+    def test_a_user_who_may_download_still_gets_the_original(self):
+        """The download url is the quality upgrade. Taking it away from
+        everyone would be a regression dressed as a fix."""
+        v, jf = self._video({"EnableContentDownloading": True})
+        self.assertIn("/Download", v.get_playback_url())
+        self.assertEqual(jf.calls[-1][0], "download")
+
+    def test_an_older_server_that_never_says_keeps_the_original(self):
+        """Fail open: a policy without the field is an answer we did not
+        get, and closing the gate on it sends every photo through the
+        resizer for no reason."""
+        v, jf = self._video({"SyncPlayAccess": "CreateAndJoinGroups"})
+        self.assertIn("/Download", v.get_playback_url())
+
+    def test_a_policy_that_could_not_be_fetched_keeps_the_original(self):
+        v, jf = self._video(None)
+        self.assertIn("/Download", v.get_playback_url())
+
+    def test_heic_ignores_the_permission_entirely(self):
+        """It was already going to the image endpoint, and for an unrelated
+        reason. Both roads lead there; neither shadows the other."""
+        for allowed in (True, False):
+            with self.subTest(allowed=allowed):
+                v, jf = self._video({"EnableContentDownloading": allowed},
+                                    Container="heic", Path="/pics/a.HEIC")
+                self.assertIn("/Images/Primary", v.get_playback_url())
+
+    def test_the_policy_is_read_once_not_per_photo(self):
+        """A slideshow calls this per slide. An uncached read would be a
+        request per picture."""
+        item = {"Type": PHOTO_TYPE, "Container": "jpg", "Path": "/p/a.jpg"}
+        parent = _Parent(item, {"EnableContentDownloading": False})
+        for _ in range(5):
+            Video("ph1", parent).get_playback_url()
+        self.assertEqual(parent.client.jellyfin.user_calls, 1)
+
+    def test_the_fallback_still_drops_the_token_when_the_header_is_set(self):
+        """The permission branch returns from inside the photo block, which
+        is the one that predates the header work -- so it has to obey the
+        same rule as the two beside it."""
+        v, jf = self._video({"EnableContentDownloading": False})
+        v.auth_via_header = True
+        url = v.get_playback_url()
+        # The endpoint assertion is what makes this about the fallback: the
+        # download url drops the token too, so a token-only check passes
+        # whether or not the permission is ever consulted.
+        self.assertIn("/Images/Primary", url)
+        self.assertNotIn("ApiKey", url)
+        self.assertIs(jf.apikeys[-1], False)
 
 
 class PhotoUrlAuthTest(unittest.TestCase):

--- a/tests/test_user_policy.py
+++ b/tests/test_user_policy.py
@@ -117,6 +117,30 @@ class LiveTvManagement(unittest.TestCase):
             _Client({"EnableLiveTvAccess": True})))
 
 
+class ContentDownloading(unittest.TestCase):
+    """`EnableContentDownloading` gates `/Items/{id}/Download`, which is not
+    only the Download button: it is the only path to a Photo's original
+    bytes and the only path to a Book's bytes at all."""
+
+    def test_the_flag_is_read(self):
+        self.assertFalse(user_policy.may_download(
+            _Client({"EnableContentDownloading": False})))
+        self.assertTrue(user_policy.may_download(
+            _Client({"EnableContentDownloading": True})))
+
+    def test_an_absent_flag_is_permitted(self):
+        """Fail open. Closing this one on a policy we could not read would
+        send every photo through the resizer."""
+        self.assertTrue(user_policy.may_download(
+            _Client({"EnableLiveTvAccess": True})))
+
+    def test_a_fetch_that_failed_is_permitted(self):
+        self.assertTrue(user_policy.may_download(_Client(raises=True)))
+
+    def test_no_client_is_permitted(self):
+        self.assertTrue(user_policy.may_download(None))
+
+
 class TheOfflineSourceAnswers(unittest.TestCase):
     """The offline source is what the online one falls back TO, so a missing
     method turns a degraded screen into an AttributeError on the fallback


### PR DESCRIPTION
Pinned by E2E tests to confirm it works on a qa-nodownload account for images and manually tested to confirm no regressions.