### PR TITLE
E2e collections support

### DIFF
--- a/docs/E2E_PLAN.md
+++ b/docs/E2E_PLAN.md
@@ -161,6 +161,7 @@ Green on both backends. See `tests/e2e/README.md` to run it.
 | `test_keyboard_nav` | contract | 20 | keyboard reach/activation of real screens; duplicate node ids |
 | `test_large_queue` | contract | — | 400-id queue metadata; the 414 request-line limit |
 | `test_connection_loss` | contract | — | server gone / token revoked / a page-in that fails after a screenful drew |
+| `test_collections` | contract | — | box sets: an unscoped toggle query, `ChildCount` 0 against a full listing, an untyped listing keeping a Series member, create/add/remove, and the permission an ordinary account lacks |
 | `test_playback_advance` | playback | 1, 5 | queue advance + watched-marking + resume position |
 | `test_playback_eof` | playback | 2, 3, 4 | last-in-queue, seek-to-end (#541), replay (#157/#323) |
 | `test_playback_failure` | playback | 7, 8 | truncated, zero-byte, single-frame |

--- a/docs/PERMISSION_GAPS.md
+++ b/docs/PERMISSION_GAPS.md
@@ -8,7 +8,7 @@ will refuse creates confusion and issue reports.** A user with SyncPlay
 revoked who is offered a SyncPlay button does not conclude they lack
 permission; they conclude the client is broken, and they are half right.
 
-**Items 1, 3 and 4 are now fixed** (`jellyfin_mpv_shim/user_policy.py`);
+**Items 1, 3, 4 and 5 are now fixed** (`jellyfin_mpv_shim/user_policy.py`);
 their sections below are kept as the record of what was wrong and why, with
 what shipped noted at the end of each. Item 2 is still open.
 
@@ -236,3 +236,66 @@ is where the field spelling is checked, and where the *premise* is: that the
 server really answers 401/403 on the download for `qa-nodownload` and really
 serves 200 on the image endpoint. If it ever stops refusing, that test is
 what will say the fallback is unnecessary.
+
+## 5. Collections are offered to users who cannot edit them  — FIXED
+
+Found while writing `tests/e2e/test_collections.py` against stdjflib's new
+collection fixtures: `POST /Collections` answered **403 for every non-admin
+account on the server**, and the shim had offered the button to all of them.
+
+`EnableCollectionManagement` is a **fifth** independently-granted permission,
+off by default for any account created on a modern server
+(`UserEntityExtensions.cs:193` adds it as `false`). What it gates is not one
+route but the whole of `CollectionController`: the `[Authorize(Policy =
+Policies.CollectionManagement)]` is on the **controller**, so creating a
+collection, adding an item to one and removing an item from one are one
+permission and one refusal. Three entry points in the shim, all of them
+unconditional:
+
+| Entry point | Where |
+| --- | --- |
+| "Collections…" in the Add To dialog | `mpvtk_browser/dialogs.py` (`add-collections`) |
+| The picker and its Create box behind it | `dialogs._show_add_to_collection` |
+| "Remove from Collection" in the tile menu | `mpvtk_browser/tiles.py` (`uncollect`) |
+
+All three were gated on `edit_apis()`, which asks whether the *apiclient* has
+the methods — a real question, and a different one from whether this user may
+call them. So the answer was yes for everybody, and pressing any of them
+produced "The change could not be applied.", indistinguishable from a
+network problem.
+
+**There is no administrator bypass**, and this is the one place to be careful
+copying jellyfin-web. `UserPermissionHandler` asks `HasPermission` and stops,
+exactly as it does for Live TV management. jellyfin-web reads the flag as
+`user.Policy.IsAdministrator || user.Policy.EnableCollectionManagement`
+(`itemContextMenu.js:143`, `multiSelect.js:198`, `LibraryToolbar.tsx:69`),
+which offers the button to an admin the API will refuse. That spelling is
+right for `BoxSet.IsAuthorizedToDelete`, which really does check both — and
+wrong for the endpoint the button calls. We ask what the endpoint asks.
+
+**What shipped.** `user_policy.may_manage_collections`, same module and the
+same fail-open rule, reached through `LibrarySource.can_manage_collections`
+and `ItemActions.can_manage_collections` — the latter answering the two
+questions together, as `can_record` does: can the apiclient, and may this
+user, both have to say yes.
+
+**Playlists deliberately do not move with it.** `PlaylistController` carries
+no such policy, so a user who cannot touch a collection can still make a
+playlist; gating both would have taken away something that works, which is
+the shape of half the bugs in this document. The Add To dialog therefore
+keeps its playlist half in full and loses only the door to the collections
+picker. `tests/test_user_policy.py:TheCollectionAffordances` asserts that as
+hard as it asserts the hiding.
+
+**The stdjflib half.** `qa-user`'s description already claimed "everything a
+non-admin can have" and this was missing from its policy, so no account on
+the QA server except the administrator could reach the feature at all — the
+same omission, and the same fix, as `EnableLiveTvManagement` in item 3.
+Granted there now; the other ten accounts still lack it, which is the state
+this gap is about and is what makes it testable.
+
+Pinned by `tests/test_user_policy.py` (the accessor, the two affordances, and
+that playlists survive) and `tests/e2e/test_collections.py:CollectionPermissionTest`,
+which is where the field *spelling* is checked and where the premise lives:
+that the server really would have refused. If Jellyfin ever relaxes this, that
+test fails and hiding the button becomes the thing to reconsider.

--- a/jellyfin_mpv_shim/mpvtk_browser/dialogs.py
+++ b/jellyfin_mpv_shim/mpvtk_browser/dialogs.py
@@ -116,7 +116,15 @@ class DialogsMixin:
             # Gated on whether the SOURCE does collections, not on whether
             # any exist — gating on the latter meant you could never create
             # your first one. The offline catalog has none either way.
-            if hasattr(self.source, "get_collections") and not self._offline:
+            #
+            # And on the permission, which is a different question from the
+            # apiclient capability `can_edit` answers: the whole of
+            # CollectionController is behind EnableCollectionManagement, and
+            # a newly created account does not have it. Without this the
+            # button opened a picker whose every row 403s. Playlists stay,
+            # because PlaylistController has no such policy.
+            if (hasattr(self.source, "get_collections") and not self._offline
+                    and self._actions.can_manage_collections(server)):
                 buttons.append(Button(
                     _("Collections…"), id="add-collections",
                     on_click=lambda: self._show_add_to_collection(

--- a/jellyfin_mpv_shim/mpvtk_browser/item_actions.py
+++ b/jellyfin_mpv_shim/mpvtk_browser/item_actions.py
@@ -428,6 +428,35 @@ class ItemActions:
         except Exception:
             return True
 
+    def can_manage_collections(self, server=None):
+        """Whether the *collection* edit affordances should be offered.
+
+        `can_edit` is the apiclient question and answers for playlists and
+        collections together; this adds the half that is only about
+        collections. `EnableCollectionManagement` gates the whole of
+        `CollectionController` — create, add and remove are one permission —
+        and a new account does not have it, so without this the Collections…
+        button and Remove from Collection are offered to most users on a
+        modern server and answer 403.
+
+        Playlists are deliberately NOT gated with it: `PlaylistController`
+        has no such policy, so a user who cannot touch a collection can still
+        make a playlist, and hiding both would take away something that works.
+
+        Fails OPEN in both halves, as `can_record` does: only a probe that
+        positively answers False hides anything.
+        """
+        if not self.can_edit():
+            return False
+        source = getattr(self.services, "source", None)
+        ask = getattr(source, "can_manage_collections", None)
+        if ask is None or server is None:
+            return True
+        try:
+            return bool(ask(server))
+        except Exception:
+            return True
+
     def can_edit(self):
         """Whether the apiclient can edit playlists/collections.
 

--- a/jellyfin_mpv_shim/mpvtk_browser/repository.py
+++ b/jellyfin_mpv_shim/mpvtk_browser/repository.py
@@ -486,6 +486,14 @@ class LibrarySource:
         except Exception:
             return True                 # fails open; see user_policy
 
+    def can_manage_collections(self, server_uuid):
+        from ..user_policy import may_manage_collections
+
+        try:
+            return may_manage_collections(self._conn(server_uuid).client)
+        except Exception:
+            return True                 # fails open; see user_policy
+
     # -- home screen layout (shared with jellyfin-web) ---------------------
 
     def _display_prefs_dto(self, api):
@@ -2687,6 +2695,11 @@ class OfflineLibrarySource:
         return NO_SYNCPLAY
 
     def can_manage_live_tv(self, server_uuid):
+        return False
+
+    def can_manage_collections(self, server_uuid):
+        """No server to write to. Declared for the same reason the others
+        are: the offline source is what the online one falls back TO."""
         return False
 
     def get_genres(self, server_uuid, parent_id=None):

--- a/jellyfin_mpv_shim/mpvtk_browser/tiles.py
+++ b/jellyfin_mpv_shim/mpvtk_browser/tiles.py
@@ -262,9 +262,13 @@ class TilesMixin:
                 and item.get("PlaylistItemId") and not self._offline
                 and self._edit_apis()):
             out.append((_("Remove from Playlist"), "delete", "unplaylist"))
+        # can_manage_collections, not _edit_apis: the apiclient having the
+        # method is not the same question as the user being allowed to call
+        # it, and EnableCollectionManagement is off for a new account.
         if (self.route.get("parent_type") == "BoxSet"
                 and item.get("Id") and not self._offline
-                and self._edit_apis()):
+                and self._actions.can_manage_collections(
+                    self.route.get("server") or self.server)):
             out.append((_("Remove from Collection"), "delete", "uncollect"))
         return out
 

--- a/jellyfin_mpv_shim/user_policy.py
+++ b/jellyfin_mpv_shim/user_policy.py
@@ -125,3 +125,29 @@ def may_download(client):
     if "EnableContentDownloading" not in policy:
         return True
     return bool(policy.get("EnableContentDownloading"))
+
+
+def may_manage_collections(client):
+    """`EnableCollectionManagement` — may this user write to a collection?
+
+    A *fifth* independently-granted permission, and the whole of
+    `CollectionController` sits behind it: `[Authorize(Policy =
+    Policies.CollectionManagement)]` is on the controller, not on individual
+    routes, so creating a collection, adding to one and removing from one are
+    one permission and one 403.
+
+    **There is no administrator bypass.** `UserPermissionHandler` asks
+    `HasPermission` and stops, exactly as it does for Live TV management — so
+    an admin without the flag is refused like anyone else. jellyfin-web reads
+    it as `IsAdministrator || EnableCollectionManagement`
+    (`itemContextMenu.js:143`), which offers the button to an admin the API
+    will refuse; that spelling is right for `BoxSet.IsAuthorizedToDelete`,
+    which really does bypass, and wrong for the endpoint the button calls.
+    We ask what the endpoint asks.
+
+    Absent means an answer we did not get, so: permitted.
+    """
+    policy = policy_for(client) or {}
+    if "EnableCollectionManagement" not in policy:
+        return True
+    return bool(policy.get("EnableCollectionManagement"))

--- a/tests/e2e/README.md
+++ b/tests/e2e/README.md
@@ -52,6 +52,7 @@ E1 and E2 exist so far:
 | `test_keyboard_nav` | E1 | reaching and activating the library by keyboard, online |
 | `test_large_queue` | E1 | a queue too big for one request line (the 414) |
 | `test_connection_loss` | E1 | the server stops answering: gone, token revoked, or a page-in that fails after a screenful drew |
+| `test_collections` | E1 | box sets: the toggle's unscoped query, a `collection.xml`'s members against its `ChildCount` of 0, a Series member surviving an untyped listing, and create/add/remove through the gateway |
 | `test_syncplay_playback` | E2 | **the real player in a real group** — stop halts rather than leaves (and leaves when the UI says the SyncPlay menu is unreachable), a halted player is not driven, resume replays the group's content |
 | `test_playback_advance` | E2 | an episode finishes and the next starts; the server agrees; resume position |
 | `test_playback_eof` | E2 | last-in-queue watched-marking, seek-to-end (#541), replaying a finished episode (#157/#323) |
@@ -260,6 +261,26 @@ runner then called failed. `_terminate_player` does it explicitly.
 exists because a use-after-free on the mpv handle is a SIGSEGV, and a segfault
 in-process loses the whole run instead of failing one test. Same reasoning as
 `tests/integration/_idle_reopen_child.py`.
+
+**A collection's `ChildCount` is 0 and its members are still there.**
+A `collection.xml` is parsed into the in-memory item and its linked children
+are never written to the table the count is read from, so every collection
+stdjflib builds from a file reports 0 for ever while `GET /Items?parentId=`
+returns all of them. Measuring a collection by `ChildCount` is what makes a
+working collection look broken; stdjflib's `docs/COLLECTION_XML_BUGS.md` has
+the reproduction. The API-made ones (`Api Made Collection` and friends) count
+correctly, which is what makes the pair a control.
+
+**A collection holds any item type, from any library, and must be listed
+untyped.** `Two Libraries, One Collection` is a Series and a Movie. The
+typed+recursive query a library grid makes returns neither — it recurses past
+the collection — so `_open_item` passes the BoxSet's own collection type,
+which is none. Test both halves or the untyped query reads as an oversight.
+
+**Creating a collection needs `EnableCollectionManagement`**, which is off for
+every non-admin account on a fresh server and has no administrator bypass —
+the same shape as `EnableLiveTvManagement`. So the edit tests run as
+`qa-admin`, and the refusal an ordinary account gets is asserted on its own.
 
 **Bulk items all share a creation time.** They are built by one scan, so
 `DateCreated` ties and the server falls back to name order — "Date Added" and

--- a/tests/e2e/README.md
+++ b/tests/e2e/README.md
@@ -277,10 +277,14 @@ typed+recursive query a library grid makes returns neither — it recurses past
 the collection — so `_open_item` passes the BoxSet's own collection type,
 which is none. Test both halves or the untyped query reads as an oversight.
 
-**Creating a collection needs `EnableCollectionManagement`**, which is off for
-every non-admin account on a fresh server and has no administrator bypass —
-the same shape as `EnableLiveTvManagement`. So the edit tests run as
-`qa-admin`, and the refusal an ordinary account gets is asserted on its own.
+**Editing a collection needs `EnableCollectionManagement`**, which is off for
+a newly created account and has no administrator bypass — the whole of
+`CollectionController` is behind it, so create, add and remove are one
+permission and one 403. stdjflib grants it to `qa-user` (and `qa-admin`), so
+the edit tests run as the **ordinary** account; the refusal is asserted
+against `qa-restricted`, one of the ten that still lack it. Deleting the
+fixture afterwards is a *different* permission (`EnableContentDeletion`),
+which is the only thing the admin session in that class is for.
 
 **Bulk items all share a creation time.** They are built by one scan, so
 `DateCreated` ties and the server falls back to name order — "Date Added" and

--- a/tests/e2e/run_e2e.py
+++ b/tests/e2e/run_e2e.py
@@ -47,6 +47,14 @@ CONTRACT = [
     "tests.e2e.test_keyboard_nav",
     "tests.e2e.test_large_queue",
     "tests.e2e.test_connection_loss",
+    # Landed after the runner's list was last touched and never added to it,
+    # so it ran only when somebody named it by hand. The README has always
+    # listed it as part of the suite.
+    "tests.e2e.test_auto_download",
+    # Collections: the one container whose DTO the server fills in wrongly
+    # (ChildCount is 0 for a collection read off disk while the listing has
+    # every member), plus the three edit endpoints nothing else calls.
+    "tests.e2e.test_collections",
     # Two real clients on one real group. No mpv: SyncPlay drives a player
     # through a handful of calls and the harness implements those, so this is
     # a contract question about the server and the protocol.

--- a/tests/e2e/test_collections.py
+++ b/tests/e2e/test_collections.py
@@ -24,14 +24,16 @@ a film from Movies. So the listing must go out **untyped and non-recursive**
 vanishes; the test below asserts both halves so the untyped query is not
 "simplified" into the typed one.
 
-**Creating a collection needs a permission a new account does not have.**
-`POST /Collections` is 403 without `EnableCollectionManagement`, which is off
-for every non-admin account on a fresh server — the same shape as
-`EnableLiveTvManagement` (see stdjflib's `docs/PERMISSION_GAPS.md`). The shim
-offers the affordance regardless and reports the failure as a toast, which is
-what `_edit`'s "RAISES on failure" contract buys; the test here is that it
-does raise, because an edit path that swallowed would leave the user looking
-at a dialog that closed and a collection that was never made.
+**Editing a collection needs a permission a new account does not have.**
+The whole of `CollectionController` is behind
+`EnableCollectionManagement` — the `[Authorize]` is on the controller, not
+its routes — and it is off for a newly created account with no administrator
+bypass, the same shape as `EnableLiveTvManagement` (see
+`docs/PERMISSION_GAPS.md` §5). So the shim hides the affordances for an
+account that lacks it, and this is where the *field name* is checked: a unit
+test builds the policy dict it then reads and would pass against a misspelt
+key. The refusal itself is asserted too, because hiding a button is only
+right for as long as pressing it would have failed.
 
 And the three edit endpoints — `new_collection`, `add_collection_items`,
 `remove_collection_items` — are exercised end to end through the real
@@ -345,9 +347,13 @@ class CollectionRouteTest(_CollectionCase):
 class CollectionEditTest(unittest.TestCase):
     """Create, add, remove — through the gateway, against the real server.
 
-    Runs as **qa-admin**, because `POST /Collections` needs
-    `EnableCollectionManagement` and no other account here has it (see
-    `CollectionPermissionTest`).
+    Runs as **qa-user**, an ordinary non-admin, because that is the account
+    the affordance is for and because `EnableCollectionManagement` has no
+    administrator bypass: asking qa-admin would prove the endpoints work for
+    somebody nobody is worried about. A second, admin session exists only to
+    **delete** the fixture — `EnableContentDeletion` is a different
+    permission that qa-user does not have and the shim never asks for, since
+    deleting a collection is not something the browser offers.
 
     This class owns its fixture: it makes its own collection and deletes it,
     in `setUp` as well as on cleanup, so a run that died halfway cannot leave
@@ -360,16 +366,21 @@ class CollectionEditTest(unittest.TestCase):
 
     @classmethod
     def setUpClass(cls):
-        cls.session = _e2e.Session("qa-admin")
-        policy = cls.session.policy() or {}
-        if not policy.get("EnableCollectionManagement"):
+        cls.session = _e2e.Session("qa-user")
+        if not (cls.session.policy() or {}).get(
+                "EnableCollectionManagement"):
             cls.session.stop()
             raise unittest.SkipTest(
-                "qa-admin cannot manage collections on this server")
+                "qa-user cannot manage collections on this server — this "
+                "library predates stdjflib granting it; reprovision")
+        cls.admin = _e2e.Session("qa-admin")
 
     @classmethod
     def tearDownClass(cls):
-        cls.session.stop()
+        try:
+            cls.admin.stop()
+        finally:
+            cls.session.stop()
 
     def setUp(self):
         from types import SimpleNamespace
@@ -398,9 +409,12 @@ class CollectionEditTest(unittest.TestCase):
         deps.clientManager = self._real_manager
 
     def _delete_fixture(self):
+        # As admin: DELETE /Items is EnableContentDeletion, a different
+        # permission from the one under test, and qa-user has neither it nor
+        # any need for it.
         for found in self._find_all():
             try:
-                self.session.api.delete_item(found["Id"])
+                self.admin.api.delete_item(found["Id"])
             except Exception:
                 pass
 
@@ -473,42 +487,100 @@ class CollectionEditTest(unittest.TestCase):
 
 @_e2e.require_server
 class CollectionPermissionTest(unittest.TestCase):
-    """Creating a collection is a permission an ordinary account lacks.
+    """An account that may not manage collections is not offered the controls.
 
     `EnableCollectionManagement` is off for a newly created Jellyfin user and
-    there is no administrator bypass, so `POST /Collections` is 403 — the
-    same gap as `EnableLiveTvManagement`, which this suite already documents
-    for timers.
+    there is no administrator bypass — `UserPermissionHandler` asks
+    `HasPermission` and stops — so the whole of `CollectionController` is 403
+    for most accounts on a modern server. The `[Authorize]` is on the
+    controller rather than its routes, so create, add and remove are one
+    permission and one refusal.
 
-    The shim offers "Collections… / Create" to everyone (`edit_apis` asks the
-    *apiclient* what it can do, not the account), so the failure has to be
-    visible. It is: `EditingMixin._edit` raises, `_edit_call` catches and
-    sets the status line. What this test refuses is the other outcome — an
-    edit path that swallows, closes the dialog, and leaves the user believing
-    a collection was made.
+    Two halves, and the second is why this is an e2e test rather than a unit
+    one: **the shim hides the affordance**, and **the server would really
+    have refused it**. `tests/test_user_policy.py` pins the branch against a
+    hand-written policy dict, which proves the logic and not the spelling of
+    the field — that answer belongs to a server.
 
-    Nothing here is a defect in the shim. If gating the affordance on the
-    policy is wanted (jellyfin-web hides it), that is a change to make on
-    purpose, and this test is where it would be re-stated.
+    `qa-restricted` rather than `qa-user`: stdjflib grants collection
+    management to qa-user (it is the account whose description claims
+    everything a non-admin can have), so the refusal has to be observed on
+    one of the ten that still lack it. qa-restricted can see Movies, which is
+    all this needs.
     """
 
-    ACCOUNT = "qa-user"
+    ACCOUNT = "qa-restricted"
 
     @classmethod
     def setUpClass(cls):
         cls.session = _e2e.Session(cls.ACCOUNT)
-        policy = cls.session.policy() or {}
-        if policy.get("EnableCollectionManagement"):
+        if (cls.session.policy() or {}).get("EnableCollectionManagement"):
             cls.session.stop()
             raise unittest.SkipTest(
                 "%s has been granted EnableCollectionManagement, so there is "
                 "no refusal to observe" % cls.ACCOUNT)
+        cls.source = cls.session.library_source()
+        cls.source.get_libraries(_e2e.SOURCE_UUID)
 
     @classmethod
     def tearDownClass(cls):
-        cls.session.stop()
+        try:
+            cls.source.stop()
+        finally:
+            cls.session.stop()
 
-    def test_the_edit_path_raises_rather_than_swallowing_a_refusal(self):
+    def test_the_source_reports_the_refusal(self):
+        """The field name itself, read off a real policy.
+
+        A unit test builds the dict it then reads, so it cannot catch a
+        misspelt key or a field the server renamed — it would pass against
+        `EnableCollectionMangement` all day.
+        """
+        self.assertFalse(
+            self.source.can_manage_collections(_e2e.SOURCE_UUID),
+            "%s may not manage collections, and the source says it may"
+            % self.ACCOUNT)
+
+    def test_the_affordances_are_not_offered(self):
+        """Both of them, from the real source: the tile entry inside a
+        collection and the door to the collections picker."""
+        from jellyfin_mpv_shim.mpvtk_browser.app import MpvtkBrowser
+
+        browser = MpvtkBrowser(app=None, source=self.source,
+                               server_uuid=_e2e.SOURCE_UUID)
+        browser._async._pool.shutdown(wait=True, cancel_futures=True)
+        browser._pool = _SyncPool()
+        self.addCleanup(browser.shutdown)
+
+        self.assertFalse(
+            browser._actions.can_manage_collections(_e2e.SOURCE_UUID),
+            "the edit affordances would be drawn for an account the server "
+            "refuses")
+
+        browser.nav_stack = [{"kind": "grid", "server": _e2e.SOURCE_UUID,
+                              "parent_id": "whatever",
+                              "parent_type": "BoxSet"}]
+        film = self.session.find_all(item_type="Movie", Limit=1)
+        if not film:
+            self.skipTest("%s can see no films" % self.ACCOUNT)
+        actions = [a for _label, _icon, a
+                   in browser._tile_menu_entries(film[0])]
+        self.assertNotIn(
+            "uncollect", actions,
+            "Remove from Collection is offered to an account that cannot "
+            "remove anything (offered: %s)" % actions)
+        self.assertIn(
+            "addto", actions,
+            "Add to Playlist went with it — PlaylistController has no such "
+            "policy, so that is a second bug wearing the first one's fix")
+
+    def test_the_server_really_would_have_refused(self):
+        """The premise. Without it, hiding the button is a guess.
+
+        Also what keeps the gate honest if Jellyfin ever relaxes this: the
+        day `POST /Collections` starts answering for an ordinary account,
+        this fails and the hiding becomes the thing to reconsider.
+        """
         from types import SimpleNamespace
         from jellyfin_mpv_shim.mpvtk_browser.gateway import deps, PlayerGateway
 
@@ -519,11 +591,16 @@ class CollectionPermissionTest(unittest.TestCase):
         self.addCleanup(lambda: setattr(deps, "clientManager", real))
         gateway = PlayerGateway.__new__(PlayerGateway)
 
-        film = self.session.find_all(
-            library="Movies", item_type="Movie", Limit=1)[0]
+        film = self.session.find_all(item_type="Movie", Limit=1)
+        if not film:
+            self.skipTest("%s can see no films" % self.ACCOUNT)
+        # RAISES, deliberately: `_edit` used to log and return, which made a
+        # refused edit look exactly like an applied one. The status line the
+        # user sees hangs off this exception.
         with self.assertRaises(Exception):
             gateway.collection_new(_e2e.SOURCE_UUID,
-                                   "JMS E2E Refused Collection", [film["Id"]])
+                                   "JMS E2E Refused Collection",
+                                   [film[0]["Id"]])
 
         self.assertEqual(
             [i for i in (self.session.api.get_collections(limit=300) or {}

--- a/tests/e2e/test_collections.py
+++ b/tests/e2e/test_collections.py
@@ -1,0 +1,537 @@
+"""Collections (box sets) against a real server.
+
+A collection is the one container in this library whose **shape the server
+gets wrong in a way no fake would ever reproduce**, and stdjflib now ships
+fixtures for every variant of it. Three claims are pinned here, each of which
+is invisible to `tests/_shell_harness.FakeSource`:
+
+**`ChildCount` is a lie for a collection read off disk.** A `collection.xml`
+is parsed into the in-memory item and its members are never written to the
+`LinkedChildren` table, so `ChildCount` reports **0** for the whole life of
+the server while `GET /Items?parentId=` on the same item returns every
+member. (Measured on 12.0; stdjflib's `docs/COLLECTION_XML_BUGS.md` has the
+reproduction and the source reading.) The browser happens not to read
+`ChildCount` anywhere — this suite is what keeps it that way, because
+"collections show as empty" is the exact bug that follows from the obvious
+optimisation, and it would show up on real libraries and on no fake.
+
+**A collection holds items of any type, from any library.** A linked child is
+an arbitrary item: `Two Libraries, One Collection` is a series from Shows and
+a film from Movies. So the listing must go out **untyped and non-recursive**
+— which is what `_open_item` arranges by passing the BoxSet's own
+`CollectionType` (there is none) to the grid. Send `LIBRARY_ITEM_TYPES`'
+`"movies"` instead, the way a library grid does, and the series silently
+vanishes; the test below asserts both halves so the untyped query is not
+"simplified" into the typed one.
+
+**Creating a collection needs a permission a new account does not have.**
+`POST /Collections` is 403 without `EnableCollectionManagement`, which is off
+for every non-admin account on a fresh server — the same shape as
+`EnableLiveTvManagement` (see stdjflib's `docs/PERMISSION_GAPS.md`). The shim
+offers the affordance regardless and reports the failure as a toast, which is
+what `_edit`'s "RAISES on failure" contract buys; the test here is that it
+does raise, because an edit path that swallowed would leave the user looking
+at a dialog that closed and a collection that was never made.
+
+And the three edit endpoints — `new_collection`, `add_collection_items`,
+`remove_collection_items` — are exercised end to end through the real
+`PlayerGateway`, because nothing else in the project ever calls them against
+a server. That is `b97dd523`'s shape: an apiclient argument the fake accepts
+and the server does not.
+
+**Fixtures.** From stdjflib's `Box Sets` / `Auto Collections` libraries. Every
+lookup skips rather than fails when a fixture is absent, so a library built
+before collections existed does not report a defect it cannot have.
+"""
+
+import os
+import sys
+import unittest
+
+sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+import _e2e  # noqa: E402
+
+REPO_ROOT = os.path.dirname(os.path.dirname(os.path.dirname(
+    os.path.abspath(__file__))))
+if REPO_ROOT not in sys.path:
+    sys.path.insert(0, REPO_ROOT)
+
+#: Collections built by stdjflib, and the one thing each is here to prove.
+LINKED = "The Linked Collection"           # 3 films, from a collection.xml
+API_MADE = "Api Made Collection"           # the same 3, via POST /Collections
+CROSS_LIBRARY = "Two Libraries, One Collection"   # a Series and a Movie
+SHORT_ONE = "One Member Is Missing"        # a member that names no file
+
+SIZE = (1280, 720)
+
+
+class _SyncPool:
+    """Run route loaders inline, so a fetch completes before the assert.
+
+    Same seam `test_route_walk` uses, and for the same reason: the work it
+    runs is a *real* request, so `navigate()` fetches and what follows reads
+    what came back rather than a spinner.
+    """
+
+    def submit(self, fn, *a, **k):
+        fn(*a, **k)
+
+    def shutdown(self, *a, **k):
+        pass
+
+
+class _CollectionCase(unittest.TestCase):
+    """A session and a real `LibrarySource`, plus fixture lookup by name."""
+
+    ACCOUNT = "qa-user"
+
+    @classmethod
+    def setUpClass(cls):
+        cls.session = _e2e.Session(cls.ACCOUNT)
+        cls.source = cls.session.library_source()
+        cls.source.get_libraries(_e2e.SOURCE_UUID)
+
+    @classmethod
+    def tearDownClass(cls):
+        try:
+            cls.source.stop()
+        finally:
+            cls.session.stop()
+
+    @property
+    def uuid(self):
+        return _e2e.SOURCE_UUID
+
+    # -- fixtures ----------------------------------------------------------
+
+    def box_sets(self):
+        """Every collection on the server, by name. Never by id."""
+        items = self.session.find_all(item_type="BoxSet",
+                                      fields="ChildCount")
+        return {i["Name"]: i for i in items}
+
+    def collection(self, name):
+        found = self.box_sets().get(name)
+        if found is None:
+            self.skipTest(
+                "no collection named %r — this library predates stdjflib's "
+                "collection fixtures; rebuild it with `stdjflib build`" % name)
+        return found
+
+    def members(self, box_set, collection_type=None):
+        """The listing the grid makes when a collection is opened.
+
+        `collection_type` is what `_open_item` passes: the BoxSet's own, and a
+        BoxSet has none. Passing one is the mistake this exists to catch.
+        """
+        items, _total = self.source.get_library_items(
+            self.uuid, box_set["Id"], limit=100,
+            collection_type=collection_type)
+        return items
+
+
+@_e2e.require_server
+class CollectionBrowseTest(_CollectionCase):
+    """Reading collections: the toggle's query, and what a collection lists."""
+
+    def test_the_collections_toggle_asks_the_whole_server(self):
+        """`get_movie_collections` carries no ParentId, deliberately.
+
+        It is reached from a movies library, but a collection is not parented
+        to one — `The Linked Collection` lives in `Box Sets`, the automatic
+        one lives under the server's data directory, and a cross-library one
+        belongs to neither. Scope the query to the library the toggle was
+        pressed in and most of them disappear.
+        """
+        items, total = self.source.get_movie_collections(self.uuid, limit=100)
+        self.assertTrue(items, "the Collections toggle returned nothing")
+        self.assertEqual(
+            total, len(items),
+            "the collections grid paged when it said it had not")
+        self.assertEqual(
+            {i.get("Type") for i in items}, {"BoxSet"},
+            "the Collections toggle returned something that is not a BoxSet")
+
+        by_name = {i["Name"]: i for i in items}
+        every = self.box_sets()
+        self.assertEqual(
+            sorted(by_name), sorted(every),
+            "the toggle's own query does not see every collection the server "
+            "has — it is scoped to something")
+
+    def test_a_collection_lists_members_the_server_counts_as_none(self):
+        """The wart, pinned: browse by listing, never by `ChildCount`.
+
+        A collection read from a `collection.xml` reports `ChildCount` 0 for
+        ever — the members are applied to the in-memory item and never
+        written to the table the count is read from. Nothing in the browser
+        reads `ChildCount`; this is what keeps it that way, because the
+        failure it buys ("all my collections are empty") reproduces on real
+        libraries and on no fake.
+        """
+        linked = self.collection(LINKED)
+        members = self.members(linked)
+        self.assertEqual(
+            len(members), 3,
+            "%s should list its three films; the listing is the only place "
+            "its membership is visible" % LINKED)
+        self.assertEqual(
+            linked.get("ChildCount") or 0, 0,
+            "this server now persists a collection.xml's members — the "
+            "12.0 defect this test documents has been fixed, and the note "
+            "above should say so rather than being deleted")
+
+    def test_a_disk_made_and_an_api_made_collection_browse_identically(self):
+        """stdjflib's controlled pair: same three films, two mechanisms.
+
+        `Api Made Collection` holds exactly what `The Linked Collection`
+        holds and was created through `POST /Collections` instead of from a
+        file. If the shim can tell them apart, it is reading something it
+        should not be — which is how "empty on disk, fine over the API" gets
+        misread as a client bug.
+        """
+        linked = {i["Name"] for i in self.members(self.collection(LINKED))}
+        api_made = {i["Name"] for i in self.members(self.collection(API_MADE))}
+        self.assertEqual(
+            linked, api_made,
+            "the two collections built from the same three films do not "
+            "browse the same")
+
+    def test_a_collection_is_listed_untyped_so_a_series_member_survives(self):
+        """Both halves: what the shim sends, and what the other query costs.
+
+        A linked child is any item at all. `Two Libraries, One Collection` is
+        a Series and a Movie, and the typed+recursive query a *library* grid
+        makes (`LIBRARY_ITEM_TYPES["movies"]`) answers with the film alone —
+        measured, not assumed. So the series is not mis-shaped or mis-sorted
+        by the wrong query, it is **absent**, which on screen is a collection
+        that is simply short an item. The negative half is the point: without
+        it, "just pass the collection type through like every other grid"
+        reads as a tidy-up rather than a bug.
+        """
+        cross = self.collection(CROSS_LIBRARY)
+        untyped = self.members(cross)
+        self.assertEqual(
+            {i.get("Type") for i in untyped}, {"Movie", "Series"},
+            "%s should list one film and one series; a collection holds "
+            "items of any type" % CROSS_LIBRARY)
+
+        typed = self.members(cross, collection_type="movies")
+        self.assertNotIn(
+            "Series", {i.get("Type") for i in typed},
+            "the typed movies query keeps the series member here, so this "
+            "test can no longer tell which query the shim sent")
+
+    def test_a_collection_short_a_member_still_opens(self):
+        """A member naming a file that does not exist is dropped silently.
+
+        On 12.0 it is dropped for good (a linked child lives in a table whose
+        child column is a non-nullable id). A client cannot distinguish that
+        from a collection that was built with one item, and must not try —
+        what it must do is open.
+        """
+        members = self.members(self.collection(SHORT_ONE))
+        self.assertEqual(
+            len(members), 1,
+            "%s should list the one member that resolves" % SHORT_ONE)
+
+    def test_the_add_to_collection_picker_lists_collections(self):
+        """`get_collections` is its own endpoint and its own request.
+
+        The picker is its only caller, so a wrong argument here fails in one
+        dialog and nowhere else — and the dialog renders an empty list, which
+        looks like "you have no collections yet".
+        """
+        collections = self.source.get_collections(self.uuid)
+        self.assertTrue(collections, "the picker would show an empty list")
+        self.assertEqual(
+            {c.get("Type") for c in collections}, {"BoxSet"},
+            "the picker offered something that is not a collection")
+        self.assertIn(
+            LINKED, {c["Name"] for c in collections},
+            "a collection made from a file is missing from the picker")
+
+
+@_e2e.require_server
+class CollectionRouteTest(_CollectionCase):
+    """Opening a collection through the browser, against real DTOs.
+
+    `test_route_walk` walks every *page kind*, and a collection is not one —
+    it is a `grid` with a `parent_type`. So the wiring that makes it work is
+    unwalked: `_open_item` has to send the BoxSet down the folder branch with
+    no collection type, and the tile menu inside one has to offer the removal
+    that only exists there.
+    """
+
+    def setUp(self):
+        from jellyfin_mpv_shim.mpvtk_browser.app import MpvtkBrowser
+        self.browser = MpvtkBrowser(app=None, source=self.source,
+                                    server_uuid=_e2e.SOURCE_UUID)
+        # __init__ already kicked the home load onto the real threaded pool;
+        # drain it before swapping, or it lands after this class has logged
+        # out. Same dance as test_route_walk.setUp.
+        self.browser._async._pool.shutdown(wait=True, cancel_futures=True)
+        self.browser._pool = _SyncPool()
+        self.addCleanup(self._shutdown)
+
+    def _shutdown(self):
+        try:
+            self.browser.shutdown()
+        except Exception:
+            pass
+
+    def _open(self, name):
+        """Click the collection's tile, the way the grid does."""
+        box_set = self.collection(name)
+        self.browser._open_item(box_set)
+        route = self.browser.route
+        self.assertEqual(route.get("kind"), "grid",
+                         "a collection did not open as a grid")
+        self.assertFalse(
+            route.get("_loading"),
+            "the collection is still loading after an inline fetch, so what "
+            "follows would be asserting against a spinner")
+        self.assertIsNone(
+            route.get("_error"),
+            "the collection failed to load: %s" % route.get("_error"))
+        return route
+
+    def test_opening_a_collection_asks_for_it_untyped(self):
+        route = self._open(CROSS_LIBRARY)
+        self.assertEqual(
+            route.get("parent_type"), "BoxSet",
+            "without parent_type the tile menu cannot offer Remove from "
+            "Collection")
+        self.assertIsNone(
+            route.get("collection_type"),
+            "a collection type on this route makes the grid's query typed "
+            "and recursive, which drops every member that is not a movie")
+        names = {i.get("Type") for i in (route.get("_items") or [])}
+        self.assertEqual(
+            names, {"Movie", "Series"},
+            "the opened collection lists %r; a series member was lost on the "
+            "way through the browser" % (names,))
+
+    def test_the_tile_menu_inside_a_collection_offers_removal(self):
+        route = self._open(LINKED)
+        items = route.get("_items") or []
+        self.assertTrue(items, "nothing to right-click")
+        entries = self.browser._tile_menu_entries(items[0])
+        labels = [label for label, _icon, _action in entries]
+        self.assertIn(
+            "uncollect", [action for _label, _icon, action in entries],
+            "Remove from Collection is missing inside a collection "
+            "(offered: %s)" % labels)
+
+    def test_a_member_of_a_collection_opens_as_itself(self):
+        """A series inside a collection opens the series screen.
+
+        The collection is browsed untyped, so its members arrive as whatever
+        they are — and a client that assumed a box set holds movies routes a
+        Series to the detail page, which draws a play button for something
+        with no media.
+        """
+        route = self._open(CROSS_LIBRARY)
+        series = next((i for i in (route.get("_items") or [])
+                       if i.get("Type") == "Series"), None)
+        self.assertIsNotNone(series, "no series member to open")
+        self.browser._open_item(series)
+        self.assertEqual(
+            self.browser.route.get("kind"), "series",
+            "a series inside a collection did not open the series screen")
+
+
+@_e2e.require_server
+class CollectionEditTest(unittest.TestCase):
+    """Create, add, remove — through the gateway, against the real server.
+
+    Runs as **qa-admin**, because `POST /Collections` needs
+    `EnableCollectionManagement` and no other account here has it (see
+    `CollectionPermissionTest`).
+
+    This class owns its fixture: it makes its own collection and deletes it,
+    in `setUp` as well as on cleanup, so a run that died halfway cannot leave
+    one behind for the next one to trip over. It touches no stdjflib
+    collection — adding a member to one would be a change every other test in
+    this file can see.
+    """
+
+    NAME = "JMS E2E Collection Fixture"
+
+    @classmethod
+    def setUpClass(cls):
+        cls.session = _e2e.Session("qa-admin")
+        policy = cls.session.policy() or {}
+        if not policy.get("EnableCollectionManagement"):
+            cls.session.stop()
+            raise unittest.SkipTest(
+                "qa-admin cannot manage collections on this server")
+
+    @classmethod
+    def tearDownClass(cls):
+        cls.session.stop()
+
+    def setUp(self):
+        from types import SimpleNamespace
+        from jellyfin_mpv_shim.mpvtk_browser.gateway import deps, PlayerGateway
+
+        # The one foreign singleton the gateway binds at import; `deps.py`
+        # exists so it can be rebound in exactly this way.
+        # tests/test_player_controller.py does the same with a broken one.
+        self._real_manager = deps.clientManager
+        deps.clientManager = SimpleNamespace(
+            clients={_e2e.SOURCE_UUID: SimpleNamespace(
+                jellyfin=self.session.api)})
+        self.addCleanup(self._restore, deps)
+        # No __init__: the editing mixin reaches nothing but deps, and
+        # building a real gateway would drag the player in and cost this
+        # module its place in the contract tier.
+        self.gateway = PlayerGateway.__new__(PlayerGateway)
+        self.assertTrue(
+            self.gateway.edit_apis(),
+            "the installed apiclient cannot edit collections, so the shim "
+            "would hide these affordances entirely")
+        self._delete_fixture()
+        self.addCleanup(self._delete_fixture)
+
+    def _restore(self, deps):
+        deps.clientManager = self._real_manager
+
+    def _delete_fixture(self):
+        for found in self._find_all():
+            try:
+                self.session.api.delete_item(found["Id"])
+            except Exception:
+                pass
+
+    def _find_all(self):
+        items = (self.session.api.get_collections(limit=300) or {}
+                 ).get("Items", [])
+        return [i for i in items if i["Name"] == self.NAME]
+
+    def _members(self, collection_id):
+        return self.session.api.user_items(
+            params={"ParentId": collection_id})["Items"]
+
+    def test_create_add_and_remove(self):
+        """One test, because it is one sequence.
+
+        Split into three it would need three fixtures or a shared one, and a
+        shared one makes the second assertion depend on the first having run
+        — which is the ordering dependency this suite refuses everywhere
+        else. The property is about the sequence anyway: what a collection
+        holds after three edits, not what one call returned.
+        """
+        film = self.session.find_all(
+            library="Movies", item_type="Movie", Limit=1)[0]
+        series = self.session.find_all(
+            library="Shows", item_type="Series", Limit=1)[0]
+
+        self.gateway.collection_new(_e2e.SOURCE_UUID, self.NAME, [film["Id"]])
+        made = self._find_all()
+        self.assertEqual(
+            len(made), 1,
+            "collection_new did not produce exactly one %r" % self.NAME)
+        collection_id = made[0]["Id"]
+        self.assertEqual(
+            [i["Name"] for i in self._members(collection_id)], [film["Name"]],
+            "a new collection did not hold the item it was created from")
+
+        # A Series, not a second film: a collection takes any item, and the
+        # add path must not quietly be movies-only.
+        self.gateway.collection_add(_e2e.SOURCE_UUID, collection_id,
+                                    [series["Id"]])
+        self.assertEqual(
+            {i["Name"] for i in self._members(collection_id)},
+            {film["Name"], series["Name"]},
+            "adding a series to a collection did not stick")
+
+        self.gateway.collection_remove(_e2e.SOURCE_UUID, collection_id,
+                                       [film["Id"]])
+        self.assertEqual(
+            [i["Name"] for i in self._members(collection_id)],
+            [series["Name"]],
+            "removing the film left the collection unchanged")
+
+    def test_adding_a_member_twice_does_not_duplicate_it(self):
+        """The server deduplicates by item id, so the second add is a no-op.
+
+        Worth a test because the browser has no guard of its own: the picker
+        offers every collection whether or not the item is already in one,
+        and the tile menu is drawn from the item, not from the membership.
+        """
+        film = self.session.find_all(
+            library="Movies", item_type="Movie", Limit=1)[0]
+        self.gateway.collection_new(_e2e.SOURCE_UUID, self.NAME, [film["Id"]])
+        collection_id = self._find_all()[0]["Id"]
+        self.gateway.collection_add(_e2e.SOURCE_UUID, collection_id,
+                                    [film["Id"]])
+        self.assertEqual(
+            [i["Name"] for i in self._members(collection_id)], [film["Name"]],
+            "adding the same item twice put it in the collection twice")
+
+
+@_e2e.require_server
+class CollectionPermissionTest(unittest.TestCase):
+    """Creating a collection is a permission an ordinary account lacks.
+
+    `EnableCollectionManagement` is off for a newly created Jellyfin user and
+    there is no administrator bypass, so `POST /Collections` is 403 — the
+    same gap as `EnableLiveTvManagement`, which this suite already documents
+    for timers.
+
+    The shim offers "Collections… / Create" to everyone (`edit_apis` asks the
+    *apiclient* what it can do, not the account), so the failure has to be
+    visible. It is: `EditingMixin._edit` raises, `_edit_call` catches and
+    sets the status line. What this test refuses is the other outcome — an
+    edit path that swallows, closes the dialog, and leaves the user believing
+    a collection was made.
+
+    Nothing here is a defect in the shim. If gating the affordance on the
+    policy is wanted (jellyfin-web hides it), that is a change to make on
+    purpose, and this test is where it would be re-stated.
+    """
+
+    ACCOUNT = "qa-user"
+
+    @classmethod
+    def setUpClass(cls):
+        cls.session = _e2e.Session(cls.ACCOUNT)
+        policy = cls.session.policy() or {}
+        if policy.get("EnableCollectionManagement"):
+            cls.session.stop()
+            raise unittest.SkipTest(
+                "%s has been granted EnableCollectionManagement, so there is "
+                "no refusal to observe" % cls.ACCOUNT)
+
+    @classmethod
+    def tearDownClass(cls):
+        cls.session.stop()
+
+    def test_the_edit_path_raises_rather_than_swallowing_a_refusal(self):
+        from types import SimpleNamespace
+        from jellyfin_mpv_shim.mpvtk_browser.gateway import deps, PlayerGateway
+
+        real = deps.clientManager
+        deps.clientManager = SimpleNamespace(
+            clients={_e2e.SOURCE_UUID: SimpleNamespace(
+                jellyfin=self.session.api)})
+        self.addCleanup(lambda: setattr(deps, "clientManager", real))
+        gateway = PlayerGateway.__new__(PlayerGateway)
+
+        film = self.session.find_all(
+            library="Movies", item_type="Movie", Limit=1)[0]
+        with self.assertRaises(Exception):
+            gateway.collection_new(_e2e.SOURCE_UUID,
+                                   "JMS E2E Refused Collection", [film["Id"]])
+
+        self.assertEqual(
+            [i for i in (self.session.api.get_collections(limit=300) or {}
+                         ).get("Items", [])
+             if i["Name"] == "JMS E2E Refused Collection"], [],
+            "the refused collection exists, so the 403 this test is built on "
+            "is no longer what the server does")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_user_policy.py
+++ b/tests/test_user_policy.py
@@ -19,9 +19,15 @@ hiding is:
   Group button is not. Treating it as a boolean gets one of those wrong.
 """
 
+import sys
 import unittest
 
-from jellyfin_mpv_shim import user_policy
+# The app parses argv the first time anything resolves the config directory,
+# which importing the shell harness does. Under `discover` some earlier
+# module has already neutralised it; running this one alone, nothing has.
+sys.argv = [sys.argv[0]]
+
+from jellyfin_mpv_shim import user_policy  # noqa: E402
 
 
 class _Client:
@@ -141,6 +147,41 @@ class ContentDownloading(unittest.TestCase):
         self.assertTrue(user_policy.may_download(None))
 
 
+class CollectionManagement(unittest.TestCase):
+    """`EnableCollectionManagement` gates the whole of `CollectionController`
+    — the `[Authorize]` is on the controller, not on its routes — so create,
+    add and remove are one permission and one 403."""
+
+    def test_the_flag_is_read(self):
+        self.assertFalse(user_policy.may_manage_collections(
+            _Client({"EnableCollectionManagement": False})))
+        self.assertTrue(user_policy.may_manage_collections(
+            _Client({"EnableCollectionManagement": True})))
+
+    def test_an_absent_flag_is_permitted(self):
+        self.assertTrue(user_policy.may_manage_collections(
+            _Client({"EnableLiveTvAccess": True})))
+
+    def test_a_fetch_that_failed_is_permitted(self):
+        self.assertTrue(user_policy.may_manage_collections(
+            _Client(raises=True)))
+
+    def test_no_client_is_permitted(self):
+        self.assertTrue(user_policy.may_manage_collections(None))
+
+    def test_being_an_administrator_is_not_the_question(self):
+        """jellyfin-web reads this as `IsAdministrator ||
+        EnableCollectionManagement`. The API does not: `UserPermissionHandler`
+        asks `HasPermission` and stops, so an admin without the flag is
+        refused like anybody else and offering the button lies to them. That
+        spelling is right for `BoxSet.IsAuthorizedToDelete`, which really
+        does bypass, and wrong for the endpoint this button calls.
+        """
+        self.assertFalse(user_policy.may_manage_collections(
+            _Client({"IsAdministrator": True,
+                     "EnableCollectionManagement": False})))
+
+
 class TheOfflineSourceAnswers(unittest.TestCase):
     """The offline source is what the online one falls back TO, so a missing
     method turns a degraded screen into an AttributeError on the fallback
@@ -149,7 +190,8 @@ class TheOfflineSourceAnswers(unittest.TestCase):
     def test_it_declares_both(self):
         from jellyfin_mpv_shim.mpvtk_browser.repository import OfflineLibrarySource
 
-        for name in ("syncplay_access", "can_manage_live_tv", "has_live_tv"):
+        for name in ("syncplay_access", "can_manage_live_tv",
+                     "can_manage_collections", "has_live_tv"):
             with self.subTest(name=name):
                 self.assertTrue(callable(getattr(OfflineLibrarySource, name, None)))
 
@@ -160,6 +202,7 @@ class TheOfflineSourceAnswers(unittest.TestCase):
         self.assertEqual(source.syncplay_access("srv1"),
                          user_policy.NO_SYNCPLAY)
         self.assertFalse(source.can_manage_live_tv("srv1"))
+        self.assertFalse(source.can_manage_collections("srv1"))
 
 
 class TheTopBarButton(unittest.TestCase):
@@ -448,6 +491,112 @@ class TheRecordButtons(unittest.TestCase):
         b = browser()
         b.source.can_manage_live_tv = lambda _srv: False
         self.assertTrue(b._actions.can_record())
+
+
+class TheCollectionAffordances(unittest.TestCase):
+    """Add to Collection and Remove from Collection, against the permission.
+
+    Both call `CollectionController`, which is gated in one piece, so both
+    answer to one question. What must NOT move with them is **Add to
+    Playlist**: `PlaylistController` carries no such policy, so a user who
+    cannot touch a collection can still make a playlist, and taking that
+    away would be a second bug wearing the first one's fix.
+    """
+
+    def _browser(self, may_manage=None, edit_apis=True):
+        from jellyfin_mpv_shim.mpvtk_browser.app import MpvtkBrowser
+        from tests._shell_harness import FakeController, FakeSource, _SyncPool
+
+        controller = FakeController()
+        controller.edit_apis = lambda: edit_apis
+        source = FakeSource()
+        source.get_collections = lambda srv: [{"Id": "c1", "Name": "Set"}]
+        source.get_playlists = lambda srv: [{"Id": "p1", "Name": "List"}]
+        if may_manage is not None:
+            source.can_manage_collections = lambda _srv: may_manage
+        browser = MpvtkBrowser(app=None, source=source, controller=controller)
+        browser._pool = _SyncPool()
+        browser.server = "srv1"
+        return browser
+
+    def _tile_actions(self, browser):
+        browser.nav_stack = [{"kind": "grid", "server": "srv1",
+                              "parent_id": "c1", "parent_type": "BoxSet"}]
+        return [entry[2] for entry in browser._tile_menu_entries(
+            {"Id": "m1", "Type": "Movie"})]
+
+    def _add_to_handlers(self, browser):
+        from tests._shell_harness import build_scene
+
+        browser._open_add_to({"Id": "m1", "Type": "Movie"})
+        _nodes, handlers = build_scene(browser)
+        return handlers
+
+    # -- the gate ----------------------------------------------------------
+
+    def test_a_refusal_takes_remove_from_collection_away(self):
+        self.assertNotIn("uncollect", self._tile_actions(
+            self._browser(may_manage=False)))
+
+    def test_a_refusal_takes_the_collections_button_away(self):
+        self.assertNotIn("add-collections",
+                         self._add_to_handlers(self._browser(may_manage=False)))
+
+    def test_permission_keeps_both(self):
+        self.assertIn("uncollect", self._tile_actions(
+            self._browser(may_manage=True)))
+        self.assertIn("add-collections",
+                      self._add_to_handlers(self._browser(may_manage=True)))
+
+    # -- fail open ---------------------------------------------------------
+
+    def test_a_source_that_cannot_answer_keeps_both(self):
+        """A test double or an older source without the method leaves the
+        affordances exactly where they were."""
+        self.assertIn("uncollect", self._tile_actions(self._browser()))
+        self.assertIn("add-collections",
+                      self._add_to_handlers(self._browser()))
+
+    def test_a_source_that_raises_keeps_both(self):
+        browser = self._browser()
+
+        def boom(_srv):
+            raise RuntimeError("server said no")
+
+        browser.source.can_manage_collections = boom
+        self.assertIn("uncollect", self._tile_actions(browser))
+        self.assertIn("add-collections", self._add_to_handlers(browser))
+
+    def test_no_server_in_hand_fails_open(self):
+        browser = self._browser(may_manage=False)
+        self.assertTrue(browser._actions.can_manage_collections())
+
+    # -- what must not move with it ---------------------------------------
+
+    def test_the_playlist_half_survives_a_refusal(self):
+        """The whole dialog is Add to Playlist; the collections picker is a
+        door out of it. Gating the door must not shut the room."""
+        from tests._shell_harness import build_scene, ids
+
+        browser = self._browser(may_manage=False)
+        browser._open_add_to({"Id": "m1", "Type": "Movie"})
+        nodes, handlers = build_scene(browser)
+        self.assertIn("add-newname", ids(nodes), "the playlist name box went")
+        self.assertIn("add-create", handlers, "the playlist Create went")
+        self.assertIn("add-pl-0", handlers, "the playlist picker went")
+
+    def test_add_to_playlist_is_still_offered_on_the_tile(self):
+        self.assertIn("addto", self._tile_actions(
+            self._browser(may_manage=False)))
+
+    # -- the older gate ----------------------------------------------------
+
+    def test_an_apiclient_that_cannot_edit_still_closes_it(self):
+        """`can_edit` is the other half and has to keep working: every
+        permission on an apiclient too old to call these is still nothing."""
+        browser = self._browser(may_manage=True, edit_apis=False)
+        self.assertNotIn("uncollect", self._tile_actions(browser))
+        self.assertFalse(browser._actions.can_manage_collections("srv1"))
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
This PR:
1. Adds an E2E test suite using stdjflib for collections.
2. Fixes collection permission handling so users without manage collections permission don't get broken UI.