### PR TITLE
Media delete option & hardware decoding settings

### DIFF
--- a/docs/PERMISSION_GAPS.md
+++ b/docs/PERMISSION_GAPS.md
@@ -336,3 +336,47 @@ that playlists survive) and `tests/e2e/test_collections.py:CollectionPermissionT
 which is where the field *spelling* is checked and where the premise lives:
 that the server really would have refused. If Jellyfin ever relaxes this, that
 test fails and hiding the button becomes the thing to reconsider.
+
+## 6. Deleting media — the one gate we take from the item, not the account  — ADDED
+
+Not a gap that was found; a feature that had to be built without making one.
+Delete from Disk (#4, `docs/UI_FIXES_4.md`) is the first thing in the browser
+that destroys anything on the server, so the question of who may press it had
+to be answered before the button existed rather than after.
+
+**The gate is the item's own `CanDelete`, and nothing else.** That is
+jellyfin-web's test (`itemContextMenu.js:210`, `if (item.CanDelete && …)`) and
+it is the only correct one available to a client: the server grants deletion
+per *library* (`EnableContentDeletionFromFolders`), so an account can be
+allowed to delete from one library and refused on another. Reading
+`EnableContentDeletion` off the user policy — the shape every other entry in
+this document uses — would be right about the account and wrong about half
+their libraries, in both directions.
+
+**It has to be asked for.** Measured against 10.11: a list query omits
+`CanDelete` entirely (the key is absent, not `False`), so an entry keyed off
+it would simply never appear; a single-item fetch returns it whatever `Fields`
+says, but depending on that would make the detail page's button rest on an
+undocumented default. It is therefore in `GRID_FIELDS`, `LIST_FIELDS` and
+`DETAIL_FIELDS`. The cost is nothing measurable — +1.8 KB on a 165 KB
+hundred-item grid, no change in query time — which is worth having measured,
+because per-item permission fields on this API are exactly the ones that have
+been expensive before.
+
+**Absent means no, and that is deliberately the opposite of §4's fail-open.**
+`may_download` fails *open* because a missing permission there costs a
+convenience and a wrong guess costs a working feature. Here the asymmetry is
+reversed: hiding a delete the user could have made is an inconvenience, and
+offering one that 403s at the point of no return is not. There is no
+`user_policy` accessor for this at all, on purpose — adding one would invite
+exactly the account-level reading the first paragraph rules out.
+
+**The stdjflib half.** The QA server's own administrator account has
+`EnableContentDeletion: False` (measured), which is a *useful* default and has
+been left alone: it makes "the entry is correctly absent" the state you get
+without arranging anything, and the granting case the one that has to be set
+up deliberately. Nothing in the test suite deletes from a real server.
+
+Pinned by `tests/test_shell_delete_item.py` — the gate, that an absent field
+is a refusal, that offline does not offer it, and that the confirmation says
+what it destroys without truncating the sentence.

--- a/docs/UI_FIXES_4.md
+++ b/docs/UI_FIXES_4.md
@@ -20,14 +20,14 @@ formatter landing as its own commit before the two items that need it.
 | [1](#1--mpv-default-mouse-modality-669) | mpv default mouse modality (#669) | todo |
 | [2](#2--the-reader-should-dismiss-the-downloading-toast) | Reader dismisses the downloading toast | todo |
 | [3](#3--dropped-zoom-and-drag-for-photos) | ~~Zoom/drag for photos~~ | **dropped [iw]** |
-| [4](#4--delete-from-disk) | Delete from Disk | todo |
+| [4](#4--delete-from-disk) | Delete from Disk | done |
 | [5](#5--lookahead-hysteresis-661) | Lookahead hysteresis (#661) | todo |
 | [6](#6--previous-item-from-next-up-650) | Previous item from Next Up (#650) | todo |
 | [7](#7--posters-and-thumbnails-on-video-pages) | Posters/thumbnails on video pages | todo |
 | [8](#8--fact-check-exif-orientation) | Fact check: EXIF orientation | **answered — no work** |
 | [9](#9--fact-check-does-playstate-reach-the-local-catalog) | Fact check: playstate → local catalog | **answered — work needed** |
-| [10](#10--playback-info-that-matches-jellyfin-webs) | Playback info matching jellyfin-web | done |
-| [11](#11--media-info-in-the-context-menu) | Media info in the context menu | todo |
+| [10](#10--playback-info-that-matches-jellyfin-webs) | Playback info matching jellyfin-web | done `faf129fd` |
+| [11](#11--media-info-in-the-context-menu) | Media info in the context menu | done `a6d5c7b4` |
 
 ---
 

--- a/docs/UI_FIXES_4.md
+++ b/docs/UI_FIXES_4.md
@@ -20,7 +20,8 @@ formatter landing as its own commit before the two items that need it.
 | [1](#1--mpv-default-mouse-modality-669) | mpv default mouse modality (#669) | todo |
 | [2](#2--the-reader-should-dismiss-the-downloading-toast) | Reader dismisses the downloading toast | todo |
 | [12](#12--a-hardware-decoding-setting) | A hardware-decoding setting | done |
-| [13](#13--shader-packs-must-not-reach-stills) | Shader packs must not reach stills | todo |
+| [13](#13--shader-packs-must-not-reach-stills) | Shader packs must not reach stills | done |
+| [15](#15--per-library--per-series-shader-profiles) | Per-library / per-series shader profiles | todo |
 | [14](#14--search-asks-for-no-fields) | Search asks for no fields | todo |
 | [3](#3--dropped-zoom-and-drag-for-photos) | ~~Zoom/drag for photos~~ | **dropped [iw]** |
 | [4](#4--delete-from-disk) | Delete from Disk | done `798edee0` |
@@ -955,12 +956,28 @@ config write like `--reset-shaders`: it exists for hardware decoding stopping
 the window opening at all, and once it has opened the setting is reachable in
 the ordinary way.
 
-### Open
+### The default
 
-**The default is Off, and that was the investigation's call rather than
-[iw]'s** — no option was picked. The argument for it: shipping a new default
-in the same release as the feature gives no signal about which of the two
-broke someone. It is one line in `conf.py` plus the doc entry to change.
+**Off. [iw]'s choice**, with the same argument the investigation reached:
+shipping a new default in the same release as the feature gives no signal
+about which of the two broke someone.
+
+(Recorded because it briefly looked otherwise: the question tool returned only
+the free-text notes attached to the answer and not the option chosen with them,
+so this file said for one commit that nobody had picked. Worth knowing for the
+next time an option is picked *and* annotated.)
+
+### Naming
+
+**[iw]** "Probably worth renaming 'On (copy back)' into 'Copy (advanced)' with
+a note that SVP/VapourSynth might need it."
+
+Which is the one real use we have for it: the direct modes do not work with
+video filters and the copy modes do, and a user running SVP has a VapourSynth
+`vf` in their own `mpv.conf`. (The shim only drives SVP's HTTP API to pick
+profiles — the filter itself is the user's.) The shader pack is *not* a video
+filter and is unaffected either way, which the note in `config.NOTES` says so
+that the two are not confused.
 
 ## 13 — Shader packs must not reach stills
 
@@ -978,6 +995,116 @@ the menu's selection and the remembered setting both read, so a still would
 silently reset the user's chosen profile. It needs a suspend/resume pair that
 keeps the remembered name — suspend on a photo (`_play_media`, `is_photo`) and
 on a comic page (`show_picture`), resume for video and on `clear_picture`.
+
+## 13b — …and the pack must not decide hardware decoding either
+
+Found by **[iw]** grepping the pack, one commit after #12 shipped:
+
+```
+pack.json:      "hwdec-default": { ... ["hwdec", "auto-copy"] },
+pack-next.json: ["hwdec", "auto-copy"], ["hwdec", "d3d11va"],
+                "default-setting-groups": [ ..., "hwdec-default" ]
+```
+
+Every profile pulls that group in, so picking any shader profile silently
+turned hardware decoding on — one commit after it became a user-facing
+setting that defaults **off**, and defaults off because a long tail of
+drivers handle it badly. The breakage would have been attributed to the
+shader profile, which is the last place anyone would look.
+
+**[iw]** "I don't want to override the user's setting. We should set
+auto-copy transparently based on shader pack settings, SVP integration
+enabled, or mpv config when a vf is detected. Default shader pack should
+otherwise NOT touch hwdec. If the user has it set to off, nothing happens.
+If the user has it set to auto, we force it to auto-copy when it's actually
+needed."
+
+So the pack's value is split, and the on/off half is simply dropped: the
+pack does not get to turn hardware decoding on.
+
+**The blanket `auto-copy` is not evidence of anything.** It is in *every*
+profile — **[iw]**: "yeah, this was just me being risk-averse in the past" —
+and a glsl shader runs inside the GPU renderer, on frames that are already
+there. So a shader profile on gpu-next needs nothing copied back, and the
+`auto-copy` in `hwdec-default` is ignored outright.
+
+**What does need system RAM is a real `vf`.** Grepping the shipped pack, there
+is exactly one, and it is instructive:
+
+```json
+"hw-d3d11va-rtxvsr": { "settings": [
+    ["hwdec", "d3d11va"], ["gpu_api", "d3d11"],
+    ["vf", "format=nv12,d3d11vpp=scale=2:scaling-mode=nvidia"] ] }
+```
+
+`d3d11vpp` is a Direct3D **video-processor** filter operating on d3d11
+surfaces, and the profile names a *direct* hwdec mode beside it for exactly
+that reason. So a filter is not automatically a reason to copy back — a
+profile naming a direct mode is saying its filter wants GPU frames, and
+copying back would break the only profile in the pack that has a filter at
+all.
+
+The rule is therefore `sets a vf AND does not name a direct hwdec mode`,
+which for the shipped pack means **no profile asks for copy-back** — which is
+the right answer, and the one that lets the user opt in from the menu instead
+**[iw]**.
+
+`hwdec_for(height, needs_copy)` then **upgrades, never enables**: `no` stays
+`no`, `auto` becomes `auto-copy`, an explicit `auto-copy` is unchanged, and
+the threshold mode upgrades only where it was already on.
+
+The other two sources of `needs_copy` are unchanged and are the ones that
+still fire in practice: `svp_enable` (a VapourSynth filter in the user's own
+mpv.conf), and **mpv's own `vf` property being non-empty** — the general
+case, and the only one that sees a filter the app knows nothing about.
+Measured: `vf` reads `[]` on a fresh handle before any file is loaded, so it
+is answerable at exactly the moment hwdec has to be decided.
+
+### Two escape hatches, both **[iw]**
+
+**A pack may state a requirement.** The first cut dropped every `hwdec` a
+profile set, which left `rtx-vsr` unable to work at all — it needs `d3d11va`
+for its Direct3D filter. **[iw]**: "maybe we should whitelist non-naive hwdec
+settings in packs, like d3d11va". So the line is *policy vs requirement*:
+
+* `auto`, `auto-copy`, `auto-safe`, `yes`, … are opinions about the machine
+  ("use hardware decoding if you can, whatever that is here") and stay
+  dropped;
+* a **named decoder** is a requirement of the profile — applied, and
+  remembered as `forced_hwdec` so the per-item write does not undo it on the
+  next file. Choosing that profile is opting in;
+* **and so is `no`** **[iw]** — "nothing sets it currently", but a profile
+  setting it would be saying its shaders need software frames, which is a
+  statement about the profile and not about the machine. Listed as a
+  requirement for what it *would* mean rather than for what any pack does
+  today.
+
+**And the user's own mpv.conf pins it.** **[iw]**: "if the user's mpv config
+sets the value, we pin it and never touch it, and show 'Pinned by config' on
+the settings page". `hwdec_for` returns **None** there and both callers treat
+that as *do not write the option at all* — which keeps mpv's own config
+precedence intact rather than modelling it here. The Settings page says so,
+because a control that is silently inert is the failure this whole feature is
+downstream of.
+
+The scan is deliberately of the **top level only**: an `hwdec` inside a
+profile section (`[name]`) is conditional, and reading it as a pin would
+disable the setting on a value that may never apply. Not pinning is the safe
+direction — the setting keeps working and mpv still applies the profile where
+it fires.
+
+### Precedence, in order
+
+1. `--disable-hwdec` — per-run recovery, wins everything.
+2. **The user's mpv.conf** — we write nothing.
+3. **A profile stating a requirement** — a named decoder, or `no`.
+
+   Enforced in `process_setting_group`, not only in `_play_media`: a profile
+   applies its settings *directly*, so the pin has to be checked where the
+   pack is read or it slips past between one file and the next. The per-item
+   write is not the only writer.
+4. The Hardware Decoding setting, plus the copy upgrade where a real filter
+   needs system RAM.
 
 ## 14 — Search asks for no fields
 
@@ -998,3 +1125,66 @@ the measurement. Note that `MediaSourceCount` is **absent rather than 1** for
 a single-version item — the server omits the property at 1, which
 `tile_renderer` already documents — so the chip correctly stays off for most
 of a library either way.
+
+---
+
+## 15 — Per-library / per-series shader profiles
+
+**[iw]** "It's probably honestly worth adding options to make the user's
+shader selection library or series specific too. Anime4K shaders are usually
+specific to the media type and specific quality defects — e.g. a poorly
+compressed anime gets a different setting than a crisp video, which gets a
+different setting from a live action movie."
+
+Which is the real shape of the problem: there is no one right Anime4K
+profile, there is a right one *per kind of source*, and the current single
+global choice makes the user re-pick it by hand or accept the wrong one.
+
+### Storage — its own file **[iw]**
+
+`settings_base.object_types` has no `dict`, so a mapping cannot be a config
+key without being encoded as a list of pairs. **[iw]** chose a separate JSON
+file, which is also the right answer for a second reason: these overrides are
+**device-local**, not account-level. Which profile runs well depends on this
+machine's GPU, so unlike `home_sections` (DisplayPreferences, server-side)
+this must not follow the user to another device.
+
+Beside `cred.json` in the config directory, keyed by item id, with the server
+uuid in the key — ids are only unique per server, and a multi-server setup is
+the norm here.
+
+### UI **[iw]**
+
+> "Maybe a Default, Library Specific, Series Specific options from the menu
+> before we show the options, and also show which of those is currently in
+> effect in the menu?"
+
+So the profile menu grows a scope step in front of it, and the scope step
+reports the answer as well as asking the question — the second half is the
+part that makes it usable, because otherwise "why is this film sharpened
+differently" has no visible cause. Something like:
+
+```
+Video Playback Profile
+  Scope:  This Series  (Anime4K: Mode B)     >
+  Default (all media)  ·  Anime4K: Mode A
+  This Library         ·  not set
+  This Series          ·  Anime4K: Mode B    <- in effect
+```
+
+### Decided
+
+* Resolution order: **series → library → default** **[iw]**.
+
+### Open questions for the design pass
+
+* **What "this library" means for an item reached by search or by a
+  by-name screen**, where there is no library in the route.
+* The menu is `menu.py` (OSD, for the lua OSCs) *and* the mpvtk HUD's gear.
+  Both need it, or the setting is unreachable in one of the two UIs — the
+  same split #12's setting avoided by living in Settings.
+* Whether an override should also pin `shader_pack_gpu_api`, which is
+  currently global and is the other half of "will this profile run here".
+
+Not started. Listed here so it is covered by the QA and code-review pass at
+the end of the batch **[iw]**.

--- a/docs/UI_FIXES_4.md
+++ b/docs/UI_FIXES_4.md
@@ -19,8 +19,11 @@ formatter landing as its own commit before the two items that need it.
 | — | [Groundwork: a shared media-info formatter](#groundwork-a-shared-media-info-formatter) | done `ac2cea8e` |
 | [1](#1--mpv-default-mouse-modality-669) | mpv default mouse modality (#669) | todo |
 | [2](#2--the-reader-should-dismiss-the-downloading-toast) | Reader dismisses the downloading toast | todo |
+| [12](#12--a-hardware-decoding-setting) | A hardware-decoding setting | done |
+| [13](#13--shader-packs-must-not-reach-stills) | Shader packs must not reach stills | todo |
+| [14](#14--search-asks-for-no-fields) | Search asks for no fields | todo |
 | [3](#3--dropped-zoom-and-drag-for-photos) | ~~Zoom/drag for photos~~ | **dropped [iw]** |
-| [4](#4--delete-from-disk) | Delete from Disk | done |
+| [4](#4--delete-from-disk) | Delete from Disk | done `798edee0` |
 | [5](#5--lookahead-hysteresis-661) | Lookahead hysteresis (#661) | todo |
 | [6](#6--previous-item-from-next-up-650) | Previous item from Next Up (#650) | todo |
 | [7](#7--posters-and-thumbnails-on-video-pages) | Posters/thumbnails on video pages | todo |
@@ -883,3 +886,115 @@ the mpv integration matrix on both backends:
    that transcodes; a multi-version item; a downloaded copy played while
    online. The path row shows for everyone, so check it as a non-admin too —
    deliberately, see #11.
+
+---
+
+## 12 — A hardware-decoding setting
+
+**[iw]** "We should also add a setting to the player for hwdec. Am debating if
+it should be enabled by default. Jellyfin Media Player enabled it by default
+and it worked fine for *most* users but caused issues for a long tail of
+users, probably sadly the same users that probably needed it the most.
+Anything 1080p or lower though probably doesn't need hardware decoding on most
+hardware from the past decade."
+
+### What the research changed
+
+The obvious design — default to `auto-safe`, mpv's "safer on" — **does not
+exist**. In current mpv `auto-safe` is documented as "exactly the same as
+auto", and `auto` is already the whitelisted mode; `auto-unsafe` is the
+anything-goes one. mpv#12948 is the proposal to default it on, and it is open
+and argued against by a maintainer:
+
+* particular vendor/GPU combinations are badly broken — AMD vaapi on Linux
+  causing GPU resets — and mpv cannot afford Chromium's allow/blocklists;
+* IINA, which does default it on, had to strip vp9 from `hwdec-codecs` after
+  Intel Macs froze;
+* one reporter has mpv **hanging with the window never opening** on
+  vp9/videotoolbox;
+* the power-saving argument is questionable below ~720p on desktop, which is
+  the same observation as **[iw]**'s about 1080p.
+
+mpv's manual, on turning it on: *"acknowledge that this may cause problems"*.
+
+### Does `auto-copy` buy us anything? — no
+
+**[iw]** asked, and the answer is no, for a reason specific to this app. mpv's
+case for copy-back is that it *"will allow CPU processing with video filters.
+This mode works with all video filters and VOs."* We use **no video filters**
+— the shader pack is `glsl-shaders`, which runs inside the GPU renderer on
+frames already on the GPU — and we set no `vo`, so we get mpv's default, which
+is **gpu-next**: a VO that does direct hwdec interop natively. JMP needed
+copy-back because `vo_libmpv` renders into Qt, which is the hard interop case.
+So it is offered as a fallback for a misbehaving direct path, not as a default.
+
+### Shape
+
+Four values: `no` (default), `over-1080p`, `auto`, `auto-copy`.
+
+`over-1080p` is the one **only this client can offer**: the source resolution
+is in the DTO before playback starts, so decoding can be software where
+software is fine and hardware only where it is not. It is the thing mpv's own
+maintainer says would be needed first ("some basic qualifiers for it like a
+minimum video resolution").
+
+Three things are load-bearing:
+
+* **It is applied per file, before `play()`**, beside the volume and
+  still-duration writes and for the same reason: `hwdec` is read at *decoder
+  init*, which is where the failure modes happen. Setting it after would apply
+  to the next file. A side benefit is that changing the setting takes effect
+  on the next item rather than the next launch.
+* **The height comes off the MediaSource, not the item.** A multi-version item
+  has one height per version and the one playing is the one at stake.
+* **An unknown height means software.** Audio, a photo, an unprobed file —
+  starting hardware and turning it off is the wrong way round.
+
+`--disable-hwdec` is the recovery path, per-run like `--ui-scale` rather than a
+config write like `--reset-shaders`: it exists for hardware decoding stopping
+the window opening at all, and once it has opened the setting is reachable in
+the ordinary way.
+
+### Open
+
+**The default is Off, and that was the investigation's call rather than
+[iw]'s** — no option was picked. The argument for it: shipping a new default
+in the same release as the feature gives no signal about which of the two
+broke someone. It is one line in `conf.py` plus the doc entry to change.
+
+## 13 — Shader packs must not reach stills
+
+**[iw]** "We need to make sure we're not applying shader packs to photos and
+comic books!"
+
+Confirmed, and it is worse than per-file: `VideoProfileManager.load_profile`
+is applied once — from the menu, or restored at startup from
+`shader_pack_profile` — and left on the mpv instance. Nothing on the play path
+touches it. So an anime-upscaling chain runs over a photograph, and over a
+comic page at 1600x2400 or larger, where it is both wrong and expensive.
+
+**The fix cannot be `unload_profile`.** That clears `current_profile`, which
+the menu's selection and the remembered setting both read, so a still would
+silently reset the user's chosen profile. It needs a suspend/resume pair that
+keeps the remembered name — suspend on a photo (`_play_media`, `is_photo`) and
+on a comic page (`show_picture`), resume for video and on `clear_picture`.
+
+## 14 — Search asks for no fields
+
+Noticed while adding `CanDelete`. `LibrarySource.search` passes **no `fields`
+at all**, which costs three things at once, measured against a real 800-item
+search:
+
+* `PrimaryImageAspectRatio` is absent on **all 800 items**, so search tiles
+  have never been shaped by their own artwork (`auto_geom` falls back for
+  every one of them);
+* `MediaSourceCount` is absent, so a multi-version item shows no version chip
+  — this is the one **[iw]** remembers being asked for;
+* `CanDelete` is absent, so #4's Delete from Disk cannot appear on a search
+  result, unlike everywhere else.
+
+Adding `GRID_FIELDS` costs +47 KB on a 1.28 MB response and was not slower in
+the measurement. Note that `MediaSourceCount` is **absent rather than 1** for
+a single-version item — the server omits the property at 1, which
+`tile_renderer` already documents — so the chip correctly stays off for most
+of a library either way.

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -22,6 +22,23 @@ You can specify a custom configuration folder with the `--config` option.
 
 You can adjust the basic transcoder settings via the menu.
 
+- `hwdec` - Hardware video decoding. Default: `no`
+  - Values: `no` (software decoding, the same default mpv itself uses),
+      `over-1080p`, `auto`, `auto-copy`.
+  - `over-1080p` is software decoding at 1080p and below and hardware above it —
+      the cautious way to turn it on. Most hardware of the last decade decodes
+      1080p without help, and often looks better doing it, so this limits
+      hardware decoding to the files that actually need it (4K HEVC, AV1).
+  - `auto` uses mpv's whitelisted hardware decoders, decoding straight into the
+      GPU. `auto-copy` is the same but copies frames back to system RAM: slower,
+      and it avoids the hardware/renderer interop paths entirely, so it is worth
+      trying if `auto` misbehaves.
+  - It is off by default because some graphics drivers handle hardware decoding
+      badly, and mpv's own maintainers decline to enable it by default for that
+      reason. If turning it on stops video working — or stops the window opening
+      at all — start the app once with `--disable-hwdec`, which forces software
+      decoding for that run without changing the setting, and then change it back.
+  - The playback HUD's *Playback Info* panel reports what is actually in use.
 - `always_transcode` - This will tell the client to always transcode. Default: `false`
   - This may be useful if you are using limited hardware that cannot handle advanced codecs.
   - Please note that Jellyfin may still direct play files that meet the transcode profile

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -33,11 +33,25 @@ You can adjust the basic transcoder settings via the menu.
       GPU. `auto-copy` is the same but copies frames back to system RAM: slower,
       and it avoids the hardware/renderer interop paths entirely, so it is worth
       trying if `auto` misbehaves.
+  - `auto-copy` is also the mode that works with **video filters**, which the
+      direct modes do not. If your `mpv.conf` runs SVP or another VapourSynth
+      filter, that is the one to pick. (The shader pack is not a video filter —
+      it runs inside the GPU renderer and is unaffected either way.)
   - It is off by default because some graphics drivers handle hardware decoding
       badly, and mpv's own maintainers decline to enable it by default for that
       reason. If turning it on stops video working — or stops the window opening
       at all — start the app once with `--disable-hwdec`, which forces software
       decoding for that run without changing the setting, and then change it back.
+  - **Your own `mpv.conf` outranks this.** If it sets `hwdec` at the top level,
+      the app writes the option nowhere at all — not from this setting, not from
+      a shader profile — and the Settings page says "Pinned by config". A
+      `hwdec` inside an mpv profile section (`[name]`) is *not* treated as a
+      pin, because those are conditional.
+  - A shader profile that states a **requirement** has it applied: a named
+      decoder (the shipped `rtx-vsr` needs `d3d11va` for its Direct3D filter),
+      or `no` if a profile ever needs software frames. Choosing that profile is
+      opting in. The blanket `auto-copy` every profile carries is ignored —
+      that is a policy about the machine, not a requirement of the profile.
   - The playback HUD's *Playback Info* panel reports what is actually in use.
 - `always_transcode` - This will tell the client to always transcode. Default: `false`
   - This may be useful if you are using limited hardware that cannot handle advanced codecs.

--- a/jellyfin_mpv_shim/args.py
+++ b/jellyfin_mpv_shim/args.py
@@ -69,6 +69,14 @@ def _build_parser() -> argparse.ArgumentParser:
         "leaves MPV unable to show video)",
     )
     parser.add_argument(
+        "--disable-hwdec",
+        dest="disable_hwdec",
+        action="store_true",
+        help="force software decoding for this run, whatever the Hardware "
+        "Decoding setting says (recovery for when hardware decoding stops "
+        "the window opening at all); not saved to the config",
+    )
+    parser.add_argument(
         "--debug",
         action="store_true",
         help="surface debug-level application log messages (does not affect mpv verbosity)",

--- a/jellyfin_mpv_shim/conf.py
+++ b/jellyfin_mpv_shim/conf.py
@@ -118,6 +118,27 @@ class Settings(SettingsBase):
     direct_paths: bool = False
     remote_direct_paths: bool = False
     path_substitutions: list = []
+    #: Hardware video decoding. "no" (mpv's own default and ours),
+    #: "over-1080p" (software below, hardware above), "auto" (mpv's
+    #: whitelisted direct modes), or "auto-copy" (the same, copied back to
+    #: system RAM).
+    #:
+    #: **Off by default, and that follows mpv rather than the other
+    #: clients.** mpv's manual on turning it on: "acknowledge that this may
+    #: cause problems", and its maintainers decline to default it on
+    #: (mpv#12948) because particular vendor/GPU combinations are badly
+    #: broken -- AMD vaapi on Linux causing GPU resets, vp9 on Intel Macs
+    #: hanging mpv before the window even opens. Jellyfin Media Player did
+    #: default it on and it worked for most people; this is about the tail
+    #: it did not work for, who are disproportionately the people on
+    #: hardware that needed it.
+    #:
+    #: "over-1080p" is the option that exists because *we* can do what mpv
+    #: cannot: the source resolution is in the DTO before playback starts,
+    #: so decoding can be software where software is fine and hardware only
+    #: where it is not. Most hardware of the last decade decodes 1080p
+    #: without help, and often looks better doing it.
+    hwdec: str = "no"
     always_transcode: bool = False
     transcode_hi10p: bool = False
     transcode_hdr: bool = False

--- a/jellyfin_mpv_shim/messages/base.pot
+++ b/jellyfin_mpv_shim/messages/base.pot
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: jellyfin-mpv-shim\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2026-08-08 15:41-0400\n"
+"POT-Creation-Date: 2026-08-08 15:57-0400\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -2445,6 +2445,28 @@ msgstr ""
 
 #: jellyfin_mpv_shim/mpvtk_browser/item_actions.py
 msgid "The recording settings could not be saved."
+msgstr ""
+
+#: jellyfin_mpv_shim/mpvtk_browser/item_actions.py
+#: jellyfin_mpv_shim/mpvtk_browser/pages/detail.py
+#: jellyfin_mpv_shim/mpvtk_browser/tiles.py
+msgid "Delete from Disk"
+msgstr ""
+
+#: jellyfin_mpv_shim/mpvtk_browser/item_actions.py
+msgid ""
+"Deleting this item will delete it from both the file system and your media "
+"library. Are you sure you wish to continue?"
+msgstr ""
+
+#: jellyfin_mpv_shim/mpvtk_browser/item_actions.py
+#, python-format
+msgid "%s was deleted."
+msgstr ""
+
+#: jellyfin_mpv_shim/mpvtk_browser/item_actions.py
+#, python-format
+msgid "%s could not be deleted."
 msgstr ""
 
 #: jellyfin_mpv_shim/mpvtk_browser/item_actions.py

--- a/jellyfin_mpv_shim/messages/base.pot
+++ b/jellyfin_mpv_shim/messages/base.pot
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: jellyfin-mpv-shim\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2026-08-08 15:57-0400\n"
+"POT-Creation-Date: 2026-08-08 16:15-0400\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -1209,6 +1209,22 @@ msgid "Skip Intro / Credits"
 msgstr ""
 
 #: jellyfin_mpv_shim/mpvtk_browser/config.py
+msgid "Off (software decoding)"
+msgstr ""
+
+#: jellyfin_mpv_shim/mpvtk_browser/config.py
+msgid "Only above 1080p"
+msgstr ""
+
+#: jellyfin_mpv_shim/mpvtk_browser/config.py
+msgid "On"
+msgstr ""
+
+#: jellyfin_mpv_shim/mpvtk_browser/config.py
+msgid "On (copy back)"
+msgstr ""
+
+#: jellyfin_mpv_shim/mpvtk_browser/config.py
 msgid "Jellyfin UI"
 msgstr ""
 
@@ -1387,6 +1403,10 @@ msgstr ""
 
 #: jellyfin_mpv_shim/mpvtk_browser/config.py
 msgid "Prefer Downloaded Copy"
+msgstr ""
+
+#: jellyfin_mpv_shim/mpvtk_browser/config.py
+msgid "Hardware Decoding"
 msgstr ""
 
 #: jellyfin_mpv_shim/mpvtk_browser/config.py
@@ -1571,6 +1591,14 @@ msgid ""
 "With \"Start Minimized\" and \"Fullscreen\" this is the classic cast-target "
 "setup: the app waits out of the way, plays fullscreen when something casts "
 "to it, and goes back to waiting when the video ends or you press Q."
+msgstr ""
+
+#: jellyfin_mpv_shim/mpvtk_browser/config.py
+msgid ""
+"Off by default because some graphics drivers handle it badly. \"Only above "
+"1080p\" is the cautious way to turn it on: most hardware decodes 1080p in "
+"software without help. If video stops working, start with --disable-hwdec "
+"and change this back."
 msgstr ""
 
 #: jellyfin_mpv_shim/mpvtk_browser/config.py

--- a/jellyfin_mpv_shim/messages/base.pot
+++ b/jellyfin_mpv_shim/messages/base.pot
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: jellyfin-mpv-shim\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2026-08-08 16:15-0400\n"
+"POT-Creation-Date: 2026-08-08 16:50-0400\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -1221,7 +1221,7 @@ msgid "On"
 msgstr ""
 
 #: jellyfin_mpv_shim/mpvtk_browser/config.py
-msgid "On (copy back)"
+msgid "Copy (advanced)"
 msgstr ""
 
 #: jellyfin_mpv_shim/mpvtk_browser/config.py
@@ -1597,8 +1597,10 @@ msgstr ""
 msgid ""
 "Off by default because some graphics drivers handle it badly. \"Only above "
 "1080p\" is the cautious way to turn it on: most hardware decodes 1080p in "
-"software without help. If video stops working, start with --disable-hwdec "
-"and change this back."
+"software without help. \"Copy (advanced)\" is slower, but it is the mode "
+"that works with video filters, so it is the one to pick if you run SVP or "
+"another VapourSynth filter. If video stops working, start with --disable-"
+"hwdec and change this back."
 msgstr ""
 
 #: jellyfin_mpv_shim/mpvtk_browser/config.py
@@ -3591,6 +3593,11 @@ msgstr ""
 msgid ""
 "Not active: the \"pypresence\" package is missing or failed to load. Install "
 "it and restart. (Details in the Logs tab.)"
+msgstr ""
+
+#: jellyfin_mpv_shim/mpvtk_browser/settings/general.py
+#, python-format
+msgid "Pinned by config: your mpv.conf sets hwdec=%s, which overrides this."
 msgstr ""
 
 #: jellyfin_mpv_shim/mpvtk_browser/settings/general.py

--- a/jellyfin_mpv_shim/mpv_options.py
+++ b/jellyfin_mpv_shim/mpv_options.py
@@ -13,6 +13,7 @@ and safe to call, but creating the config tree is a side effect and belongs
 with the code that is actually starting a player.
 """
 
+import logging
 import platform
 import sys
 from collections import OrderedDict
@@ -22,9 +23,61 @@ from .conf import settings
 from .constants import APP_NAME, DESKTOP_ID, USER_APP_NAME
 from .utils import get_resource
 
+log = logging.getLogger("mpv_options")
+
 #: Styles that must not leave mpv's built-in OSC on: two that replace it
 #: with something of ours, and one that replaces it with nothing.
 _REPLACES_OSC = ("mpv", "mpvtk", "none")
+
+
+#: Config value -> the mpv ``hwdec`` value, where it is a constant.
+#: "over-1080p" is absent because it is not one: see :func:`hwdec_for`.
+_HWDEC_STATIC = {"no": "no", "auto": "auto", "auto-copy": "auto-copy"}
+
+#: Above this source height, "over-1080p" turns hardware decoding on.
+#: Strictly greater, so a 1920x1080 file decodes in software and a 4K one
+#: does not -- which is the line the setting is named after.
+HWDEC_THRESHOLD_H = 1080
+
+
+def hwdec_for(height=None):
+    """mpv's ``hwdec`` for the configured mode and this file's height.
+
+    ``height`` is the source's video height, or None when nothing is loaded
+    (mpv's construction, and any item whose height we could not read). None
+    resolves the threshold mode to "no": starting a file with hardware
+    decoding already on and turning it off is the wrong way round -- the
+    failure modes this setting is cautious about happen at *decoder init*.
+
+    ``--disable-hwdec`` overrides everything and is checked here, so there
+    is one place that can be wrong. It is a per-run override rather than a
+    config write (like --ui-scale, unlike --reset-shaders): it exists for
+    the case where hardware decoding stops the window opening at all, and
+    once it has opened the setting is reachable in the ordinary way.
+    """
+    from .args import get_args
+
+    try:
+        if getattr(get_args(), "disable_hwdec", False):
+            return "no"
+    except Exception:
+        # Argument parsing is not available in every embedding of this
+        # module (tests import it bare). A missing override is "no
+        # override", never a crash on the playback path.
+        log.debug("could not read the hwdec override", exc_info=True)
+    mode = (settings.hwdec or "no").strip().lower()
+    if mode in _HWDEC_STATIC:
+        return _HWDEC_STATIC[mode]
+    if mode == "over-1080p":
+        try:
+            return "auto" if int(height or 0) > HWDEC_THRESHOLD_H else "no"
+        except (TypeError, ValueError):
+            return "no"
+    # A value hand-edited into the JSON. Software decoding is the answer
+    # that cannot make things worse, and handing an unknown string to mpv
+    # would fail the option at construction and take the player with it.
+    log.warning("Unknown hwdec setting %r; using software decoding.", mode)
+    return "no"
 
 
 def resolve_osc_style():
@@ -125,6 +178,13 @@ def build_mpv_options(osc_style, scripts, ext_mpv, browser_wants_window):
                 "start_retry_delay_ms": settings.mpv_ext_start_retry_delay_ms,
             }
         )
+
+    # Hardware decoding, at construction. The threshold mode resolves to
+    # "no" here (nothing is loaded, so there is no height) and is raised
+    # per file in PlayerManager._play_media -- which is also where the
+    # static modes are re-applied, so that changing this setting takes
+    # effect on the next item rather than the next launch.
+    mpv_options["hwdec"] = hwdec_for()
 
     if osc_style in _REPLACES_OSC:
         # "mpv" loads the patched stock OSC as a script; "mpvtk" has the

--- a/jellyfin_mpv_shim/mpv_options.py
+++ b/jellyfin_mpv_shim/mpv_options.py
@@ -40,8 +40,79 @@ _HWDEC_STATIC = {"no": "no", "auto": "auto", "auto-copy": "auto-copy"}
 HWDEC_THRESHOLD_H = 1080
 
 
-def hwdec_for(height=None):
+#: hwdec values that are a *policy* rather than a requirement: "use
+#: hardware decoding if you can, whatever that turns out to be here". A
+#: shader pack naming one of these is expressing an opinion about the
+#: machine, which is not its to have.
+#:
+#: Every other value is a requirement of the profile and survives -- a
+#: named decoder (``d3d11va``, which the shipped rtx-vsr needs for its
+#: Direct3D filter) **and ``no``**, which is a profile saying its shaders
+#: need software frames. Nothing in the current pack sets ``no``; it is
+#: listed as a requirement rather than a policy because that is what it
+#: would mean if one did [iw].
+NAIVE_HWDEC = frozenset({
+    "yes", "auto", "auto-safe", "auto-unsafe",
+    "auto-copy", "auto-copy-safe", "auto-copy-unsafe",
+})
+
+
+def hwdec_pinned_by_config():
+    """The ``hwdec`` the user's own ``mpv.conf`` sets, or None.
+
+    **A pin, not a default: where this answers, nothing else writes hwdec
+    at all** -- not the setting, not the copy upgrade, not a shader
+    profile. Somebody who has written the option into mpv.conf has said
+    something more specific than any of them, and silently overriding it
+    was the complaint that the whole of this feature is downstream of.
+
+    Deliberately a plain scan of the top level of the file rather than an
+    mpv-accurate parse: profile sections (``[name]``) are conditional and
+    reading them as unconditional would pin on a value that may never
+    apply. A `hwdec` reachable only inside a profile is therefore *not*
+    treated as a pin, which is the safe direction -- the setting keeps
+    working and mpv's own precedence still applies it where it fires.
+    """
+    from . import conffile
+    from .constants import APP_NAME
+
+    try:
+        path = conffile.get(APP_NAME, "mpv.conf", True)
+        with open(path, encoding="utf-8", errors="replace") as fh:
+            for line in fh:
+                line = line.split("#", 1)[0].strip()
+                if line.startswith("["):
+                    break            # a profile section; see the docstring
+                if not line:
+                    continue
+                key, sep, value = line.partition("=")
+                if sep and key.strip().lstrip("-") == "hwdec":
+                    return value.strip().strip("\"'") or None
+    except Exception:
+        log.debug("could not read mpv.conf for an hwdec pin", exc_info=True)
+    return None
+
+
+#: Direct mode -> the copy-back variant of the same thing. Used when
+#: something in the pipeline needs frames in system RAM; see hwdec_for.
+_COPY_OF = {"auto": "auto-copy"}
+
+
+def hwdec_for(height=None, needs_copy=False):
     """mpv's ``hwdec`` for the configured mode and this file's height.
+
+    ``needs_copy`` says something downstream needs frames in system RAM --
+    a video filter, which the direct modes cannot feed. It **upgrades**, it
+    never enables: off stays off, because the user turning hardware
+    decoding off is not a preference about *which* hardware decoding. A
+    mode that is already copy-back is unchanged.
+
+    That asymmetry is the whole design. The shader pack asks for
+    ``hwdec: auto-copy`` in every profile, which conflates two things --
+    "turn hardware decoding on" (not the pack's call, and the reason the
+    setting defaults off is a long tail of broken drivers) and "if it is
+    on, I need the copy kind" (entirely the pack's call, since it knows
+    what it is going to do with the frames). Only the second survives.
 
     ``height`` is the source's video height, or None when nothing is loaded
     (mpv's construction, and any item whose height we could not read). None
@@ -65,14 +136,25 @@ def hwdec_for(height=None):
         # module (tests import it bare). A missing override is "no
         # override", never a crash on the playback path.
         log.debug("could not read the hwdec override", exc_info=True)
+    pinned = hwdec_pinned_by_config()
+    if pinned is not None:
+        # Not "use their value" -- *do not write the option at all*, so
+        # mpv's own config precedence stands and nothing here has to model
+        # it. Callers treat None as "leave it alone".
+        return None
+
+    def resolved(value):
+        return _COPY_OF.get(value, value) if needs_copy else value
+
     mode = (settings.hwdec or "no").strip().lower()
     if mode in _HWDEC_STATIC:
-        return _HWDEC_STATIC[mode]
+        return resolved(_HWDEC_STATIC[mode])
     if mode == "over-1080p":
         try:
-            return "auto" if int(height or 0) > HWDEC_THRESHOLD_H else "no"
+            on = int(height or 0) > HWDEC_THRESHOLD_H
         except (TypeError, ValueError):
-            return "no"
+            on = False
+        return resolved("auto") if on else "no"
     # A value hand-edited into the JSON. Software decoding is the answer
     # that cannot make things worse, and handing an unknown string to mpv
     # would fail the option at construction and take the player with it.
@@ -184,7 +266,9 @@ def build_mpv_options(osc_style, scripts, ext_mpv, browser_wants_window):
     # per file in PlayerManager._play_media -- which is also where the
     # static modes are re-applied, so that changing this setting takes
     # effect on the next item rather than the next launch.
-    mpv_options["hwdec"] = hwdec_for()
+    hwdec = hwdec_for()
+    if hwdec is not None:
+        mpv_options["hwdec"] = hwdec
 
     if osc_style in _REPLACES_OSC:
         # "mpv" loads the patched stock OSC as a script; "mpvtk" has the

--- a/jellyfin_mpv_shim/mpvtk_browser/config.py
+++ b/jellyfin_mpv_shim/mpvtk_browser/config.py
@@ -205,7 +205,7 @@ LABELED_ENUMS = {
         (_("Off (software decoding)"), "no"),
         (_("Only above 1080p"), "over-1080p"),
         (_("On"), "auto"),
-        (_("On (copy back)"), "auto-copy"),
+        (_("Copy (advanced)"), "auto-copy"),
     ],
     "osc_style": [
         (_("Jellyfin UI"), "mpvtk"),
@@ -387,8 +387,10 @@ NOTES = {
     "hwdec": _("Off by default because some graphics drivers handle it "
                "badly. \"Only above 1080p\" is the cautious way to turn "
                "it on: most hardware decodes 1080p in software without "
-               "help. If video stops working, start with --disable-hwdec "
-               "and change this back."),
+               "help. \"Copy (advanced)\" is slower, but it is the mode "
+               "that works with video filters, so it is the one to pick if "
+               "you run SVP or another VapourSynth filter. If video stops "
+               "working, start with --disable-hwdec and change this back."),
     "close_to_tray": CAST_TARGET_NOTE,
     "allow_background": CAST_TARGET_NOTE,
     # Advanced-only (see SECTIONS), and the note is why: it reads like "turn

--- a/jellyfin_mpv_shim/mpvtk_browser/config.py
+++ b/jellyfin_mpv_shim/mpvtk_browser/config.py
@@ -141,8 +141,8 @@ TAB_SECTIONS = {
         (_("Player Controls"), ["osc_style", "hud_grab_keys", "hud_wake_key",
                                 "hud_scrim", "hud_autohide", "hud_hide_secs",
                                 "mouse_chapter_nav"]),
-        (_("Playback"), ["auto_play", "always_transcode", "local_kbps",
-                         "remote_kbps", "direct_paths",
+        (_("Playback"), ["auto_play", "hwdec", "always_transcode",
+                         "local_kbps", "remote_kbps", "direct_paths",
                          "remote_direct_paths", "playback_timeout"]),
         # Passthrough keys are listed in full here; sections() drops the
         # ones the selected mode cannot carry.
@@ -201,6 +201,12 @@ _SEGMENT_ACTIONS = [
 
 # Enums whose stored value isn't presentable: [(label, value), ...].
 LABELED_ENUMS = {
+    "hwdec": [
+        (_("Off (software decoding)"), "no"),
+        (_("Only above 1080p"), "over-1080p"),
+        (_("On"), "auto"),
+        (_("On (copy back)"), "auto-copy"),
+    ],
     "osc_style": [
         (_("Jellyfin UI"), "mpvtk"),
         (_("MPV UI with thumbnails"), "mpv"),
@@ -297,6 +303,7 @@ LABELED_ENUMS = {
 LABEL_OVERRIDES = {
     "sync_path": _("Download Folder"),
     "prefer_downloaded": _("Prefer Downloaded Copy"),
+    "hwdec": _("Hardware Decoding"),
     "auto_download_enable": _("Automatically Download Upcoming Episodes"),
     "auto_download_next_up": _("Include Next Up"),
     "auto_download_next_up_limit": _("Next Up Entries to Consider"),
@@ -373,6 +380,15 @@ CAST_TARGET_NOTE = _(
 # Explanatory line rendered under a setting, for the ones whose default
 # isn't self-explanatory from the label alone.
 NOTES = {
+    # The reason this is off by default, in the place someone deciding
+    # whether to change it is looking. mpv's own manual says to
+    # "acknowledge that this may cause problems"; the tail it breaks for
+    # is disproportionately the hardware that needed it.
+    "hwdec": _("Off by default because some graphics drivers handle it "
+               "badly. \"Only above 1080p\" is the cautious way to turn "
+               "it on: most hardware decodes 1080p in software without "
+               "help. If video stops working, start with --disable-hwdec "
+               "and change this back."),
     "close_to_tray": CAST_TARGET_NOTE,
     "allow_background": CAST_TARGET_NOTE,
     # Advanced-only (see SECTIONS), and the note is why: it reads like "turn

--- a/jellyfin_mpv_shim/mpvtk_browser/dialogs.py
+++ b/jellyfin_mpv_shim/mpvtk_browser/dialogs.py
@@ -742,14 +742,33 @@ class DialogsMixin:
             text += " " + _("Use MPV 0.41 or newer.")
         self._message(text, title=_("Clipboard"))
 
-    def _confirm(self, text, on_yes, title=None, yes=None):
+    def _confirm(self, text, on_yes, title=None, yes=None, detail=None):
+        """Ask before doing something. ``detail`` is a second, emphasised
+        line for a confirmation whose *consequence* is the point.
+
+        The message wraps. It used to be a bare Text, which ellipsizes at
+        the shell's width -- so "Remove <a long film name> from this
+        playlist?" was already being cut off, and a confirmation that
+        explains what it is about to destroy would have had the explanation
+        truncated. `_message` had worked this out and used
+        `chrome.paragraph`; this one had not.
+        """
         title = title or _("Confirm")
         yes = yes or _("OK")
 
         def build():
-            return Dialog("confirm", self._dialog_shell("confirm", [
+            from .components import chrome
+
+            rows = [
                 Text(title, size=22, bold=True),
-                Text(text, size=16, color=theme.SUBTLE_FG),
+                chrome.paragraph(text, 16, self.MESSAGE_W,
+                                 color=theme.SUBTLE_FG),
+            ]
+            if detail:
+                # Not SUBTLE_FG: this is the sentence the dialog exists to
+                # make sure was read.
+                rows.append(chrome.paragraph(detail, 16, self.MESSAGE_W))
+            return Dialog("confirm", self._dialog_shell("confirm", rows + [
                 self._dialog_buttons([
                     Button(_("Cancel"), id="dlg-cancel",
                            on_click=self._close_dialog),

--- a/jellyfin_mpv_shim/mpvtk_browser/gateway/editing.py
+++ b/jellyfin_mpv_shim/mpvtk_browser/gateway/editing.py
@@ -84,6 +84,23 @@ class EditingMixin(GatewayCore):
     def playlist_delete(self, server_uuid, playlist_id):
         self._edit(server_uuid, lambda jf: jf.delete_item(playlist_id))
 
+    def delete_item(self, server_uuid, item_id):
+        """Delete an item from the server, files and all.
+
+        The same endpoint its playlist sibling above uses, and it raises the
+        same way: a destructive call that reports success it did not have is
+        the bug ``delete_download`` was fixed for, and here the cost of
+        getting it wrong is the user believing a file is gone when it is
+        not -- or, worse, looking for it to come back.
+
+        No permission check here. The server decides, and the *item* carries
+        its answer (``CanDelete``), which is what the menu is keyed off --
+        deletion is granted per library, so a client-side reading of the
+        user policy would be right about the account and wrong about half
+        their libraries.
+        """
+        self._edit(server_uuid, lambda jf: jf.delete_item(item_id))
+
     def playlist_update(self, server_uuid, playlist_id, name=None,
                         is_public=None):
         self._edit(server_uuid,

--- a/jellyfin_mpv_shim/mpvtk_browser/item_actions.py
+++ b/jellyfin_mpv_shim/mpvtk_browser/item_actions.py
@@ -522,6 +522,84 @@ class ItemActions:
         """Ask the shell for the download dialog (size estimate, options)."""
         self.dialogs.open_download(item)
 
+    # -- deleting from the server ------------------------------------------
+
+    @staticmethod
+    def can_delete(item):
+        """Whether to offer Delete from Disk for this item.
+
+        ``CanDelete`` off the DTO, which is jellyfin-web's own test
+        (itemContextMenu.js) and the only correct one: the server computes
+        it from the user's policy **and** the library the item is in, so
+        deletion can be granted for one library and not another and no
+        client-side reading of the account can know which.
+
+        Absent means no, and that is the opposite of ``may_download``'s
+        fail-open on purpose: hiding a delete the user could have made is an
+        inconvenience, and offering one that 403s at the point of no return
+        is not.
+        """
+        return bool((item or {}).get("CanDelete"))
+
+    def confirm_delete_item(self, item, server, on_done=None):
+        """Confirm, loudly, then delete this item from the server.
+
+        The wording is jellyfin-web's ``ConfirmDeleteItem`` verbatim -- so it
+        seeds into 86 locales -- and the name goes on its own line rather
+        than into the sentence, which is both more legible and the only way
+        it *can* seed (their placeholder is ``{0}`` and ours would be
+        ``%s``, and the seeder compares placeholder shapes).
+
+        "Delete from Disk" on the title and on the button, not "Delete":
+        every other Delete on these screens removes a *download*, and the
+        two are one careless press apart.
+        """
+        name = item.get("Name") or ""
+        self.dialogs.confirm(
+            name,
+            lambda: self.delete_item(item, server, on_done=on_done),
+            title=_("Delete from Disk"),
+            yes=_("Delete from Disk"),
+            detail=_("Deleting this item will delete it from both the file "
+                     "system and your media library. Are you sure you wish "
+                     "to continue?"))
+
+    def delete_item(self, item, server, on_done=None):
+        """Delete on the server, then drop any local copy.
+
+        **The download goes too.** Leaving it behind means the library says
+        the item is gone while this machine still plays it -- and the local
+        file is now the only copy of something the user asked to destroy,
+        which is a surprise in the more alarming direction. Best effort and
+        after the fact: the server delete is the one that has to be
+        reported, and a catalog row that failed to clear is a cosmetic
+        problem next to it.
+
+        ``on_done`` is how the *page* decides what to do next, because only
+        it knows whether the deleted item was the thing on screen or a tile
+        in a list.
+        """
+        iid = item.get("Id")
+        if not iid:
+            return
+        name = item.get("Name") or ""
+
+        def gone():
+            ctl = self.services.controller
+            try:
+                if ctl is not None:
+                    ctl.delete_download(item_id=iid)
+            except Exception:
+                log.debug("could not drop the local copy of %s", iid,
+                          exc_info=True)
+            self._on_downloads_changed()
+            self.services.set_status(_("%s was deleted.") % name)
+            if on_done is not None:
+                on_done()
+
+        self.edit(lambda c: c.delete_item(server, iid), on_ok=gone,
+                  error=_("%s could not be deleted.") % name)
+
     def confirm_remove_download(self, item):
         """Confirm, then delete this item's downloaded copy."""
         self.dialogs.confirm(

--- a/jellyfin_mpv_shim/mpvtk_browser/pages/detail.py
+++ b/jellyfin_mpv_shim/mpvtk_browser/pages/detail.py
@@ -131,6 +131,13 @@ class DetailPage(Page):
             btns.append(controls.action_btn(
                 "info", _("Media Info"), "act-minfo",
                 lambda: self.ctx.dialogs.media_info(item, server)))
+        if self.ctx.actions.can_delete(item):
+            # Last in the row, like the tile menu, and for the same reason:
+            # it is the only control here that destroys anything.
+            btns.append(controls.action_btn(
+                "delete", _("Delete from Disk"), "act-delete",
+                lambda: self.ctx.actions.confirm_delete_item(
+                    item, server, on_done=self._left_after_delete)))
         if item.get("Type") == "Episode" and item.get("SeriesId"):
             btns.append(controls.action_btn(
                 "movie", _("Go to Series"), "act-series",
@@ -139,6 +146,16 @@ class DetailPage(Page):
                     "item_id": item["SeriesId"],
                     "title": item.get("SeriesName", "")})))
         return Row(btns, gap=8, align="center")
+
+    def _left_after_delete(self):
+        """Leave the page once its item is gone.
+
+        Unlike a grid, this screen *is* the deleted item: re-reading it
+        would fetch a 404 and show an error where a film used to be. Back,
+        which lands on the list it was opened from -- and that list re-reads
+        itself on the way in, so the tile goes too.
+        """
+        self.ctx.nav.go_back()
 
     def _start(self, item, server, offset_ticks=None):
         """Play `item` with the version and tracks selected **now**.

--- a/jellyfin_mpv_shim/mpvtk_browser/repository.py
+++ b/jellyfin_mpv_shim/mpvtk_browser/repository.py
@@ -60,7 +60,7 @@ log = logging.getLogger("mpvtk_browser.repository")
 # to answer (it is the length of the item's own alternate-version lists, not a
 # media-source resolution -- that is MediaSources, which DETAIL_FIELDS pays
 # for and a browse query must not).
-LIST_FIELDS = "PrimaryImageAspectRatio,Overview,MediaSourceCount"
+LIST_FIELDS = "PrimaryImageAspectRatio,Overview,MediaSourceCount,CanDelete"
 
 #: An item's own artwork counts as landscape at or above this, which is what
 #: lets `backdrop_spec` use a home video's extracted still for its header and
@@ -77,7 +77,18 @@ _LANDSCAPE_ART = 0.8
 # a clicked one seeds a page that shows the text while the real DTO loads.
 # jellyfin-web's grid asks for the aspect ratio only when the view is Primary;
 # MediaSourceCount it asks for everywhere, and so do we -- see LIST_FIELDS.
-GRID_FIELDS = "PrimaryImageAspectRatio,MediaSourceCount"
+GRID_FIELDS = "PrimaryImageAspectRatio,MediaSourceCount,CanDelete"
+
+#: CanDelete is in all three sets, and it has to be ASKED FOR: a list query
+#: omits it entirely (measured -- the key is absent, not False), so a Delete
+#: from Disk entry keyed off it would simply never appear. A single-item
+#: fetch returns it whatever Fields says, but relying on that would make the
+#: detail page's button depend on an undocumented default.
+#:
+#: It costs nothing measurable: +1.8 KB on a 165 KB hundred-item grid, and
+#: no change in query time -- which is worth having measured, because the
+#: per-item permission fields on this API are exactly the ones that have
+#: been expensive before (see the note on Items/Filters).
 
 #: ...and what a BOOKS grid asks for on top.
 #:
@@ -179,7 +190,7 @@ MUSIC_FIELDS = "PrimaryImageAspectRatio,ItemCounts"
 DETAIL_FIELDS = (
     "Path,Overview,Genres,Studios,People,Taglines,SortName,"
     "MediaSources,MediaStreams,Chapters,ProviderIds,"
-    "PrimaryImageAspectRatio,DateCreated"
+    "PrimaryImageAspectRatio,DateCreated,CanDelete"
 )
 
 # CollectionTypes we do not surface (video-only browser, phase 1). Playlists

--- a/jellyfin_mpv_shim/mpvtk_browser/settings/general.py
+++ b/jellyfin_mpv_shim/mpvtk_browser/settings/general.py
@@ -221,6 +221,19 @@ class GeneralTabMixin:
             return _("Not active: the \"pypresence\" package is missing or "
                      "failed to load. Install it and restart. (Details in "
                      "the Logs tab.)")
+        if key == "hwdec":
+            # A pin, not a preference: where mpv.conf sets hwdec, nothing
+            # here writes the option at all, so the control above is inert
+            # and has to say so. Silently ignoring a setting the user is
+            # looking straight at is the failure this whole feature is
+            # downstream of.
+            from ...mpv_options import hwdec_pinned_by_config
+
+            pinned = hwdec_pinned_by_config()
+            if pinned is None:
+                return None
+            return _("Pinned by config: your mpv.conf sets hwdec=%s, which "
+                     "overrides this.") % pinned
         if key != "auto_download_enable":
             return None
         name = self._auto_dl_scope_name()

--- a/jellyfin_mpv_shim/mpvtk_browser/tiles.py
+++ b/jellyfin_mpv_shim/mpvtk_browser/tiles.py
@@ -333,6 +333,15 @@ class TilesMixin:
             # with, so this is one of the few entries that answers just as
             # well with the server away.
             out.append((_("Media Info"), "info", "mediainfo"))
+        # Last, and deliberately: it is the only entry here that destroys
+        # anything, and a menu whose most dangerous item sits next to Play
+        # is a menu that gets misclicked. The condition is the item's own
+        # CanDelete (ItemActions.can_delete) -- not a type set, because
+        # deletion is granted per library and only the server knows which.
+        # Offline is out: there is nothing to delete *on*, and the local
+        # copy has its own Remove Download.
+        if not self._offline and self._actions.can_delete(item):
+            out.append((_("Delete from Disk"), "delete", "deleteitem"))
         # Only inside a playlist, and only for an entry that carries its
         # PlaylistItemId — removal is by entry, not by item id (the same
         # item can appear twice).
@@ -410,6 +419,13 @@ class TilesMixin:
             self._close_menu()
             self._open_media_info(item, server)
             return
+        elif action == "deleteitem":
+            self._close_menu()
+            # Reload the list it came from: the tile is now a row pointing
+            # at nothing, and leaving it there invites a second press.
+            self._actions.confirm_delete_item(
+                item, server, on_done=self._reload_after_delete)
+            return
         elif action == "unplaylist":
             self._close_menu()
             self._remove_from_playlist(item)
@@ -467,6 +483,21 @@ class TilesMixin:
         else:
             self._actions.cancel_series_timer(item.get("SeriesTimerId"),
                                               server, on_done=done)
+
+    def _reload_after_delete(self):
+        """Re-read the list the deleted tile came from.
+
+        Same shape as ``_do_remove_from_collection``'s re-read, and for the
+        same reason: the grid still lists what is no longer there, and a
+        tile pointing at nothing invites a second press. Dropping ``_items``
+        as well as ``_loading`` matters -- a load that finds the route
+        already holding items returns without fetching.
+        """
+        route = self.route
+        route.pop("_items", None)
+        route.pop("_data", None)
+        route.pop("_loading", None)
+        self._load_route(route)
 
     def _remove_from_playlist(self, item):
         entry = item.get("PlaylistItemId")

--- a/jellyfin_mpv_shim/player.py
+++ b/jellyfin_mpv_shim/player.py
@@ -1777,6 +1777,63 @@ class PlayerManager(AudioMixin, ReportingMixin, WindowMixin):
         return True
 
     @synchronous("_lock")
+    def _forced_hwdec(self):
+        """Whether a shader profile has named the decoder it requires.
+
+        A profile naming a *specific* decoder (``d3d11va``, ``vaapi``, …)
+        is stating a hardware requirement of the thing the user just chose
+        -- the shipped ``rtx-vsr`` needs d3d11va because its d3d11vpp
+        filter operates on d3d11 surfaces. That is different in kind from
+        the blanket ``auto-copy`` every profile used to carry, which was an
+        opinion about the machine. The specific one is applied by the
+        profile itself; this just stops the per-item write from undoing it
+        on the next file.
+        """
+        try:
+            profiles = self.menu.profile_manager if self.menu else None
+            return bool(profiles is not None
+                        and getattr(profiles, "forced_hwdec", None))
+        except Exception:
+            log.debug("could not read the shader profile", exc_info=True)
+            return False
+
+    def _needs_copy_hwdec(self):
+        """Whether anything downstream needs frames in system RAM.
+
+        The direct hardware-decoding modes hand mpv frames that live on the
+        GPU, which a video filter cannot read -- so where there is a filter,
+        hardware decoding has to be the copy-back kind or it silently does
+        not apply. Three sources, and none of them is a guess:
+
+        * the active shader profile said so (``wants_copy_hwdec`` -- the
+          pack names a ``-copy`` mode because it knows what it will do with
+          the frames);
+        * SVP is enabled, which means a VapourSynth filter in the user's
+          own mpv.conf;
+        * mpv reports a filter chain. This is the general case and catches
+          the other two as well once playback is running, but it is asked
+          separately because it is the only one that sees a filter the app
+          knows nothing about.
+
+        Never raises: an unanswerable question here means "no filter", and
+        the cost of being wrong is a filter that does not apply -- not a
+        player that fails to start.
+        """
+        try:
+            profiles = self.menu.profile_manager if self.menu else None
+            if profiles is not None and getattr(profiles, "wants_copy_hwdec",
+                                                False):
+                return True
+        except Exception:
+            log.debug("could not read the shader profile", exc_info=True)
+        if settings.svp_enable:
+            return True
+        try:
+            return bool(self._player.vf)
+        except Exception:
+            log.debug("could not read the filter chain", exc_info=True)
+        return False
+
     def _play_media(
         self,
         video: "Video_type",
@@ -1826,6 +1883,22 @@ class PlayerManager(AudioMixin, ReportingMixin, WindowMixin):
                                    else settings.video_volume)
         except _mpv_errors:
             pass
+        # A shader pack is for moving pictures. It is applied once and
+        # left on the mpv instance, so without this an anime-upscaling
+        # chain runs over a photograph -- and over a comic page, which is
+        # 1600x2400 or larger, where it is expensive as well as wrong. The
+        # name is kept while suspended, so the menu still shows the profile
+        # the user chose and nothing rewrites the remembered setting.
+        try:
+            profiles = self.menu.profile_manager if self.menu else None
+            if profiles is not None:
+                if getattr(video, "is_photo", False):
+                    profiles.suspend_for_still()
+                else:
+                    profiles.resume_after_still()
+        except Exception:
+            log.debug("could not adjust the shader profile for this item",
+                      exc_info=True)
         # Hardware decoding, BEFORE play() for the same reason as the two
         # above: hwdec is read when the decoder is initialised, and the
         # failures this setting is cautious about (a driver that resets the
@@ -1839,7 +1912,15 @@ class PlayerManager(AudioMixin, ReportingMixin, WindowMixin):
         try:
             from .mpv_options import hwdec_for
 
-            self._player.hwdec = hwdec_for(_source_height(video))
+            # None means somebody more specific has already spoken -- the
+            # user's own mpv.conf, or a shader profile naming the decoder
+            # its filter requires. Both outrank the setting, and both are
+            # already applied, so the right move is not to write at all.
+            forced = self._forced_hwdec()
+            want = None if forced else hwdec_for(_source_height(video),
+                                                 self._needs_copy_hwdec())
+            if want is not None:
+                self._player.hwdec = want
         except Exception:
             # Never let a decode *preference* stop playback: mpv keeps
             # whatever it had, which is at worst the previous item's.

--- a/jellyfin_mpv_shim/player.py
+++ b/jellyfin_mpv_shim/player.py
@@ -113,6 +113,26 @@ def bound_ipc_replies(seconds=IPC_TEARDOWN_TIMEOUT):
 
 
 
+def _source_height(video):
+    """The video height of what is about to play, or None.
+
+    Read off the **MediaSource**, not the item: an item with several
+    versions has one height per version, and the one being played is the
+    one that decides whether hardware decoding is worth its risk. A photo,
+    an audio track and anything the server did not probe all answer None,
+    which every caller treats as "software" -- see mpv_options.hwdec_for.
+    """
+    try:
+        streams = (getattr(video, "media_source", None) or {}).get(
+            "MediaStreams") or []
+        for stream in streams:
+            if stream.get("Type") == "Video" and stream.get("Height"):
+                return int(stream["Height"])
+    except Exception:
+        log.debug("could not read the source height", exc_info=True)
+    return None
+
+
 def runtime_force_window_works(version):
     """Whether this mpv acts on a force-window change made while idle.
 
@@ -1806,6 +1826,24 @@ class PlayerManager(AudioMixin, ReportingMixin, WindowMixin):
                                    else settings.video_volume)
         except _mpv_errors:
             pass
+        # Hardware decoding, BEFORE play() for the same reason as the two
+        # above: hwdec is read when the decoder is initialised, and the
+        # failures this setting is cautious about (a driver that resets the
+        # GPU, a vp9 path that hangs before the window opens) happen there.
+        # Setting it afterwards would apply to the file after this one.
+        #
+        # Re-applied per item rather than only at construction, which is
+        # what lets "over-1080p" be a policy at all -- and, for the static
+        # modes, what makes a settings change take effect on the next item
+        # instead of the next launch.
+        try:
+            from .mpv_options import hwdec_for
+
+            self._player.hwdec = hwdec_for(_source_height(video))
+        except Exception:
+            # Never let a decode *preference* stop playback: mpv keeps
+            # whatever it had, which is at worst the previous item's.
+            log.debug("could not apply the hwdec setting", exc_info=True)
         # How long mpv holds a still. BEFORE play(), not after the load
         # succeeds: this is what mpv reports as the file's `duration`, so
         # the duration wait below and the HUD's scrub bar both depend on it

--- a/jellyfin_mpv_shim/player_window.py
+++ b/jellyfin_mpv_shim/player_window.py
@@ -404,6 +404,29 @@ class WindowMixin:
 
     # ---------------------------------------------------- still pictures
 
+    def _suspend_shaders_for_still(self):
+        """Take the shader profile off for a picture. Best effort.
+
+        Shared by the comic reader and by photo playback (which reaches it
+        through _play_media, not here) so the two cannot drift about what
+        counts as a still.
+        """
+        try:
+            profiles = self.menu.profile_manager if self.menu else None
+            if profiles is not None:
+                profiles.suspend_for_still()
+        except Exception:
+            wlog.debug("could not suspend the shader profile", exc_info=True)
+
+    def _resume_shaders_after_still(self):
+        """Put back whatever :meth:`_suspend_shaders_for_still` took off."""
+        try:
+            profiles = self.menu.profile_manager if self.menu else None
+            if profiles is not None:
+                profiles.resume_after_still()
+        except Exception:
+            wlog.debug("could not restore the shader profile", exc_info=True)
+
     def show_picture(self, path):
         """Display a local image file in the browse window.
 
@@ -436,6 +459,13 @@ class WindowMixin:
             # and video-zoom had no visible effect at all, because a
             # stretched picture already fills the window at every zoom.
             self._player.keepaspect = True
+            # A shader pack is for moving pictures. It sits on the mpv
+            # instance until something takes it off, so an anime-upscaling
+            # chain would run over every comic page -- at 1600x2400 or
+            # larger, which is where it is expensive as well as wrong.
+            # Suspended, not unloaded: the name is kept, so the menu still
+            # shows the profile the user chose. clear_picture puts it back.
+            self._suspend_shaders_for_still()
             # An image has no duration, so mpv shows it for
             # image_display_duration (1s) and then idles.
             self._player.image_display_duration = "inf"
@@ -507,6 +537,12 @@ class WindowMixin:
         reproducing half of it here is how the two drift.
         """
         self.reset_picture_view()
+        # Before the guard, like reset_picture_view above and for the same
+        # reason: playback starting is one of the ways a comic stops being
+        # on screen, and the profile is a global mpv setting -- a film that
+        # inherited the suspension would play unshaded. _play_media resumes
+        # too, so this is belt and braces on the path that has no video.
+        self._resume_shaders_after_still()
         if not self._mpv_alive or self._video is not None:
             return
         if self.mpvtk_active:

--- a/jellyfin_mpv_shim/video_profile.py
+++ b/jellyfin_mpv_shim/video_profile.py
@@ -1,4 +1,5 @@
 from .conf import settings
+from .mpv_options import NAIVE_HWDEC, hwdec_pinned_by_config
 from . import conffile
 from .utils import get_resource
 from .constants import APP_NAME
@@ -86,6 +87,21 @@ class VideoProfileManager:
         self.menu = menu
         self.playerManager = player_manager
         self.used_settings = set()
+        #: True while the loaded profile needs frames in system RAM. Not
+        #: "hardware decoding is on" -- it is "if it is on, it has to be the
+        #: copy kind". Derived, not read: see _wants_copy.
+        self.wants_copy_hwdec = False
+        #: Working state for that derivation, per load.
+        self._sets_vf = False
+        self._names_direct_hwdec = False
+        #: A specific decoder the loaded profile requires, or None.
+        #: Not the naive auto/auto-copy every profile carries -- see
+        #: process_setting_group.
+        self.forced_hwdec = None
+        #: Profile name parked by suspend_for_still, or None. Distinct from
+        #: current_profile, which stays set while suspended so the menu and
+        #: the remembered setting still say what the user chose.
+        self._suspended = None
         self.current_profile = None
         self.player = player
         self.profile_subtypes = []
@@ -201,6 +217,51 @@ class VideoProfileManager:
     ):
         group = self.groups[group_name]
         for key, value in group.get("settings", []):
+            if key == "hwdec":
+                # **A naive value is the pack's opinion about the machine;
+                # a named decoder is a requirement of the profile.**
+                #
+                # Every profile pulls in a "hwdec-default" group setting
+                # hwdec to auto-copy -- [iw]: "this was just me being
+                # risk-averse in the past". That is a policy ("use hardware
+                # decoding if you can"), and it is not the pack's to have:
+                # hwdec is a user-facing setting that defaults OFF because
+                # a long tail of graphics drivers handle it badly, up to
+                # mpv hanging before the window opens (mpv#12948). Picking
+                # a shader profile must not switch it back on, or the
+                # breakage gets attributed to the profile -- the last place
+                # anyone would look. Dropped.
+                #
+                # A *specific* decoder is different in kind. The shipped
+                # rtx-vsr names d3d11va because its d3d11vpp filter
+                # operates on Direct3D surfaces: the profile does not work
+                # without it, and choosing that profile IS opting in.
+                # Applied, and remembered, so the per-item write in
+                # _play_media does not undo it on the next file.
+                # The user's own mpv.conf outranks a pack as well as the
+                # setting: where it pins hwdec, nothing writes the option.
+                # Checked here rather than left to _play_media, because a
+                # profile applies its settings directly and would otherwise
+                # slip past the pin between one file and the next.
+                if hwdec_pinned_by_config() is not None:
+                    log.info("Not applying the shader pack's hwdec=%s; "
+                             "mpv.conf pins it.", value)
+                    continue
+                if str(value).strip().lower() in NAIVE_HWDEC:
+                    log.info("Not applying the shader pack's hwdec=%s; "
+                             "hardware decoding follows the Hardware "
+                             "Decoding setting.", value)
+                    if not str(value).endswith("-copy"):
+                        self._names_direct_hwdec = True
+                    continue
+                log.info("Shader profile requires hwdec=%s; applying it.",
+                         value)
+                self.forced_hwdec = value
+                self._names_direct_hwdec = not str(value).endswith("-copy")
+            if key == "vf":
+                # A real video filter, which is the one thing here that
+                # genuinely cannot read GPU frames -- unlike a glsl shader.
+                self._sets_vf = True
             if key in ("gpu_api", "fbo_format"):
                 value = self.api_setting_override(key, value)
                 if value is None:
@@ -239,6 +300,14 @@ class VideoProfileManager:
 
         settings_to_apply = []
         shaders_to_apply = []
+        # Recomputed from the groups below rather than left standing: a
+        # load with reset=False (the still-image resume, the startup
+        # restore) does not go through unload_profile, so a stale True
+        # would outlive the profile that set it.
+        self.wants_copy_hwdec = False
+        self._sets_vf = False
+        self._names_direct_hwdec = False
+        self.forced_hwdec = None
         try:
             # Read Settings & Shaders
             for group in self.default_groups:
@@ -274,6 +343,8 @@ class VideoProfileManager:
                     setattr(self.player, key, value)
                 already_set.add((key, value))
 
+            self.wants_copy_hwdec = self._wants_copy()
+
             # Apply Shaders
             log.info("Set shaders: {0}".format(shaders_to_apply))
             self.player.glsl_shaders = shaders_to_apply
@@ -283,8 +354,75 @@ class VideoProfileManager:
             log.error("Could not apply shader profile.", exc_info=True)
             return False
 
+    def suspend_for_still(self):
+        """Take the shader profile off while a still image is on screen.
+
+        A shader pack is applied once -- from the menu, or restored at
+        startup from ``shader_pack_profile`` -- and then left on the mpv
+        instance. Nothing on the play path touched it, so an anime-upscaling
+        chain ran over a photograph, and over a comic page at 1600x2400 or
+        larger, where it is both wrong and expensive: these packs are built
+        for moving pictures at broadcast resolutions and a scanned page is
+        neither.
+
+        **Not ``unload_profile``**, which is the whole reason this exists:
+        that clears ``current_profile``, and the menu's selection and
+        ``menu_handle``'s persistence both read it -- so opening a photo
+        would have silently reset the user's chosen profile. This is a
+        suspension: mpv is put back to defaults, the *name* is kept, and
+        :meth:`resume_after_still` puts it back.
+
+        Idempotent. Photos arrive in queues, and every one of them runs the
+        play path.
+        """
+        if self._suspended is not None or self.current_profile is None:
+            return
+        self._suspended = self.current_profile
+        log.info("Suspending shader profile %s for a still image.",
+                 self._suspended)
+        name = self.current_profile
+        self.unload_profile()
+        self.current_profile = name
+
+    def resume_after_still(self):
+        """Put back a profile :meth:`suspend_for_still` took off.
+
+        A no-op when nothing was suspended, which is the ordinary case: this
+        runs on every playback start, and almost none of them follow a
+        still.
+        """
+        name, self._suspended = self._suspended, None
+        if name is None:
+            return
+        log.info("Restoring shader profile %s.", name)
+        # reset=False: unload already ran, and unloading again would write
+        # every default a second time for nothing.
+        self.load_profile(name, reset=False)
+
+    def _wants_copy(self):
+        """Does this profile need frames in system RAM?
+
+        Only a real ``vf`` does -- a glsl shader runs inside the GPU
+        renderer, on frames that are already on the GPU. So the pack's
+        blanket ``hwdec: auto-copy`` is not the question; whether the
+        profile installs a filter is.
+
+        And a profile that names a **direct** hwdec mode alongside its
+        filter is saying the opposite: its filter wants GPU frames. In the
+        shipped pack that is exactly ``rtx-vsr``, whose
+        ``format=nv12,d3d11vpp=scale=2:scaling-mode=nvidia`` is a Direct3D
+        video-processor filter that operates on d3d11 surfaces --
+        copying back would break the only profile in the pack that has a
+        filter at all.
+        """
+        return self._sets_vf and not self._names_direct_hwdec
+
     def unload_profile(self):
         log.info("Unloading shader profile.")
+        self.wants_copy_hwdec = False
+        self._sets_vf = False
+        self._names_direct_hwdec = False
+        self.forced_hwdec = None
         self.player.glsl_shaders = []
         for setting in self.used_settings:
             value = self.defaults[setting]

--- a/tests/test_mpv_options.py
+++ b/tests/test_mpv_options.py
@@ -301,3 +301,105 @@ class ExternalMpvTest(SettingsCase):
 
 if __name__ == "__main__":
     unittest.main()
+
+
+class HwdecTest(SettingsCase):
+    """Hardware decoding — the setting, and the policy behind "over-1080p".
+
+    Off by default, following mpv rather than the other Jellyfin clients:
+    mpv's manual says to "acknowledge that this may cause problems" and its
+    maintainers decline to enable it by default (mpv#12948), because
+    particular vendor/GPU combinations are badly broken. "over-1080p" is
+    the option only *this* client can offer — the source resolution is in
+    the DTO before playback starts, so decoding can be software where
+    software is fine.
+    """
+
+    def test_the_default_is_software_decoding(self):
+        self.assertEqual(settings.hwdec, "no")
+        self.assertEqual(mpv_options.hwdec_for(2160), "no")
+
+    def test_the_static_modes_ignore_the_height(self):
+        for mode, expected in (("no", "no"), ("auto", "auto"),
+                               ("auto-copy", "auto-copy")):
+            self.set(hwdec=mode)
+            for height in (None, 480, 1080, 2160):
+                self.assertEqual(mpv_options.hwdec_for(height), expected,
+                                 "%s at %r" % (mode, height))
+
+    def test_the_threshold_is_strictly_above_1080(self):
+        # 1920x1080 decodes in software and 4K does not, which is the line
+        # the setting is named after.
+        self.set(hwdec="over-1080p")
+        self.assertEqual(mpv_options.hwdec_for(1080), "no")
+        self.assertEqual(mpv_options.hwdec_for(1081), "auto")
+        self.assertEqual(mpv_options.hwdec_for(2160), "auto")
+
+    def test_an_unknown_height_stays_on_software(self):
+        """Audio, a photo, or anything the server did not probe. Starting a
+        file with hardware decoding already on and turning it off is the
+        wrong way round — decoder init is where the bad paths hang."""
+        self.set(hwdec="over-1080p")
+        for height in (None, 0, "", "not a number"):
+            self.assertEqual(mpv_options.hwdec_for(height), "no",
+                             "height=%r" % (height,))
+
+    def test_a_hand_edited_value_falls_back_to_software(self):
+        # Handing an unknown string to mpv fails the option at
+        # construction, which takes the whole player with it.
+        self.set(hwdec="turbo-mode")
+        with self.assertLogs("mpv_options", level="WARNING"):
+            self.assertEqual(mpv_options.hwdec_for(2160), "no")
+
+    def test_the_construction_default_is_software_for_the_threshold_mode(self):
+        # Nothing is loaded at construction, so there is no height to judge;
+        # _play_media raises it per file.
+        self.set(hwdec="over-1080p")
+        self.assertEqual(self.build()["hwdec"], "no")
+
+    def test_a_static_mode_reaches_the_option_dict(self):
+        self.set(hwdec="auto-copy")
+        self.assertEqual(self.build()["hwdec"], "auto-copy")
+
+    def test_the_cli_override_beats_every_mode(self):
+        """`--disable-hwdec` is the recovery path for hardware decoding
+        stopping the window opening at all, so nothing may outrank it."""
+        for mode in ("auto", "auto-copy", "over-1080p"):
+            self.set(hwdec=mode)
+            with mock.patch.object(mpv_options, "hwdec_for",
+                                   mpv_options.hwdec_for):
+                with mock.patch("jellyfin_mpv_shim.args.get_args") as ga:
+                    ga.return_value = mock.Mock(disable_hwdec=True)
+                    self.assertEqual(mpv_options.hwdec_for(2160), "no", mode)
+
+    def test_it_survives_argument_parsing_being_unavailable(self):
+        # Imported bare in tests and tools; a missing override is "no
+        # override", never a crash on the playback path.
+        self.set(hwdec="auto")
+        with mock.patch("jellyfin_mpv_shim.args.get_args",
+                        side_effect=RuntimeError("no argv")):
+            self.assertEqual(mpv_options.hwdec_for(2160), "auto")
+
+
+class SourceHeightTest(unittest.TestCase):
+    """What `over-1080p` judges. Read off the MediaSource, not the item: an
+    item with several versions has one height per version, and the one
+    playing is the one whose decoding is at stake."""
+
+    def _height(self, source):
+        from jellyfin_mpv_shim.player import _source_height
+        return _source_height(mock.Mock(media_source=source))
+
+    def test_it_reads_the_video_stream(self):
+        self.assertEqual(self._height({"MediaStreams": [
+            {"Type": "Audio", "Height": 999},
+            {"Type": "Video", "Height": 2160}]}), 2160)
+
+    def test_an_audio_only_source_has_no_height(self):
+        self.assertIsNone(self._height({"MediaStreams": [
+            {"Type": "Audio", "Channels": 2}]}))
+
+    def test_degenerate_sources(self):
+        for source in ({}, None, {"MediaStreams": []},
+                       {"MediaStreams": [{"Type": "Video"}]}):
+            self.assertIsNone(self._height(source), repr(source))

--- a/tests/test_mpv_options.py
+++ b/tests/test_mpv_options.py
@@ -403,3 +403,67 @@ class SourceHeightTest(unittest.TestCase):
         for source in ({}, None, {"MediaStreams": []},
                        {"MediaStreams": [{"Type": "Video"}]}):
             self.assertIsNone(self._height(source), repr(source))
+
+
+class HwdecConfigPinTest(SettingsCase):
+    """The user's own mpv.conf outranks everything here.
+
+    Silently overriding an option somebody wrote into mpv.conf is the
+    failure this whole feature is downstream of, so where the file speaks
+    the app writes nothing at all — `hwdec_for` answers None and both
+    callers treat that as "leave it alone", which keeps mpv's own config
+    precedence intact instead of modelling it here.
+    """
+
+    def _with_conf(self, text):
+        import tempfile
+        import os
+        d = tempfile.mkdtemp()
+        path = os.path.join(d, "mpv.conf")
+        with open(path, "w") as fh:
+            fh.write(text)
+        return mock.patch("jellyfin_mpv_shim.conffile.get",
+                          return_value=path)
+
+    def test_no_pin_when_the_file_says_nothing(self):
+        with self._with_conf("# nothing here\nvolume=80\n"):
+            self.assertIsNone(mpv_options.hwdec_pinned_by_config())
+
+    def test_a_plain_setting_pins(self):
+        with self._with_conf("hwdec=vaapi\n"):
+            self.assertEqual(mpv_options.hwdec_pinned_by_config(), "vaapi")
+
+    def test_spacing_dashes_and_quotes(self):
+        for line in ('hwdec = vaapi', '--hwdec=vaapi', 'hwdec="vaapi"',
+                     "hwdec='vaapi'", 'hwdec=vaapi   # why not'):
+            with self._with_conf(line + "\n"):
+                self.assertEqual(mpv_options.hwdec_pinned_by_config(),
+                                 "vaapi", line)
+
+    def test_a_commented_out_line_is_not_a_pin(self):
+        with self._with_conf("#hwdec=vaapi\n"):
+            self.assertIsNone(mpv_options.hwdec_pinned_by_config())
+
+    def test_a_profile_section_is_not_a_pin(self):
+        """mpv profile sections are conditional. Reading one as
+        unconditional would pin on a value that may never apply, and the
+        safe direction is to leave the setting working — mpv's own
+        precedence still applies the profile where it fires."""
+        with self._with_conf("volume=80\n\n[hq]\nhwdec=vaapi\n"):
+            self.assertIsNone(mpv_options.hwdec_pinned_by_config())
+
+    def test_a_pin_stops_us_writing_the_option_at_all(self):
+        self.set(hwdec="auto")
+        with self._with_conf("hwdec=vaapi\n"):
+            self.assertIsNone(mpv_options.hwdec_for(2160))
+            self.assertNotIn("hwdec", self.build())
+
+    def test_a_pin_outranks_the_copy_upgrade_too(self):
+        self.set(hwdec="auto")
+        with self._with_conf("hwdec=nvdec\n"):
+            self.assertIsNone(mpv_options.hwdec_for(2160, needs_copy=True))
+
+    def test_an_unreadable_config_is_not_a_pin(self):
+        with mock.patch("jellyfin_mpv_shim.conffile.get",
+                        side_effect=OSError("gone")):
+            self.assertIsNone(mpv_options.hwdec_pinned_by_config())

--- a/tests/test_shader_gpu_api.py
+++ b/tests/test_shader_gpu_api.py
@@ -48,6 +48,15 @@ class FakeProfileManager:
                          "vf": ""}
         self.revert_ignore = {"gpu_api", "profile", "hwdec"}
         self.used_settings = set()
+        #: Modelled because process_setting_group writes it: a profile
+        #: naming a *-copy hwdec is recorded as "this profile needs frames
+        #: in system RAM", which is the one part of the pack's hwdec value
+        #: that survives. A fake without it makes that path raise where
+        #: nothing is looking.
+        self.wants_copy_hwdec = False
+        self._sets_vf = False
+        self._names_direct_hwdec = False
+        self.forced_hwdec = None
         self.shader_pack = "/nonexistent"
 
     process_setting_group = VideoProfileManager.process_setting_group
@@ -75,8 +84,10 @@ class ShaderGpuApiTests(unittest.TestCase):
         applied = FakeProfileManager().applied()
         self.assertNotIn("gpu_api", applied)
         self.assertNotIn("fbo_format", applied)
-        # The rest of the group still has to be applied.
-        self.assertEqual(applied["hwdec"], "auto-copy")
+        # The rest of the group still has to be applied -- except hwdec,
+        # which the pack no longer gets to set (it is a user setting now;
+        # see ThePackDoesNotSetHwdecTest in tests/test_shader_stills.py).
+        self.assertNotIn("hwdec", applied)
         self.assertEqual(applied["profile"], "gpu-hq")
 
     def test_fbo_format_stays_dropped_when_an_api_is_forced(self):
@@ -107,6 +118,10 @@ class ShaderGpuApiTests(unittest.TestCase):
         settings.shader_pack_gpu_api = "auto"
         out = applied(RTX_VSR)
         self.assertEqual(out["gpu_api"], "d3d11")
+        # ...and its hwdec too, because d3d11va NAMES a decoder rather than
+        # expressing a policy. Its d3d11vpp filter operates on Direct3D
+        # surfaces, so the profile does not work without it -- unlike the
+        # blanket auto-copy every profile carries, which is dropped.
         self.assertEqual(out["hwdec"], "d3d11va")
 
     def test_the_user_still_outranks_a_profile_that_names_an_api(self):

--- a/tests/test_shader_stills.py
+++ b/tests/test_shader_stills.py
@@ -1,0 +1,309 @@
+"""A shader pack must not run over a still image (#13).
+
+`VideoProfileManager.load_profile` is applied once — from the menu, or
+restored at startup from ``shader_pack_profile`` — and then left on the mpv
+instance. Nothing on the play path touched it, so an anime-upscaling chain
+ran over a photograph, and over a comic page at 1600x2400 or larger, where
+it is expensive as well as wrong.
+
+The fix is a *suspension*, and that distinction is the whole point: the
+obvious `unload_profile` clears ``current_profile``, which the menu's
+selection and ``menu_handle``'s persistence both read — so opening a photo
+would have silently reset the user's chosen profile.
+"""
+
+import sys
+import unittest
+from unittest import mock
+
+sys.argv = [sys.argv[0]]      # importing the shim reaches args.get_args()
+
+from jellyfin_mpv_shim.video_profile import VideoProfileManager  # noqa: E402
+
+
+def _manager(current="anime4k"):
+    """A VideoProfileManager with the file/network parts stubbed.
+
+    __init__ reads a shader pack off disk and probes mpv for every setting
+    the pack names, none of which this behaviour depends on.
+    """
+    m = VideoProfileManager.__new__(VideoProfileManager)
+    m.player = mock.Mock()
+    m.player.glsl_shaders = ["/packs/shaders/a.glsl"]
+    m.used_settings = {"scale", "cscale"}
+    m.defaults = {"scale": "bilinear", "cscale": "bilinear"}
+    m.current_profile = current
+    m._suspended = None
+    m.profiles = {"anime4k": {"shaders": ["a.glsl"]}}
+    m.default_groups = []
+    m.groups = {}
+    m.revert_ignore = set()
+    m.shader_pack = "/packs"
+    return m
+
+
+class SuspendKeepsTheChoiceTest(unittest.TestCase):
+
+    def test_suspending_clears_the_shaders(self):
+        m = _manager()
+        m.suspend_for_still()
+        self.assertEqual(m.player.glsl_shaders, [])
+
+    def test_suspending_puts_the_settings_back_to_their_defaults(self):
+        m = _manager()
+        m.suspend_for_still()
+        self.assertEqual(m.player.scale, "bilinear")
+        self.assertEqual(m.player.cscale, "bilinear")
+
+    def test_but_it_keeps_the_profile_name(self):
+        """The regression this is shaped to avoid: unload_profile clears
+        current_profile, and the menu selection and the remembered setting
+        both read it. Opening a photo would have reset the user's choice."""
+        m = _manager()
+        m.suspend_for_still()
+        self.assertEqual(m.current_profile, "anime4k")
+
+    def test_resuming_reapplies_it(self):
+        m = _manager()
+        m.suspend_for_still()
+        with mock.patch.object(m, "load_profile") as load:
+            m.resume_after_still()
+        load.assert_called_once_with("anime4k", reset=False)
+
+    def test_resuming_without_a_suspension_does_nothing(self):
+        # This runs on every playback start and almost none of them follow
+        # a still; re-applying a whole profile each time would be waste.
+        m = _manager()
+        with mock.patch.object(m, "load_profile") as load:
+            m.resume_after_still()
+        load.assert_not_called()
+
+    def test_suspending_twice_does_not_lose_the_name(self):
+        """Photos arrive in queues and every one runs the play path. A
+        second suspension must not park None over the real profile."""
+        m = _manager()
+        m.suspend_for_still()
+        m.suspend_for_still()
+        with mock.patch.object(m, "load_profile") as load:
+            m.resume_after_still()
+        load.assert_called_once_with("anime4k", reset=False)
+
+    def test_with_no_profile_chosen_there_is_nothing_to_do(self):
+        m = _manager(current=None)
+        m.suspend_for_still()
+        self.assertIsNone(m._suspended)
+        with mock.patch.object(m, "load_profile") as load:
+            m.resume_after_still()
+        load.assert_not_called()
+
+    def test_resume_is_not_a_second_unload(self):
+        # load_profile(reset=False): unload already ran, and unloading
+        # again would write every default a second time for nothing.
+        m = _manager()
+        m.suspend_for_still()
+        with mock.patch.object(m, "unload_profile") as unload:
+            with mock.patch.object(m, "load_profile"):
+                m.resume_after_still()
+        unload.assert_not_called()
+
+
+class TheStillPathsAskForItTest(unittest.TestCase):
+    """Both kinds of still reach the suspension, by different routes: a
+    photo is ordinary playback (_play_media) and a comic page is not
+    (show_picture). Checked from the source, because constructing either
+    path needs a real mpv."""
+
+    @staticmethod
+    def _source(name):
+        import os
+        import jellyfin_mpv_shim
+        base = os.path.dirname(os.path.abspath(jellyfin_mpv_shim.__file__))
+        with open(os.path.join(base, name), encoding="utf-8") as fh:
+            return fh.read()
+
+    def test_photo_playback_suspends_and_video_resumes(self):
+        src = self._source("player.py")
+        self.assertIn("suspend_for_still()", src)
+        self.assertIn("resume_after_still()", src)
+
+    def test_the_comic_reader_suspends_and_restores(self):
+        src = self._source("player_window.py")
+        self.assertIn("_suspend_shaders_for_still()", src)
+        self.assertIn("_resume_shaders_after_still()", src)
+
+
+if __name__ == "__main__":
+    unittest.main()
+
+
+class ThePackDoesNotSetHwdecTest(unittest.TestCase):
+    """default-shader-pack pulls a "hwdec-default" group into every
+    profile, setting hwdec to auto-copy (d3d11va in pack-next). That was
+    fine while hwdec was nobody's setting; it is now a user-facing one that
+    defaults off *because* some drivers handle hardware decoding badly, and
+    a shader profile switching it back on reintroduces exactly that failure
+    in the last place anyone would look for it."""
+
+    def _apply(self, group_settings):
+        m = _manager()
+        m.groups = {"g": {"settings": group_settings}}
+        m.defaults = {"scale": "bilinear", "hwdec": "no"}
+        m.used_settings = set()
+        m.forced_hwdec = None
+        m._sets_vf = False
+        m._names_direct_hwdec = False
+        applied, shaders = [], []
+        m.process_setting_group("g", applied, shaders)
+        return m, applied
+
+    def test_the_packs_hwdec_is_dropped(self):
+        _m, applied = self._apply([["hwdec", "auto-copy"],
+                                   ["scale", "ewa_lanczossharp"]])
+        self.assertEqual(applied, [("scale", "ewa_lanczossharp")])
+
+    def test_but_a_named_decoder_is_applied(self):
+        """The line is policy vs requirement. `auto-copy` says "use hardware
+        decoding if you can", which is an opinion about the machine and not
+        the pack's to have. `d3d11va` names the decoder the profile's
+        d3d11vpp filter needs to exist at all, and choosing that profile is
+        opting in."""
+        m, applied = self._apply([["hwdec", "auto-copy"],
+                                  ["hwdec", "d3d11va"]])
+        self.assertEqual(applied, [("hwdec", "d3d11va")])
+        self.assertEqual(m.forced_hwdec, "d3d11va")
+
+    def test_a_profile_that_names_nothing_forces_nothing(self):
+        m, _applied = self._apply([["hwdec", "auto-copy"]])
+        self.assertIsNone(m.forced_hwdec)
+
+    def test_a_pack_turning_it_off_is_also_a_requirement(self):
+        """Nothing in the current pack sets `no`, but if one did it would
+        mean "my shaders need software frames" — a statement about the
+        profile, not an opinion about the machine [iw]. So it survives,
+        where `auto` and `auto-copy` do not."""
+        m, applied = self._apply([["hwdec", "no"]])
+        self.assertEqual(applied, [("hwdec", "no")])
+        self.assertEqual(m.forced_hwdec, "no")
+
+    def test_the_users_config_outranks_the_pack_too(self):
+        """A profile applies its settings directly, so without this the
+        pack would slip past the mpv.conf pin between one file and the
+        next — the per-item write in _play_media is not the only writer."""
+        with mock.patch("jellyfin_mpv_shim.video_profile."
+                        "hwdec_pinned_by_config", return_value="vaapi"):
+            m, applied = self._apply([["hwdec", "d3d11va"]])
+        self.assertEqual(applied, [])
+        self.assertIsNone(m.forced_hwdec)
+
+    def test_it_never_becomes_a_setting_the_profile_reverts(self):
+        """Dropped before used_settings, so unload_profile does not write
+        hwdec either — which also keeps the still-image suspension from
+        quietly changing the decoder."""
+        m, _applied = self._apply([["hwdec", "auto-copy"]])
+        self.assertNotIn("hwdec", m.used_settings)
+
+    def test_everything_else_in_the_group_still_applies(self):
+        _m, applied = self._apply([["scale", "ewa_lanczossharp"],
+                                   ["hwdec", "auto-copy"]])
+        self.assertIn(("scale", "ewa_lanczossharp"), applied)
+
+
+class CopyBackIsAnUpgradeNotASwitchTest(unittest.TestCase):
+    """When does a profile actually need frames in system RAM?
+
+    Not when it says ``hwdec: auto-copy`` — every profile in the shipped
+    pack says that, from a time when being cautious about it cost nothing
+    [iw], and a glsl shader runs inside the GPU renderer on frames that are
+    already there. What needs system RAM is a real ``vf``.
+
+    And a profile naming a **direct** hwdec mode beside its filter is
+    saying the opposite. In the shipped pack that is exactly ``rtx-vsr``:
+    ``format=nv12,d3d11vpp=scale=2:scaling-mode=nvidia`` is a Direct3D
+    video-processor filter operating on d3d11 surfaces, so copying back
+    would break the only profile in the pack that has a filter at all.
+    """
+
+    def _wants_copy(self, group_settings):
+        m = _manager()
+        m.groups = {"g": {"settings": group_settings}}
+        m.defaults = {"hwdec": "no", "vf": "", "gpu_api": "auto",
+                      "scale": "bilinear", "profile": ""}
+        m.used_settings = set()
+        m._sets_vf = False
+        m._names_direct_hwdec = False
+        m.process_setting_group("g", [], [])
+        return m._wants_copy()
+
+    def test_the_blanket_auto_copy_is_not_evidence(self):
+        # "hwdec-default", which every profile in the pack pulls in.
+        self.assertFalse(self._wants_copy([["hwdec", "auto-copy"],
+                                           ["profile", "gpu-hq"]]))
+
+    def test_a_shader_only_profile_needs_nothing(self):
+        self.assertFalse(self._wants_copy([["scale", "ewa_lanczossharp"]]))
+
+    def test_a_real_filter_does(self):
+        self.assertTrue(self._wants_copy([["vf", "lavfi=[negate]"]]))
+
+    def test_but_not_when_the_profile_wants_gpu_frames(self):
+        # The shipped rtx-vsr group, verbatim.
+        self.assertFalse(self._wants_copy([
+            ["hwdec", "d3d11va"],
+            ["gpu_api", "d3d11"],
+            ["vf", "format=nv12,d3d11vpp=scale=2:scaling-mode=nvidia"]]))
+
+    def test_unloading_forgets_it(self):
+        m = _manager()
+        m.wants_copy_hwdec = True
+        m.unload_profile()
+        self.assertFalse(m.wants_copy_hwdec)
+
+    def test_a_reset_free_load_recomputes_it(self):
+        """load_profile(reset=False) skips unload — the still-image resume
+        and the startup restore both use it — so a stale True would outlive
+        the profile that set it."""
+        m = _manager()
+        m.wants_copy_hwdec = True
+        m.groups = {"g": {"settings": [["scale", "bilinear"]]}}
+        m.defaults = {"scale": "bilinear"}
+        m.profiles = {"plain": {"setting-groups": ["g"]}}
+        m.load_profile("plain", reset=False)
+        self.assertFalse(m.wants_copy_hwdec)
+
+
+class HwdecUpgradeTest(unittest.TestCase):
+    """`needs_copy` upgrades, it never enables."""
+
+    def setUp(self):
+        from jellyfin_mpv_shim.conf import settings
+        self.settings = settings
+        self._saved = settings.hwdec
+        self.addCleanup(lambda: setattr(settings, "hwdec", self._saved))
+
+    def _for(self, mode, height=None, needs_copy=False):
+        from jellyfin_mpv_shim import mpv_options
+        self.settings.hwdec = mode
+        return mpv_options.hwdec_for(height, needs_copy)
+
+    def test_off_stays_off_however_much_something_wants_frames(self):
+        # Turning hardware decoding off is not a preference about *which*
+        # hardware decoding, and a filter is not a reason to overrule it.
+        self.assertEqual(self._for("no", 2160, needs_copy=True), "no")
+
+    def test_a_direct_mode_becomes_the_copy_variant(self):
+        self.assertEqual(self._for("auto", 2160, needs_copy=True),
+                         "auto-copy")
+
+    def test_the_threshold_mode_upgrades_only_where_it_was_on(self):
+        self.assertEqual(self._for("over-1080p", 2160, needs_copy=True),
+                         "auto-copy")
+        self.assertEqual(self._for("over-1080p", 1080, needs_copy=True),
+                         "no")
+
+    def test_an_explicit_copy_choice_is_unchanged(self):
+        self.assertEqual(self._for("auto-copy", 2160, needs_copy=True),
+                         "auto-copy")
+
+    def test_without_a_filter_nothing_is_upgraded(self):
+        self.assertEqual(self._for("auto", 2160), "auto")
+        self.assertEqual(self._for("over-1080p", 2160), "auto")

--- a/tests/test_shell_delete_item.py
+++ b/tests/test_shell_delete_item.py
@@ -1,0 +1,235 @@
+"""Delete from Disk (#4) — the one destructive thing in the browser.
+
+Three properties, and each has already been a bug somewhere in this app:
+
+* **the gate is the item's own ``CanDelete``**, not the account's policy.
+  The server grants deletion per *library*, so a client-side reading of
+  the user is right about the account and wrong about half their libraries
+  — and absent must mean no, which is the opposite of ``may_download``'s
+  fail-open (see docs/PERMISSION_GAPS.md §4/§6).
+* **the confirmation says what it destroys, in full.** ``_confirm`` drew
+  its message with a bare Text, which ellipsizes at the shell width; a
+  dialog whose whole point is the warning cannot have the warning cut off.
+* **the local copy goes with it**, or the library says the item is gone
+  while this machine still plays it.
+"""
+
+import unittest
+
+from jellyfin_mpv_shim.mpvtk_browser.app import MpvtkBrowser
+
+from tests._shell_harness import (
+    FakeController,
+    FakeSource,
+    _SyncPool,
+    build_scene,
+    ids,
+)
+
+
+class DeleteMenuEntryTest(unittest.TestCase):
+
+    def _browser(self, offline=False):
+        b = MpvtkBrowser(app=None, source=FakeSource(),
+                         controller=FakeController())
+        b.nav_stack = [{"kind": "grid", "server": "srv"}]
+        b._pool = _SyncPool()
+        b._offline = offline
+        return b
+
+    def _entries(self, item, offline=False):
+        return [e[2] for e in self._browser(offline)._tile_menu_entries(item)]
+
+    def test_an_item_the_server_says_is_deletable_offers_it(self):
+        self.assertIn("deleteitem", self._entries(
+            {"Id": "x", "Type": "Movie", "CanDelete": True}))
+
+    def test_an_item_that_says_no_does_not(self):
+        self.assertNotIn("deleteitem", self._entries(
+            {"Id": "x", "Type": "Movie", "CanDelete": False}))
+
+    def test_an_absent_answer_is_a_no(self):
+        """The opposite of may_download's fail-open, deliberately: hiding a
+        delete the user could have made is an inconvenience; offering one
+        that 403s at the point of no return is not. A list query really does
+        omit the field unless asked (measured against 10.11), so this is the
+        state a stale field set produces."""
+        self.assertNotIn("deleteitem",
+                         self._entries({"Id": "x", "Type": "Movie"}))
+
+    def test_it_is_the_last_entry(self):
+        # The only entry that destroys anything; next to Play it gets
+        # misclicked.
+        entries = self._entries({"Id": "x", "Type": "Movie",
+                                 "CanDelete": True})
+        self.assertEqual(entries[-1], "deleteitem")
+
+    def test_offline_does_not_offer_it(self):
+        # Nothing to delete *on*, and the local copy has its own
+        # Remove Download.
+        self.assertNotIn("deleteitem",
+                         self._entries({"Id": "x", "Type": "Movie",
+                                        "CanDelete": True}, offline=True))
+
+    def test_it_is_not_restricted_by_type(self):
+        """Deliberately no type set: the server already answered, and a
+        second gate here could only ever be wrong in the direction of
+        refusing something the user is allowed to do."""
+        for t in ("Movie", "Episode", "Series", "Season", "Audio", "Book",
+                  "MusicAlbum", "Video"):
+            self.assertIn("deleteitem",
+                          self._entries({"Id": "x", "Type": t,
+                                         "CanDelete": True}),
+                          "%s should offer it when the server says yes" % t)
+
+
+class DeleteFlowTest(unittest.TestCase):
+
+    def setUp(self):
+        self.b = MpvtkBrowser(app=None, source=FakeSource(),
+                              controller=FakeController())
+        self.b.nav_stack = [{"kind": "grid", "server": "srv"}]
+        self.b._pool = _SyncPool()
+        self.item = {"Id": "m1", "Type": "Movie", "Name": "The Film",
+                     "CanDelete": True}
+
+    def _texts(self, nodes):
+        return [n.get("text") or "" for n in nodes]
+
+    def _confirm_scene(self):
+        self.b._actions.confirm_delete_item(self.item, "srv")
+        return build_scene(self.b, (1280, 720))
+
+    def _calls(self, name):
+        """Gateway calls by name. The base FakeController routes anything
+        it does not declare through its catch-all recorder, which is where
+        both of these land -- `transport_kw` because the local cleanup is
+        called with a keyword."""
+        return [(a, k) for n, a, k in self.b.controller.transport_kw
+                if n == name]
+
+    def test_it_asks_before_doing_anything(self):
+        nodes, _h = self._confirm_scene()
+        self.assertIn("confirm", ids(nodes))
+        self.assertEqual(self._calls("delete_item"), [])
+
+    def test_the_warning_says_it_destroys_the_file(self):
+        nodes, _h = self._confirm_scene()
+        joined = " ".join(self._texts(nodes))
+        self.assertIn("delete it from both the file system and your media "
+                      "library", joined)
+        self.assertIn("The Film", joined)
+
+    def test_the_warning_is_not_cut_off(self):
+        """A bare Text ellipsizes at the shell width, and this dialog is
+        nothing but its explanation. Asserted on the drawn nodes, because
+        that is the only place the truncation would show."""
+        nodes, _h = self._confirm_scene()
+        self.assertNotIn("…", " ".join(self._texts(nodes)))
+
+    def test_both_the_title_and_the_button_say_from_disk(self):
+        # Every other Delete on these screens removes a download; the two
+        # are one careless press apart.
+        nodes, _h = self._confirm_scene()
+        self.assertEqual(
+            [t for t in self._texts(nodes) if t == "Delete from Disk"],
+            ["Delete from Disk", "Delete from Disk"])
+
+    def test_cancelling_deletes_nothing(self):
+        _nodes, handlers = self._confirm_scene()
+        handlers["dlg-cancel"]["click"]()
+        self.assertEqual(self._calls("delete_item"), [])
+        self.assertEqual(self._calls("delete_download"), [])
+        nodes, _h = build_scene(self.b, (1280, 720))
+        self.assertNotIn("confirm", ids(nodes))
+
+    def test_confirming_deletes_on_the_server(self):
+        _nodes, handlers = self._confirm_scene()
+        handlers["dlg-ok"]["click"]()
+        calls = [c for c in self.b.controller.transport
+                 if c[0] == "delete_item"]
+        self.assertEqual(calls, [("delete_item", ("srv", "m1"))])
+
+    def test_the_downloaded_copy_goes_too(self):
+        """Or the library says the item is gone while this machine still
+        plays it — and the local file is now the only copy of something the
+        user asked to destroy."""
+        _nodes, handlers = self._confirm_scene()
+        handlers["dlg-ok"]["click"]()
+        self.assertEqual(self._calls("delete_download"),
+                         [((), {"item_id": "m1"})])
+
+    def test_a_refused_delete_is_reported(self):
+        """A destructive call that reports success it did not have is the
+        bug delete_download was fixed for."""
+        def boom(*_a, **_k):
+            raise RuntimeError("403")
+
+        self.b.controller.delete_item = boom
+        _nodes, handlers = self._confirm_scene()
+        handlers["dlg-ok"]["click"]()
+        self.assertIn("could not be deleted", self.b.status)
+        # And the local copy survives: the server still has it.
+        self.assertEqual(self._calls("delete_download"), [])
+
+    def test_a_failed_local_cleanup_does_not_hide_the_success(self):
+        # The server delete is the one that has to be reported; a catalog
+        # row that failed to clear is cosmetic next to it.
+        def boom(*_a, **_k):
+            raise RuntimeError("catalog locked")
+
+        self.b.controller.delete_download = boom
+        _nodes, handlers = self._confirm_scene()
+        handlers["dlg-ok"]["click"]()
+        self.assertIn("was deleted", self.b.status)
+
+
+if __name__ == "__main__":
+    unittest.main()
+
+
+class DeleteFromTheDetailPageTest(unittest.TestCase):
+    """The other door. It differs from the tile menu in what happens
+    *after*: a grid re-reads its list, but this screen IS the deleted item,
+    so re-reading it would fetch a 404 and show an error where a film was."""
+
+    def _browser(self, can_delete=True):
+        src = FakeSource()
+        item = {"Id": "m1", "Type": "Movie", "Name": "The Film",
+                "MediaSources": [], "CanDelete": can_delete}
+        src.get_item = lambda server, item_id: dict(item)
+        b = MpvtkBrowser(app=None, source=src, controller=FakeController())
+        b._pool = _SyncPool()
+        b.nav_stack = [{"kind": "grid", "server": "srv"},
+                       {"kind": "detail", "server": "srv", "item_id": "m1",
+                        "title": "The Film"}]
+        b._load_route(b.route)
+        return b
+
+    def test_the_button_is_offered_when_the_server_allows_it(self):
+        nodes, _h = build_scene(self._browser(), (1280, 720))
+        self.assertIn("act-delete", ids(nodes))
+
+    def test_and_absent_when_it_does_not(self):
+        nodes, _h = build_scene(self._browser(can_delete=False), (1280, 720))
+        self.assertNotIn("act-delete", ids(nodes))
+
+    def test_pressing_it_asks_first(self):
+        b = self._browser()
+        _nodes, handlers = build_scene(b, (1280, 720))
+        handlers["act-delete"]["click"]()
+        nodes, _h = build_scene(b, (1280, 720))
+        self.assertIn("confirm", ids(nodes))
+
+    def test_confirming_deletes_and_leaves_the_page(self):
+        b = self._browser()
+        _nodes, handlers = build_scene(b, (1280, 720))
+        handlers["act-delete"]["click"]()
+        _nodes, handlers = build_scene(b, (1280, 720))
+        handlers["dlg-ok"]["click"]()
+        calls = [(a, k) for n, a, k in b.controller.transport_kw
+                 if n == "delete_item"]
+        self.assertEqual(calls, [(("srv", "m1"), {})])
+        # Back to the grid it was opened from — not still showing a page
+        # whose item no longer exists.
+        self.assertEqual([r["kind"] for r in b.nav_stack], ["grid"])


### PR DESCRIPTION
This PR adds delete from disk actions and hardware decoding options exposed in settings. It also removes the ability for shader packs to override hardware decoding settings, except in three narrow cases:
1. It can explicitly disable hardware decoding.
2. It can require copy-back if hardware decoding is already enabled.
3. It can require a specific hardware decoding mode that needs to be pinned for a specific upscaler to work.