### PR TITLE
Avoid full re-syncs of offline store by tracking websocket events & user activity

### DIFF
--- a/docs/UI_FIXES_4.md
+++ b/docs/UI_FIXES_4.md
@@ -776,6 +776,111 @@ notifies the browser when something actually moved. `db.update_userdata` now
 returns whether it changed anything, which is what makes that last part
 possible.
 
+### Then measured, and mostly replaced
+
+The pull above was the right shape and the wrong mechanism, and three
+measurements said so. What replaced it:
+
+**The server already pushes the answer.** `UserDataChanged` carries
+`UserDataList[]` — `ItemId`, `Played`, `PlaybackPositionTicks`, `PlayCount`,
+`IsFavorite` — so the episode watched on a phone can be applied from the
+message that announced it, at **zero requests**. `event_handler.py` had been
+taking that payload as `_arguments` and dropping it, and the five-minute poll
+existed to go and ask for what the socket had already said.
+`SyncManager.apply_userdata_event` is the consumer.
+
+**And then the interval went away entirely**, which was **[iw]**'s question:
+if the push is the mechanism, a timer is only needed for when the push
+*fails* — otherwise reconnect and startup are the whole schedule. That is
+right, and the reason it is right is that a sweep covers *a stretch during
+which nothing was listening*, which is not a duration but an interval with
+**edges**: it starts when a server drops and ends when one connects. So the
+trigger is a server appearing in `clientManager.clients`
+(`_note_connected_servers`), which also covers startup with no special case,
+and there is no periodic sweep at all. An idle app with a live socket now
+asks the server nothing, ever.
+
+Watched rather than subscribed: `on_server_connected` means almost exactly
+this, but it is a single slot `ui.py` assigns *after* `syncManager.start()`
+runs, and it is a notification — five call sites today, and a sixth path that
+reconnects without firing it would leave a gap invisible until somebody's
+catalog was stale. The registry is the state, so a set comparison against it
+cannot miss a transition however the server came back. (**[iw]** noted the
+CLI half of the original argument was moot, since downloads are GUI-only;
+that is true and it is not the reason.)
+
+`USERDATA_SWEEP_FLOOR` (300 s) is all that remains of the timer, and it is
+there for the one trigger with no edge — a server that *flaps*. It **defers**
+a pending sweep rather than dropping it: a suppressed trigger would be a
+stretch of time nobody ever looks at again. So twenty reconnects inside one
+floor cost one sweep, and the twenty-first still sweeps once the floor lifts.
+
+**The pull was asking for 29 fields to read one.** `get_items(batch)` with no
+`fields` sends the apiclient's `info()` default, `MediaSources` included.
+Measured against 12.0, 60 ids: **73 ms / 191 KB** with the default against
+**13 ms / 60 KB** with `fields=""`, for byte-identical `UserData`. (This is
+the "not acted on" item below, now acted on — and the reasoning recorded there
+for deferring it was wrong.)
+
+**And the requests went out in one burst.** `USERDATA_BATCH_PAUSE` spaces them
+by three seconds; nothing is waiting on the sweep, and a catalog of a few
+hundred is several requests at a server that may also be streaming to us.
+
+**The local half had a second gate nobody had noticed.** `_mirror_locally`
+writes either way — but all three reporting call sites reached it only through
+`hasattr(video, "record_offline_progress")`, which is true only of a video
+played *from the downloaded file*. So streaming an episode you also had
+downloaded still wrote nothing, and the copy on disk never learned it had been
+watched. `ReportingMixin._record_progress` is now one helper with no gate at
+all; `db.update_userdata` answering False for an item it holds no row for is
+what makes that safe to call for everything played.
+
+### Three things about the server, measured against 10.11.11 and 12.0.0
+
+All three were assumptions somewhere in this app, and one of them was wrong in
+the comment that justified a design.
+
+1. **A progress report announces nothing.**
+   `UserDataChangeNotifier.OnUserDataManagerUserDataSaved` returns early on
+   `UserDataSaveReason.PlaybackProgress`. Three progress reports produce zero
+   events. The comment on `event_handler.user_data_change` had claimed the
+   opposite — "fires every few seconds while watching" — and `USERDATA_DEBOUNCE`
+   and `USERDATA_REQUEST_FLOOR` were both sized against that.
+2. **Not even the one that finishes the item.** The obvious guess, and the one
+   the first draft of the e2e suite pinned: a progress report that carries an
+   item past the completion threshold is saved under `PlaybackProgress` like
+   any other. `Video.PropagatePlayedState` is the only thing done differently,
+   and it returns immediately for a video with no alternate versions. So
+   another device can watch something to the end and this client is told
+   nothing until that device sends its **stop** — which a client killed
+   mid-playback never does. That gap is why the sweep survives at all, and why
+   making it cheap mattered more than making it rare.
+3. **The message is not filtered by origin.** It goes to every session the
+   *user* has, including the one that caused it. Measured symmetric.
+
+`MinDateLastSavedForUser` was also considered as a "what changed since T"
+watermark and is **not one**: `BaseItemRepository.TranslateQuery.cs:282`
+filters `e.DateLastSaved`, the item's metadata save date, identical to
+`MinDateLastSaved`. Measured, right after marking an item played: a
+year-old mark returns all 3,224 items and an hour-old mark returns none.
+
+### And an e2e suite, because all of the above is somebody else's code
+
+`tests/e2e/test_offline_sync.py`. The fast suite answers the server from a
+mock, and `tests/integration/test_e2e_offline.py` fakes the HTTP client by its
+own admission — so every belief about *when* the server announces a change was
+untested. Both directions, the websocket path through the real `EventHandler`,
+and the two counter-intuitive facts above, against a real server on both major
+versions.
+
+Two things it had to learn the hard way, both the repo's existing live-test
+rules: a wait satisfied by **stale evidence** (`setUp`'s own `reset_played`
+emits an event, so waiting without clearing first returns that one and the real
+event lands in a just-emptied list — which is what made fact 2 look false), and
+a **negative assertion that cannot fail** (silence over a socket reads the same
+as a dead socket, so the same window is made to produce an event on demand
+before the absence of one is believed).
+
 **Advance-only, still.** The local copy is a floor, not a mirror: an item
 un-watched on another device stays watched here. That is the existing rule
 rather than a decision taken here, and it is the one thing about this worth
@@ -1991,10 +2096,18 @@ path fires.
 
 ### Not acted on
 
-The userdata pull asking for the apiclient's default field set. Real but
+~~The userdata pull asking for the apiclient's default field set. Real but
 small, and `UserData` rides `EnableUserData` rather than `Fields`, so the
 tightening is a `fields=""` experiment rather than a fix. Left for the next
-pass.
+pass.~~
+
+**Done, and the reasoning here was wrong.** `UserData` does ride
+`EnableUserData`, which is why `fields=""` is safe — but that is the argument
+for making the change, not against it: the default field set is 29 fields
+including `MediaSources`, and dropping it costs nothing that is read.
+Measured, 60 ids against 12.0: 73 ms / 191 KB down to 13 ms / 60 KB. "Real but
+small" was an estimate where a measurement was available. See *Then measured,
+and mostly replaced* above.
 
 ### One that was missed, and how
 

--- a/docs/UI_FIXES_4.md
+++ b/docs/UI_FIXES_4.md
@@ -884,7 +884,84 @@ before the absence of one is believed).
 **Advance-only, still.** The local copy is a floor, not a mirror: an item
 un-watched on another device stays watched here. That is the existing rule
 rather than a decision taken here, and it is the one thing about this worth
-revisiting — flagged in the method's docstring.
+revisiting — flagged in the method's docstring. Revisited below.
+
+### Revisited: a deliberate mark is not a report **[iw]**
+
+The flag above, taken. Advance-only is right for everything that *reports* —
+progress arrives out of order, a queue replayed after a week must not rewind
+another device, a pull is a floor — and wrong for the one thing that
+*decides*: a person choosing Mark Watched or Mark Unwatched. Under one rule
+for both, un-watching was the only deliberate action in the app that silently
+did nothing to the downloaded copy. Offline you were then shown the tick you
+had just removed, and "delete watched downloads" — which reads `userdata_json`
+with no server fallback — was still willing to throw the item away.
+
+So there is now a second writer, `db.set_watched`, verbatim in both
+directions, kept apart from `update_userdata` for the same reason
+`set_reading_position` is. It mirrors what the server does with the same
+request (`BaseItem.MarkPlayed` / `ResetPlayedState`, the controller passing
+`resetPosition: true`): played clears the resume point and puts the play count
+at one, unplayed clears position, count and last-played date. Matching matters
+beyond tidiness — where the two disagree, the next sweep reads the difference
+back as a change and the catalog flickers between them.
+
+Three call sites, one rule: `SyncManager.mirror_watched` (fan-out over a series
+or season through `db.watched_targets`, notify only when something moved),
+which the browser gateway calls after the server takes the mark, and which
+`media.Video.set_played` calls too — that last one is *streamed* playback's
+"Quit and Mark Unwatched", the same gap `mirror_playstate` was added for, in
+the direction it could not express. The resolver sits on `SyncDB` rather than
+the manager because every part of it is a catalog read, and because the offline
+path reaches it through a handle it already has.
+
+**Not changed, deliberately:** un-watching *offline* is still refused. The
+replay queue is advance-only, so a local un-watch would diverge from the server
+with nothing left to reconcile it, and the UI's optimistic tick rolls back on
+the `False`. And the two *pull* paths (`apply_userdata_event`, the sweep) stay
+advance-only: what another device did arrives as a floor, as before.
+
+### Revisited: when the first sweep of a session runs **[iw]**
+
+The sweep had no interval, three triggers and a five-minute floor — and at
+launch it did the wrong thing with all of them. `mpv_shim.main` starts the sync
+worker *before* `user_interface.login_servers()`, so the worker's first pass
+runs with an empty client registry: it reached no server, swept nothing, and
+stamped `_last_userdata` on the way past. The server appeared a second later,
+`_note_connected_servers` re-armed the sweep, and the floor then held it off
+for **five minutes** — exactly the stretch the sweep exists to cover, since
+what it covers is what happened while the app was off. Opening Home did not
+bring it forward either; that trigger is floored the same way.
+
+Two changes, and the second is the one that fixes it:
+
+* **A pass with nobody to ask is not a sweep.** `_sweep_if_due` now checks the
+  registry first and leaves the trigger up, so the startup trigger survives to
+  the moment there is a server. This also covers a login slower than the
+  settle — `connect_retry_mins`, a captive portal — where the settle alone
+  would hand the trigger to another empty pass.
+* **A settle, `USERDATA_SWEEP_SETTLE = 60`.** Startup is when every other part
+  of the app wants the network at once and the sweep is the only one nobody is
+  waiting for, so it stands down for the first minute after the catalog opens.
+
+The floor is also skipped while `_last_userdata` is zero, for the same reason
+it is measured with `time.monotonic()`: that clock counts from boot, so on a
+machine launching this at startup "five minutes since the epoch" was a real
+comparison, and it suppressed the first sweep of the session.
+
+### One more server fact, measured on 12.0.0
+
+After a **series** is marked played, its episodes come back *played* from
+`GET /Items?ids=` and *unplayed* from both per-item reads
+(`GET /UserItems/{id}/UserData`, `GET /Users/{uid}/Items/{id}`). The fan-out
+did happen; the per-item answer is the stale one. It is load-bearing twice: the
+sweep asks with `get_items`, which is why "watched on the phone by marking the
+series" reaches the catalog at all, and `_sync_playstate` compares against
+`get_userdata_for_item` before pushing, so it can be told an item is unplayed
+that the server considers played — harmless today, because it only ever pushes
+forward, but that comparison cannot be trusted for anything else. Pinned in
+`tests/e2e/test_offline_sync.py`, and it goes red when the server starts
+agreeing with itself.
 
 ### Test
 

--- a/jellyfin_mpv_shim/event_handler.py
+++ b/jellyfin_mpv_shim/event_handler.py
@@ -281,7 +281,7 @@ class EventHandler(object):
 
     @bind("UserDataChanged")
     def user_data_change(
-        self, client: "JellyfinClient_type", _event_name, _arguments: dict
+        self, client: "JellyfinClient_type", _event_name, arguments: dict
     ):
         """Watched / resume state moved for this user, somewhere.
 
@@ -291,11 +291,41 @@ class EventHandler(object):
         which is what #560 reported. The row is not cosmetically stale
         afterwards -- it is offering to resume something already watched.
 
-        Only a nudge; the browser decides whether the screen it is showing
-        cares, and debounces. The server sends one of these per progress
-        report, including for our OWN playback, so this fires every few
-        seconds while watching.
+        Two consumers, and they want opposite things from the message. The
+        **browser** wants only the nudge: it decides whether the screen it
+        is showing cares, and debounces. The **download catalog** wants the
+        payload, because ``arguments`` carries the new values themselves --
+        so applying them costs no request at all, and is what keeps offline
+        watched state current without a poll.
+
+        `arguments`, not `_arguments`: it was discarded here for a long
+        time, and the sweep that existed to make up for it re-read the whole
+        catalog every five minutes to learn what this message had already
+        said.
+
+        What this does NOT fire for is a progress report -- the server
+        drops those before building the message, on every version measured.
+        So it announces a start and a stop, a few per playback, and not the
+        "every few seconds while watching" that the browser's debounce was
+        written against.
+
+        **Including the progress report that finishes the item.** Another
+        device can play something through to the end, the server can record
+        it watched, and nothing is sent until that device reports its stop
+        -- which a client killed mid-playback never does. That gap is not
+        closable from here, and is what `_refresh_userdata` is left in the
+        design to cover. `tests/e2e/test_offline_sync.py` pins both halves
+        against a real server, because the obvious guess is the other one.
         """
+        try:
+            from .sync.manager import syncManager
+
+            syncManager.apply_userdata_event(arguments)
+        except Exception:
+            # Never let the catalog take the browser's nudge down with it:
+            # a stale row is a cosmetic problem, a dropped event is the
+            # screen not updating at all.
+            log.debug("could not apply pushed userdata", exc_info=True)
         if self.user_data_changed:
             try:
                 self.user_data_changed(client)

--- a/jellyfin_mpv_shim/media.py
+++ b/jellyfin_mpv_shim/media.py
@@ -925,7 +925,25 @@ class Video(object):
                 return ticks / 10000000
 
     def set_played(self, watched: bool = True):
+        """Mark this item played/unplayed on the server, and locally.
+
+        The local half matters for the same reason `mirror_playstate` does:
+        an item can be *streamed* while a downloaded copy of it sits on
+        disk, and that copy -- the one kept precisely for when the server is
+        gone -- was the only thing that never heard about "Quit and Mark
+        Unwatched". Deliberate marks are authoritative in both directions,
+        so this goes through `mirror_watched` rather than the advance-only
+        playback path; it is a no-op for an item nothing was downloaded for.
+        `OfflineVideo` overrides this and keeps its own replay queue.
+        """
         self.client.jellyfin.item_played(self.item_id, watched)
+        try:
+            from .sync.manager import syncManager
+
+            syncManager.mirror_watched(self.item_id, watched)
+        except Exception:
+            log.debug("Could not mirror the watched mark for %s",
+                      self.item_id, exc_info=True)
 
     def set_streams(self, aid: Optional[int], sid: Optional[int]):
         need_restart = False

--- a/jellyfin_mpv_shim/mpvtk_browser/app.py
+++ b/jellyfin_mpv_shim/mpvtk_browser/app.py
@@ -600,10 +600,17 @@ class MpvtkBrowser(DialogsMixin, LiveTvDialogsMixin, AuthMixin, SettingsMixin,
         route["_refreshing"] = True
         self._load_route(route)
 
-    #: How long a UserDataChanged burst settles before Home re-reads. The
-    #: server sends one per progress report -- including for our own
-    #: playback -- so without this, watching a film would refetch the home
-    #: screen every few seconds behind the video.
+    #: How long a UserDataChanged burst settles before Home re-reads.
+    #:
+    #: Not as large a burst as it once said here. That comment claimed the
+    #: server sends one per progress report, including for our own playback,
+    #: so watching a film would refetch Home every few seconds; measured
+    #: against 10.11.11 and 12.0.0, progress saves are dropped before the
+    #: message is built and three progress reports produce zero events. What
+    #: is left is a start, a stop, and whatever anyone marks by hand -- the
+    #: server already coalescing 500 ms of those into one message. So this
+    #: is settling a handful of events, not a stream, and it stays because
+    #: a handful still arrives together and Home is several requests.
     USERDATA_DEBOUNCE = 3.0
 
     def refresh_home(self, _client=None, now=False):

--- a/jellyfin_mpv_shim/mpvtk_browser/gateway/userdata.py
+++ b/jellyfin_mpv_shim/mpvtk_browser/gateway/userdata.py
@@ -26,11 +26,27 @@ class UserDataMixin(GatewayCore):
         if client is not None:
             try:
                 client.jellyfin.item_played(item_id, bool(watched))
-                return True
             except Exception:
                 log.error("mpvtk set_watched failed", exc_info=True)
                 return False
+            # ...and onto the copy on disk, in the same breath. The server
+            # announces this over the socket a moment later, but that path
+            # is advance-only, so an un-watch never arrived by it -- and a
+            # change made right here should not be waiting on a socket in
+            # either direction. Costs nothing when nothing is downloaded.
+            self._mirror_watched_locally(item_id, bool(watched))
+            return True
         return self._queue_offline_watched(server_uuid, item_id, watched)
+
+    @staticmethod
+    def _mirror_watched_locally(item_id, watched):
+        """Write a deliberate mark straight into the sync catalog."""
+        from ...sync.manager import syncManager
+        try:
+            syncManager.mirror_watched(item_id, watched)
+        except Exception:
+            log.debug("could not mirror the watched mark for %s", item_id,
+                      exc_info=True)
 
     @staticmethod
     def _queue_offline_watched(server_uuid, item_id, watched):
@@ -39,7 +55,6 @@ class UserDataMixin(GatewayCore):
         Only "watched" is representable: the pending queue is advance-only,
         so un-watching offline is dropped rather than silently half-applied.
         A series/season id fans out to its downloaded episodes."""
-        from ...sync.db import STATUS_COMPLETE
         from ...sync.manager import syncManager
 
         db = getattr(syncManager, "db", None)
@@ -48,18 +63,13 @@ class UserDataMixin(GatewayCore):
                         item_id)
             return False
         try:
-            if db.is_complete(item_id):
-                targets = [(item_id, server_uuid)]
-            else:
-                targets = [(r["item_id"], r["server_uuid"] or server_uuid)
-                           for r in db.list(status=STATUS_COMPLETE)
-                           if item_id in (r["series_id"], r["season_id"])]
+            targets = db.watched_targets(item_id, server_uuid)
             for target_id, target_server in targets:
                 db.upsert_playstate(target_server, target_id, played=True)
                 # The browser overlay and the watched-based delete read
                 # userdata_json, not the pending queue — without this the
                 # mark is invisible until the server syncs.
-                db.update_userdata(target_id, played=True)
+                db.set_watched(target_id, True)
             if not targets:
                 log.warning("Nothing downloaded matches %s; watched mark "
                             "not queued.", item_id)

--- a/jellyfin_mpv_shim/player_reporting.py
+++ b/jellyfin_mpv_shim/player_reporting.py
@@ -414,24 +414,22 @@ class ReportingMixin:
                     except:
                         log.error("Error syncing playback time.", exc_info=True)
                 # ...and the local catalog gets it either way. **Not an
-                # `elif`**, which is the bug this replaces: every call site
-                # was gated on being offline, so making
-                # record_offline_progress write locally-either-way fixed a
-                # method that was never *called* when there was a server.
-                # The catalog is what the app reads when the server is
-                # away, so it has to be written while the server is there.
+                # `elif`**, which is the bug this replaces: this site used
+                # to be gated on being offline, and the catalog is what the
+                # app reads when the server is away -- so it has to be
+                # written while the server is still there. See
+                # `_record_progress` for the second gate that had to come
+                # off, and why there is now no gate here at all.
                 #
                 # Throttled, so this does not hammer SQLite on every 5s
-                # tick. The name is now a misnomer: it records progress,
-                # and only the *replay queue* half of it is offline-only.
-                if hasattr(video, "record_offline_progress"):
-                    now = time.monotonic()
-                    if now - self._last_offline_record >= 30:
-                        options = self.get_timeline_options(video=video)
-                        if options is not None:
-                            self._last_offline_record = now
-                            video.record_offline_progress(
-                                options.get("PositionTicks"))
+                # tick.
+                now = time.monotonic()
+                if now - self._last_offline_record >= 30:
+                    options = self.get_timeline_options(video=video)
+                    if options is not None:
+                        self._last_offline_record = now
+                        self._record_progress(
+                            video, options.get("PositionTicks"))
         except _mpv_errors:
             log.warning("MPV connection lost during timeline update.")
             self._handle_mpv_disconnect()
@@ -446,6 +444,44 @@ class ReportingMixin:
             # Progress reports are gated on this — never leave it clear, even on
             # error, or timeline updates would stall for the whole session.
             self._session_ready.set()
+
+    def _record_progress(self, video, position_ticks, finished=False):
+        """Keep this position where the app can still read it offline.
+
+        One helper for the three reporting paths, because the thing that
+        went wrong here twice is a call site: first all three were gated on
+        being *offline*, so the method that had just been made to write
+        either way was never called when there was a server; then all three
+        were gated on the video being an `OfflineVideo`, so streaming an
+        episode you also had downloaded wrote nothing and the copy on disk
+        never learned you had watched it.
+
+        So the gate is gone rather than corrected. Both branches below are
+        no-ops for an item this app holds no download of, and neither
+        cares whether a server is reachable:
+
+        * an `OfflineVideo` keeps `record_offline_progress`, which also owns
+          the *replay queue* half -- the list of changes the server has not
+          been told about, and still the one part that is offline-only;
+        * anything else mirrors into the catalog by item id, which
+          `db.update_userdata` answers False for when there is no row.
+
+        Never raises: this runs on the timeline thread and on a daemon
+        thread during teardown, and losing a resume position must not take
+        a stop report down with it.
+        """
+        try:
+            if hasattr(video, "record_offline_progress"):
+                video.record_offline_progress(position_ticks, finished)
+                return
+            from .sync.manager import syncManager
+
+            syncManager.mirror_playstate(
+                getattr(video, "item_id", None), position_ticks,
+                played=True if finished else None)
+        except Exception:
+            log.warning("Could not record playback progress locally.",
+                        exc_info=True)
 
     def send_timeline_initial(self):
         video = self._video
@@ -484,10 +520,9 @@ class ReportingMixin:
         # position is set at all -- the periodic tick above may never have
         # fired. Gating it was why a downloaded episode watched online and
         # then opened on a train started from the beginning.
-        if video is not None and options is not None \
-                and hasattr(video, "record_offline_progress"):
-            video.record_offline_progress(
-                options.get("PositionTicks"), finished)
+        if video is not None and options is not None:
+            self._record_progress(video, options.get("PositionTicks"),
+                                  finished)
 
         if client is None:
             client = video.client if video else None
@@ -571,11 +606,7 @@ class ReportingMixin:
         }
         # Keep the position locally so closing the mpv window doesn't lose
         # it -- online too, for the reason in send_timeline_stopped above.
-        if hasattr(video, "record_offline_progress"):
-            try:
-                video.record_offline_progress(options.get("PositionTicks"), False)
-            except Exception:
-                log.warning("Could not record offline progress.", exc_info=True)
+        self._record_progress(video, options.get("PositionTicks"), False)
         try:
             self.send_timeline_stopped(options=options, client=video.client)
         except Exception:

--- a/jellyfin_mpv_shim/sync/db.py
+++ b/jellyfin_mpv_shim/sync/db.py
@@ -461,6 +461,96 @@ class SyncDB:
                     raise
             return changed
 
+    def watched_targets(self, item_id, server_uuid=None):
+        """Which downloaded rows a watched mark for ``item_id`` covers.
+
+        An id from the library is not always a leaf: the tick on a series or
+        a season means every episode under it, which is what the server does
+        with the same request (``Folder.MarkPlayed`` fans out to children).
+        The catalog holds leaves only, so the fan-out is a scan of it rather
+        than a question anyone can be asked -- and offline there is nobody
+        to ask at all, which is why it is resolved here rather than read off
+        the item.
+
+        Here rather than on the manager because every part of it is a
+        catalog read, and because the offline path reaches this through a
+        catalog handle it already has.
+
+        Returns ``[(item_id, server_uuid)]``, empty when nothing we hold is
+        covered. ``server_uuid`` is the fallback for a row written before
+        that column was populated.
+        """
+        if not item_id:
+            return []
+        if self.is_complete(item_id):
+            return [(item_id, server_uuid)]
+        return [(row["item_id"], row["server_uuid"] or server_uuid)
+                for row in self.list(status=STATUS_COMPLETE)
+                if item_id in (row["series_id"], row["season_id"])]
+
+    def set_watched(self, item_id, played):
+        """Store a deliberate watched mark **verbatim**, both directions.
+
+        The one non-advancing writer of this column, and the reason it is a
+        separate method rather than a flag on ``update_userdata``: every
+        caller of that one is playback, where a value that went backwards is
+        a stale report rather than a change of mind. A person choosing "Mark
+        Unwatched" is the opposite -- it is the only thing they could have
+        meant, and advance-only made it the one deliberate action in the app
+        that silently did nothing to the copy on disk. Offline browsing then
+        showed the tick it had just been told to remove, and "delete watched
+        downloads" was still counting the item as fair game.
+
+        Mirrors what the server does with the same request, which is what
+        keeps the next sweep from looking like a change (measured against
+        ``BaseItem.MarkPlayed`` / ``ResetPlayedState``, with the controller
+        passing ``resetPosition: true``): marking played clears the resume
+        point and puts the play count at least at one; marking unplayed
+        clears the position, the count and the last-played date as well as
+        the flag. ``PlayedPercentage`` is derived and is dropped either way,
+        so a stale server-seeded value cannot shadow the new state.
+
+        Returns whether anything moved -- the callers use it to decide
+        whether the browser needs redrawing. Local only: what is *sent* to
+        the server is the caller's business, and the offline replay queue
+        stays advance-only (``upsert_playstate``) so a client that has been
+        away cannot rewind another device.
+        """
+        with self._lock:
+            if self._conn is None:
+                return False
+            row = self._conn.execute(
+                "SELECT userdata_json FROM downloads WHERE item_id=?",
+                (item_id,)).fetchone()
+            if row is None:
+                return False
+            try:
+                userdata = json.loads(row["userdata_json"] or "{}")
+            except ValueError:
+                userdata = {}
+            before = dict(userdata)
+            if played:
+                userdata["Played"] = True
+                userdata["PlaybackPositionTicks"] = 0
+                userdata["PlayCount"] = max(userdata.get("PlayCount") or 0, 1)
+            else:
+                userdata["Played"] = False
+                userdata["PlaybackPositionTicks"] = 0
+                userdata["PlayCount"] = 0
+                userdata["LastPlayedDate"] = None
+            userdata.pop("PlayedPercentage", None)
+            if userdata == before:
+                return False
+            try:
+                self._conn.execute(
+                    "UPDATE downloads SET userdata_json=? WHERE item_id=?",
+                    (json.dumps(userdata), item_id))
+                self._conn.commit()
+            except sqlite3.Error:
+                self._conn.rollback()
+                raise
+            return True
+
     def set_reading_position(self, item_id, position_ticks):
         """Store a reader's cursor **verbatim**, not advance-only.
 

--- a/jellyfin_mpv_shim/sync/manager.py
+++ b/jellyfin_mpv_shim/sync/manager.py
@@ -63,6 +63,25 @@ PLAYSTATE_INTERVAL = 30    # replay offline playstate at least this often (s)
 #: (see `_run`), so no trigger is ever lost -- only delayed.
 USERDATA_SWEEP_FLOOR = 300
 
+#: How long after the catalog opens the first sweep waits.
+#:
+#: Startup is the one moment every part of this app wants the network at
+#: once -- logging in, the home screen's rows, artwork for every one of
+#: them -- and the sweep is the only one of them nobody is waiting for. A
+#: minute is long enough for the first screen to have settled and short
+#: enough that "watched on the flight out" is right by the time anyone
+#: scrolls to it.
+#:
+#: It also fixes something the floor used to do by accident. The worker
+#: starts in `mpv_shim.main` *before* `login_servers()`, so its first pass
+#: ran with no clients registered at all: it swept nothing, and stamped
+#: `_last_userdata` on the way past. The server then appeared a second
+#: later, re-armed the sweep -- and the floor held it off for five minutes,
+#: which is precisely the stretch the sweep exists to cover. So a pass with
+#: no client to ask now leaves the trigger up and costs nothing (see
+#: `_sweep_if_due`), and this settle is what paces the first real one.
+USERDATA_SWEEP_SETTLE = 60
+
 #: Ids per request. They travel in the query string, which servers and
 #: proxies cap (the apiclient's own note on get_items says so), and a
 #: catalog of a few hundred downloads would otherwise be one 414.
@@ -195,6 +214,10 @@ class SyncManager:
         #: told us about. True at construction because starting up is one of
         #: those things -- the app was not listening a moment ago.
         self._sweep_due = True
+        #: When the catalog was opened, for USERDATA_SWEEP_SETTLE. Zero
+        #: until then, which reads as "no settle to serve" -- a manager
+        #: driven directly (every test) is not a client starting up.
+        self._started_at = 0.0
         #: Server uuids that had a client last time the worker looked. The
         #: transition *into* this set is the reconnect signal; see
         #: _note_connected_servers for why it is watched here rather than
@@ -232,6 +255,9 @@ class SyncManager:
         through exactly the same recover/reconcile path as a fresh launch.
         """
         os.makedirs(self.root, exist_ok=True)
+        # Stamped before anything slow: the settle is measured from the app
+        # opening its catalog, not from the end of a disk reconcile.
+        self._started_at = time.monotonic()
         self.db = SyncDB(os.path.join(self.root, "catalog.db"))
         # Recover rows interrupted mid-download on a previous run.
         for row in self.db.list(status=STATUS_DOWNLOADING):
@@ -1008,11 +1034,37 @@ class SyncManager:
         soon as it is allowed to, which is what makes a flapping server
         cost one sweep per floor rather than one per flap.
 
+        Two things hold a due sweep back besides the floor, and neither
+        consumes it. **The settle**: nothing sweeps in the first
+        `USERDATA_SWEEP_SETTLE` seconds after the catalog opens, so the
+        first screen has the network to itself. And **having nobody to
+        ask**: the worker's first pass happens before `login_servers()` has
+        registered a single client, and a sweep there reaches no server, so
+        counting it burned the startup trigger and left the floor to defer
+        the real one by five minutes. A pass with no clients is not a sweep
+        that found nothing -- it is a sweep that did not happen.
+
+        The floor is skipped while `_last_userdata` is zero for the same
+        reason it is measured with `time.monotonic()`: that clock counts
+        from boot on every platform we run on, so on a machine launching
+        this at startup "five minutes since the epoch" is a real comparison
+        and it used to suppress the first sweep of the session.
+
         Returns whether it swept, which is what the tests read.
         """
         if not self._sweep_due:
             return False
-        if now - self._last_userdata < USERDATA_SWEEP_FLOOR:
+        if now - self._started_at < USERDATA_SWEEP_SETTLE:
+            return False
+        if (self._last_userdata
+                and now - self._last_userdata < USERDATA_SWEEP_FLOOR):
+            return False
+        try:
+            if not self.get_clients():
+                return False    # nobody to ask; the trigger stays up
+        except Exception:
+            log.debug("could not read the connected server list",
+                      exc_info=True)
             return False
         self._sweep_due = False
         self._last_userdata = now
@@ -1114,6 +1166,55 @@ class SyncManager:
             log.debug("Could not mirror playstate for %s", item_id,
                       exc_info=True)
             return False
+
+    def mirror_watched(self, item_id, played):
+        """Record a *deliberate* watched mark in the catalog, immediately.
+
+        The counterpart to :meth:`mirror_playstate`, and deliberately not
+        the same rule. That one is playback, where advance-only is right:
+        reports arrive out of order and a position that went backwards is a
+        stale one. This one is a person choosing Mark Watched or Mark
+        Unwatched, which is the only signal in the app that is authoritative
+        in **both** directions -- so it writes verbatim, through
+        ``db.set_watched``.
+
+        Un-watching is the half that did not work before. Every writer of
+        this column was advance-only, so a downloaded item un-watched from
+        this app's own menu stayed watched on the copy on disk, forever: the
+        sweep is advance-only too, so nothing would ever have corrected it.
+        Offline browsing showed a tick the user had just removed, and
+        "delete watched downloads" was still willing to throw the item away.
+
+        Unconditional at the call sites, like ``mirror_playstate``: no check
+        of whether the item is downloaded, because ``db.watched_targets``
+        answers with nothing for an item we hold no copy of. That is what
+        keeps it from being forgotten at a call site again.
+
+        Fans out over a series or season id. Never raises; returns how many
+        rows moved.
+        """
+        db = self.db
+        if db is None:
+            return 0
+        try:
+            targets = db.watched_targets(item_id)
+        except Exception:
+            log.debug("Could not resolve downloads for %s", item_id,
+                      exc_info=True)
+            return 0
+        moved = 0
+        for target_id, _server in targets:
+            try:
+                if db.set_watched(target_id, played):
+                    moved += 1
+            except Exception:
+                log.debug("Could not mirror the watched mark for %s",
+                          target_id, exc_info=True)
+        if moved:
+            log.debug("Mirrored a watched mark onto %d downloaded item(s).",
+                      moved)
+            self._notify_change()
+        return moved
 
     def apply_userdata_event(self, arguments):
         """Apply a ``UserDataChanged`` push to the catalog. No requests.

--- a/jellyfin_mpv_shim/sync/manager.py
+++ b/jellyfin_mpv_shim/sync/manager.py
@@ -46,22 +46,42 @@ CHUNK = 1 << 20            # 1 MiB
 PROGRESS_STEP = 4 << 20    # push progress every ~4 MiB
 PLAYSTATE_INTERVAL = 30    # replay offline playstate at least this often (s)
 
-#: ...and pull the server's answer back down this often. Slower than the
-#: replay: what it catches is somebody watching an episode on another
-#: device, which is not a thing that needs noticing within the minute, and
-#: it costs a request per batch against every reachable server.
-USERDATA_REFRESH_INTERVAL = 300
-
-#: Floor on how often a *request* (the home screen loading) can bring the
-#: pull forward. Without it, bouncing in and out of Home is a refresh per
-#: visit; with it, the screen you are about to read is up to date and the
-#: server is asked at most twice a minute.
-USERDATA_REQUEST_FLOOR = 30
+#: Minimum gap between two catalog sweeps, whatever asked for them.
+#:
+#: **There is deliberately no interval to go with it.** The sweep is not a
+#: poll: `apply_userdata_event` applies changes as the server pushes them,
+#: so a timer would be asking, over and over, about a period during which
+#: anything that happened has already been applied. What a sweep covers is
+#: a *stretch with nobody listening*, and that stretch has edges the app
+#: can see -- it starts when a server drops and ends when one connects. So
+#: sweeps are triggered by those edges (`_note_connected_servers`, plus
+#: the first pass after start), never by elapsed time.
+#:
+#: This floor exists for the one thing that has no edge: a server that
+#: flaps, reconnecting every few seconds, would otherwise sweep on each
+#: one. A pending sweep is **deferred** by the floor rather than dropped
+#: (see `_run`), so no trigger is ever lost -- only delayed.
+USERDATA_SWEEP_FLOOR = 300
 
 #: Ids per request. They travel in the query string, which servers and
 #: proxies cap (the apiclient's own note on get_items says so), and a
 #: catalog of a few hundred downloads would otherwise be one 414.
 USERDATA_BATCH = 60
+
+#: Seconds between one sweep request and the next. The sweep is background
+#: work with nobody waiting on it, and a catalog of a few hundred items is
+#: several requests: sending them back to back is a burst at a server that
+#: may also be streaming to this client. Spread them instead -- 500 items
+#: is 9 requests over ~24s rather than 9 at once. Waited on `_wake`, which
+#: `stop()` sets, so shutdown does not sit out the delay.
+USERDATA_BATCH_PAUSE = 3
+
+#: A UserDataChanged carrying more entries than this is applied by marking
+#: the sweep due rather than one row at a time. The ordinary message is two
+#: entries (the item and its parent); something that moved hundreds at once
+#: is a bulk mark or a plugin, and walking it on the websocket thread would
+#: hold up every other event behind it.
+USERDATA_EVENT_MAX = 200
 STOP_JOIN_TIMEOUT = 10     # how long stop() waits for the worker to unwind (s)
 
 
@@ -167,8 +187,22 @@ class SyncManager:
         # that is mid-move.
         self._relocating = False
         self._last_playstate = 0.0
-        #: Same shape as _last_playstate, for the pull direction.
+        #: When the last catalog sweep ran, for USERDATA_SWEEP_FLOOR. Unlike
+        #: _last_playstate this does not schedule anything: nothing is due
+        #: because time passed, only because something asked.
         self._last_userdata = 0.0
+        #: Set when something has happened that the websocket could not have
+        #: told us about. True at construction because starting up is one of
+        #: those things -- the app was not listening a moment ago.
+        self._sweep_due = True
+        #: Server uuids that had a client last time the worker looked. The
+        #: transition *into* this set is the reconnect signal; see
+        #: _note_connected_servers for why it is watched here rather than
+        #: subscribed to.
+        self._connected_servers = set()
+        #: All connected clients, for the above. Set in start(); the default
+        #: keeps a directly-driven manager (every test) safe.
+        self.get_clients = lambda: {}
         # item_id -> (last downloaded size, consecutive no-progress short reads).
         # A short read normally leaves the row pending to resume; but a server
         # that cleanly truncates at the same offset every time would resume
@@ -183,6 +217,8 @@ class SyncManager:
         auto-download; both optional so existing callers and the tests keep
         working, in which case auto-download simply finds no servers."""
         self.get_client = get_client
+        if get_clients is not None:
+            self.get_clients = get_clients
         self.auto = AutoDownloader(self, get_clients=get_clients,
                                    is_busy=is_busy,
                                    should_stop=lambda: self._stop)
@@ -875,9 +911,8 @@ class SyncManager:
                 if now - self._last_playstate >= PLAYSTATE_INTERVAL:
                     self._last_playstate = now
                     self._sync_playstate()
-                if now - self._last_userdata >= USERDATA_REFRESH_INTERVAL:
-                    self._last_userdata = now
-                    self._refresh_userdata()
+                self._note_connected_servers()
+                self._sweep_if_due(now)
                 row = self._next_runnable()
                 # Only between downloads: a pass here would otherwise
                 # enqueue work while the user's own download is streaming,
@@ -962,41 +997,211 @@ class SyncManager:
             log.info("Synced %d offline playstate change(s) to the server.",
                      len(done))
 
+    def _sweep_if_due(self, now):
+        """Run a pending catalog sweep, unless one ran too recently.
+
+        The floor **defers, it does not drop**. A suppressed trigger would
+        be a stretch of time nobody ever looks at again -- the flag is set
+        because something happened that the websocket could not report, and
+        that does not stop being true because a sweep happened to run three
+        minutes ago. So `_sweep_due` stays up and the sweep goes out as
+        soon as it is allowed to, which is what makes a flapping server
+        cost one sweep per floor rather than one per flap.
+
+        Returns whether it swept, which is what the tests read.
+        """
+        if not self._sweep_due:
+            return False
+        if now - self._last_userdata < USERDATA_SWEEP_FLOOR:
+            return False
+        self._sweep_due = False
+        self._last_userdata = now
+        self._refresh_userdata()
+        return True
+
+    def _note_connected_servers(self):
+        """Watch for a server appearing, and mark a sweep due when one does.
+
+        This is the whole schedule. A sweep covers a stretch during which
+        nothing was listening, and a server *becoming reachable* is the end
+        of exactly such a stretch -- so it is the trigger, in place of the
+        interval this used to have. Startup is the same event (every server
+        transitions into the set on the first pass) and needs no special
+        case, though `_sweep_due` starts True anyway so a catalog is swept
+        even on a machine with no servers configured yet.
+
+        **Watched here rather than subscribed to.** `clientManager` has an
+        `on_server_connected` hook that means almost precisely this, and
+        two things argue against hanging the sweep off it. It is a single
+        slot that `mpvtk_browser/ui.py` already assigns, and it is assigned
+        *after* `syncManager.start()` runs -- so taking it would mean either
+        clobbering the browser's use of it or growing a fan-out for one more
+        listener. And it is a notification: it fires from five call sites,
+        and a sixth path that reconnects without calling it would leave a
+        gap that is invisible until somebody's catalog is stale. The
+        registry is the state itself, so a comparison against it cannot
+        miss a transition however the server came back -- health check,
+        websocket redial, or the user logging in -- and it is a set
+        comparison on a loop that already runs every five seconds.
+
+        Disappearances are recorded but trigger nothing: there is nothing to
+        catch up on with a server that just went away.
+        """
+        try:
+            connected = set(self.get_clients() or {})
+        except Exception:
+            log.debug("could not read the connected server list",
+                      exc_info=True)
+            return
+        if connected - self._connected_servers:
+            log.debug("Server(s) %s reachable again; catalog sweep due.",
+                      ", ".join(sorted(connected - self._connected_servers)))
+            self._sweep_due = True
+        self._connected_servers = connected
+
     def request_userdata_refresh(self):
-        """Bring the userdata pull forward — the home screen is loading.
+        """Ask for a catalog sweep — the home screen is loading.
 
-        The five-minute tick is right for a background poll and wrong for
-        the moment somebody opens the screen that draws watched state: an
-        episode finished on a phone should not need up to five minutes to
-        show here, and going offline in that window shows the stale answer
-        for as long as you are offline.
+        The one trigger that is not an edge the app can see, and the only
+        thing left covering the gap measured in
+        `tests/e2e/test_offline_sync.py`: another client can play something
+        to the end and never report its stop, and the server announces that
+        to nobody. No reconnect happens, so nothing else here would ever
+        notice. Home is where it would show, and a person opening Home is
+        the closest thing to a signal that exists.
 
-        Cheap and non-blocking: this only marks the pull due and wakes the
+        Not floored here -- `_run` defers rather than drops, so bouncing in
+        and out of Home cannot turn this into a poll and cannot lose a
+        request either.
+
+        Cheap and non-blocking: this only marks the sweep due and wakes the
         worker, so the requests happen on the sync thread rather than on
         whatever loaded the page.
         """
-        now = time.monotonic()
-        if now - self._last_userdata < USERDATA_REQUEST_FLOOR:
-            return          # one just ran; the screen is already current
-        self._last_userdata = 0.0       # due on the next tick
+        self._sweep_due = True
         self._wake.set()
+
+    def mirror_playstate(self, item_id, position_ticks=None, played=None):
+        """Record what *this* app just played, for an item we hold a copy of.
+
+        The catalog is what offline browsing reads, and until this existed
+        it was written only when the file being played was the downloaded
+        one. Streaming an episode you also have downloaded therefore left
+        the catalog at position 0 -- so the copy on disk, the one you keep
+        precisely because you are about to lose the network, was the one
+        thing that did not know you had watched it.
+
+        Unconditional on purpose: no check of whether the server is
+        reachable, and no check of whether the item is downloaded. The
+        server half is somebody else's job (the timeline reports to it, and
+        `_sync_playstate` replays what it missed); the downloaded half is
+        answered by ``db.update_userdata``, which returns False for an item
+        it holds no row for. That makes this safe to call for every item
+        played, which is the property that keeps it from being forgotten at
+        a call site again.
+
+        Advance-only, like every other writer of this column. Never raises.
+        """
+        if not item_id or (played is None and position_ticks is None):
+            return False
+        db = self.db
+        if db is None:
+            return False
+        try:
+            return db.update_userdata(item_id, played=played,
+                                      position_ticks=position_ticks)
+        except Exception:
+            log.debug("Could not mirror playstate for %s", item_id,
+                      exc_info=True)
+            return False
+
+    def apply_userdata_event(self, arguments):
+        """Apply a ``UserDataChanged`` push to the catalog. No requests.
+
+        This is how watched state normally arrives, and it is free: the
+        server sends the changed values themselves, so the item finished on
+        a phone is written here from the message that announced it rather
+        than from a sweep that goes and asks. `_refresh_userdata` is what
+        covers the gap where nobody was listening.
+
+        The payload is ``{UserId, ServerId, UserDataList: [...]}``, each
+        entry a ``UserItemDataDto`` -- ``ItemId``, ``Played``,
+        ``PlaybackPositionTicks``, ``PlayCount``, ``IsFavorite``. Measured
+        against 10.11.11 and 12.0.0, which agree.
+
+        **Not every save produces one**, and the exception is the one that
+        would otherwise matter most: the server drops ``PlaybackProgress``
+        saves before it ever builds this message
+        (``UserDataChangeNotifier.OnUserDataManagerUserDataSaved``), so a
+        client streaming somewhere else announces its *start* and its
+        *stop* and nothing in between. That is why this does not replace
+        the sweep, and why it is not a problem that it does not: a position
+        this client did not see move is caught at the stop, and our own
+        playback is mirrored locally without the server's help.
+
+        Ids not in the catalog cost one indexed SELECT and are dropped --
+        which is most of them, since the server adds each item's *parent*
+        to the list for its own indicator refresh. Runs on the websocket
+        thread, so a list long enough to hold that thread up is handed to
+        the sweep instead of walked here.
+        """
+        entries = (arguments or {}).get("UserDataList") or []
+        if not entries:
+            return
+        if len(entries) > USERDATA_EVENT_MAX:
+            log.debug("UserDataChanged carried %d entries; sweeping instead.",
+                      len(entries))
+            self.request_userdata_refresh()
+            return
+        db = self.db
+        if db is None:
+            return              # catalog not open (or already closed)
+        updated = 0
+        for entry in entries:
+            item_id = entry.get("ItemId")
+            if not item_id:
+                continue
+            try:
+                # `or None` on played, matching the sweep: db.update_userdata
+                # is advance-only, and False there would mean "leave it
+                # alone" anyway. An un-watch elsewhere does not retreat the
+                # local copy -- see _refresh_userdata's note on that rule,
+                # which this deliberately does not change.
+                if db.update_userdata(
+                        item_id,
+                        played=entry.get("Played") or None,
+                        position_ticks=entry.get("PlaybackPositionTicks")):
+                    updated += 1
+            except Exception:
+                log.debug("Could not apply pushed userdata for %s", item_id,
+                          exc_info=True)
+        if updated:
+            log.debug("Applied pushed watched state for %d downloaded "
+                      "item(s).", updated)
+            self._notify_change()
 
     def _refresh_userdata(self):
         """Pull the server's watched state for what we hold, and store it.
 
-        The other direction from :meth:`_sync_playstate`, and the half that
-        needs the server *asked*: an episode watched on a phone changes
-        nothing here until somebody tells us. Without it the catalog is a
-        download-time snapshot, so offline browsing shows a series you have
-        since finished as untouched -- and "delete watched downloads", which
-        reads ``userdata_json`` with no server fallback, quietly skips
-        everything watched elsewhere.
+        The other direction from :meth:`_sync_playstate`, and **the
+        fallback rather than the mechanism**. An episode watched on a phone
+        is normally applied here for free, by `apply_userdata_event`, the
+        moment the server pushes it. What this covers is what the socket
+        cannot: the stretch where nothing was listening -- offline, logged
+        out, not running -- after which there is nothing to replay and only
+        asking will do, and the narrower case of another client that
+        finished something and never reported its stop, which the server
+        records and announces to nobody (see `apply_userdata_event`).
+        Without it the catalog would be a download-time snapshot across
+        exactly that gap, so offline browsing shows a series you finished on
+        the flight out as untouched, and "delete watched downloads" (which
+        reads ``userdata_json`` with no server fallback) quietly skips it.
 
         Batched: one request per ``USERDATA_BATCH`` ids per server, rather
-        than the per-item call the auto-download reaper makes. That reaper
-        is the reason this is worth having at all -- it already pays a round
-        trip per row to work around the stale snapshot, and it is the only
-        consumer that could.
+        than the per-item call the auto-download reaper makes, and spaced by
+        ``USERDATA_BATCH_PAUSE`` so a large catalog does not arrive as a
+        burst. Nothing is waiting on it, so the spacing costs nothing that
+        anyone can see.
 
         **Advance-only**, because it goes through ``db.update_userdata``:
         the local copy is a floor, not a mirror. An item un-watched on
@@ -1016,6 +1221,7 @@ class SyncManager:
                 by_server.setdefault(row.get("server_uuid"), []).append(
                     row["item_id"])
         updated = 0
+        sent = 0
         for server_uuid, ids in by_server.items():
             client = self.get_client(server_uuid)
             if client is None:
@@ -1023,9 +1229,25 @@ class SyncManager:
             for start in range(0, len(ids), USERDATA_BATCH):
                 if self._stop:
                     return      # shutdown: the catalog closes behind us
+                if sent:
+                    # Between requests, never before the first: a sweep of
+                    # one batch must not pay for spacing it does not need.
+                    # Counted across servers too -- two servers' worth of
+                    # batches back to back is the same burst from this
+                    # machine's uplink even though neither server sees it.
+                    self._wake.wait(USERDATA_BATCH_PAUSE)
+                    if self._stop:
+                        return
+                sent += 1
                 batch = ids[start:start + USERDATA_BATCH]
                 try:
-                    result = client.jellyfin.get_items(batch) or {}
+                    # `fields=""`, not the apiclient's default: that default
+                    # is info(), 29 fields including MediaSources, and this
+                    # wants exactly one field group -- UserData, which comes
+                    # back whatever Fields says. Measured against 12.0 for
+                    # 60 ids: 73 ms and 191 KB with the default, 13 ms and
+                    # 60 KB without it, for byte-identical UserData.
+                    result = client.jellyfin.get_items(batch, fields="") or {}
                 except Exception:
                     log.debug("Userdata refresh failed for %s", server_uuid,
                               exc_info=True)

--- a/tests/e2e/run_e2e.py
+++ b/tests/e2e/run_e2e.py
@@ -108,6 +108,14 @@ CONTRACT = [
     # no position at all. Pinned because reading it wrong looks exactly
     # like a client bug.
     "tests.e2e.test_audiobooks",
+    # Offline watched state, both directions, plus the websocket message
+    # the whole design now rests on. The fast suite answers the server from
+    # a mock and the offline integration test fakes the HTTP client by its
+    # own admission, so every belief about *when* the server announces a
+    # change was untested until this -- and the obvious guess about the one
+    # that matters (does finishing something elsewhere announce itself?) is
+    # the wrong one.
+    "tests.e2e.test_offline_sync",
 ]
 
 # Playback tier: a real mpv, so once per backend under xvfb.

--- a/tests/e2e/test_offline_sync.py
+++ b/tests/e2e/test_offline_sync.py
@@ -1,0 +1,544 @@
+"""Offline watched state, against a real server, in both directions.
+
+`tests/test_playstate_mirror.py` is thorough about the *rules* -- advance
+only, the queue is offline-only, a pull that changed nothing does not
+redraw -- and every one of those tests answers the server from a mock that
+returns what the test told it to. All of them would stay green if this
+shim's beliefs about the server were wrong, and this feature is almost
+entirely beliefs about the server. `tests/integration/test_e2e_offline.py`
+goes further (real files, real catalog, real mpv) and stops at exactly this
+line: its own docstring says the Jellyfin client is the one thing it fakes,
+"because a real server is not available here".
+
+This is that boundary, tested. What it pins:
+
+* **The push half.** A change made with the server away reaches it once the
+  server is back, and does not rewind anything that moved on in the
+  meantime.
+* **The pull half.** A change made somewhere else reaches the catalog --
+  the copy on disk, which is what offline browsing reads, and which
+  nothing else in this app will ever go and check.
+* **The push the server makes.** `UserDataChanged` carries the new values,
+  so the ordinary case costs no request at all. The whole redesign of this
+  feature rests on that message's shape and on when it is sent, both of
+  which are somebody else's code and neither of which is documented. Two
+  answers here are not the intuitive ones and both are pinned below: a
+  progress report announces nothing *even when it finishes the item*, and
+  the message is not filtered by which session caused it -- this app is
+  told about its own marks as well as another device's.
+* **That the trimmed request still answers.** The sweep asks with
+  ``Fields=""`` because measuring showed the default was 6x the server
+  time for identical UserData. An empty Fields is exactly the kind of
+  parameter a server is free to reinterpret, and if it ever stops
+  returning UserData the sweep silently stops working -- the catalog would
+  simply never change, which looks like "nothing has been watched".
+
+Files are not downloaded here. Catalog rows are written directly, because
+what is under test is the synchronisation of *state* and a real transfer
+would add minutes to say nothing extra. Everything below the row is real:
+a real SyncDB on disk, the real SyncManager methods, a real client, a real
+websocket.
+
+**On fixture durations.** stdjflib's clips are ~20 seconds, and the
+server's resume rule discards a position on anything shorter than
+`MinResumeDurationSeconds` (300) -- marking it *played* instead. That rule
+lives in `UserDataManager.UpdatePlayState`, which is the **playback
+reporting** path only. `POST UserItems/{id}/UserData`, which is what both
+this suite and `_sync_playstate` write with, stores what it is given. So
+exact positions are assertable here, and a test that reported playback
+instead would fail in a way that reads as a client bug. (It is the same
+trap that made audiobook resume look broken until the fixtures grew.)
+
+Run: JMS_E2E_SERVER=http://127.0.0.1:8096 python3 -m unittest \\
+     tests.e2e.test_offline_sync
+"""
+
+import json
+import os
+import shutil
+import sys
+import tempfile
+import time
+import unittest
+
+sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+import _e2e  # noqa: E402
+
+REPO_ROOT = os.path.dirname(os.path.dirname(os.path.dirname(
+    os.path.abspath(__file__))))
+if REPO_ROOT not in sys.path:
+    sys.path.insert(0, REPO_ROOT)
+
+SERVER_UUID = "srv-e2e"
+
+#: Well inside the server's resume band and nowhere near either end, so a
+#: value that comes back changed has been changed by something this suite
+#: is about rather than by a rule it is not.
+POSITION = 5 * 10_000_000          # 5 seconds
+LATER = 9 * 10_000_000
+EARLIER = 2 * 10_000_000
+
+
+def _catalog_row(item, path="x.mp4"):
+    """A complete download row for a real server item.
+
+    `userdata_json` starts at the download-time snapshot -- unwatched, at
+    zero -- which is the state every one of these tests has to move away
+    from for its assertion to mean anything.
+    """
+    return {
+        "item_id": item["Id"],
+        "server_uuid": SERVER_UUID,
+        "server_id": item.get("ServerId") or "s1",
+        "name": item.get("Name") or "",
+        "type": item.get("Type") or "Movie",
+        "status": "complete",
+        "file_path": path,
+        "size_bytes": 1,
+        "downloaded_bytes": 1,
+        "runtime_ticks": item.get("RunTimeTicks") or 0,
+        "item_json": json.dumps(item),
+        "userdata_json": json.dumps({"Played": False,
+                                     "PlaybackPositionTicks": 0}),
+    }
+
+
+@_e2e.require_server
+class OfflineStateSyncTest(unittest.TestCase):
+    """One catalog, one server, both directions."""
+
+    @classmethod
+    def setUpClass(cls):
+        cls.session = _e2e.Session("qa-user")
+        # Two items, because several assertions here are "this one moved and
+        # that one did not" -- a single-item test cannot tell a working sync
+        # from one that writes every row it sees.
+        cls.items = cls.session.find_all(library="Movies",
+                                         item_type="Movie")[:2]
+        if len(cls.items) < 2:
+            raise unittest.SkipTest("need two movies in the QA library")
+
+    @classmethod
+    def tearDownClass(cls):
+        cls.session.stop()
+
+    def setUp(self):
+        from jellyfin_mpv_shim.sync.db import SyncDB
+        from jellyfin_mpv_shim.sync.manager import SyncManager
+
+        self.tmp = tempfile.mkdtemp(prefix="jms-e2e-sync-")
+        self.addCleanup(shutil.rmtree, self.tmp, ignore_errors=True)
+
+        self.db = SyncDB(os.path.join(self.tmp, "catalog.db"))
+        self.addCleanup(self.db.close)
+        for item in self.items:
+            self.db.upsert(_catalog_row(item))
+
+        # A real manager, constructed rather than started: `start()` would
+        # put a worker thread on the same catalog, and every assertion here
+        # is about what one specific pass did. The methods under test are
+        # the ones that pass calls.
+        self.mgr = SyncManager()
+        self.mgr.db = self.db
+        self.mgr.root = self.tmp
+        self.mgr.get_client = lambda uuid: (
+            self.session.client if uuid == SERVER_UUID else None)
+
+        self.ids = [i["Id"] for i in self.items]
+        self.addCleanup(self.session.reset_played, *self.ids)
+        self.session.reset_played(*self.ids)
+
+    # -- helpers -----------------------------------------------------------
+
+    def stored(self, item_id):
+        """The catalog's copy of this item's userdata, off disk."""
+        row = self.db.get(item_id) or {}
+        return json.loads(row.get("userdata_json") or "{}")
+
+    def elsewhere(self, item_id, **userdata):
+        """Make a change the way another client would."""
+        self.session.api.update_userdata_for_item(item_id, userdata)
+
+    # -- push: what we did offline, once the server is back ----------------
+
+    def test_a_mark_made_offline_reaches_the_server(self):
+        item_id = self.ids[0]
+        self.db.upsert_playstate(SERVER_UUID, item_id, played=True)
+        self.mgr._sync_playstate()
+        self.assertTrue(self.session.user_data(item_id).get("Played"))
+
+    def test_a_position_reached_offline_reaches_the_server(self):
+        item_id = self.ids[0]
+        self.db.upsert_playstate(SERVER_UUID, item_id, position_ticks=POSITION)
+        self.mgr._sync_playstate()
+        self.assertEqual(
+            self.session.user_data(item_id).get("PlaybackPositionTicks"),
+            POSITION)
+
+    def test_it_does_not_rewind_what_moved_on_without_us(self):
+        """The whole point of the queue being advance-only: this client was
+        off for a week, and the phone is further ahead than we are."""
+        item_id = self.ids[0]
+        self.elsewhere(item_id, PlaybackPositionTicks=LATER)
+        self.db.upsert_playstate(SERVER_UUID, item_id,
+                                 position_ticks=EARLIER)
+        self.mgr._sync_playstate()
+        self.assertEqual(
+            self.session.user_data(item_id).get("PlaybackPositionTicks"),
+            LATER, "an offline client rewound another device's progress")
+
+    def test_a_replayed_change_is_not_replayed_forever(self):
+        """Multi-step, per the repo rule. The failure this catches is the
+        queue never draining: every later pass would re-push a stale value
+        and undo whatever had happened since."""
+        item_id = self.ids[0]
+        self.db.upsert_playstate(SERVER_UUID, item_id, position_ticks=POSITION)
+        self.mgr._sync_playstate()
+        self.assertEqual(self.db.list_playstate(), [],
+                         "the queue still holds a change already sent")
+        # Somebody else moves on; three more passes must not touch it.
+        self.elsewhere(item_id, PlaybackPositionTicks=LATER)
+        for _ in range(3):
+            self.mgr._sync_playstate()
+        self.assertEqual(
+            self.session.user_data(item_id).get("PlaybackPositionTicks"),
+            LATER)
+
+    def test_only_the_queued_item_is_touched(self):
+        self.db.upsert_playstate(SERVER_UUID, self.ids[0], played=True)
+        self.mgr._sync_playstate()
+        self.assertFalse(self.session.user_data(self.ids[1]).get("Played"))
+
+    # -- pull: what somebody else did, into the catalog ---------------------
+
+    def test_the_sweep_brings_another_device_s_mark_down(self):
+        item_id = self.ids[0]
+        self.session.api.item_played(item_id, True)
+        self.mgr._refresh_userdata()
+        self.assertTrue(self.stored(item_id).get("Played"),
+                        "the catalog still says unwatched, so offline this "
+                        "episode is still offering to be watched")
+
+    def test_the_sweep_brings_a_position_down(self):
+        item_id = self.ids[0]
+        self.elsewhere(item_id, PlaybackPositionTicks=LATER)
+        self.mgr._refresh_userdata()
+        self.assertEqual(
+            self.stored(item_id).get("PlaybackPositionTicks"), LATER)
+
+    def test_the_trimmed_request_still_carries_userdata(self):
+        """`Fields=""` is what makes the sweep cheap, and an empty Fields is
+        exactly the sort of parameter a server may reinterpret. If UserData
+        ever stops coming back the sweep does not fail, it silently stops
+        working -- so this asserts on the wire, not on the catalog."""
+        result = self.session.api.get_items(self.ids, fields="") or {}
+        items = result.get("Items") or []
+        self.assertEqual(len(items), len(self.ids))
+        for item in items:
+            self.assertIn("UserData", item)
+            self.assertIn("PlaybackPositionTicks", item["UserData"])
+
+    def test_the_sweep_leaves_untouched_items_alone(self):
+        self.session.api.item_played(self.ids[0], True)
+        self.mgr._refresh_userdata()
+        self.assertFalse(self.stored(self.ids[1]).get("Played"))
+
+    def test_the_two_directions_converge(self):
+        """Several rounds of both halves, per the repo's multi-step rule.
+
+        The shape of bug this catches is the two directions feeding each
+        other: a pull that re-queues what it just learned, or a push that
+        leaves a row behind for the next pull to undo. One round of each
+        cannot see it -- it needs the third pass to diverge.
+        """
+        item_id = self.ids[0]
+        self.db.upsert_playstate(SERVER_UUID, item_id, position_ticks=POSITION)
+        for _ in range(3):
+            self.mgr._sync_playstate()
+            self.mgr._refresh_userdata()
+        self.assertEqual(
+            self.session.user_data(item_id).get("PlaybackPositionTicks"),
+            POSITION)
+        self.assertEqual(
+            self.stored(item_id).get("PlaybackPositionTicks"), POSITION)
+        self.assertEqual(self.db.list_playstate(), [])
+
+
+@_e2e.require_server
+class PushedUserDataReachesTheCatalogTest(unittest.TestCase):
+    """The message the redesign rests on, from a real server.
+
+    Everything here runs through the app's own `EventHandler` rather than
+    calling the manager directly, because the handler discarding the
+    payload is precisely the bug this replaced -- for a long time it took
+    `_arguments` and dropped it, and a five-minute sweep re-read the whole
+    catalog to learn what this message had already said.
+    """
+
+    @classmethod
+    def setUpClass(cls):
+        # A socket on one session and the changes made from another, which
+        # is the real arrangement: the shim listening, a phone acting.
+        cls.watcher = _e2e.Session("qa-user", websocket=True)
+        cls.actor = _e2e.Session("qa-user", device_id="jms-e2e-udactor")
+        cls.items = cls.actor.find_all(library="Movies",
+                                       item_type="Movie")[:1]
+        if not cls.items:
+            cls.watcher.stop()
+            cls.actor.stop()
+            raise unittest.SkipTest("need a movie in the QA library")
+        # The socket is up a moment before the server will send to it.
+        time.sleep(1.5)
+
+    @classmethod
+    def tearDownClass(cls):
+        cls.watcher.stop()
+        cls.actor.stop()
+
+    def setUp(self):
+        from unittest import mock
+
+        from jellyfin_mpv_shim import event_handler as eh
+        from jellyfin_mpv_shim.sync import manager as mgr
+        from jellyfin_mpv_shim.sync.db import SyncDB
+        from jellyfin_mpv_shim.sync.manager import SyncManager
+
+        self.tmp = tempfile.mkdtemp(prefix="jms-e2e-ws-")
+        self.addCleanup(shutil.rmtree, self.tmp, ignore_errors=True)
+        self.db = SyncDB(os.path.join(self.tmp, "catalog.db"))
+        self.addCleanup(self.db.close)
+        self.item = self.items[0]
+        self.item_id = self.item["Id"]
+        self.db.upsert(_catalog_row(self.item))
+
+        self.mgr = SyncManager()
+        self.mgr.db = self.db
+        #: Any call here is a request the push was supposed to make
+        #: unnecessary, so it is an assertion rather than a stub.
+        self.asked = []
+        self.mgr.get_client = lambda uuid: self.asked.append(uuid)
+
+        patcher = mock.patch.object(mgr, "syncManager", self.mgr)
+        patcher.start()
+        self.addCleanup(patcher.stop)
+
+        self.handler = eh.EventHandler()
+        self.handler.user_data_changed = None
+        # Feed every UserDataChanged the real socket delivers through the
+        # real handler, which is what the app does via ClientManager.
+        self.watcher.listeners.append(self._on_event)
+        self.addCleanup(self.watcher.listeners.remove, self._on_event)
+
+        self.actor.reset_played(self.item_id)
+        self.addCleanup(self.actor.reset_played, self.item_id)
+
+    def _on_event(self, name, data):
+        if name == "UserDataChanged":
+            self.handler.user_data_change(self.watcher.client, name, data)
+
+    def stored(self):
+        row = self.db.get(self.item_id) or {}
+        return json.loads(row.get("userdata_json") or "{}")
+
+    def test_a_mark_elsewhere_reaches_the_catalog_over_the_socket(self):
+        self.actor.api.item_played(self.item_id, True)
+        _e2e.wait_for(lambda: self.stored().get("Played") or None, timeout=15)
+        self.assertTrue(self.stored().get("Played"))
+
+    def test_a_position_set_elsewhere_reaches_the_catalog(self):
+        self.actor.api.update_userdata_for_item(
+            self.item_id, {"PlaybackPositionTicks": LATER})
+        _e2e.wait_for(
+            lambda: self.stored().get("PlaybackPositionTicks") or None,
+            timeout=15)
+        self.assertEqual(self.stored().get("PlaybackPositionTicks"), LATER)
+
+    def test_it_costs_no_request_at_all(self):
+        """The reason this replaced the poll. The values are in the message,
+        so nothing needs to be asked."""
+        self.actor.api.item_played(self.item_id, True)
+        _e2e.wait_for(lambda: self.stored().get("Played") or None, timeout=15)
+        self.assertEqual(self.asked, [],
+                         "applying a pushed change went back to the server")
+
+    def test_our_own_actions_come_back_to_us_too(self):
+        """The message is broadcast to every session the *user* has, not to
+        every session except the one that caused it.
+
+        Worth pinning because the natural assumption is the opposite -- that
+        a client is not told about its own doing -- and two things here read
+        differently depending on which is true. `apply_userdata_event` will
+        be handed this app's own playback marks (harmless: advance-only,
+        and `_record_progress` has already written the same values), and
+        Home's refresh fires on our own start and stop as well as on
+        somebody else's. If the server ever starts excluding the origin,
+        neither breaks, but both stop being reachable this way and the
+        local paths become the only ones -- which is a thing to know before
+        trusting the socket for it.
+
+        Measured symmetric: same result whichever session acts.
+        """
+        self.watcher.events.clear()
+        self.watcher.api.item_played(self.item_id, True)
+        data = self.watcher.wait_for_event("UserDataChanged", timeout=15)
+        self.assertTrue(
+            [e for e in (data.get("UserDataList") or [])
+             if e.get("ItemId") == self.item_id],
+            "the session that made the change was not told about it")
+
+    def test_the_payload_names_the_item_and_its_parent(self):
+        """The shape `apply_userdata_event` is written against, and the
+        reason it must tolerate ids it has never heard of: the server adds
+        each changed item's parent for its own indicator refresh."""
+        self.watcher.events.clear()
+        self.actor.api.item_played(self.item_id, True)
+        data = self.watcher.wait_for_event("UserDataChanged", timeout=15)
+        entries = data.get("UserDataList") or []
+        self.assertTrue(entries, "no UserDataList in the message")
+        mine = [e for e in entries if e.get("ItemId") == self.item_id]
+        self.assertEqual(len(mine), 1)
+        self.assertIn("Played", mine[0])
+        self.assertIn("PlaybackPositionTicks", mine[0])
+        self.assertGreater(
+            len(entries), 1,
+            "the parent entry is gone: apply_userdata_event tolerates "
+            "unknown ids because of it, and this is where that is checked")
+
+    def _progress(self, ticks):
+        self.actor.api.session_progress({
+            "ItemId": self.item_id, "PlayMethod": "DirectPlay",
+            "PositionTicks": int(ticks), "CanSeek": True, "IsPaused": False})
+
+    def _settle(self, seconds=2.5):
+        """Long enough that anything the server meant to send has been sent.
+
+        The notifier coalesces on a 500 ms timer, so this is five times the
+        window it batches over -- which is what makes asserting a *negative*
+        here meaningful rather than a race.
+        """
+        time.sleep(seconds)
+        return [d for n, d in list(self.watcher.events)
+                if n == "UserDataChanged"]
+
+    def _start_playback_and_quiesce(self):
+        """Open a playback session and get back to a genuinely empty inbox.
+
+        Both halves matter, and both were learned the hard way here -- this
+        is the repo's standing rule for live tests, that a wait must never
+        be satisfiable by evidence that predates the action.
+
+        The mark is taken **before** `session_playing`, because `setUp`'s
+        own `reset_played` emits a UserDataChanged of its own: waiting
+        without clearing first returns *that* one instantly, and the start's
+        event then lands in the list a moment after it was emptied -- which
+        is indistinguishable from a progress report having emitted it, and
+        is what the first version of this suite reported.
+
+        And it settles **after** the wait, because the start can be followed
+        by more than one message; clearing the instant the first arrives
+        leaves the rest to appear inside the window under test.
+        """
+        self.watcher.events.clear()
+        self.actor.api.session_playing({
+            "ItemId": self.item_id, "PlayMethod": "DirectPlay",
+            "PositionTicks": 0, "CanSeek": True, "IsPaused": False})
+        self.watcher.wait_for_event("UserDataChanged", timeout=15)
+        self._settle(1.5)
+        self.watcher.events.clear()
+
+    def test_progress_reports_send_no_event(self):
+        """A belief, held by three separate pieces of this app, that is
+        false in the obvious direction and would be expensive to be wrong
+        about.
+
+        The server drops `PlaybackProgress` saves before it builds this
+        message (`UserDataChangeNotifier`), so a client streaming elsewhere
+        does not narrate itself position by position. Everything
+        downstream is sized for that: Home's debounce is settling a handful
+        of events rather than a stream, and `apply_userdata_event` walks
+        the list on the websocket thread rather than handing it off.
+
+        If a future server starts sending one per progress report, this
+        goes red and both of those want re-reading -- which is the entire
+        reason to assert a negative. (The comment this replaced claimed the
+        opposite, and had for years.)
+
+        The mark at the end is not decoration. A negative assertion over a
+        socket passes just as well when the socket is dead, the listener
+        was never attached, or the item id was wrong -- so the same window
+        is made to produce an event on demand before the absence of one is
+        believed.
+        """
+        runtime = self.item.get("RunTimeTicks") or 0
+        self.assertTrue(runtime, "fixture has no runtime; the server's "
+                                 "resume rules cannot be reasoned about")
+        self._start_playback_and_quiesce()
+        # Under MinResumePct, so the server stores nothing and this stays a
+        # test about announcements rather than about the resume rule.
+        for fraction in (0.01, 0.02, 0.03):
+            self._progress(runtime * fraction)
+            time.sleep(0.6)
+        pushed = self._settle()
+        self.actor.api.session_stop({"ItemId": self.item_id,
+                                     "PositionTicks": 0})
+        self.assertEqual(
+            pushed, [],
+            "the server now pushes UserDataChanged for progress reports; "
+            "see this test's docstring for what assumed otherwise")
+        # The control: this socket, this listener, this item.
+        self.watcher.events.clear()
+        self.actor.api.item_played(self.item_id, True)
+        self.assertTrue(
+            self._settle(),
+            "nothing announced a plain mark either, so the silence above "
+            "was the socket rather than the server's filter")
+
+    def test_not_even_the_one_that_finishes_it(self):
+        """The exception that isn't, and the reason the sweep survives.
+
+        The obvious guess -- and the first version of this suite's guess --
+        is that a progress report which carries an item *past the
+        completion threshold* must announce itself, since it is no longer
+        merely progress. It does not. `SessionManager.OnPlaybackProgress`
+        saves the completion under `PlaybackProgress` like any other, and
+        the only thing it does differently is
+        `Video.PropagatePlayedState`, which returns immediately for a video
+        with no alternate versions and skips the item itself in any case.
+
+        So: another device can play something all the way through, the
+        server can record it as watched, and **this client is told
+        nothing** until that device sends its stop. A client that is killed
+        mid-playback never sends one. That gap is exactly what
+        `_refresh_userdata` is left in the design to cover, and it is why
+        making the sweep cheap mattered more than making it rare.
+
+        Both halves are asserted here because the first version of this
+        file pinned the opposite, on evidence that turned out to be the
+        previous action's event arriving after the inbox was cleared.
+        """
+        runtime = self.item.get("RunTimeTicks") or 0
+        self.assertTrue(runtime)
+        self._start_playback_and_quiesce()
+        self._progress(runtime * 0.95)
+        pushed = self._settle()
+        self.assertEqual(pushed, [],
+                         "a completing progress report now announces "
+                         "itself; the sweep's justification has changed")
+        # The server did take it -- so this is silence about a real change,
+        # not silence about nothing happening.
+        self.assertTrue(
+            self.actor.api.get_item(self.item_id).get("UserData", {})
+            .get("Played"),
+            "the server did not record the completion, so this test is "
+            "asserting silence about an event that never occurred")
+        self.assertFalse(self.stored().get("Played"))
+        # ...and the stop is what finally tells us, which is the path the
+        # catalog actually gets "finished on another device" from.
+        self.actor.api.session_stop({"ItemId": self.item_id,
+                                     "PositionTicks": 0})
+        _e2e.wait_for(lambda: self.stored().get("Played") or None, timeout=15)
+        self.assertTrue(self.stored().get("Played"))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/e2e/test_offline_sync.py
+++ b/tests/e2e/test_offline_sync.py
@@ -26,6 +26,15 @@ This is that boundary, tested. What it pins:
   progress report announces nothing *even when it finishes the item*, and
   the message is not filtered by which session caused it -- this app is
   told about its own marks as well as another device's.
+* **The marks a person makes.** Mark Watched and Mark Unwatched are
+  authoritative in both directions and are written to the catalog where they
+  are made -- no sweep, no socket. Both halves are somebody else's code
+  again: that the server clears what our local write clears, and that a
+  container mark fans out to its children.
+* **When the first sweep of a session runs.** Against the real client
+  registry, over the sequence a launch produces -- the worker's first pass
+  happens before `login_servers()`, so a pass with nobody to ask must not
+  spend the startup trigger.
 * **That the trimmed request still answers.** The sweep asks with
   ``Fields=""`` because measuring showed the default was 6x the server
   time for identical UserData. An empty Fields is exactly the kind of
@@ -538,6 +547,422 @@ class PushedUserDataReachesTheCatalogTest(unittest.TestCase):
                                      "PositionTicks": 0})
         _e2e.wait_for(lambda: self.stored().get("Played") or None, timeout=15)
         self.assertTrue(self.stored().get("Played"))
+
+
+@_e2e.require_server
+class DeliberateMarksReachTheCatalogTest(unittest.TestCase):
+    """Mark Watched / Mark Unwatched, through the real gateway, against the
+    real server, with a real catalog on disk.
+
+    The unit tests answer "does the shim write what it believes"; this one
+    answers the two things they cannot, both of which are beliefs about
+    somebody else's code. **That the server does what the local write
+    mirrors** -- `db.set_watched` was written against `BaseItem.MarkPlayed`
+    and `ResetPlayedState`, and if the two ever disagree the next sweep
+    reads the difference back as a change and the catalog flickers between
+    them. And **that the mark does not need the socket**: it used to arrive
+    (when it arrived at all) as a `UserDataChanged` push, which is
+    advance-only on this side, so un-watching never reached the copy on
+    disk by any route.
+
+    Un-watching is asserted at every step for that reason: it is the
+    direction that had no writer, and the direction a test written the
+    obvious way (mark, assert, done) never exercises.
+    """
+
+    @classmethod
+    def setUpClass(cls):
+        cls.session = _e2e.Session("qa-user")
+        cls.items = cls.session.find_all(library="Movies",
+                                         item_type="Movie")[:2]
+        if len(cls.items) < 2:
+            raise unittest.SkipTest("need two movies in the QA library")
+
+    @classmethod
+    def tearDownClass(cls):
+        cls.session.stop()
+
+    def setUp(self):
+        from unittest import mock
+
+        from jellyfin_mpv_shim.mpvtk_browser.gateway import userdata as gw
+        from jellyfin_mpv_shim.sync import manager as mgr
+        from jellyfin_mpv_shim.sync.db import SyncDB
+        from jellyfin_mpv_shim.sync.manager import SyncManager
+
+        self.tmp = tempfile.mkdtemp(prefix="jms-e2e-mark-")
+        self.addCleanup(shutil.rmtree, self.tmp, ignore_errors=True)
+        self.db = SyncDB(os.path.join(self.tmp, "catalog.db"))
+        self.addCleanup(self.db.close)
+        for item in self.items:
+            self.db.upsert(_catalog_row(item))
+
+        self.mgr = SyncManager()
+        self.mgr.db = self.db
+        self.mgr.get_client = lambda uuid: (
+            self.session.client if uuid == SERVER_UUID else None)
+        patcher = mock.patch.object(mgr, "syncManager", self.mgr)
+        patcher.start()
+        self.addCleanup(patcher.stop)
+
+        # The gateway the library's context menu and detail page call, with
+        # the real client behind it -- not a stub that agrees.
+        class _Gateway(gw.UserDataMixin):
+            pass
+
+        self.gw = _Gateway()
+        deps_patcher = mock.patch.object(gw, "deps")
+        deps = deps_patcher.start()
+        self.addCleanup(deps_patcher.stop)
+        deps.clientManager.clients = {SERVER_UUID: self.session.client}
+
+        self.ids = [i["Id"] for i in self.items]
+        self.addCleanup(self.session.reset_played, *self.ids)
+        self.session.reset_played(*self.ids)
+
+    def stored(self, item_id):
+        row = self.db.get(item_id) or {}
+        return json.loads(row.get("userdata_json") or "{}")
+
+    def mark(self, item_id, watched):
+        self.assertTrue(self.gw.set_watched(SERVER_UUID, item_id, watched),
+                        "the gateway reported the mark as not recorded")
+
+    def server_played(self, item_id):
+        """The server's answer, read the way the sweep reads it.
+
+        Which endpoint is asked matters after a *container* mark and only
+        then -- see `test_a_per_item_read_still_says_unplayed`. The sweep
+        uses `get_items`, so that is what the catalog is compared against
+        here.
+        """
+        result = self.session.api.get_items([item_id], fields="") or {}
+        for item in result.get("Items") or []:
+            if item.get("Id") == item_id:
+                return bool((item.get("UserData") or {}).get("Played"))
+        return None
+
+    # -- both directions, both places --------------------------------------
+
+    def test_marking_watched_reaches_the_server_and_the_catalog(self):
+        item_id = self.ids[0]
+        self.mark(item_id, True)
+        self.assertTrue(self.session.user_data(item_id).get("Played"))
+        self.assertTrue(self.stored(item_id).get("Played"),
+                        "the server has it and the copy on disk does not")
+
+    def test_marking_unwatched_does_too(self):
+        """The half that had no writer at all: every path into this column
+        was advance-only, so `Played` could be set and never cleared."""
+        item_id = self.ids[0]
+        self.session.api.item_played(item_id, True)
+        self.mgr._refresh_userdata()
+        self.assertTrue(self.stored(item_id).get("Played"))
+
+        self.mark(item_id, False)
+        self.assertFalse(self.session.user_data(item_id).get("Played"))
+        self.assertFalse(self.stored(item_id).get("Played"),
+                         "offline this still shows the tick the user just "
+                         "removed, and delete-watched would still take it")
+
+    def test_it_needs_no_sweep_and_no_socket(self):
+        """The mark is written where it is made. Nothing here has a
+        websocket attached and nothing asks the server anything: if this
+        only passes with a sweep, the state is minutes late and wrong for
+        the whole of a flight."""
+        item_id = self.ids[0]
+        asked = []
+        self.mgr.get_client = lambda uuid: asked.append(uuid)
+        self.mark(item_id, True)
+        self.assertTrue(self.stored(item_id).get("Played"))
+        self.assertEqual(asked, [], "the local write went back to the server")
+
+    def test_only_the_marked_item_moves(self):
+        self.mark(self.ids[0], True)
+        self.assertFalse(self.stored(self.ids[1]).get("Played"))
+
+    # -- what the server actually stores -----------------------------------
+
+    def test_the_catalog_stores_what_the_server_stores(self):
+        """The measurement `db.set_watched` was written from, taken from a
+        live server rather than from the C#.
+
+        Marking played clears the resume point (the controller passes
+        `resetPosition: true`) and marking unplayed clears position and play
+        count. If the local write and the server ever diverge here, the next
+        sweep reads the difference back as a change.
+        """
+        item_id = self.ids[0]
+        self.session.api.update_userdata_for_item(
+            item_id, {"PlaybackPositionTicks": POSITION})
+
+        self.mark(item_id, True)
+        server = self.session.user_data(item_id)
+        self.assertEqual(server.get("PlaybackPositionTicks"), 0,
+                         "the server kept a resume point through a mark; "
+                         "db.set_watched clears it and would now diverge")
+        self.assertEqual(self.stored(item_id).get("PlaybackPositionTicks"),
+                         server.get("PlaybackPositionTicks"))
+        self.assertGreaterEqual(server.get("PlayCount") or 0, 1)
+        self.assertGreaterEqual(self.stored(item_id).get("PlayCount") or 0, 1)
+
+        self.mark(item_id, False)
+        server = self.session.user_data(item_id)
+        self.assertEqual(server.get("PlayCount") or 0, 0)
+        self.assertEqual(self.stored(item_id).get("PlayCount") or 0, 0)
+        self.assertEqual(self.stored(item_id).get("PlaybackPositionTicks"), 0)
+
+    def test_a_sweep_after_a_mark_finds_nothing_to_change(self):
+        """The two writers agreeing, asserted as the property rather than
+        field by field: a pull straight after a mark must be a no-op. When
+        they disagree this is where it shows -- the catalog would be
+        corrected back to the server's answer a minute later."""
+        item_id = self.ids[0]
+        self.mark(item_id, True)
+        before = self.stored(item_id)
+        self.mgr._refresh_userdata()
+        after = self.stored(item_id)
+        self.assertEqual(after.get("Played"), before.get("Played"))
+        self.assertEqual(after.get("PlaybackPositionTicks"),
+                         before.get("PlaybackPositionTicks"))
+
+    def test_it_tracks_over_several_flips(self):
+        """Multi-step, per the repo rule. Advance-only is invisible in one
+        direction and latched in the other, so a single mark cannot see it:
+        the failure is the third step, where the catalog stops following."""
+        item_id = self.ids[0]
+        seen = []
+        for watched in (True, False, True, False):
+            self.mark(item_id, watched)
+            seen.append((self.session.user_data(item_id).get("Played") or
+                         False,
+                         self.stored(item_id).get("Played") or False))
+        self.assertEqual(seen, [(True, True), (False, False),
+                                (True, True), (False, False)])
+
+    def test_a_series_mark_fans_out_the_way_the_server_does(self):
+        """The catalog holds leaves, so a series tick has to be fanned out
+        here -- and the answer has to be the server's, which marks every
+        child (`Folder.MarkPlayed`). Asserted against the real episodes
+        rather than against our own idea of them."""
+        eps = None
+        for series in self.session.find_all(library="Shows",
+                                            item_type="Series"):
+            found = self.session.find_all(parent_id=series["Id"],
+                                          item_type="Episode")
+            if len(found) >= 2:
+                eps = found[:2]
+                break
+        if eps is None:
+            self.skipTest("need a series with two episodes")
+        series_id = eps[0]["SeriesId"]
+        for ep in eps:
+            # The columns the fan-out is resolved from: a downloader writes
+            # them, `_catalog_row` (a movie row) does not.
+            row = _catalog_row(ep)
+            row["series_id"] = ep.get("SeriesId")
+            row["season_id"] = ep.get("SeasonId")
+            self.db.upsert(row)
+        ids = [e["Id"] for e in eps]
+        self.addCleanup(self.session.reset_played, *ids)
+        self.session.reset_played(*ids)
+
+        self.mark(series_id, True)
+        for item_id in ids:
+            self.assertTrue(self.server_played(item_id),
+                            "the server did not fan the mark out, so this "
+                            "test is asserting our fan-out against nothing")
+            self.assertTrue(self.stored(item_id).get("Played"),
+                            "%s missed the fan-out" % item_id)
+
+    def test_a_per_item_read_still_says_unplayed(self):
+        """A server fact, measured on 12.0.0 and pinned because two things
+        here depend on which endpoint asks.
+
+        After a *series* is marked played, its episodes come back **played**
+        from `GET /Items?ids=` and **unplayed** from both per-item reads
+        (`GET /UserItems/{id}/UserData` and `GET /Users/{uid}/Items/{id}`).
+        The fan-out really happened -- the list endpoint is not inventing
+        it -- so the per-item answer is the stale one.
+
+        It is load-bearing twice. The sweep asks with `get_items`, which is
+        why "watched on the phone by marking the series" reaches the
+        catalog at all. And `_sync_playstate` compares against
+        `get_userdata_for_item` before pushing, so it can be told an item
+        is unplayed that the server considers played -- harmless today,
+        since it only ever pushes *forward*, but it is the reason that
+        comparison cannot be trusted for anything else.
+
+        This goes red when the server starts agreeing with itself, which is
+        the point: both of the above want re-reading if it does.
+        """
+        eps = None
+        for series in self.session.find_all(library="Shows",
+                                            item_type="Series"):
+            found = self.session.find_all(parent_id=series["Id"],
+                                          item_type="Episode")
+            if len(found) >= 1:
+                eps = found[:1]
+                break
+        if eps is None:
+            self.skipTest("need a series with an episode")
+        item_id = eps[0]["Id"]
+        self.addCleanup(self.session.reset_played, item_id)
+        self.session.reset_played(item_id)
+
+        self.session.api.item_played(eps[0]["SeriesId"], True)
+        self.assertTrue(self.server_played(item_id),
+                        "the list endpoint no longer shows the fan-out")
+        self.assertFalse(
+            self.session.api.get_userdata_for_item(item_id).get("Played"),
+            "the per-item endpoint now agrees with the list one; the sweep "
+            "and _sync_playstate's comparison both want re-reading")
+        # A mark on the item itself is not affected -- so this is about
+        # container fan-out, not about the endpoint being broken.
+        self.session.api.item_played(item_id, True)
+        self.assertTrue(
+            self.session.api.get_userdata_for_item(item_id).get("Played"))
+
+
+@_e2e.require_server
+class TheFirstSweepOfASessionTest(unittest.TestCase):
+    """When the sweep runs at launch, against a real registry.
+
+    The unit tests drive `_sweep_if_due` with a hand-built manager; this
+    drives the real one, with the real client registry it reads, over the
+    sequence a launch produces -- `mpv_shim.main` starts the worker
+    *before* `login_servers()`, so the first pass has nobody to ask. It is
+    a clock-driven test rather than a slow one: `now` is passed in, so a
+    six-minute session is asserted in milliseconds. What is real here is
+    the registry, the catalog, and the requests the sweep makes when it
+    finally runs.
+    """
+
+    @classmethod
+    def setUpClass(cls):
+        cls.session = _e2e.Session("qa-user")
+        cls.items = cls.session.find_all(library="Movies",
+                                         item_type="Movie")[:1]
+        if not cls.items:
+            raise unittest.SkipTest("need a movie in the QA library")
+
+    @classmethod
+    def tearDownClass(cls):
+        cls.session.stop()
+
+    def setUp(self):
+        from jellyfin_mpv_shim.sync.db import SyncDB
+        from jellyfin_mpv_shim.sync.manager import SyncManager
+
+        self.tmp = tempfile.mkdtemp(prefix="jms-e2e-settle-")
+        self.addCleanup(shutil.rmtree, self.tmp, ignore_errors=True)
+        self.db = SyncDB(os.path.join(self.tmp, "catalog.db"))
+        self.addCleanup(self.db.close)
+        self.item_id = self.items[0]["Id"]
+        self.db.upsert(_catalog_row(self.items[0]))
+
+        self.mgr = SyncManager()
+        self.mgr.db = self.db
+        self.clients = {}
+        self.mgr.get_clients = lambda: dict(self.clients)
+        self.mgr.get_client = lambda uuid: self.clients.get(uuid)
+        self.start = 40_000.0           # monotonic counts from boot
+        self.mgr._started_at = self.start
+
+        self.addCleanup(self.session.reset_played, self.item_id)
+        self.session.reset_played(self.item_id)
+
+    def stored(self):
+        row = self.db.get(self.item_id) or {}
+        return json.loads(row.get("userdata_json") or "{}")
+
+    def login(self):
+        self.clients[SERVER_UUID] = self.session.client
+
+    def run_session(self, seconds, login_at=1):
+        """Drive the worker's idle loop over a session, returning when each
+        sweep ran (in seconds since the catalog opened)."""
+        from jellyfin_mpv_shim.sync import manager as mgr
+
+        swept = []
+        for tick in range(0, seconds, 5):
+            if login_at is not None and tick >= login_at:
+                self.login()
+            self.mgr._note_connected_servers()
+            if self.mgr._sweep_if_due(self.start + tick):
+                swept.append(tick)
+        self.assertLess(len(swept), seconds // mgr.USERDATA_SWEEP_FLOOR + 2)
+        return swept
+
+    def test_the_first_sweep_lands_a_minute_in_and_pulls_state(self):
+        """The whole point of the change, asserted end to end: something
+        watched elsewhere while this app was closed is in the catalog
+        within about a minute of launch, not five.
+
+        The state is set on the server *before* the session starts, which
+        is what "changed while nobody was listening" means -- no socket
+        could have carried it, so only the sweep can have.
+        """
+        from jellyfin_mpv_shim.sync import manager as mgr
+
+        self.session.api.item_played(self.item_id, True)
+        self.assertFalse(self.stored().get("Played"))
+
+        swept = self.run_session(400)
+        self.assertTrue(swept, "the session never swept at all")
+        self.assertGreaterEqual(swept[0], mgr.USERDATA_SWEEP_SETTLE)
+        self.assertLess(swept[0], mgr.USERDATA_SWEEP_SETTLE + 10,
+                        "the first sweep waited out the floor rather than "
+                        "the settle -- the five-minute gap is back")
+        self.assertTrue(self.stored().get("Played"),
+                        "the sweep ran but the catalog did not move")
+
+    def test_nothing_is_asked_before_the_settle(self):
+        """A negative worth asserting because it is the reason for the
+        delay: the first screen has the network to itself."""
+        from jellyfin_mpv_shim.sync import manager as mgr
+
+        self.session.api.item_played(self.item_id, True)
+        asked = []
+        real = self.mgr.get_client
+        self.mgr.get_client = lambda uuid: (asked.append(uuid) or real(uuid))
+        for tick in range(0, mgr.USERDATA_SWEEP_SETTLE, 5):
+            self.login()
+            self.mgr._note_connected_servers()
+            self.mgr._sweep_if_due(self.start + tick)
+        self.assertEqual(asked, [])
+        self.assertFalse(self.stored().get("Played"))
+        # The control: the same setup does sweep once the settle is over,
+        # so the silence above is the settle and not a broken fixture.
+        self.mgr._sweep_if_due(self.start + mgr.USERDATA_SWEEP_SETTLE + 1)
+        self.assertTrue(self.stored().get("Played"))
+
+    def test_a_login_slower_than_the_settle_still_sweeps_promptly(self):
+        """The pass the settle releases can still have nobody to ask -- a
+        retrying login, a captive portal. Spending the trigger there is
+        what put the first real sweep five minutes past the login."""
+        from jellyfin_mpv_shim.sync import manager as mgr
+
+        self.session.api.item_played(self.item_id, True)
+        swept = self.run_session(500, login_at=120)
+        self.assertTrue(swept, "the session never swept at all")
+        self.assertGreaterEqual(swept[0], 120)
+        self.assertLess(swept[0], 120 + mgr.USERDATA_SWEEP_FLOOR,
+                        "the sweep waited out a floor started by a pass "
+                        "with no server to ask")
+        self.assertTrue(self.stored().get("Played"))
+
+    def test_the_session_does_not_then_poll(self):
+        """The floor is still doing its job afterwards: six minutes of an
+        idle app with a live registry is not a request every five seconds.
+        """
+        from jellyfin_mpv_shim.sync import manager as mgr
+
+        swept = self.run_session(400)
+        self.assertLessEqual(len(swept), 2, "the sweep became a poll")
+        if len(swept) > 1:
+            self.assertGreaterEqual(swept[1] - swept[0],
+                                    mgr.USERDATA_SWEEP_FLOOR)
 
 
 if __name__ == "__main__":

--- a/tests/test_player_controller.py
+++ b/tests/test_player_controller.py
@@ -324,6 +324,23 @@ class TestOfflineWatchedQueue(unittest.TestCase):
         def update_userdata(self, item_id, played=False):
             self.userdata.append((item_id, played))
 
+        # Modelled rather than stubbed: the real one is the fan-out this
+        # class is largely about, and a stand-in that answered with the id
+        # it was handed would make every series test below pass on an app
+        # that had stopped fanning out at all.
+        def watched_targets(self, item_id, server_uuid=None):
+            if not item_id:
+                return []
+            if self.is_complete(item_id):
+                return [(item_id, server_uuid)]
+            return [(r["item_id"], r["server_uuid"] or server_uuid)
+                    for r in self.list()
+                    if item_id in (r["series_id"], r["season_id"])]
+
+        def set_watched(self, item_id, played):
+            self.userdata.append((item_id, played))
+            return True
+
     def _with_db(self, db):
         import jellyfin_mpv_shim.sync.manager as manager_mod
 

--- a/tests/test_playstate_mirror.py
+++ b/tests/test_playstate_mirror.py
@@ -26,13 +26,29 @@ sys.argv = [sys.argv[0]]      # importing the shim reaches args.get_args()
 
 
 class FakeDb:
-    """Enough of sync.db for the mirror: advance-only userdata per item."""
+    """Enough of sync.db for the mirror: advance-only userdata per item.
 
-    def __init__(self):
+    ``held`` is the set of item ids the catalog has a download row for, and
+    modelling it is not decoration. The real ``update_userdata`` answers
+    False for an item it holds no row for, and two callers lean on exactly
+    that: `mirror_playstate` is called for *every* item played, and
+    `apply_userdata_event` is handed the parent of every changed item by
+    the server. A fake that quietly creates a row for whatever it is asked
+    about cannot fail either of those tests -- it would report a pass while
+    the shim wrote catalog rows for things nobody has downloaded.
+
+    None means "holds everything", which is what the mirror tests want:
+    their item is downloaded by construction.
+    """
+
+    def __init__(self, held=None):
         self.userdata = {}
         self.playstate = []
+        self.held = held
 
     def update_userdata(self, item_id, played=None, position_ticks=None):
+        if self.held is not None and item_id not in self.held:
+            return False
         data = self.userdata.setdefault(item_id, {})
         changed = False
         if played:
@@ -50,6 +66,29 @@ class FakeDb:
 
     def upsert_playstate(self, server_uuid, item_id, **kw):
         self.playstate.append((server_uuid, item_id, kw))
+
+
+class _RecordingWake:
+    """Stands in for the manager's `_wake` event during a sweep.
+
+    Records what it was asked to wait for and returns immediately. `set` is
+    modelled too because the manager's own `stop()` calls it, so a test that
+    stops mid-sweep goes through the same object.
+    """
+
+    def __init__(self):
+        self.waits = []
+        self.is_set_flag = False
+
+    def wait(self, timeout=None):
+        self.waits.append(timeout)
+        return self.is_set_flag
+
+    def set(self):
+        self.is_set_flag = True
+
+    def clear(self):
+        self.is_set_flag = False
 
 
 def _video(online=True):
@@ -140,13 +179,20 @@ class MirrorsWhileOnlineTest(unittest.TestCase):
 class PullFromTheServerTest(unittest.TestCase):
     """The other half: what was watched on *another* device."""
 
-    def _manager(self, items, rows=None):
+    def _manager(self, items, rows=None, held=None):
         from jellyfin_mpv_shim.sync.manager import SyncManager
 
         m = SyncManager.__new__(SyncManager)
-        m.db = FakeDb()
+        m.db = FakeDb(held=held)
         m._stop = False
         m._notify_change = mock.Mock()
+        # The real manager always has this (it is built in __init__); the
+        # sweep waits on it between requests so that stopping does not have
+        # to sit out the delay. Recorded rather than really waited on: a
+        # test that slept the spacing would take longer than the rest of
+        # this file put together, and what is worth asserting is *that* the
+        # requests were spaced, not that the process was idle for it.
+        m._wake = _RecordingWake()
         m.db.list = lambda status=None: rows if rows is not None else [
             {"item_id": "ep1", "server_uuid": "srv"},
             {"item_id": "ep2", "server_uuid": "srv"},
@@ -198,6 +244,224 @@ class PullFromTheServerTest(unittest.TestCase):
         m = self._manager([])
         m._api.get_items.side_effect = RuntimeError("down")
         m._refresh_userdata()   # must not raise
+
+    def test_it_asks_for_no_fields_it_does_not_use(self):
+        """The whole request exists to read `UserData`, which comes back
+        whatever Fields says.
+
+        Left to the apiclient's default this sends info() -- 29 fields
+        including MediaSources -- and measured against 12.0 that is 73 ms
+        and 191 KB per 60 ids against 13 ms and 60 KB, for identical
+        UserData. Asserted as `fields=""` rather than "not the default"
+        because the default is what a dropped keyword silently restores.
+        """
+        m = self._manager([])
+        m._refresh_userdata()
+        self.assertEqual(m._api.get_items.call_args.kwargs.get("fields"), "")
+
+    def test_requests_are_spaced_apart(self):
+        """A few hundred downloads is several requests, and nothing is
+        waiting on them; they go out spread rather than as a burst."""
+        from jellyfin_mpv_shim.sync import manager as mgr
+        rows = [{"item_id": "e%d" % i, "server_uuid": "srv"}
+                for i in range(mgr.USERDATA_BATCH * 3)]
+        m = self._manager([], rows=rows)
+        m._refresh_userdata()
+        self.assertEqual(m._api.get_items.call_count, 3)
+        # Between the requests, so one fewer than there are requests --
+        # a sweep that paused before the first would delay the only case
+        # that has somebody waiting on it (Home asking on the way in).
+        self.assertEqual(m._wake.waits,
+                         [mgr.USERDATA_BATCH_PAUSE] * 2)
+
+    def test_a_single_batch_waits_for_nothing(self):
+        m = self._manager([])
+        m._refresh_userdata()
+        self.assertEqual(m._wake.waits, [])
+
+    def test_two_servers_are_spaced_from_each_other_too(self):
+        """Neither server sees a burst, but this machine's uplink does."""
+        m = self._manager([], rows=[{"item_id": "a", "server_uuid": "srv"},
+                                    {"item_id": "b", "server_uuid": "srv2"}])
+        api = m._api
+        m.get_client = lambda uuid: mock.Mock(jellyfin=api)
+        m._refresh_userdata()
+        self.assertEqual(api.get_items.call_count, 2)
+        self.assertEqual(len(m._wake.waits), 1)
+
+    def test_stopping_during_the_pause_ends_the_sweep(self):
+        """Shutdown must not wait out the spacing, and must not keep
+        asking after the catalog has been told to close."""
+        from jellyfin_mpv_shim.sync import manager as mgr
+        rows = [{"item_id": "e%d" % i, "server_uuid": "srv"}
+                for i in range(mgr.USERDATA_BATCH * 3)]
+        m = self._manager([], rows=rows)
+
+        def stop_on_first_wait(timeout=None):
+            m._wake.waits.append(timeout)
+            m._stop = True
+            return True
+
+        m._wake.wait = stop_on_first_wait
+        m._refresh_userdata()
+        # One request went out, the pause after it observed the stop, and
+        # the third batch was never asked for.
+        self.assertEqual(m._api.get_items.call_count, 1)
+
+
+class PushedUserDataTest(unittest.TestCase):
+    """`UserDataChanged` carries the new values, so applying them is free.
+
+    This is what replaced the five-minute sweep as the way watched state
+    normally arrives. Measured against 10.11.11 and 12.0.0: the payload is
+    `{UserId, ServerId, UserDataList: [UserItemDataDto, ...]}` and the
+    server adds each changed item's *parent* to that list, so most entries
+    are for things this catalog has never heard of.
+    """
+
+    def _manager(self, held=("ep1",)):
+        from jellyfin_mpv_shim.sync.manager import SyncManager
+
+        m = SyncManager.__new__(SyncManager)
+        m.db = FakeDb(held=set(held))
+        m._stop = False
+        m._wake = _RecordingWake()
+        m._notify_change = mock.Mock()
+        m.request_userdata_refresh = mock.Mock()
+        m.get_client = lambda uuid: None
+        return m
+
+    @staticmethod
+    def _event(*entries):
+        return {"UserId": "u", "ServerId": "s",
+                "UserDataList": list(entries)}
+
+    def test_a_push_reaches_the_catalog(self):
+        m = self._manager()
+        m.apply_userdata_event(self._event(
+            {"ItemId": "ep1", "Played": True, "PlaybackPositionTicks": 0}))
+        self.assertTrue(m.db.userdata["ep1"]["Played"])
+
+    def test_it_asks_the_server_for_nothing(self):
+        """The point of the whole change: the values are in the message."""
+        m = self._manager()
+        m.get_client = mock.Mock()
+        m.apply_userdata_event(self._event({"ItemId": "ep1", "Played": True}))
+        m.get_client.assert_not_called()
+
+    def test_an_item_we_hold_no_copy_of_is_dropped(self):
+        """Most entries are: the server appends each item's parent, and a
+        user's library is mostly things they have not downloaded."""
+        m = self._manager(held=("ep1",))
+        m.apply_userdata_event(self._event(
+            {"ItemId": "some-series", "Played": True}))
+        self.assertEqual(m.db.userdata, {})
+        m._notify_change.assert_not_called()
+
+    def test_a_position_from_another_client_lands(self):
+        m = self._manager()
+        m.apply_userdata_event(self._event(
+            {"ItemId": "ep1", "Played": False,
+             "PlaybackPositionTicks": 4500000000}))
+        self.assertEqual(
+            m.db.userdata["ep1"]["PlaybackPositionTicks"], 4500000000)
+
+    def test_a_push_that_changed_nothing_does_not_redraw(self):
+        m = self._manager()
+        m.apply_userdata_event(self._event(
+            {"ItemId": "ep1", "Played": False, "PlaybackPositionTicks": 0}))
+        m._notify_change.assert_not_called()
+
+    def test_a_push_that_changed_something_does(self):
+        m = self._manager()
+        m.apply_userdata_event(self._event({"ItemId": "ep1", "Played": True}))
+        m._notify_change.assert_called_once()
+
+    def test_several_pushes_track_rather_than_latch(self):
+        """The repo's standing rule: drive it more than once.
+
+        A position that only ever moves forward is the property; a single
+        push cannot tell that from one that overwrites, and cannot see the
+        stale re-send that a reconnect replays.
+        """
+        m = self._manager()
+        for ticks in (1000, 5000, 9000):
+            m.apply_userdata_event(self._event(
+                {"ItemId": "ep1", "PlaybackPositionTicks": ticks}))
+        self.assertEqual(m.db.userdata["ep1"]["PlaybackPositionTicks"], 9000)
+        # ...and a late duplicate of an earlier one does not rewind it.
+        m.apply_userdata_event(self._event(
+            {"ItemId": "ep1", "PlaybackPositionTicks": 5000}))
+        self.assertEqual(m.db.userdata["ep1"]["PlaybackPositionTicks"], 9000)
+
+    def test_an_enormous_list_is_swept_instead_of_walked(self):
+        """This runs on the websocket thread. A bulk mark is one message
+        with hundreds of entries, and walking it here holds up every event
+        queued behind it."""
+        from jellyfin_mpv_shim.sync import manager as mgr
+        m = self._manager()
+        entries = [{"ItemId": "e%d" % i, "Played": True}
+                   for i in range(mgr.USERDATA_EVENT_MAX + 1)]
+        m.apply_userdata_event(self._event(*entries))
+        m.request_userdata_refresh.assert_called_once()
+        self.assertEqual(m.db.userdata, {})
+
+    def test_a_list_at_the_limit_is_still_applied_inline(self):
+        from jellyfin_mpv_shim.sync import manager as mgr
+        m = self._manager()
+        entries = [{"ItemId": "e%d" % i, "Played": True}
+                   for i in range(mgr.USERDATA_EVENT_MAX)]
+        m.apply_userdata_event(self._event(*entries))
+        m.request_userdata_refresh.assert_not_called()
+
+    def test_junk_is_survivable(self):
+        """Straight off the network, onto the socket thread."""
+        m = self._manager()
+        for payload in (None, {}, {"UserDataList": None},
+                        {"UserDataList": []}, {"UserDataList": [{}]},
+                        {"UserDataList": [{"ItemId": None}]}):
+            m.apply_userdata_event(payload)   # must not raise
+        m._notify_change.assert_not_called()
+
+    def test_a_closed_catalog_is_not_an_error(self):
+        """Events keep arriving while the app is shutting down."""
+        m = self._manager()
+        m.db = None
+        m.apply_userdata_event(self._event({"ItemId": "ep1", "Played": True}))
+
+
+class TheEventHandlerFeedsItTest(unittest.TestCase):
+    """At the caller, not the method.
+
+    The same mistake this file's other suite documents: `user_data_change`
+    took `_arguments` and dropped it for a long time, so a manager method
+    that applies the payload is worth nothing until the handler passes it.
+    """
+
+    def test_the_websocket_event_hands_the_payload_to_the_catalog(self):
+        from jellyfin_mpv_shim import event_handler as eh
+        from jellyfin_mpv_shim.sync import manager as mgr
+
+        handler = eh.EventHandler()
+        handler.user_data_changed = None
+        payload = {"UserDataList": [{"ItemId": "ep1", "Played": True}]}
+        with mock.patch.object(mgr.syncManager, "apply_userdata_event") as ap:
+            handler.user_data_change(mock.Mock(), "UserDataChanged", payload)
+        ap.assert_called_once_with(payload)
+
+    def test_a_catalog_failure_does_not_cost_the_browser_its_nudge(self):
+        """A stale row is cosmetic; a dropped event is a screen that never
+        updates at all. So the browser hook runs either way."""
+        from jellyfin_mpv_shim import event_handler as eh
+        from jellyfin_mpv_shim.sync import manager as mgr
+
+        handler = eh.EventHandler()
+        handler.user_data_changed = mock.Mock()
+        with mock.patch.object(mgr.syncManager, "apply_userdata_event",
+                               side_effect=RuntimeError("catalog gone")):
+            handler.user_data_change(mock.Mock(), "UserDataChanged",
+                                     {"UserDataList": []})
+        handler.user_data_changed.assert_called_once()
 
 
 if __name__ == "__main__":
@@ -316,6 +580,138 @@ class TheReportingPathsActuallyCallItTest(unittest.TestCase):
         pm.send_timeline_stopped(finished=False, client=None)
 
 
+class StreamingSomethingYouAlsoHoldTest(unittest.TestCase):
+    """The gate after the gate.
+
+    The suite above records the first bug: three call sites gated on being
+    *offline*, so the method that wrote the catalog either way was never
+    reached when there was a server. The fix left a second gate in the same
+    three places -- `hasattr(video, "record_offline_progress")`, which is
+    true only for a video played *from the downloaded file*.
+
+    So watching a downloaded episode by streaming it (which is what
+    happens whenever the server is reachable and the user presses play from
+    the library rather than from Downloads) wrote nothing to the catalog.
+    The copy on disk -- kept precisely because the network is about to go
+    away -- was the one thing that never learned it had been watched.
+
+    These are at the caller for the reason the docstring above gives, and
+    the video here deliberately has **no** `record_offline_progress`: a
+    stand-in carrying it is the version that cannot fail.
+    """
+
+    def _reporter(self):
+        import threading
+
+        from jellyfin_mpv_shim.player_reporting import ReportingMixin
+
+        pm = ReportingMixin.__new__(ReportingMixin)
+        pm._tl_lock = threading.RLock()
+        pm._lock = threading.RLock()
+        pm._lock = threading.RLock()
+        pm.should_send_timeline = True
+        pm._last_offline_record = 0.0
+        pm._reporter = mock.Mock()
+        pm.syncplay = mock.Mock()
+        pm.syncplay.is_enabled.return_value = False
+        # `terminate_transcode` is on the spec because the teardown path
+        # calls it, not because this suite is about it -- a stand-in that
+        # omits it makes _report_stopped_offline raise before it reaches
+        # the line under test.
+        video = mock.Mock(spec=["client", "is_photo", "playback_info",
+                                "item_id", "is_transcode",
+                                "terminate_transcode"])
+        video.client = mock.Mock()
+        video.is_photo = False
+        video.is_transcode = False
+        video.item_id = "ep1"
+        video.playback_info = {"PlaySessionId": "s"}
+        pm._video = video
+        pm.last_seek = 900.0
+        pm.start_time = 0.0
+        return pm, video
+
+    def setUp(self):
+        from jellyfin_mpv_shim.sync import manager as mgr
+        self.db = FakeDb(held={"ep1"})
+        patcher = mock.patch.object(mgr.syncManager, "db", self.db)
+        patcher.start()
+        self.addCleanup(patcher.stop)
+
+    def test_a_streamed_download_still_reaches_the_catalog(self):
+        pm, _video = self._reporter()
+        pm.get_timeline_options = mock.Mock(
+            return_value={"PositionTicks": 9_000_000_000})
+        pm.send_timeline_stopped(finished=False, client=None)
+        self.assertEqual(
+            self.db.userdata.get("ep1", {}).get("PlaybackPositionTicks"),
+            9_000_000_000,
+            "streaming an item you also have downloaded left the catalog "
+            "at zero, so offline resume started it over")
+
+    def test_finishing_it_marks_the_downloaded_copy_watched(self):
+        pm, _video = self._reporter()
+        pm.get_timeline_options = mock.Mock(
+            return_value={"PositionTicks": 9_000_000_000})
+        pm.send_timeline_stopped(finished=True, client=None)
+        self.assertTrue(self.db.userdata.get("ep1", {}).get("Played"))
+
+    def test_closing_the_window_records_it_too(self):
+        pm, video = self._reporter()
+        pm._video = None       # the state this path actually runs in
+        pm._report_stopped_offline(video)
+        self.assertEqual(
+            self.db.userdata.get("ep1", {}).get("PlaybackPositionTicks"),
+            9_000_000_000)
+
+    def test_an_item_with_no_download_writes_nothing(self):
+        """Called for everything played, so this is the common case: the
+        catalog answers 'no row' and nothing is created."""
+        pm, video = self._reporter()
+        video.item_id = "not-downloaded"
+        pm.get_timeline_options = mock.Mock(
+            return_value={"PositionTicks": 9_000_000_000})
+        pm.send_timeline_stopped(finished=False, client=None)
+        self.assertEqual(self.db.userdata, {})
+
+    def test_it_tracks_across_several_reports(self):
+        """Multi-step, per the repo rule: the stored position must follow
+        playback rather than latch on the first report."""
+        pm, _video = self._reporter()
+        for ticks in (1_000_000_000, 4_000_000_000, 9_000_000_000):
+            pm._record_progress(pm._video, ticks)
+        self.assertEqual(
+            self.db.userdata["ep1"]["PlaybackPositionTicks"], 9_000_000_000)
+
+    def test_a_catalog_failure_never_breaks_the_stop_report(self):
+        from jellyfin_mpv_shim.sync import manager as mgr
+
+        pm, video = self._reporter()
+        pm.get_timeline_options = mock.Mock(
+            return_value={"PositionTicks": 1})
+        with mock.patch.object(mgr.syncManager, "mirror_playstate",
+                               side_effect=RuntimeError("disk full")):
+            pm.send_timeline_stopped(finished=False, client=None)
+
+    def test_the_downloaded_path_still_owns_the_replay_queue(self):
+        """The offline-only half must survive the gate coming off: an
+        OfflineVideo still goes through `record_offline_progress`, which is
+        what queues the change for replay when there is no server."""
+        pm, _ = self._reporter()
+        offline = mock.Mock(spec=["client", "is_photo", "playback_info",
+                                  "item_id", "is_transcode",
+                                  "record_offline_progress"])
+        offline.client = None
+        offline.is_photo = False
+        offline.item_id = "ep1"
+        offline.playback_info = {"PlaySessionId": "s"}
+        pm._video = offline
+        pm.get_timeline_options = mock.Mock(
+            return_value={"PositionTicks": 5})
+        pm.send_timeline_stopped(finished=False, client=None)
+        offline.record_offline_progress.assert_called_once_with(5, False)
+
+
 class HomeAsksForAFreshPullTest(unittest.TestCase):
     """The home screen brings the pull forward.
 
@@ -325,40 +721,159 @@ class HomeAsksForAFreshPullTest(unittest.TestCase):
     answer is then what they have for as long as they are offline.
     """
 
-    def _manager(self, last=0.0, now=1000.0):
+    def _manager(self, last=0.0, due=False, connected=()):
         from jellyfin_mpv_shim.sync.manager import SyncManager
 
         m = SyncManager.__new__(SyncManager)
         m._last_userdata = last
+        m._sweep_due = due
+        m._connected_servers = set(connected)
+        m.get_clients = lambda: {}
         m._wake = mock.Mock()
+        m._refresh_userdata = mock.Mock()
         return m
 
-    def test_a_request_makes_the_pull_due_and_wakes_the_worker(self):
-        import time as _time
-        m = self._manager(last=0.0)
-        with mock.patch.object(_time, "monotonic", return_value=1000.0):
-            m.request_userdata_refresh()
-        self.assertEqual(m._last_userdata, 0.0)
-        m._wake.set.assert_called_once()
+    # -- what asks for one -------------------------------------------------
 
-    def test_bouncing_in_and_out_of_home_does_not_hammer_it(self):
-        """Without a floor this is a round trip per visit."""
-        import time as _time
-        from jellyfin_mpv_shim.sync import manager as mgr
-
+    def test_a_request_marks_a_sweep_due_and_wakes_the_worker(self):
         m = self._manager()
-        with mock.patch.object(_time, "monotonic", return_value=1000.0):
-            m._last_userdata = 1000.0 - (mgr.USERDATA_REQUEST_FLOOR / 2)
-            m.request_userdata_refresh()
-        self.assertNotEqual(m._last_userdata, 0.0)
-        m._wake.set.assert_not_called()
+        m.request_userdata_refresh()
+        self.assertTrue(m._sweep_due)
+        m._wake.set.assert_called_once()
 
     def test_it_does_not_block_whoever_asked(self):
         """Marks it due and returns -- the requests happen on the sync
         thread, not on the one that was loading a page."""
-        import time as _time
         m = self._manager()
-        m._refresh_userdata = mock.Mock()
-        with mock.patch.object(_time, "monotonic", return_value=1000.0):
-            m.request_userdata_refresh()
+        m.request_userdata_refresh()
         m._refresh_userdata.assert_not_called()
+
+    def test_a_server_becoming_reachable_marks_one_due(self):
+        """The trigger that replaced the interval."""
+        m = self._manager(connected=())
+        m.get_clients = lambda: {"srv": object()}
+        m._note_connected_servers()
+        self.assertTrue(m._sweep_due)
+
+    def test_the_same_servers_still_being_there_does_not(self):
+        """Otherwise this is an interval again, at the loop's own period."""
+        m = self._manager(connected=("srv",))
+        m.get_clients = lambda: {"srv": object()}
+        for _ in range(5):
+            m._note_connected_servers()
+        self.assertFalse(m._sweep_due)
+
+    def test_a_server_going_away_does_not(self):
+        """There is nothing to catch up on with a server that just left."""
+        m = self._manager(connected=("srv", "srv2"))
+        m.get_clients = lambda: {"srv": object()}
+        m._note_connected_servers()
+        self.assertFalse(m._sweep_due)
+
+    def test_a_server_coming_back_does(self):
+        """Multi-step, and the case the whole trigger exists for: down for a
+        while, so the socket delivered nothing, then back."""
+        m = self._manager(connected=("srv",))
+        clients = {"srv": object()}
+        m.get_clients = lambda: dict(clients)
+        m._note_connected_servers()
+        self.assertFalse(m._sweep_due)
+        clients.clear()                 # the server drops
+        m._note_connected_servers()
+        self.assertFalse(m._sweep_due)
+        clients["srv"] = object()       # ...and comes back
+        m._note_connected_servers()
+        self.assertTrue(m._sweep_due)
+
+    def test_a_manager_that_never_started_is_safe(self):
+        """get_clients has a default because every test, and the CLI before
+        start(), drives this without one."""
+        from jellyfin_mpv_shim.sync.manager import SyncManager
+
+        m = SyncManager()
+        m._note_connected_servers()     # must not raise
+        self.assertEqual(m._connected_servers, set())
+
+    def test_an_unreadable_client_list_is_not_fatal(self):
+        m = self._manager()
+        m.get_clients = mock.Mock(side_effect=RuntimeError("mid-switch"))
+        m._note_connected_servers()     # must not raise
+
+    def test_startup_sweeps_without_being_asked(self):
+        """A fresh manager has been listening to nothing at all."""
+        from jellyfin_mpv_shim.sync.manager import SyncManager
+
+        self.assertTrue(SyncManager()._sweep_due)
+
+    # -- and what actually runs one ----------------------------------------
+
+    def test_nothing_due_means_no_requests_however_long_it_runs(self):
+        """The property the interval used to break. An idle app with a live
+        socket asks the server nothing, ever."""
+        from jellyfin_mpv_shim.sync import manager as mgr
+
+        m = self._manager(due=False, last=0.0)
+        for tick in range(10):
+            m._sweep_if_due(tick * mgr.USERDATA_SWEEP_FLOOR * 10)
+        m._refresh_userdata.assert_not_called()
+
+    def test_a_due_sweep_runs(self):
+        m = self._manager(due=True, last=0.0)
+        self.assertTrue(m._sweep_if_due(10_000.0))
+        m._refresh_userdata.assert_called_once()
+
+    def test_bouncing_in_and_out_of_home_does_not_hammer_it(self):
+        """Without the floor this is a round trip per visit."""
+        from jellyfin_mpv_shim.sync import manager as mgr
+
+        m = self._manager(due=False, last=0.0)
+        now = 10_000.0
+        m.request_userdata_refresh()
+        m._sweep_if_due(now)
+        for i in range(5):
+            m.request_userdata_refresh()
+            m._sweep_if_due(now + i)
+        self.assertEqual(m._refresh_userdata.call_count, 1)
+
+    def test_a_deferred_request_is_not_lost(self):
+        """The half a floor gets wrong. A suppressed trigger is a stretch of
+        time nobody will look at again -- so it has to be delayed, not
+        dropped, or a server that flaps inside the floor leaves the catalog
+        stale until something else happens to ask."""
+        from jellyfin_mpv_shim.sync import manager as mgr
+
+        m = self._manager(due=True, last=0.0)
+        self.assertTrue(m._sweep_if_due(10_000.0),
+                        "the setup sweep did not run, so there is no floor "
+                        "for the rest of this test to be inside")
+        m.request_userdata_refresh()
+        self.assertFalse(m._sweep_if_due(10_001.0),
+                         "swept inside the floor")
+        self.assertTrue(m._sweep_due, "the request was dropped, not deferred")
+        self.assertTrue(
+            m._sweep_if_due(10_000.0 + mgr.USERDATA_SWEEP_FLOOR + 1),
+            "the deferred request never ran")
+
+    def test_a_flapping_server_costs_one_sweep_per_floor(self):
+        """Multi-step: the failure is a sweep per reconnect, which is the
+        hammering this whole change is about."""
+        from jellyfin_mpv_shim.sync import manager as mgr
+
+        m = self._manager(connected=("srv",), last=0.0)
+        clients = {"srv": object()}
+        m.get_clients = lambda: dict(clients)
+        now = 10_000.0
+        for i in range(20):
+            clients.clear()
+            m._note_connected_servers()
+            clients["srv"] = object()
+            m._note_connected_servers()
+            m._sweep_if_due(now + i)        # 20 flaps inside one floor
+        self.assertEqual(m._refresh_userdata.call_count, 1)
+        # ...and the flapping is still noticed once the floor lifts.
+        m._sweep_if_due(now + mgr.USERDATA_SWEEP_FLOOR + 1)
+        self.assertEqual(m._refresh_userdata.call_count, 2)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_playstate_mirror.py
+++ b/tests/test_playstate_mirror.py
@@ -18,6 +18,7 @@ and assert the stored value tracks rather than latching.
 """
 
 import json
+import os
 import sys
 import unittest
 from unittest import mock
@@ -712,6 +713,246 @@ class StreamingSomethingYouAlsoHoldTest(unittest.TestCase):
         offline.record_offline_progress.assert_called_once_with(5, False)
 
 
+class DeliberateMarksReachTheCatalogTest(unittest.TestCase):
+    """Mark Watched / Mark Unwatched, onto the copy on disk, at once.
+
+    Everything else that writes this column is advance-only, and rightly:
+    playback reports arrive out of order, a queue replayed after a week
+    must not rewind another device, and a pull is a floor rather than a
+    mirror. A person choosing "Mark Unwatched" is none of those -- it is the
+    one signal in the app that is authoritative in both directions -- and
+    under the old rule it was the only deliberate action here that silently
+    did nothing to the downloaded copy. Offline you were shown the tick you
+    had just removed, and "delete watched downloads" (which reads
+    `userdata_json` with no server fallback) would still have thrown it out.
+
+    A real SyncDB rather than `FakeDb`, because the rule under test *is*
+    what that column ends up holding.
+    """
+
+    def setUp(self):
+        import tempfile
+        from jellyfin_mpv_shim.sync.db import COLUMNS, SyncDB, STATUS_COMPLETE
+
+        self.tmp = tempfile.TemporaryDirectory()
+        self.addCleanup(self.tmp.cleanup)
+        self.db = SyncDB(os.path.join(self.tmp.name, "cat.db"))
+        self.addCleanup(self.db.close)
+        self.COLUMNS = COLUMNS
+        self.STATUS_COMPLETE = STATUS_COMPLETE
+
+    def row(self, item_id, userdata=None, **overrides):
+        row = {c: None for c in self.COLUMNS}
+        row["item_id"] = item_id
+        row["server_uuid"] = "srv"
+        row["status"] = self.STATUS_COMPLETE
+        row["runtime_ticks"] = 100 * 10_000_000
+        row["userdata_json"] = json.dumps(
+            userdata if userdata is not None
+            else {"Played": False, "PlaybackPositionTicks": 0})
+        row.update(overrides)
+        self.db.upsert(row)
+        return row
+
+    def stored(self, item_id):
+        row = self.db.get(item_id) or {}
+        return json.loads(row.get("userdata_json") or "{}")
+
+    def manager(self):
+        from jellyfin_mpv_shim.sync.manager import SyncManager
+
+        m = SyncManager.__new__(SyncManager)
+        m.db = self.db
+        m.on_change = mock.Mock()
+        return m
+
+    # -- the writer --------------------------------------------------------
+
+    def test_marking_watched_stores_it_and_clears_the_resume_point(self):
+        self.row("ep1", {"Played": False,
+                         "PlaybackPositionTicks": 42 * 10_000_000})
+        self.assertTrue(self.db.set_watched("ep1", True))
+        self.assertEqual(self.stored("ep1")["Played"], True)
+        self.assertEqual(self.stored("ep1")["PlaybackPositionTicks"], 0)
+
+    def test_marking_unwatched_clears_it(self):
+        """The direction no writer of this column had. Under the old rule
+        `played=False` meant "leave it alone", so this was unreachable."""
+        self.row("ep1", {"Played": True, "PlayCount": 3,
+                         "PlaybackPositionTicks": 42 * 10_000_000})
+        self.assertTrue(self.db.set_watched("ep1", False))
+        stored = self.stored("ep1")
+        self.assertEqual(stored["Played"], False)
+        self.assertEqual(stored["PlaybackPositionTicks"], 0)
+        self.assertEqual(stored["PlayCount"], 0)
+
+    def test_it_stores_what_the_server_stores(self):
+        """Measured against `BaseItem.MarkPlayed` / `ResetPlayedState`, with
+        the controller passing `resetPosition: true`. If the two disagree
+        the next sweep reads back as a change and the catalog flickers."""
+        self.row("ep1", {"Played": False, "PlayCount": 0,
+                         "LastPlayedDate": "2020-01-01T00:00:00Z"})
+        self.db.set_watched("ep1", True)
+        self.assertGreaterEqual(self.stored("ep1")["PlayCount"], 1)
+        self.db.set_watched("ep1", False)
+        self.assertIsNone(self.stored("ep1")["LastPlayedDate"])
+
+    def test_a_stale_percentage_cannot_shadow_the_new_state(self):
+        self.row("ep1", {"Played": True, "PlayedPercentage": 100})
+        self.db.set_watched("ep1", False)
+        self.assertNotIn("PlayedPercentage", self.stored("ep1"))
+
+    def test_it_tracks_rather_than_latching(self):
+        """Multi-step, per the repo rule: the failure shape here is a value
+        that can only move one way, which one flip cannot see."""
+        self.row("ep1")
+        seen = []
+        for played in (True, False, True, False):
+            self.db.set_watched("ep1", played)
+            seen.append(self.stored("ep1")["Played"])
+        self.assertEqual(seen, [True, False, True, False])
+
+    def test_nothing_moving_is_reported_as_nothing_moving(self):
+        self.row("ep1", {"Played": True, "PlayCount": 1,
+                         "PlaybackPositionTicks": 0})
+        self.assertFalse(self.db.set_watched("ep1", True),
+                         "an unchanged row asked the browser to redraw")
+
+    def test_an_item_we_hold_no_copy_of_is_left_alone(self):
+        self.assertFalse(self.db.set_watched("nothing-here", True))
+
+    def test_playback_is_still_advance_only(self):
+        """The guard on the change: `update_userdata` is the playback rule
+        and must not have acquired this one."""
+        self.row("ep1", {"Played": True})
+        self.db.update_userdata("ep1", played=False)
+        self.assertTrue(self.stored("ep1")["Played"])
+
+    # -- the fan-out -------------------------------------------------------
+
+    def test_a_series_mark_reaches_every_downloaded_episode(self):
+        self.row("ep1", series_id="show")
+        self.row("ep2", series_id="show")
+        self.row("other")
+        self.assertEqual(self.manager().mirror_watched("show", True), 2)
+        self.assertTrue(self.stored("ep1")["Played"])
+        self.assertTrue(self.stored("ep2")["Played"])
+        self.assertFalse(self.stored("other")["Played"],
+                         "the mark reached an item it does not cover")
+
+    def test_a_season_mark_does_too(self):
+        self.row("ep1", series_id="show", season_id="s1")
+        self.row("ep2", series_id="show", season_id="s2")
+        self.manager().mirror_watched("s1", True)
+        self.assertTrue(self.stored("ep1")["Played"])
+        self.assertFalse(self.stored("ep2")["Played"])
+
+    def test_an_item_with_nothing_downloaded_is_a_no_op(self):
+        """Called for every mark, downloaded or not -- which is what keeps
+        it from being forgotten at a call site."""
+        m = self.manager()
+        self.assertEqual(m.mirror_watched("never-heard-of-it", True), 0)
+        m.on_change.assert_not_called()
+
+    def test_it_redraws_only_when_something_moved(self):
+        self.row("ep1")
+        m = self.manager()
+        m.mirror_watched("ep1", True)
+        m.on_change.assert_called_once()
+        m.mirror_watched("ep1", True)
+        m.on_change.assert_called_once()
+
+    def test_a_catalog_failure_is_survivable(self):
+        self.row("ep1")
+        m = self.manager()
+        m.db = mock.Mock()
+        m.db.watched_targets.side_effect = RuntimeError("boom")
+        self.assertEqual(m.mirror_watched("ep1", True), 0)
+
+
+class TheUiMarksGoThroughItTest(unittest.TestCase):
+    """The call sites. A rule with no caller is the shape this repo keeps
+    finding (`mirror_playstate` existed before anything played through it),
+    so the gateway the context menu uses and the player's own explicit
+    marks are asserted here rather than assumed."""
+
+    def setUp(self):
+        from jellyfin_mpv_shim.mpvtk_browser.gateway import userdata as gw
+
+        self.gw = gw
+
+        class _Gateway(gw.UserDataMixin):
+            pass
+
+        self.controller = _Gateway()
+        self.client = mock.Mock()
+        patcher = mock.patch.object(gw, "deps")
+        deps = patcher.start()
+        self.addCleanup(patcher.stop)
+        deps.clientManager.clients = {"srv": self.client}
+        self.clients = deps.clientManager.clients
+
+        from jellyfin_mpv_shim.sync import manager as mgr
+        self.sm = mock.Mock()
+        patcher = mock.patch.object(mgr, "syncManager", self.sm)
+        patcher.start()
+        self.addCleanup(patcher.stop)
+
+    def test_marking_watched_online_writes_the_catalog_too(self):
+        self.assertTrue(self.controller.set_watched("srv", "ep1", True))
+        self.client.jellyfin.item_played.assert_called_once_with("ep1", True)
+        self.sm.mirror_watched.assert_called_once_with("ep1", True)
+
+    def test_marking_unwatched_online_does(self):
+        """The case that could not previously reach the catalog at all: the
+        socket announces it, and every path the announcement takes is
+        advance-only."""
+        self.assertTrue(self.controller.set_watched("srv", "ep1", False))
+        self.sm.mirror_watched.assert_called_once_with("ep1", False)
+
+    def test_a_server_that_refused_does_not_move_the_catalog(self):
+        self.client.jellyfin.item_played.side_effect = RuntimeError("no")
+        self.assertFalse(self.controller.set_watched("srv", "ep1", True))
+        self.sm.mirror_watched.assert_not_called()
+
+    def test_a_catalog_failure_does_not_lose_the_mark(self):
+        self.sm.mirror_watched.side_effect = RuntimeError("boom")
+        self.assertTrue(self.controller.set_watched("srv", "ep1", True),
+                        "the server took the mark; the UI was told it did "
+                        "not because the local copy failed")
+
+    def test_offline_un_watching_is_still_refused(self):
+        """Deliberately unchanged. The replay queue cannot carry an
+        un-watch, so applying one locally would diverge from the server
+        with nothing left to reconcile it -- and the UI rolls its optimistic
+        tick back on the False."""
+        self.clients.clear()
+        self.assertFalse(self.controller.set_watched("srv", "ep1", False))
+        self.sm.mirror_watched.assert_not_called()
+
+    def test_the_player_s_own_mark_reaches_the_catalog(self):
+        """"Quit and Mark Unwatched" on something you *streamed* while
+        holding a downloaded copy -- the same gap `mirror_playstate` was
+        added for, in the one direction it cannot express."""
+        from jellyfin_mpv_shim import media
+
+        video = media.Video.__new__(media.Video)
+        video.item_id = "ep1"
+        video.client = mock.Mock()
+        video.set_played(False)
+        video.client.jellyfin.item_played.assert_called_once_with("ep1", False)
+        self.sm.mirror_watched.assert_called_once_with("ep1", False)
+
+    def test_a_catalog_failure_does_not_break_the_player_s_mark(self):
+        from jellyfin_mpv_shim import media
+
+        self.sm.mirror_watched.side_effect = RuntimeError("boom")
+        video = media.Video.__new__(media.Video)
+        video.item_id = "ep1"
+        video.client = mock.Mock()
+        video.set_played(True)          # must not raise
+
+
 class HomeAsksForAFreshPullTest(unittest.TestCase):
     """The home screen brings the pull forward.
 
@@ -721,14 +962,20 @@ class HomeAsksForAFreshPullTest(unittest.TestCase):
     answer is then what they have for as long as they are offline.
     """
 
-    def _manager(self, last=0.0, due=False, connected=()):
+    def _manager(self, last=0.0, due=False, connected=(), clients=("srv",),
+                 started=0.0):
         from jellyfin_mpv_shim.sync.manager import SyncManager
 
         m = SyncManager.__new__(SyncManager)
         m._last_userdata = last
         m._sweep_due = due
         m._connected_servers = set(connected)
-        m.get_clients = lambda: {}
+        m._started_at = started
+        # A client by default: a sweep with nobody to ask is now a distinct
+        # state (it keeps the trigger and asks nothing), so a helper that
+        # handed out an empty registry would make every test below a test
+        # of *that* instead of of the floor it names.
+        m.get_clients = lambda: {uuid: object() for uuid in clients}
         m._wake = mock.Mock()
         m._refresh_userdata = mock.Mock()
         return m
@@ -853,6 +1100,118 @@ class HomeAsksForAFreshPullTest(unittest.TestCase):
         self.assertTrue(
             m._sweep_if_due(10_000.0 + mgr.USERDATA_SWEEP_FLOOR + 1),
             "the deferred request never ran")
+
+    # -- and when the first one is allowed to ---------------------------
+
+    def test_nothing_sweeps_in_the_first_minute(self):
+        """Startup is when every other part of the app wants the network,
+        and the sweep is the only one of them nobody is waiting for."""
+        from jellyfin_mpv_shim.sync import manager as mgr
+
+        m = self._manager(due=True, started=10_000.0)
+        self.assertFalse(m._sweep_if_due(10_000.0 + 1))
+        self.assertFalse(m._sweep_if_due(
+            10_000.0 + mgr.USERDATA_SWEEP_SETTLE - 1))
+        m._refresh_userdata.assert_not_called()
+
+    def test_the_settle_delays_the_sweep_and_does_not_drop_it(self):
+        from jellyfin_mpv_shim.sync import manager as mgr
+
+        m = self._manager(due=True, started=10_000.0)
+        m._sweep_if_due(10_000.0 + 1)
+        self.assertTrue(m._sweep_due, "the settle dropped the trigger")
+        self.assertTrue(m._sweep_if_due(
+            10_000.0 + mgr.USERDATA_SWEEP_SETTLE + 1))
+        m._refresh_userdata.assert_called_once()
+
+    def test_a_pass_with_nobody_to_ask_is_not_a_sweep(self):
+        """The bug the settle was added around, and the more expensive half
+        of it. The worker's first pass runs before `login_servers()` has
+        registered anything, so it reaches no server at all -- and counting
+        it as a sweep spent the startup trigger *and* started the floor."""
+        m = self._manager(due=True, clients=())
+        self.assertFalse(m._sweep_if_due(10_000.0))
+        m._refresh_userdata.assert_not_called()
+        self.assertTrue(m._sweep_due, "the trigger was spent on nobody")
+        self.assertEqual(m._last_userdata, 0.0,
+                         "the floor started counting from a sweep that "
+                         "never asked anything")
+
+    def test_an_unreadable_registry_holds_the_sweep_rather_than_spending_it(
+            self):
+        m = self._manager(due=True)
+        m.get_clients = mock.Mock(side_effect=RuntimeError("boom"))
+        self.assertFalse(m._sweep_if_due(10_000.0))
+        self.assertTrue(m._sweep_due)
+
+    def test_the_launch_sequence_sweeps_a_minute_in(self):
+        """The property, over the sequence a real launch produces.
+
+        Multi-step because no single call can see it: the first pass (no
+        clients yet), the server arriving a second later, and then every
+        five seconds of the worker's idle loop. What this catches is the
+        shipped behaviour -- the trigger burned at t=0 and the reconnect
+        deferred behind a five-minute floor, so the first sweep of a
+        session landed at t+300 rather than during the first screen.
+        """
+        from jellyfin_mpv_shim.sync import manager as mgr
+
+        start = 40_000.0                # monotonic counts from boot
+        m = self._manager(due=True, clients=(), started=start)
+        clients = {}
+        m.get_clients = lambda: dict(clients)
+
+        m._note_connected_servers()
+        m._sweep_if_due(start)          # worker's first pass, pre-login
+        clients["srv"] = object()       # login_servers finishes
+
+        swept_at = None
+        for tick in range(0, 400, 5):   # the idle loop, for six minutes
+            m._note_connected_servers()
+            if m._sweep_if_due(start + tick) and swept_at is None:
+                swept_at = tick
+        self.assertIsNotNone(swept_at, "the session never swept at all")
+        self.assertGreaterEqual(swept_at, mgr.USERDATA_SWEEP_SETTLE)
+        self.assertLess(swept_at, mgr.USERDATA_SWEEP_SETTLE + 10,
+                        "the first sweep of the session waited out the "
+                        "floor instead of the settle")
+        self.assertEqual(m._refresh_userdata.call_count, 1,
+                         "the rest of the six minutes swept again")
+
+    def test_a_slow_login_still_sweeps_when_it_lands(self):
+        """The settle alone is not enough, which is what the client gate is
+        for. A server behind `connect_retry_mins`, a laptop waking on a
+        captive portal: login finishes *after* the settle, so the pass that
+        the settle released had nobody to ask. Spending the trigger there
+        puts the first sweep of the session a floor away from the login
+        rather than a moment after it."""
+        from jellyfin_mpv_shim.sync import manager as mgr
+
+        start = 40_000.0
+        m = self._manager(due=True, clients=(), started=start)
+        clients = {}
+        m.get_clients = lambda: dict(clients)
+
+        swept_at = None
+        for tick in range(0, 500, 5):
+            if tick == 120:             # login finally completes
+                clients["srv"] = object()
+            m._note_connected_servers()
+            if m._sweep_if_due(start + tick) and swept_at is None:
+                swept_at = tick
+        self.assertIsNotNone(swept_at, "the session never swept at all")
+        self.assertLess(swept_at, 120 + mgr.USERDATA_SWEEP_FLOOR,
+                        "the sweep waited out a floor started by a pass "
+                        "that had no server to ask")
+        self.assertGreaterEqual(swept_at, 120)
+
+    def test_a_manager_that_was_never_started_serves_no_settle(self):
+        """Every test in this file, and the integration harness, drives a
+        manager built by hand. `_started_at` is zero there, which has to
+        read as "not a client starting up" rather than as "started at the
+        epoch, so wait a minute"."""
+        m = self._manager(due=True)
+        self.assertTrue(m._sweep_if_due(10_000.0))
 
     def test_a_flapping_server_costs_one_sweep_per_floor(self):
         """Multi-step: the failure is a sweep per reconnect, which is the

--- a/tests/test_ui_review_fixes.py
+++ b/tests/test_ui_review_fixes.py
@@ -182,6 +182,14 @@ class OfflineWatchTargetsTest(unittest.TestCase):
             {"item_id": "m1", "series_id": None, "season_id": None,
              "server_uuid": "srv"},
         ]
+        # The fan-out rule moved onto SyncDB, and it is what this class is
+        # about -- so run the real one against this mock's rows rather than
+        # restating it here, which would be a test agreeing with itself.
+        from jellyfin_mpv_shim.sync.db import SyncDB
+
+        db.watched_targets.side_effect = (
+            lambda item_id, server_uuid=None:
+            SyncDB.watched_targets(db, item_id, server_uuid))
         return db
 
     def test_leaf_item(self):


### PR DESCRIPTION
Fixes the sync problems identified in the previous review.

Sync data sources now used:
- UserDataChanged websocket event
- Sync of user data via API on initial server connect and subsequent re-connects (could have missed UserDataChanged)
- Syncs watched/unwatched events to local store (regular syncs usually refuse to regress watched state)
- Syncs state changes for offline content immediately within the app

Also added tests. The offline sync flows were manually tested as well to ensure they function correctly, that was how the gap was initially caught.