### PR TITLE
Fix windows CI build

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -25,7 +25,21 @@ jobs:
       uses: robinraju/release-downloader@v1
       with:
         repository: 'shinchiro/mpv-winbuild-cmake'
-        latest: true
+        # Pinned rather than `latest: true`, and the pin is load-bearing.
+        # shinchiro's builds from 20260808 onward link vulkan-1.dll as a HARD
+        # import -- twelve vk* symbols in the import table, delay-load
+        # directory empty -- and the Vulkan loader is a driver-installed
+        # system component, not something we ship. On a machine without one,
+        # Windows refuses to load libmpv at all; the shim reads that as "no
+        # libmpv", falls back to the external backend, finds no mpv.exe to
+        # spawn, and dies at startup before any UI exists. Their own mpv.exe
+        # archive carries no vulkan-1.dll either, so this is an upstream
+        # regression and not a redistributable we were meant to be carrying.
+        #
+        # 20260610 is the last release before it. Raising the pin is fine as
+        # soon as a release is clean -- the job checks, so an unpin that
+        # reintroduces this fails the build instead of shipping.
+        tag: '20260610'
         fileName: 'mpv-dev-x86_64-v3*.7z'
     - name: Install dependencies
       run: |
@@ -80,7 +94,8 @@ jobs:
       uses: robinraju/release-downloader@v1
       with:
         repository: 'shinchiro/mpv-winbuild-cmake'
-        latest: true
+        # Pinned for the vulkan-1.dll regression; see build-win64 above.
+        tag: '20260610'
         fileName: 'mpv-dev-x86_64-[0-9]*-git-*.7z'
     - name: Install dependencies
       run: |
@@ -143,7 +158,8 @@ jobs:
       uses: robinraju/release-downloader@v1
       with:
         repository: 'shinchiro/mpv-winbuild-cmake'
-        latest: true
+        # Pinned for the vulkan-1.dll regression; see build-win64 above.
+        tag: '20260610'
         fileName: 'mpv-dev-aarch64-*.7z'
     - name: Install dependencies
       run: |
@@ -221,7 +237,8 @@ jobs:
       uses: robinraju/release-downloader@v1
       with:
         repository: 'shinchiro/mpv-winbuild-cmake'
-        latest: true
+        # Pinned for the vulkan-1.dll regression; see build-win64 above.
+        tag: '20260610'
         fileName: 'mpv-dev-i686*.7z'
     - name: Install dependencies
       run: |

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -36,6 +36,15 @@ jobs:
         winget install --id JRSoftware.InnoSetup -e -s winget || true || true
         ./gen_pkg.sh --skip-build
       shell: bash
+    - name: Check what libmpv needs
+      # The pin on the download above exists because of a dependency this
+      # step reads. It runs on every build rather than only when raising the
+      # pin, because nothing else in the pipeline ever loads this file: an
+      # mpv-2.dll that Windows will refuse is not a build error, it is a
+      # client that dies at startup on the user's machine.
+      run: |
+        python tools/check_win_libmpv_deps.py mpv-2.dll
+      shell: bash
     - name: PyInstaller Bootloader
       run: |
         ./gen_pkg.sh --get-pyinstaller; cd pyinstaller/bootloader; python ./waf distclean all; cd ..; pip install .
@@ -81,6 +90,15 @@ jobs:
         pip install .[all] pywin32
         winget install --id JRSoftware.InnoSetup -e -s winget || true
         ./gen_pkg.sh --skip-build
+      shell: bash
+    - name: Check what libmpv needs
+      # The pin on the download above exists because of a dependency this
+      # step reads. It runs on every build rather than only when raising the
+      # pin, because nothing else in the pipeline ever loads this file: an
+      # mpv-2.dll that Windows will refuse is not a build error, it is a
+      # client that dies at startup on the user's machine.
+      run: |
+        python tools/check_win_libmpv_deps.py mpv-2.dll
       shell: bash
     - name: PyInstaller Bootloader
       run: |
@@ -134,6 +152,15 @@ jobs:
         pip install wheel
         pip install .[all] pywin32
         ./gen_pkg.sh --skip-build
+      shell: bash
+    - name: Check what libmpv needs
+      # The pin on the download above exists because of a dependency this
+      # step reads. It runs on every build rather than only when raising the
+      # pin, because nothing else in the pipeline ever loads this file: an
+      # mpv-2.dll that Windows will refuse is not a build error, it is a
+      # client that dies at startup on the user's machine.
+      run: |
+        python tools/check_win_libmpv_deps.py mpv-2.dll
       shell: bash
     - name: Verify the inputs are ARM64
       # Before anything is built, because nothing downstream can tell. Windows
@@ -204,6 +231,15 @@ jobs:
         pip install .[all] pywin32
         winget install --id JRSoftware.InnoSetup -e -s winget || true
         ./gen_pkg.sh --skip-build
+      shell: bash
+    - name: Check what libmpv needs
+      # The pin on the download above exists because of a dependency this
+      # step reads. It runs on every build rather than only when raising the
+      # pin, because nothing else in the pipeline ever loads this file: an
+      # mpv-2.dll that Windows will refuse is not a build error, it is a
+      # client that dies at startup on the user's machine.
+      run: |
+        python tools/check_win_libmpv_deps.py mpv-2.dll
       shell: bash
     - name: PyInstaller Bootloader
       run: |

--- a/jellyfin_mpv_shim/player.py
+++ b/jellyfin_mpv_shim/player.py
@@ -57,7 +57,17 @@ if not settings.mpv_ext:
 
         log.info("Using libmpv playback backend.")
     except OSError:
-        log.warning("Could not find libmpv.")
+        # With the exception, not just the fact of it. "Could not find
+        # libmpv" is only one of the two things this OSError means, and on
+        # the Windows build it is never the right one: libmpv ships *inside*
+        # the installer, so what this reports there is that the DLL was
+        # found and would not load -- a dependency of its own that the
+        # machine does not have. 3.0.0pre12 shipped exactly that (a libmpv
+        # hard-linked against vulkan-1.dll), and the log said only that
+        # something was wrong with libmpv, while the traceback that reached
+        # the user blamed a missing mpv.exe. The chained cause carries the
+        # WinError and the path; it is the whole diagnosis.
+        log.warning("Could not load libmpv.", exc_info=True)
         python_mpv_available = False
 
 if settings.mpv_ext or not python_mpv_available:
@@ -65,6 +75,40 @@ if settings.mpv_ext or not python_mpv_available:
 
     log.info("Using external mpv playback backend.")
     is_using_ext_mpv = True
+
+
+def _explain_missing_mpv():
+    """Say why there is no mpv, before the traceback says something else.
+
+    The external backend starts an mpv binary, so its failure to find one is
+    reported by ``subprocess`` as a missing file -- accurate, and misleading
+    whenever this backend was not the user's choice. Two different situations
+    arrive here and they want opposite advice, and the one thing neither can
+    be told from the traceback is which of them it is.
+    """
+    if not is_using_ext_mpv:
+        # Nothing here spawns anything, so this is some other missing file
+        # and neither explanation below applies. Say nothing rather than
+        # guess -- the traceback is the better answer.
+        return
+    if settings.mpv_ext:
+        log.error(
+            "Could not start mpv. The external mpv backend is selected, so "
+            "an mpv binary has to be on PATH or named by the mpv_ext_path "
+            "setting."
+        )
+    else:
+        # Not the user's doing: libmpv failed to load and the fallback took
+        # over silently. On the Windows and Flatpak builds libmpv is what
+        # ships, and there is no mpv binary to fall back to, so this is
+        # fatal and the libmpv failure is the thing to go and read.
+        log.error(
+            "Could not start mpv. libmpv would not load (see the earlier "
+            "warning for why), and the external mpv backend it fell back to "
+            "found no mpv binary to run. This build ships libmpv, so the "
+            "earlier warning is the failure worth reporting."
+        )
+
 
 # Collect backend-specific exceptions for MPV disconnection/shutdown.
 # libmpv raises ShutdownError; external mpv (jsonipc) raises BrokenPipeError
@@ -780,6 +824,18 @@ class PlayerManager(AudioMixin, ReportingMixin, WindowMixin):
 
         try:
             return mpv.MPV(**kwargs, **mpv_options)
+        except FileNotFoundError:
+            # There is no mpv binary to spawn. Handled ahead of the lua
+            # retry below rather than by it, for two reasons: dropping
+            # --osc cannot conjure one, so the retry only spends the
+            # start-retry budget and then reraises the same error; and the
+            # error it reraises comes from `subprocess`, which reads as
+            # "mpv is not installed" even when nobody was ever asked to
+            # install it. That is how the vulkan-1.dll regression presented
+            # -- libmpv would not load, this backend was chosen for us, and
+            # the traceback named a missing mpv.exe.
+            _explain_missing_mpv()
+            raise
         except Exception:
             if OSC_OPTION not in mpv_options:
                 raise

--- a/tests/test_check_win_libmpv_deps.py
+++ b/tests/test_check_win_libmpv_deps.py
@@ -1,0 +1,213 @@
+"""The import-table guard, against PE files built to have the answer in them.
+
+``tools/check_win_libmpv_deps.py`` is what makes raising the pinned mpv release
+safe: it reads libmpv's import table and fails the build on a dependency
+Windows does not have. It only earns that if it reads the table correctly, and
+the file it reads in CI is a 120 MB binary nothing here can carry -- so the
+fixtures are synthesized, with the imports chosen by the test.
+
+The three things worth getting wrong, and therefore worth pinning:
+
+* **Hard versus delay-loaded.** They are separate directories with different
+  record layouts, and only the first is fatal. A checker that merges them
+  fails a build over a dependency that costs nothing until it is used.
+* **PE32 versus PE32+.** The data directories sit at a different offset in
+  each, and this project ships a 32-bit installer as well as a 64-bit one.
+  Reading the wrong offset does not raise -- it finds no imports and passes.
+* **The API set stubs.** ``api-ms-win-crt-*`` and friends are contract names
+  resolved by the loader, not files; a checker that demands them by name
+  rejects every real libmpv.
+"""
+
+import contextlib
+import io
+import struct
+import unittest
+
+from tools.check_win_libmpv_deps import (
+    NotAPeFile,
+    imported_dlls,
+    is_system_dll,
+    main,
+)
+
+SECTION_RVA = 0x1000
+SECTION_RAW = 0x400
+
+
+def build_pe(hard=(), delayed=(), magic=0x20B) -> bytes:
+    """A PE image with exactly the import descriptors asked for.
+
+    Minimal but structurally real: a DOS stub, a COFF header, an optional
+    header of the requested kind, sixteen data directories and one section
+    holding both import directories and their name strings.
+    """
+    blob = bytearray()
+    names = {}
+
+    def name_rva(name: str) -> int:
+        if name not in names:
+            names[name] = SECTION_RVA + len(blob)
+            blob.extend(name.encode("ascii") + b"\0")
+        return names[name]
+
+    # Lay the strings down first so the descriptors can point back at them.
+    for name in list(hard) + list(delayed):
+        name_rva(name)
+
+    import_rva = SECTION_RVA + len(blob)
+    for name in hard:
+        # IMAGE_IMPORT_DESCRIPTOR: the name is the third of five dwords.
+        blob.extend(struct.pack("<IIIII", 0, 0, 0, names[name], 0))
+    blob.extend(b"\0" * 20)
+    import_size = SECTION_RVA + len(blob) - import_rva
+
+    delay_rva = SECTION_RVA + len(blob)
+    for name in delayed:
+        # ImgDelayDescr: attributes, then the name, then six more dwords.
+        blob.extend(struct.pack("<IIIIIIII", 1, names[name], 0, 0, 0, 0, 0, 0))
+    blob.extend(b"\0" * 32)
+    delay_size = SECTION_RVA + len(blob) - delay_rva
+
+    directories = [(0, 0)] * 16
+    directories[1] = (import_rva, import_size)
+    directories[13] = (delay_rva, delay_size)
+
+    optional_head = 112 if magic == 0x20B else 96
+    optional_size = optional_head + 16 * 8
+
+    image = bytearray(b"MZ" + b"\0" * 0x3E)
+    struct.pack_into("<I", image, 0x3C, 0x40)
+    image.extend(b"PE\0\0")
+    image.extend(struct.pack(
+        "<HHIIIHH",
+        0x8664 if magic == 0x20B else 0x014C,  # Machine
+        1,                                     # NumberOfSections
+        0, 0, 0,                               # timestamps / symbol table
+        optional_size,
+        0x2022,                                # Characteristics: DLL
+    ))
+
+    optional = bytearray(b"\0" * optional_size)
+    struct.pack_into("<H", optional, 0, magic)
+    for index, (rva, size) in enumerate(directories):
+        struct.pack_into("<II", optional, optional_head + index * 8, rva, size)
+    image.extend(optional)
+
+    image.extend(struct.pack(
+        "<8sIIII IIHHI",
+        b".rdata",
+        len(blob),      # VirtualSize
+        SECTION_RVA,    # VirtualAddress
+        len(blob),      # SizeOfRawData
+        SECTION_RAW,    # PointerToRawData
+        0, 0, 0, 0, 0,  # relocations, line numbers, characteristics
+    ))
+
+    image.extend(b"\0" * (SECTION_RAW - len(image)))
+    image.extend(blob)
+    return bytes(image)
+
+
+class ImportTableTest(unittest.TestCase):
+    def _write(self, data: bytes) -> str:
+        import os
+        import tempfile
+
+        handle, path = tempfile.mkstemp(suffix=".dll")
+        os.write(handle, data)
+        os.close(handle)
+        self.addCleanup(os.unlink, path)
+        return path
+
+    def test_reads_the_hard_imports(self):
+        path = self._write(build_pe(hard=["KERNEL32.dll", "vulkan-1.dll"]))
+        hard, delayed = imported_dlls(path)
+        self.assertEqual(hard, ["KERNEL32.dll", "vulkan-1.dll"])
+        self.assertEqual(delayed, [])
+
+    def test_keeps_the_delay_imports_apart(self):
+        path = self._write(
+            build_pe(hard=["KERNEL32.dll"], delayed=["vulkan-1.dll"])
+        )
+        hard, delayed = imported_dlls(path)
+        self.assertEqual(hard, ["KERNEL32.dll"])
+        self.assertEqual(delayed, ["vulkan-1.dll"])
+
+    def test_reads_a_32_bit_image(self):
+        # The directories move by 16 bytes between PE32 and PE32+, and the
+        # 32-bit installer is built from a real i686 libmpv. Reading the
+        # wrong offset yields no imports, which is a silent pass.
+        path = self._write(build_pe(hard=["vulkan-1.dll"], magic=0x10B))
+        hard, _ = imported_dlls(path)
+        self.assertEqual(hard, ["vulkan-1.dll"])
+
+    def test_refuses_something_that_is_not_a_pe(self):
+        path = self._write(b"this is not a dll")
+        with self.assertRaises(NotAPeFile):
+            imported_dlls(path)
+
+
+class SystemDllTest(unittest.TestCase):
+    def test_matches_regardless_of_case(self):
+        # Real import tables mix them: IPHLPAPI.DLL next to KERNEL32.dll.
+        self.assertTrue(is_system_dll("KERNEL32.dll"))
+        self.assertTrue(is_system_dll("IPHLPAPI.DLL"))
+        self.assertTrue(is_system_dll("kernel32.DLL"))
+
+    def test_accepts_the_api_set_stubs(self):
+        self.assertTrue(is_system_dll("api-ms-win-crt-stdio-l1-1-0.dll"))
+        self.assertTrue(is_system_dll("ext-ms-win-ntuser-window-l1-1-0.dll"))
+
+    def test_does_not_accept_the_vulkan_loader(self):
+        self.assertFalse(is_system_dll("vulkan-1.dll"))
+
+
+class ExitCodeTest(unittest.TestCase):
+    def _write(self, data: bytes) -> str:
+        import os
+        import tempfile
+
+        handle, path = tempfile.mkstemp(suffix=".dll")
+        os.write(handle, data)
+        os.close(handle)
+        self.addCleanup(os.unlink, path)
+        return path
+
+    def _run(self, argv) -> int:
+        # It is a CI script and reports on both streams; keep that out of
+        # the suite's own output.
+        with contextlib.redirect_stdout(io.StringIO()), \
+                contextlib.redirect_stderr(io.StringIO()):
+            return main(argv)
+
+    def test_passes_a_libmpv_that_needs_only_windows(self):
+        path = self._write(build_pe(hard=[
+            "KERNEL32.dll", "api-ms-win-crt-heap-l1-1-0.dll", "OPENGL32.dll",
+        ]))
+        self.assertEqual(self._run([path]), 0)
+
+    def test_fails_the_vulkan_regression(self):
+        path = self._write(build_pe(hard=["KERNEL32.dll", "vulkan-1.dll"]))
+        self.assertEqual(self._run([path]), 1)
+
+    def test_a_delay_loaded_dependency_is_not_a_failure(self):
+        # This is the version of the same import that would have been fine:
+        # resolved on first use, so a machine without a Vulkan loader loses
+        # the Vulkan output rather than the whole DLL.
+        path = self._write(
+            build_pe(hard=["KERNEL32.dll"], delayed=["vulkan-1.dll"])
+        )
+        self.assertEqual(self._run([path]), 0)
+
+    def test_allow_accepts_something_shipped_beside_it(self):
+        path = self._write(build_pe(hard=["vulkan-1.dll"]))
+        self.assertEqual(self._run(["--allow", "vulkan-1.dll", path]), 0)
+
+    def test_a_file_it_cannot_read_is_a_failure(self):
+        path = self._write(b"not a pe file at all")
+        self.assertEqual(self._run([path]), 1)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_lua_only_options.py
+++ b/tests/test_lua_only_options.py
@@ -209,5 +209,68 @@ class RediscoveryTest(unittest.TestCase):
         self.assertEqual(calls[0].kwargs["vo"], "gpu")
 
 
+class MissingMpvBinaryTest(unittest.TestCase):
+    """"There is no mpv to run" must not be read as "this mpv has no lua".
+
+    The external backend spawns an mpv binary, so when there is none it
+    raises `FileNotFoundError` from `subprocess` -- which lands in the same
+    `except` the lua retry lives in. Two things then go wrong, and 3.0.0pre12
+    shipped both: the retry spends the start-retry budget on an error that
+    dropping `--osc` cannot fix, and the traceback the user sees names a
+    missing mpv.exe on a build that ships libmpv and no mpv.exe by design.
+    """
+
+    def _construct(self, options):
+        from jellyfin_mpv_shim import player
+
+        me = mock.Mock()
+        me._lua_works = None
+        with mock.patch.object(player, "mpv") as fake_mpv:
+            fake_mpv.MPV.side_effect = FileNotFoundError(
+                2, "The system cannot find the file specified")
+            with self.assertRaises(FileNotFoundError):
+                player.PlayerManager._construct_mpv(me, options)
+        return fake_mpv.MPV.call_args_list, me
+
+    def test_it_is_not_retried_without_osc(self):
+        calls, _me = self._construct({"osc": False, "vo": "gpu"})
+        self.assertEqual(len(calls), 1, "it spent a start-retry budget "
+                         "retrying an error --osc cannot cause")
+
+    def test_it_does_not_claim_lua_is_absent(self):
+        _calls, me = self._construct({"osc": False})
+        self.assertIsNone(me._lua_works)
+
+    def _said(self, mpv_ext, external=True):
+        from jellyfin_mpv_shim import player
+
+        with mock.patch.object(player, "is_using_ext_mpv", external), \
+                mock.patch.object(player.settings, "mpv_ext", mpv_ext):
+            logging.getLogger("player").error("marker")
+            with self.assertLogs("player", level="ERROR") as caught:
+                logging.getLogger("player").error("marker")
+                self._construct({"osc": False})
+        return "\n".join(caught.output)
+
+    def test_the_fallback_case_points_at_libmpv(self):
+        # libmpv failed to load, this backend was chosen for us, and the
+        # thing worth reporting is the earlier warning -- not mpv.exe.
+        self.assertIn("libmpv", self._said(mpv_ext=False))
+
+    def test_the_deliberate_case_says_how_to_supply_one(self):
+        # The user asked for the external backend, so a missing binary is
+        # theirs to fix and the advice is the opposite one.
+        said = self._said(mpv_ext=True)
+        self.assertIn("mpv_ext_path", said)
+        self.assertNotIn("libmpv", said)
+
+    def test_the_libmpv_backend_is_told_nothing(self):
+        # Neither explanation is about libmpv, which spawns nothing -- a
+        # FileNotFoundError from there is some other missing file, and
+        # blaming a missing mpv binary would be a lie in the log.
+        said = self._said(mpv_ext=False, external=False)
+        self.assertNotIn("Could not start mpv", said)
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/tools/check_win_libmpv_deps.py
+++ b/tools/check_win_libmpv_deps.py
@@ -1,0 +1,240 @@
+#!/usr/bin/env python3
+"""Assert that a Windows libmpv imports nothing the installer does not ship.
+
+The shim loads ``mpv-2.dll`` with ctypes at runtime, so a DLL it cannot load
+is not a build error -- it is a client that dies at startup. And the way it
+dies hides the cause twice over: ``python-mpv`` raises ``OSError``, ``player``
+reads that as "no libmpv" and switches to the external backend, and the
+external backend fails looking for an ``mpv.exe`` the Windows build has never
+shipped. The traceback that reaches the user names ``subprocess``.
+
+That is exactly what shipped in 3.0.0pre12. shinchiro's builds from 20260808
+onward link ``vulkan-1.dll`` as a *hard* import rather than loading it
+dynamically, and the Vulkan loader is installed by the GPU driver -- so on a
+machine without one, ``LoadLibrary`` refuses ``mpv-2.dll`` outright.
+
+Nothing downstream can notice: the build machine never loads the DLL, and a
+developer's machine almost certainly has a Vulkan loader, so the one place the
+question can be asked cheaply is the import table itself.
+
+So: read the imports, and check every name against the set of DLLs a stock
+Windows install actually has. A name that is not on that list is either
+something to ship beside the DLL or something to confirm is a system component
+and add to ``SYSTEM_DLLS`` -- it is a lead, not a verdict.
+"""
+
+import argparse
+import struct
+import sys
+from typing import List, Optional, Set, Tuple
+
+# DLLs present on a stock Windows install, so an import of one needs nothing
+# shipped with it. This is the union of what libmpv has been observed to want
+# across the builds this project has used; add to it only after confirming the
+# name really is a Windows component, because the whole value of the check is
+# that an unfamiliar name stops the build.
+SYSTEM_DLLS: Set[str] = {
+    "advapi32.dll",
+    "avicap32.dll",
+    "avrt.dll",
+    "bcrypt.dll",
+    "bcryptprimitives.dll",
+    "cfgmgr32.dll",
+    "crypt32.dll",
+    "d2d1.dll",
+    "d3d11.dll",
+    "dwmapi.dll",
+    "dwrite.dll",
+    "dxgi.dll",
+    "gdi32.dll",
+    "imm32.dll",
+    "iphlpapi.dll",
+    "kernel32.dll",
+    "msvcrt.dll",
+    "normaliz.dll",
+    "ntdll.dll",
+    "ole32.dll",
+    "oleaut32.dll",
+    "opengl32.dll",
+    "secur32.dll",
+    "setupapi.dll",
+    "shcore.dll",
+    "shell32.dll",
+    "shlwapi.dll",
+    "user32.dll",
+    "uxtheme.dll",
+    "version.dll",
+    "winmm.dll",
+    "wldap32.dll",
+    "ws2_32.dll",
+}
+
+# The API set / MinWin contract stubs. These are resolved by the loader
+# against whatever implements them on the running system rather than being
+# files anyone ships, so match them by prefix instead of listing hundreds.
+SYSTEM_PREFIXES: Tuple[str, ...] = ("api-ms-win-", "ext-ms-win-")
+
+# Data directory indices from the PE spec.
+DIR_IMPORT = 1
+DIR_DELAY_IMPORT = 13
+
+
+class NotAPeFile(Exception):
+    pass
+
+
+class _Image:
+    """Just enough of a PE image to walk its import descriptors."""
+
+    def __init__(self, data: bytes):
+        if len(data) < 0x40 or data[:2] != b"MZ":
+            raise NotAPeFile("not a PE image (no MZ signature)")
+        (pe_offset,) = struct.unpack_from("<I", data, 0x3C)
+        if data[pe_offset:pe_offset + 4] != b"PE\0\0":
+            raise NotAPeFile(f"no PE signature at {pe_offset:#x}")
+
+        coff = pe_offset + 4
+        section_count, = struct.unpack_from("<H", data, coff + 2)
+        optional_size, = struct.unpack_from("<H", data, coff + 16)
+        optional = coff + 20
+
+        magic, = struct.unpack_from("<H", data, optional)
+        if magic == 0x20B:  # PE32+
+            directories = optional + 112
+        elif magic == 0x10B:  # PE32
+            directories = optional + 96
+        else:
+            raise NotAPeFile(f"unknown optional header magic {magic:#06x}")
+
+        self._data = data
+        self._directories = directories
+        # (virtual address, virtual size, raw offset, raw size) per section,
+        # which is all an RVA -> file offset translation needs.
+        self._sections = []
+        table = optional + optional_size
+        for index in range(section_count):
+            entry = table + index * 40
+            virtual_size, virtual_address, raw_size, raw_offset = struct.unpack_from(
+                "<IIII", data, entry + 8
+            )
+            self._sections.append((virtual_address, virtual_size, raw_offset, raw_size))
+
+    def directory(self, index: int) -> Tuple[int, int]:
+        """The (RVA, size) of one data directory entry."""
+        return struct.unpack_from("<II", self._data, self._directories + index * 8)
+
+    def offset_of(self, rva: int) -> Optional[int]:
+        for virtual_address, virtual_size, raw_offset, raw_size in self._sections:
+            if virtual_address <= rva < virtual_address + max(virtual_size, raw_size):
+                offset = raw_offset + (rva - virtual_address)
+                if offset < len(self._data):
+                    return offset
+        return None
+
+    def string_at(self, rva: int) -> Optional[str]:
+        offset = self.offset_of(rva)
+        if offset is None:
+            return None
+        end = self._data.find(b"\0", offset)
+        if end < 0:
+            return None
+        return self._data[offset:end].decode("ascii", "replace")
+
+
+def _walk_descriptors(image: _Image, directory: int, stride: int, name_field: int):
+    """Yield the DLL name from each descriptor in one import directory.
+
+    The two directories differ only in their record layout -- the ordinary
+    import descriptor is 20 bytes with the name at offset 12, the delay-load
+    one is 32 bytes with the name at offset 4 -- and both are terminated by an
+    all-zero record.
+    """
+    rva, size = image.directory(directory)
+    if not rva or not size:
+        return
+    offset = image.offset_of(rva)
+    if offset is None:
+        return
+    while True:
+        record = image._data[offset:offset + stride]
+        if len(record) < stride or not any(record):
+            return
+        (name_rva,) = struct.unpack_from("<I", record, name_field)
+        name = image.string_at(name_rva)
+        if name:
+            yield name
+        offset += stride
+
+
+def imported_dlls(path: str) -> Tuple[List[str], List[str]]:
+    """Return (hard imports, delay-loaded imports) for a PE file.
+
+    The two are kept apart because only the first is fatal. A delay-loaded
+    dependency is resolved on first use, so a missing one costs the feature
+    that needs it; a hard one costs the whole DLL, at load time, before any
+    code of ours runs.
+    """
+    with open(path, "rb") as handle:
+        image = _Image(handle.read())
+    hard = list(_walk_descriptors(image, DIR_IMPORT, 20, 12))
+    delayed = list(_walk_descriptors(image, DIR_DELAY_IMPORT, 32, 4))
+    return hard, delayed
+
+
+def is_system_dll(name: str) -> bool:
+    lowered = name.lower()
+    if lowered in SYSTEM_DLLS:
+        return True
+    return lowered.startswith(SYSTEM_PREFIXES)
+
+
+def main(argv: Optional[list] = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__.splitlines()[0])
+    parser.add_argument(
+        "--allow",
+        action="append",
+        default=[],
+        help="an additional DLL name to accept, for one that is shipped "
+             "beside the file being checked (repeatable)",
+    )
+    parser.add_argument("files", nargs="+", help="PE files (.dll/.exe) to check")
+    args = parser.parse_args(argv)
+
+    allowed = {name.lower() for name in args.allow}
+    problems = []
+
+    for path in args.files:
+        try:
+            hard, delayed = imported_dlls(path)
+        except (OSError, NotAPeFile, struct.error) as error:
+            problems.append(f"{path}: {error}")
+            continue
+
+        unknown = [
+            name for name in hard
+            if not is_system_dll(name) and name.lower() not in allowed
+        ]
+        print(f"{path}: {len(hard)} imports, {len(delayed)} delay-loaded")
+        for name in sorted(delayed, key=str.lower):
+            if not is_system_dll(name) and name.lower() not in allowed:
+                # Not an error: a delay-loaded dependency that is absent
+                # costs the feature that uses it, not the load.
+                print(f"  note: delay-loads {name}, which Windows may not have")
+        for name in sorted(unknown, key=str.lower):
+            problems.append(
+                f"{path} hard-imports {name}, which is not a Windows system "
+                f"DLL and is not shipped with it -- the file will not load on "
+                f"a machine without it"
+            )
+
+    if problems:
+        print("", file=sys.stderr)
+        for problem in problems:
+            print(f"error: {problem}", file=sys.stderr)
+        return 1
+
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
Latest `libmpv-2.dll` is broken due to a hard dependency on `vulkan-1.dll`. This PR pins it and adds a checker script for this issue so CI fails in the future when it's unpinned if it re-occurs.