### PR TITLE
Fix cursor autohide

### DIFF
--- a/Jellyfin MPV Shim.iss
+++ b/Jellyfin MPV Shim.iss
@@ -2,7 +2,7 @@
 ; SEE THE DOCUMENTATION FOR DETAILS ON CREATING INNO SETUP SCRIPT FILES!
 
 #define MyAppName "Jellyfin MPV Shim"
-#define MyAppVersion "3.0.0pre12"
+#define MyAppVersion "3.0.0pre13"
 #define MyAppPublisher "Izzie Walton"
 #define MyAppURL "https://github.com/jellyfin/jellyfin-mpv-shim"
 #define MyAppExeName "run.exe"

--- a/jellyfin_mpv_shim/constants.py
+++ b/jellyfin_mpv_shim/constants.py
@@ -5,7 +5,7 @@ USER_APP_NAME = "Jellyfin MPV Shim"
 # how a Linux desktop finds the window's icon — see player.py's x11_name /
 # wayland_app_id. Changing one without the others loses the icon silently.
 DESKTOP_ID = "com.github.iwalton3.jellyfin-mpv-shim"
-CLIENT_VERSION = "3.0.0pre12"
+CLIENT_VERSION = "3.0.0pre13"
 USER_AGENT = "Jellyfin-MPV-Shim/%s" % CLIENT_VERSION
 CAPABILITIES = {
     "PlayableMediaTypes": ["Video"],

--- a/jellyfin_mpv_shim/player.py
+++ b/jellyfin_mpv_shim/player.py
@@ -1672,6 +1672,28 @@ class PlayerManager(AudioMixin, ReportingMixin, WindowMixin):
 
     # ------------------------------------------------------ the OSD menu
 
+    #: The flags every section of ours is enabled with -- the same string
+    #: mpv's own defaults.lua gives a script's bindings, and the same one
+    #: python-mpv gives every key we bind through it.
+    #:
+    #: A section's mouse area defaults to the WHOLE SCREEN (input.c:
+    #: get_bind_section starts it at INT_MIN..INT_MAX), and an enabled
+    #: section covering the pointer without ``allow-hide-cursor`` is how mpv
+    #: is told "a script's UI is under the mouse": every call to
+    #: mp_input_get_mouse_event_counter bumps the counter, which re-arms
+    #: handle_cursor_autohide's timer, so **the cursor never hides again**.
+    #: Ours hold keyboard keys and have no UI at all, so the fullscreen
+    #: standing claim -- installed at mpv creation and never released --
+    #: left a pointer sitting over every film for the whole session.
+    #: ``allow-vo-dragging`` is the same mistake in the other direction:
+    #: without it mp_input_test_dragging refuses to move the window from a
+    #: drag on the video, which is mpv's own behaviour everywhere else.
+    #: (renderer.lua withholds ``allow-hide-cursor`` from its own mouse
+    #: sections on purpose -- while the library or the HUD is up the pointer
+    #: really is over a UI -- and they are enabled only for as long as it
+    #: is. These are enabled for the life of the process.)
+    SECTION_FLAGS = "allow-hide-cursor+allow-vo-dragging"
+
     #: Section and message for the OSD menu's own arrow keys.
     MENU_SECTION = "jms_menu"
     MENU_MESSAGE = "jms-menu"
@@ -1706,7 +1728,8 @@ class PlayerManager(AudioMixin, ReportingMixin, WindowMixin):
             )
             self._player.command("define-section", self.MENU_SECTION,
                                  lines, "force")
-            self._player.command("enable-section", self.MENU_SECTION)
+            self._player.command("enable-section", self.MENU_SECTION,
+                                 self.SECTION_FLAGS)
         except Exception:
             log.debug("could not update the menu key section", exc_info=True)
 
@@ -1805,7 +1828,8 @@ class PlayerManager(AudioMixin, ReportingMixin, WindowMixin):
                 "define-section", self.KEY_SECTION,
                 keysweep.section_lines(claims, self.KEY_MESSAGE, suppress),
                 "force")
-            self._player.command("enable-section", self.KEY_SECTION)
+            self._player.command("enable-section", self.KEY_SECTION,
+                                 self.SECTION_FLAGS)
         except Exception:
             log.debug("could not update the key section", exc_info=True)
 

--- a/tests/test_key_claims.py
+++ b/tests/test_key_claims.py
@@ -392,3 +392,58 @@ class AfterMigrationTest(unittest.TestCase):
         pm = PlayerManager.__new__(PlayerManager)
         with mock.patch("jellyfin_mpv_shim.player.settings", s):
             self.assertTrue(pm._seek_is_ours())
+
+
+class SectionFlagsTest(unittest.TestCase):
+    """Every section we enable must carry ``allow-hide-cursor``.
+
+    mpv gives a section a mouse area of the whole screen unless one is set
+    (input.c: ``get_bind_section``), and ``mp_input_get_mouse_event_counter``
+    bumps its counter on every call while an enabled section without
+    ``allow-hide-cursor`` covers the pointer -- which is how a script says
+    "my UI is under the mouse". ``handle_cursor_autohide`` re-arms its timer
+    on every bump, so the mouse cursor never hides again. The fullscreen
+    claim is installed at mpv creation and never released, so this held the
+    cursor on screen over every film for the whole session.
+
+    ``allow-vo-dragging`` is the same mistake pointed the other way: without
+    it ``mp_input_test_dragging`` refuses to move the window from a drag on
+    the video. Asserted here because neither symptom shows up anywhere near
+    the key that was claimed.
+    """
+
+    #: What mpv's own defaults.lua enables a script's sections with.
+    WANT = {"allow-hide-cursor", "allow-vo-dragging"}
+
+    def _flags(self, pm):
+        return [set((c[2] if len(c) > 2 else "").split("+"))
+                for c in pm._player.commands if c[0] == "enable-section"]
+
+    def test_a_key_claim_lets_the_cursor_hide(self):
+        pm = _pm()
+        pm.claim_keys("syncplay", {PAUSE})
+        flags = self._flags(pm)
+        self.assertTrue(flags, "no section was enabled")
+        for got in flags:
+            self.assertTrue(self.WANT <= got,
+                            "%s is missing %s" % (got, self.WANT - got))
+
+    def test_the_menu_section_lets_the_cursor_hide(self):
+        pm = _pm()
+        settings = mock.Mock(kb_menu_left="LEFT", kb_menu_right="RIGHT",
+                             kb_menu_up="UP", kb_menu_down="DOWN")
+        with mock.patch("jellyfin_mpv_shim.player.settings", settings):
+            pm.claim_menu_keys(True)
+        flags = self._flags(pm)
+        self.assertTrue(flags, "no section was enabled")
+        for got in flags:
+            self.assertTrue(self.WANT <= got,
+                            "%s is missing %s" % (got, self.WANT - got))
+
+    def test_the_standing_fullscreen_claim_is_what_makes_this_matter(self):
+        """It is enabled once and never disabled, so a missing flag is not
+        a transient state -- it is the rest of the session."""
+        pm = _pm()
+        pm.claim_keys("fullscreen", {FULLSCREEN})
+        self.assertTrue(_sections(pm)[PlayerManager.KEY_SECTION])
+        self.assertTrue(self.WANT <= self._flags(pm)[-1])


### PR DESCRIPTION
Fixes #685

Caused by keyclaim mechanism setting a config section which disabled mouse autohide.