### PR TITLE
Add gamepad support

### DIFF
--- a/README.md
+++ b/README.md
@@ -470,7 +470,8 @@ true in MPV's own meson options), so no extra configuration is needed. Afterward
 
 Note, if it has been a while since you have compiled mpv, modern copies of `mpv-build` don't
 support `--enable-libmpv-shared` in the `mpv_options` file, you can clear the file as `libmpv`
-is now enabled by default.
+is now enabled by default. Add `-Dsdl2-gamepad=enabled` to `mpv_options` if you want gamepad
+support.
 
 ## <h2 id="osx-installation">macOS Installation</h2>
 Currently on macOS only the external MPV backend seems to be working. I cannot test on macOS, so please report any issues you find.

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -651,6 +651,24 @@ You can reconfigure the custom keyboard shortcuts. You can also set them to `nul
 - `kb_fullscreen` - Toggle fullscreen. (Default: `f`)
 - `kb_kill_shader` - Disable shader packs. (Default: `k`)
 - `media_keys` - Enable binding of MPV to media keys. Default: `true`
+- `input_gamepad` - Enable game controller input, so a pad can drive the
+  library and playback. Also in Settings → General → Input. mpv reads
+  this once when it starts, so it takes effect on the next launch. The d-pad and left stick move the selection, A
+  (cross) activates, B (circle) goes back, the shoulder buttons page, and
+  Start opens the context menu. Default: `false`
+
+  Off by default for two reasons, both worth knowing before turning it on.
+  **A controller is not focus-aware**: mpv reads it through SDL without a
+  window, so the shim responds to your pad even when another application is
+  in front. And **most builds of mpv cannot do this at all** — the feature is
+  compiled out unless mpv was built with `-Dsdl2-gamepad=enabled`, which is
+  not its default. Debian's mpv has it, and so do the Windows builds this
+  client ships. If yours does not, the setting is ignored with a line in the
+  log and nothing else changes.
+
+  mpv supports one controller at a time, and only pads it recognises through
+  SDL's controller database; an unrecognised stick is ignored rather than
+  mapped to something arbitrary.
 
 - `ui_text_scale` - Multiply the size of every piece of text in the
   interface. `1.25` is a quarter larger, `0.9` a tenth smaller. Unlike

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -653,9 +653,39 @@ You can reconfigure the custom keyboard shortcuts. You can also set them to `nul
 - `media_keys` - Enable binding of MPV to media keys. Default: `true`
 - `input_gamepad` - Enable game controller input, so a pad can drive the
   library and playback. Also in Settings → General → Input. mpv reads
-  this once when it starts, so it takes effect on the next launch. The d-pad and left stick move the selection, A
-  (cross) activates, B (circle) goes back, the shoulder buttons page, and
-  Start opens the context menu. Default: `false`
+  this once when it starts, so it takes effect on the next launch.
+  Default: `false`
+
+  The d-pad and **left stick** move the selection; the **right stick**
+  seeks, by the same distances your arrow keys do. The bottom face button
+  (A on an Xbox-style pad) selects, the right one (B) goes back, the left
+  one (X) pauses, the shoulder buttons page through long lists, and Start
+  opens the context menu — the player's settings menu while something is
+  playing. The two sticks are deliberately different: a keyboard has one
+  set of arrows and has to share them between navigating and seeking, and a
+  controller does not.
+
+  Held controls repeat, but much more slowly than mpv repeats a held key
+  (`--input-ar-rate`, 40 a second by default) — a direction about seven
+  times a second, the shoulder buttons about three, the right stick's seek
+  about two and a half. Confirm, back, play/pause and Start do not repeat at
+  all. If you rebind a control in `input.conf` you get mpv's own repeat
+  behaviour for it instead, since the binding is then yours.
+
+  Every button is an ordinary mpv binding, so **you can reassign any of them
+  in your own `input.conf`** by naming the key:
+
+  ```
+  GAMEPAD_ACTION_UP       cycle fullscreen
+  GAMEPAD_BACK            keypress ESC
+  GAMEPAD_RIGHT_STICK_UP  seek 600
+  GAMEPAD_LEFT_TRIGGER    add speed -0.1
+  ```
+
+  A line there wins over the shim's own binding for that key, and nothing
+  has to be disabled first. `GAMEPAD_ACTION_UP` (Y/triangle), `GAMEPAD_BACK`
+  (Select/View) and both triggers are left unbound on purpose, so they are
+  free for whatever you want on them.
 
   Off by default for two reasons, both worth knowing before turning it on.
   **A controller is not focus-aware**: mpv reads it through SDL without a
@@ -669,6 +699,17 @@ You can reconfigure the custom keyboard shortcuts. You can also set them to `nul
   mpv supports one controller at a time, and only pads it recognises through
   SDL's controller database; an unrecognised stick is ignored rather than
   mapped to something arbitrary.
+
+- `gamepad_swap_confirm` - Put the confirm button on the **right** face
+  button and back on the bottom one, instead of the other way round. Also in
+  Settings → General → Input, and it applies immediately. Default: `false`
+
+  mpv reports the face buttons by *position*, not by the letter printed on
+  them, and the two common layouts disagree about where A is: an Xbox-style
+  pad puts it at the bottom, a Nintendo-style one (Switch Pro, most 8BitDo
+  pads) puts it on the right. Nothing in the button events distinguishes
+  them, so this is you telling the shim which pad is in your hands. It moves
+  those two buttons and nothing else on the controller.
 
 - `ui_text_scale` - Multiply the size of every piece of text in the
   interface. `1.25` is a quarter larger, `0.9` a tenth smaller. Unlike

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -692,9 +692,9 @@ You can reconfigure the custom keyboard shortcuts. You can also set them to `nul
   window, so the shim responds to your pad even when another application is
   in front. And **most builds of mpv cannot do this at all** — the feature is
   compiled out unless mpv was built with `-Dsdl2-gamepad=enabled`, which is
-  not its default. Debian's mpv has it, and so do the Windows builds this
-  client ships. If yours does not, the setting is ignored with a line in the
-  log and nothing else changes.
+  not its default. Debian's mpv has it, the Windows builds this client ships
+  have it, and the Flatpak builds its own mpv with it. If yours does not, the
+  setting is ignored with a line in the log and nothing else changes.
 
   mpv supports one controller at a time, and only pads it recognises through
   SDL's controller database; an unrecognised stick is ignored rather than

--- a/flatpak/com.github.iwalton3.jellyfin-mpv-shim.json
+++ b/flatpak/com.github.iwalton3.jellyfin-mpv-shim.json
@@ -9,12 +9,14 @@
         "--socket=fallback-x11",
         "--socket=wayland",
         "--device=dri",
+        "--device=input",
         "--share=network",
         "--socket=pulseaudio",
         "--filesystem=xdg-run/pipewire-0:ro",
         "--talk-name=org.gnome.SessionManager",
         "--env=LC_NUMERIC=C"
     ],
+    "//gamepad-note": "Game controller support needs BOTH of these and is silent without either. mpv's `sdl2-gamepad` is `value: 'disabled'` in its own meson.options -- not `auto` -- so having SDL2 present changes nothing and the flag is required; without it `--input-gamepad` does not exist and the shim drops it with a warning at every launch. And `--device=input` is required for the sandbox to expose /dev/input at all, which is where SDL finds the pad: with the build flag but not the device, mpv starts its SDL thread, sees no controller ever, and nothing anywhere says why. SDL2 itself needs no module -- 2.32.x ships in both org.gnome.Sdk (headers) and org.gnome.Platform (libSDL2-2.0.so.0), checked, so libmpv resolves it at runtime. `--device=input` rather than `--device=all`: this needs joysticks, not the camera and everything else.",
     "//build-options-note": "flatpak-builder only passes a libdir to meson and cmake by default from 1.4.4 on; Ubuntu 24.04 ships 1.4.2, which lets each build system pick. Both then choose lib64 -- meson on x86_64, cmake on aarch64 -- and the .pc files land off the pkg-config path, so mpv cannot find libplacebo and libayatana-indicator cannot find ayatana-ido. Pinning it here makes every builder version agree, and would put libmpv.so where python-mpv looks for it even if nothing failed at build time.",
     "build-options": {
         "libdir": "/app/lib"
@@ -52,7 +54,8 @@
                 "-Dlcms2=enabled",
                 "-Djpeg=enabled",
                 "-Dlibarchive=enabled",
-                "-Dcplugins=enabled"
+                "-Dcplugins=enabled",
+        "-Dsdl2-gamepad=enabled"
             ],
             "sources": [
                 {

--- a/jellyfin_mpv_shim/conf.py
+++ b/jellyfin_mpv_shim/conf.py
@@ -496,6 +496,7 @@ class Settings(SettingsBase):
     ignore_ssl_cert: bool = False
     menu_mouse: bool = True
     media_keys: bool = True
+    input_gamepad: bool = False
     connect_retry_mins: int = 0
     transcode_warning: bool = True
     lang_filter: str = "und,eng,jpn,mis,mul,zxx"

--- a/jellyfin_mpv_shim/conf.py
+++ b/jellyfin_mpv_shim/conf.py
@@ -497,6 +497,14 @@ class Settings(SettingsBase):
     menu_mouse: bool = True
     media_keys: bool = True
     input_gamepad: bool = False
+    #: Which face button confirms. mpv reports the face buttons by POSITION
+    #: -- ACTION_DOWN is the bottom one whatever is printed on it -- and the
+    #: two common layouts disagree about where A lives: Xbox-style pads put
+    #: it at the bottom, Nintendo-style ones (Switch Pro, most 8BitDo) put it
+    #: on the right. There is no way to tell them apart from the button
+    #: events, so this is the user saying which pad is in their hands. See
+    #: gamepad.py.
+    gamepad_swap_confirm: bool = False
     connect_retry_mins: int = 0
     transcode_warning: bool = True
     lang_filter: str = "und,eng,jpn,mis,mul,zxx"

--- a/jellyfin_mpv_shim/gamepad.py
+++ b/jellyfin_mpv_shim/gamepad.py
@@ -137,11 +137,12 @@ DEFAULT_BINDS = (
 
 
 def bindings(swap_confirm=False):
-    """The binding table as a list of ``[key, kind, argument]``.
+    """The binding table as a list of ``[key, kind, argument, repeat]``.
 
     Lists rather than tuples because this is JSON on the way to the renderer,
     and a tuple would come back as a list anyway -- pinning the shape here
-    keeps the tests honest about what Lua actually receives.
+    keeps the tests honest about what Lua actually receives. The renderer
+    reads all four positionally, so the arity is part of the contract.
     """
     swapped = {}
     if swap_confirm:

--- a/jellyfin_mpv_shim/gamepad.py
+++ b/jellyfin_mpv_shim/gamepad.py
@@ -1,0 +1,152 @@
+"""Which gamepad button does what.
+
+The controller is **not a second input model**. Every button here resolves to
+something the shim already has: a keyboard key it already binds, or the seek
+the arrow keys already perform. That is deliberate and it is the whole design
+-- a parallel set of gamepad handlers is a second implementation of the
+navigation ladder, and the second implementation is where the drift happens.
+
+Two kinds, and the split is not cosmetic:
+
+* :data:`KEY` is a *synthetic keypress*. The renderer issues the keyboard key
+  and whatever is bound to it right now answers -- the browser's spatial
+  navigation while the library is up, the playback HUD's summon while a video
+  is on, mpv's own default when neither claims it. So the d-pad follows the
+  UI from screen to screen without knowing any of them exist, and a page that
+  claims ENTER (the epub reader, a dialog) gets the controller's confirm
+  button for free.
+* :data:`SEEK` goes to ``PlayerManager.kb_seek``, which is the *keyboard's*
+  seek and not a number of ours: it reads the distance out of the user's own
+  ``input.conf`` binding, applies ``use_web_seek``, and routes through a seek
+  that a SyncPlay group hears about. A raw ``seek 5`` from Lua would be none
+  of those three, and the third one is a desync the group then corrects.
+
+**The sticks are asymmetric on purpose.** The left stick and d-pad drive the
+UI; the right stick seeks. That is why the left stick wakes a hidden playback
+HUD rather than falling through to mpv's arrows the way the keyboard does
+under the default ``hud_grab_keys``: a keyboard has one set of arrows and has
+to share them, and a controller does not.
+
+**mpv names the face buttons by POSITION, not by label.** ``ACTION_DOWN`` is
+the bottom button and ``ACTION_RIGHT`` the right one, whatever is printed on
+them -- which is exactly the problem, because the two common layouts disagree
+about where A is. An Xbox-style pad puts A at the bottom, a Nintendo-style
+one (Switch Pro, most 8BitDo) puts it on the right, and SDL reports both by
+position. So "confirm is A" is not a statement this code can make, and
+``swap_confirm`` is the user telling us which pad is in their hands.
+
+Buttons deliberately left unbound -- ``GAMEPAD_ACTION_UP`` (Y/X),
+``GAMEPAD_BACK`` (Select/View) and both triggers -- are free for
+``input.conf``. Every binding here is registered *non-forced*, so a line in
+``input.conf`` naming the same key wins outright and nothing has to be
+disabled first. Inventing a meaning for the spare buttons would take that
+away from the people who have a use for them.
+
+Pure data plus one function: no mpv, no settings import, no I/O.
+"""
+
+#: Send the keyboard key named in the third field, and let whatever is bound
+#: to it answer.
+KEY = "key"
+
+#: Seek the way that arrow key seeks. The third field is a ``kb_seek``
+#: direction ("up" / "down" / "left" / "right").
+SEEK = "seek"
+
+#: Hand the third field to ``PlayerManager.menu_action`` -- the remote
+#: control's own ladder. For a button whose meaning *changes* between the
+#: library and a playing video and which has no single keyboard key covering
+#: both: MENU is the focused item's context menu while browsing and the
+#: player's settings menu over a video, and only that ladder knows which.
+NAV = "nav"
+
+#: How often a held control may fire, in seconds between events, and **0
+#: means it does not auto-repeat at all**.
+#:
+#: mpv repeats a held key at ``--input-ar-rate``, which defaults to 40 a
+#: second. On a keyboard that is a cursor moving through text; on a stick it
+#: is forty rows of a library per second, which is not something anybody can
+#: aim -- [iw]: "it spams inputs way faster than I can control them". An
+#: analog stick is worse than the d-pad again, because an axis resting near
+#: the threshold chatters across it and each crossing is a fresh press
+#: rather than a repeat -- which is why the limit is applied to every event
+#: and not only to the ones mpv marks as repeats.
+#:
+#: Per control rather than one number, because holding these does not mean
+#: the same thing. A direction is "keep going" and wants to feel like a
+#: scroll; a page is a jump and wants to be slower; a **seek repeats over
+#: real time**, so at the direction's rate a resting thumb would cross a
+#: film in a couple of seconds. And confirm, back, play/pause and the menu
+#: do not repeat at all: holding a button is not a request to press it
+#: again, and an auto-repeating Select activates whatever it landed on over
+#: and over.
+DIRECTION_REPEAT = 0.15
+PAGE_REPEAT = 0.35
+SEEK_REPEAT = 0.4
+NO_REPEAT = 0
+
+#: The two face buttons that mean confirm and back, in POSITION order --
+#: bottom first. ``swap_confirm`` exchanges what they carry, and nothing else
+#: on the pad moves.
+CONFIRM_BUTTON = "GAMEPAD_ACTION_DOWN"
+BACK_BUTTON = "GAMEPAD_ACTION_RIGHT"
+
+#: ``(gamepad key, kind, argument, repeat interval)``, in bind order.
+DEFAULT_BINDS = (
+    # Direction. The d-pad and the left stick are the same control as far as
+    # anything downstream is concerned.
+    ("GAMEPAD_DPAD_UP", KEY, "UP", DIRECTION_REPEAT),
+    ("GAMEPAD_DPAD_DOWN", KEY, "DOWN", DIRECTION_REPEAT),
+    ("GAMEPAD_DPAD_LEFT", KEY, "LEFT", DIRECTION_REPEAT),
+    ("GAMEPAD_DPAD_RIGHT", KEY, "RIGHT", DIRECTION_REPEAT),
+    ("GAMEPAD_LEFT_STICK_UP", KEY, "UP", DIRECTION_REPEAT),
+    ("GAMEPAD_LEFT_STICK_DOWN", KEY, "DOWN", DIRECTION_REPEAT),
+    ("GAMEPAD_LEFT_STICK_LEFT", KEY, "LEFT", DIRECTION_REPEAT),
+    ("GAMEPAD_LEFT_STICK_RIGHT", KEY, "RIGHT", DIRECTION_REPEAT),
+
+    # Confirm and back. ENTER because that is what the browser's nav
+    # activates on and what the hidden HUD wakes on; ESC because it already
+    # steps out exactly one layer -- page, dialog, menu, playback -- and a
+    # second implementation of that ladder would drift from it. The mouse's
+    # back button is routed the same way for the same reason.
+    (CONFIRM_BUTTON, KEY, "ENTER", NO_REPEAT),
+    (BACK_BUTTON, KEY, "ESC", NO_REPEAT),
+
+    # Play/pause. SPACE rather than `cycle pause`, so it lands on the shim's
+    # claim of that key: in a SyncPlay group a local pause is not a pause,
+    # it is a desync the group then corrects.
+    ("GAMEPAD_ACTION_LEFT", KEY, "SPACE", NO_REPEAT),
+
+    # The context menu of whatever is focused -- Play / Queue / Watched /
+    # Favourite / Download -- and the player's settings menu over a video.
+    # NAV rather than a MENU keypress because the MENU *key* is a browser
+    # nav binding, so over a playing video it is bound to nothing at all and
+    # the button would go dead exactly where the remote's hamburger works.
+    ("GAMEPAD_START", NAV, "menu", NO_REPEAT),
+
+    # A page at a time through a long library row or list.
+    ("GAMEPAD_LEFT_SHOULDER", KEY, "PGUP", PAGE_REPEAT),
+    ("GAMEPAD_RIGHT_SHOULDER", KEY, "PGDWN", PAGE_REPEAT),
+
+    # The right stick seeks, with the amounts the arrow keys use.
+    ("GAMEPAD_RIGHT_STICK_UP", SEEK, "up", SEEK_REPEAT),
+    ("GAMEPAD_RIGHT_STICK_DOWN", SEEK, "down", SEEK_REPEAT),
+    ("GAMEPAD_RIGHT_STICK_LEFT", SEEK, "left", SEEK_REPEAT),
+    ("GAMEPAD_RIGHT_STICK_RIGHT", SEEK, "right", SEEK_REPEAT),
+)
+
+
+def bindings(swap_confirm=False):
+    """The binding table as a list of ``[key, kind, argument]``.
+
+    Lists rather than tuples because this is JSON on the way to the renderer,
+    and a tuple would come back as a list anyway -- pinning the shape here
+    keeps the tests honest about what Lua actually receives.
+    """
+    swapped = {}
+    if swap_confirm:
+        swapped = {CONFIRM_BUTTON: BACK_BUTTON, BACK_BUTTON: CONFIRM_BUTTON}
+    out = []
+    for key, kind, arg, rate in DEFAULT_BINDS:
+        out.append([swapped.get(key, key), kind, arg, rate])
+    return out

--- a/jellyfin_mpv_shim/messages/base.pot
+++ b/jellyfin_mpv_shim/messages/base.pot
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: jellyfin-mpv-shim\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2026-08-17 12:17-0400\n"
+"POT-Creation-Date: 2026-08-18 13:23-0400\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -1163,6 +1163,10 @@ msgid "This Device"
 msgstr ""
 
 #: jellyfin_mpv_shim/mpvtk_browser/config.py
+msgid "Input"
+msgstr ""
+
+#: jellyfin_mpv_shim/mpvtk_browser/config.py
 msgid "Window"
 msgstr ""
 
@@ -1469,6 +1473,10 @@ msgid "Custom (set in config)"
 msgstr ""
 
 #: jellyfin_mpv_shim/mpvtk_browser/config.py
+msgid "Game Controller"
+msgstr ""
+
+#: jellyfin_mpv_shim/mpvtk_browser/config.py
 msgid "Download Folder"
 msgstr ""
 
@@ -1710,6 +1718,15 @@ msgid ""
 "With \"Start Minimized\" and \"Fullscreen\" this is the classic cast-target "
 "setup: the app waits out of the way, plays fullscreen when something casts "
 "to it, and goes back to waiting when the video ends or you press Q."
+msgstr ""
+
+#: jellyfin_mpv_shim/mpvtk_browser/config.py
+msgid ""
+"Takes effect after a restart. Move with the d-pad or left stick, A to "
+"select, B to go back, shoulder buttons to page, Start for the menu. A "
+"controller is not focus-aware, so it will reach this app even when another "
+"window is in front. Needs an mpv built with SDL2 gamepad support; if yours "
+"lacks it this setting is ignored and the log says so."
 msgstr ""
 
 #: jellyfin_mpv_shim/mpvtk_browser/config.py
@@ -3121,6 +3138,10 @@ msgstr ""
 msgid "Volume"
 msgstr ""
 
+#: jellyfin_mpv_shim/mpvtk_browser/pages/base.py
+msgid "Could not open that link."
+msgstr ""
+
 #: jellyfin_mpv_shim/mpvtk_browser/pages/books.py
 #, python-format
 msgid "%d chapters"
@@ -3216,10 +3237,6 @@ msgstr ""
 #: jellyfin_mpv_shim/mpvtk_browser/pages/detail.py
 #: jellyfin_mpv_shim/mpvtk_browser/pages/series.py
 msgid "More Like This"
-msgstr ""
-
-#: jellyfin_mpv_shim/mpvtk_browser/pages/detail.py
-msgid "Could not open that link."
 msgstr ""
 
 #: jellyfin_mpv_shim/mpvtk_browser/pages/detail.py

--- a/jellyfin_mpv_shim/messages/base.pot
+++ b/jellyfin_mpv_shim/messages/base.pot
@@ -1477,6 +1477,10 @@ msgid "Game Controller"
 msgstr ""
 
 #: jellyfin_mpv_shim/mpvtk_browser/config.py
+msgid "Swap Confirm and Back Buttons"
+msgstr ""
+
+#: jellyfin_mpv_shim/mpvtk_browser/config.py
 msgid "Download Folder"
 msgstr ""
 
@@ -1722,11 +1726,18 @@ msgstr ""
 
 #: jellyfin_mpv_shim/mpvtk_browser/config.py
 msgid ""
-"Takes effect after a restart. Move with the d-pad or left stick, A to "
-"select, B to go back, shoulder buttons to page, Start for the menu. A "
-"controller is not focus-aware, so it will reach this app even when another "
-"window is in front. Needs an mpv built with SDL2 gamepad support; if yours "
-"lacks it this setting is ignored and the log says so."
+"Takes effect after a restart. Move with the d-pad or left stick, seek with "
+"the right stick, shoulder buttons to page, Start for the menu. A controller "
+"is not focus-aware, so it will reach this app even when another window is in "
+"front. Needs an mpv built with SDL2 gamepad support; if yours lacks it this "
+"setting is ignored and the log says so. Any button can be reassigned in your "
+"input.conf."
+msgstr ""
+
+#: jellyfin_mpv_shim/mpvtk_browser/config.py
+msgid ""
+"Turn this on for a controller whose A button is on the right rather than at "
+"the bottom (Switch Pro, most 8BitDo pads). Applies immediately."
 msgstr ""
 
 #: jellyfin_mpv_shim/mpvtk_browser/config.py

--- a/jellyfin_mpv_shim/mpv_options.py
+++ b/jellyfin_mpv_shim/mpv_options.py
@@ -251,6 +251,27 @@ def mpv_binary_location():
 OSC_OPTION = "osc"
 
 
+#: The option mpv only registers when it was built with SDL2 gamepad support.
+#:
+#: `sdl2-gamepad` is `value: 'disabled'` in mpv's own `meson.options` -- not
+#: `auto` -- so having SDL2 installed is not enough and most builds simply do
+#: not have this. Debian's does; shinchiro's Windows builds pass
+#: `-Dsdl2-gamepad=enabled` explicitly, so the mpv-2.dll CI ships does too.
+#:
+#: Like `OSC_OPTION`, an mpv without it does not ignore the flag -- it refuses
+#: to start -- so `_construct_mpv` drops it and remembers. Only ever present
+#: when the user asked for it, so nobody who leaves the setting alone can be
+#: affected by any of this.
+#:
+#: It must be set at construction. mpv reads `use_gamepad` exactly once, in
+#: `mp_input_load_config` (input/input.c) called once from player/main.c, and
+#: `load-config-file` does not re-read it -- but the option group carries
+#: UPDATE_INPUT, so a runtime write *succeeds and reads back yes* while the
+#: SDL thread is never started. Measured; the setting would look applied and
+#: do nothing.
+GAMEPAD_OPTION = "input_gamepad"
+
+
 #: What each ``motion_interpolation`` value writes, as mpv property names.
 #:
 #: All three ON values set ``video-sync`` as well, and that is not
@@ -467,5 +488,10 @@ def build_mpv_options(osc_style, scripts, ext_mpv, browser_wants_window):
     if sys.platform not in ("win32", "darwin"):
         mpv_options["x11_name"] = DESKTOP_ID
         mpv_options["wayland_app_id"] = DESKTOP_ID
+
+    # Game controllers. Only added when asked for, so the default path never
+    # carries a build-gated option and can never pay for one.
+    if settings.input_gamepad:
+        mpv_options[GAMEPAD_OPTION] = True
 
     return mpv_options

--- a/jellyfin_mpv_shim/mpv_shim.py
+++ b/jellyfin_mpv_shim/mpv_shim.py
@@ -120,6 +120,57 @@ def _claim_sigterm(halt):
                           exc_info=True)
 
 
+def _use_spawn_start_method():
+    """Force 'spawn' for the tray child, whatever already resolved a context.
+
+    - macOS: avoids Objective-C fork crashes with GUI frameworks (3.14's
+      'forkserver' also crashes with Obj-C, issue #473).
+    - Linux/Windows: the child is started *after* the timeline/action/sync
+      worker threads, so a plain fork can inherit a held lock (e.g. logging)
+      and deadlock the child. 'spawn' gives a clean interpreter; the child
+      relies only on its IPC-supplied options, not on inherited globals.
+
+    **``force=True``, because without it this call did nothing when launched
+    from ``run.py``.** ``set_start_method`` raises rather than overriding a
+    context that is already resolved -- and a context resolves on the first
+    *read*, not only on a set. ``run.py`` calls ``multiprocessing.freeze_
+    support()`` before ``main``, whose first line is ``self.get_start_
+    method()``, which materialises the platform default. So on Linux the
+    context was pinned to **fork** before this ran, the ``RuntimeError`` was
+    swallowed as "already set" -- which read as "somebody set it to what we
+    wanted" and was the opposite -- and every tray child was forked. The
+    installed console script has no ``freeze_support`` call and did spawn, so
+    this was a from-source and frozen-Windows-build bug only.
+
+    What that cost is not theoretical: a forked child inherits the parent's
+    signal handlers, so it took a copy of `_claim_sigterm`'s SIGTERM handler
+    -- which sets an `Event` that, in the child, nothing waits on. Every
+    ``TrayManager.stop()`` (a ``terminate()``, i.e. a SIGTERM) was therefore
+    swallowed, and the tray process outlived the app that started it and had
+    to be SIGKILLed. `tray._reset_inherited_signals` and the escalation in
+    ``TrayManager.stop`` are the layers under this.
+
+    Reported rather than merely attempted: a start method that is not spawn
+    is a real hazard on every platform, and the failure is silent.
+    """
+    try:
+        multiprocessing.set_start_method("spawn", force=True)
+    except (RuntimeError, ValueError):
+        # A platform without a spawn context. Nothing here is required for
+        # correct operation; the tray child is simply started the other way.
+        root_logger.debug("Could not select the spawn start method.",
+                          exc_info=True)
+    # allow_none=False: if the set above failed, the default is what the
+    # children will actually be started with, and naming it is the point.
+    actual = multiprocessing.get_start_method()
+    if actual != "spawn":
+        root_logger.warning(
+            "Child processes will be started with the %r method, not "
+            "'spawn'. They inherit this process's signal handlers and "
+            "locks, which can leave the system tray process behind on "
+            "the way out.", actual)
+
+
 def main():
     args = get_args()
 
@@ -190,19 +241,7 @@ def main():
 
     enable_manual_dumps()
 
-    try:
-        # Use 'spawn' for the tray/browser child processes on every platform.
-        # - macOS: avoids Objective-C fork crashes with GUI frameworks
-        #   (3.14's 'forkserver' also crashes with Obj-C, issue #473).
-        # - Linux/Windows: these children are forked *after* the timeline/action/
-        #   sync worker threads start, so a plain fork can inherit a held lock
-        #   (e.g. logging) and deadlock the child. 'spawn' gives a clean
-        #   interpreter; the children already rely only on their IPC-supplied
-        #   options, not inherited globals, so this is safe.
-        multiprocessing.set_start_method("spawn")
-    except RuntimeError:
-        # Context already set, ignore
-        pass
+    _use_spawn_start_method()
 
     from .single_instance import SingleInstance
 

--- a/jellyfin_mpv_shim/mpv_shim.py
+++ b/jellyfin_mpv_shim/mpv_shim.py
@@ -4,6 +4,7 @@ import hashlib
 import logging
 import os
 import platform
+import signal
 import sys
 import multiprocessing
 from threading import Event
@@ -50,6 +51,73 @@ def scratch_namespace():
                       os.path.abspath(conffile.confdir(APP_NAME)))
     digest = hashlib.sha1(key.encode("utf-8", "replace")).hexdigest()
     return "%s.%s" % (APP_NAME, digest[:8])
+
+
+def _claim_sigterm(halt):
+    """Make SIGTERM run the orderly shutdown, and take the signal before SDL
+    can.
+
+    Two things at once, and the second is why this is here rather than in the
+    player.
+
+    **SIGTERM had no handler at all**, so `kill` skipped the whole shutdown
+    sequence: no final progress report (the server goes on showing the
+    session as playing until the websocket times out), no window geometry
+    saved, no credentials flushed. `jellyfin-mpv-shim stop` has always been
+    the orderly path -- it goes through the instance lock, not a signal --
+    but `kill` is what a person reaches for, and systemd and a session logout
+    both send exactly this.
+
+    **And claiming it is what keeps it.** SDL installs its own SIGINT/SIGTERM
+    handlers when mpv's gamepad support initialises, but
+    ``SDL_AddSignalHandler`` only replaces a handler that is still
+    ``SIG_DFL`` -- which is precisely why standalone mpv is unaffected (it
+    installs its own first) and we were not. CPython claims SIGINT and leaves
+    SIGTERM at the default, so SDL took it, turned it into an ``SDL_QUIT``,
+    and mpv's gamepad loop -- which handles controller events and nothing
+    else -- dropped it. The app could not be stopped by anything short of
+    SIGKILL.
+
+    Measured, gamepad on, with ``SDL_NO_SIGNAL_HANDLERS`` deliberately NOT
+    set, so this is the handler doing the work and not the environment:
+
+        no handler installed -> SIGTERM never arrives
+        this                 -> handler runs, shutdown proceeds
+
+    So it is a fix that does not depend on a ``putenv`` in this interpreter
+    being visible to a ``getenv`` inside SDL2 -- which is certain on glibc
+    and was never verified on Windows. The environment variable survives for
+    the *child* mpv of the external backend, which has no handler of its own;
+    see ``player._disarm_sdl_signal_handlers``.
+
+    Installed here rather than beside the mpv construction because ordering
+    is the whole point: it has to be in place before SDL initialises, and
+    `playerManager` is a module-level singleton whose import creates mpv. The
+    imports that reach it are all below this line. The main thread is also
+    the only thread `signal.signal` may be called from, and this is it.
+
+    Sets the event the run loop waits on rather than exiting: everything that
+    makes a shutdown orderly happens in `main`'s `finally`, and
+    `exit_watchdog` is already armed there to force the exit if a step wedges.
+    """
+    def on_sigterm(signum, frame):
+        # No logging from inside a signal handler -- it can land while the
+        # logging lock is held on another thread, and a deadlock here is a
+        # process that cannot be stopped, which is the bug being fixed.
+        halt.set()
+
+    try:
+        signal.signal(signal.SIGTERM, on_sigterm)
+    except (ValueError, OSError, AttributeError):
+        # Not the main thread, or a platform without SIGTERM. Nothing here is
+        # required for correct operation on a machine that never sends one.
+        #
+        # `root_logger`, not `log`: that name is a LOCAL inside main(), and
+        # reaching for it here raised NameError on exactly the platforms this
+        # branch exists to tolerate -- i.e. the handler failing to install
+        # would have taken startup down with it.
+        root_logger.debug("Could not install a SIGTERM handler.",
+                          exc_info=True)
 
 
 def main():
@@ -171,6 +239,7 @@ def main():
     # startup is honoured rather than acknowledged and dropped.
     halt = Event()
     single.on_stop = halt.set
+    _claim_sigterm(halt)
 
     # Give this configuration's scratch caches their own directory, and with
     # it the right to reclaim everything already in it: anything else in

--- a/jellyfin_mpv_shim/mpvtk/app.py
+++ b/jellyfin_mpv_shim/mpvtk/app.py
@@ -305,6 +305,17 @@ class MpvtkApp:
         # to it. Runs on the loop thread.
         self.on_key = None
         self._claimed_keys = ()
+        # Game controller, both called on the loop thread. The pad's UI
+        # buttons are NOT routed here -- they are synthetic keypresses the
+        # renderer issues locally, so a d-pad held down does not queue a
+        # round trip per repeat. These two are the ones a keypress cannot
+        # express: `on_gamepad_seek` with a "up"/"down"/"left"/"right"
+        # direction (the arrows' seek, which is the user's input.conf
+        # distance and has to be SyncPlay-aware), and `on_gamepad_nav` with
+        # a remote-control action name for a button whose meaning differs
+        # between the library and a playing video. See gamepad.py.
+        self.on_gamepad_seek = None
+        self.on_gamepad_nav = None
         # called with no arguments immediately after a scene has been PUSHED
         # to the renderer. Runs on the loop thread.
         #
@@ -446,6 +457,29 @@ class MpvtkApp:
             json.dumps({"s": scaling.scale(),
                         "t": theme.text_factor(),
                         "m": theme.min_size()})
+        )
+
+    def push_gamepad(self):
+        """Forward the game controller binding table to the renderer.
+
+        Sent on ready and again whenever the button layout setting changes,
+        which is what lets a swap apply without a restart -- unlike
+        ``input_gamepad`` itself, which mpv reads once at startup.
+
+        Pushed unconditionally, not gated on ``input_gamepad``. The bindings
+        are inert without it (mpv delivers no GAMEPAD_* events at all), and
+        gating would add a state to get wrong for no gain: a user who turns
+        the setting on still has to restart before anything arrives, so
+        there is nothing the gate could make correct that the restart does
+        not already.
+        """
+        from ..conf import settings
+        from ..gamepad import bindings
+
+        self.backend.command(
+            "script-message", "mpvtk-gamepad",
+            json.dumps(bindings(
+                bool(getattr(settings, "gamepad_swap_confirm", False))))
         )
 
     def push_scroll_config(self):
@@ -660,6 +694,7 @@ class MpvtkApp:
                 self.push_theme()
                 self.push_scale()
                 self.push_scroll_config()
+                self.push_gamepad()
                 self.ready.set()
             return
         if t == "debug_state":
@@ -694,6 +729,20 @@ class MpvtkApp:
                     self.on_hud_skip()
                 except Exception:
                     log.exception("on_hud_skip handler failed")
+            return
+        if t == "gpseek":
+            if self.on_gamepad_seek is not None:
+                try:
+                    self.on_gamepad_seek(evt.get("dir") or "")
+                except Exception:
+                    log.exception("on_gamepad_seek handler failed")
+            return
+        if t == "gpnav":
+            if self.on_gamepad_nav is not None:
+                try:
+                    self.on_gamepad_nav(evt.get("a") or "")
+                except Exception:
+                    log.exception("on_gamepad_nav handler failed")
             return
         if t == "key":
             if self.on_key is not None:

--- a/jellyfin_mpv_shim/mpvtk/layout.py
+++ b/jellyfin_mpv_shim/mpvtk/layout.py
@@ -521,6 +521,8 @@ def _base(el, t, x, y, w, h, sc, path):
         node["af"] = True
     if getattr(el, "disabled", False):
         node["dis"] = True
+    if getattr(el, "nav_gravity", False):
+        node["grav"] = True
     return node
 
 

--- a/jellyfin_mpv_shim/mpvtk/renderer.lua
+++ b/jellyfin_mpv_shim/mpvtk/renderer.lua
@@ -4149,6 +4149,18 @@ local function nav_pick_row(cur, cands, dy, filter)
     if not nearest then return nil end
     local _, nyy = eff(nearest)
     local best, score
+    -- A node in the row may declare `grav` -- "this is the one an arrow
+    -- arriving here meant". Tracked separately and preferred outright,
+    -- because the alternative (a distance bonus) is a number that is
+    -- right at one window width and wrong at another, which is the very
+    -- thing this fixes: coming DOWN off the full-width seek bar, nearest
+    -- to the middle is whichever transport button the current width
+    -- happens to have centred. Ties among several fall back to distance.
+    --
+    -- Vertical only, by construction: this function IS the vertical case.
+    -- Horizontal navigation steps ALONG a row, and a control with gravity
+    -- there could never be stepped past.
+    local gbest, gscore
     for _, c in ipairs(cands) do
         if c.id ~= cur.id and (filter == nil or filter(c)) then
             local ok = beyond(c)
@@ -4157,10 +4169,13 @@ local function nav_pick_row(cur, cands, dy, filter)
             if ok and ey < nyy + nearest.h and nyy < ey + c.h then
                 local s = math.abs(ex + c.w / 2 - cx)
                 if score == nil or s < score then best, score = c, s end
+                if c.grav and (gscore == nil or s < gscore) then
+                    gbest, gscore = c, s
+                end
             end
         end
     end
-    return best
+    return gbest or best
 end
 
 -- One entry point: row-based for vertical, overlap-confined for
@@ -4363,7 +4378,20 @@ local function nav_activate()
         state.dd_scroll = dd_state(node).sel or 0
         request_render()
     elseif node.t == 'slider' then
-        if state.nav_adjust then
+        if state.nav_adjust and node.aadj and not state.nav_scrubbed then
+            -- **An always-adjust bar is live the moment it is focused**,
+            -- so "in adjust mode" does not mean a gesture is in flight --
+            -- `nav_scrubbed` is what means that. With nothing pending,
+            -- committing seeks to the position playback is already at: a
+            -- round trip, and on a transcode a restart, to arrive where
+            -- you were. Select on an untouched seek bar means play/pause,
+            -- which is what it means everywhere else on a player and what
+            -- a ten-foot UI does with it.
+            --
+            -- pause_now rather than `cycle pause`, because in a SyncPlay
+            -- group a local pause is not a pause -- see its definition.
+            state.pause_now()
+        elseif state.nav_adjust then
             -- commit BEFORE dropping adjust mode: sl_state treats a
             -- scrubbing slider as busy, so clearing first would let
             -- force=true snap the value back to the scene position
@@ -4580,35 +4608,6 @@ local NAV_KEYS = {
     { 'HOME', function() if not keyclaim.take('HOME') then key_scroll('HOME') end end },
     { 'END', function() if not keyclaim.take('END') then key_scroll('END') end end },
 
-    -- Game controller. Aliases, not a second input model: each one runs the
-    -- handler its keyboard equivalent runs and claims under the keyboard
-    -- name, so a page that claimed 'UP' gets the d-pad too and nothing has
-    -- to learn about controllers.
-    --
-    -- Bound unconditionally, and that is safe: the GAMEPAD_* names live in
-    -- mpv's keycode table whether or not SDL2 gamepad support was compiled
-    -- in, so on a build without it these resolve and simply never fire.
-    -- Whether events arrive at all is `--input-gamepad`, which the shim only
-    -- sets when the user asks (mpv_options.GAMEPAD_OPTION).
-    --
-    -- ACTION_DOWN is A/cross and ACTION_RIGHT is B/circle -- mpv names them
-    -- by position, so this is the same physical pair on every pad. B routes
-    -- through a synthetic ESC for the reason the mouse back button does:
-    -- ESC already steps out exactly one layer, and a second implementation
-    -- of that ladder would drift from it.
-    { 'GAMEPAD_DPAD_UP', function() if not keyclaim.take('UP') then nav_move(0, -1) end end },
-    { 'GAMEPAD_DPAD_DOWN', function() if not keyclaim.take('DOWN') then nav_move(0, 1) end end },
-    { 'GAMEPAD_DPAD_LEFT', function() if not keyclaim.take('LEFT') then nav_move(-1, 0) end end },
-    { 'GAMEPAD_DPAD_RIGHT', function() if not keyclaim.take('RIGHT') then nav_move(1, 0) end end },
-    { 'GAMEPAD_LEFT_STICK_UP', function() if not keyclaim.take('UP') then nav_move(0, -1) end end },
-    { 'GAMEPAD_LEFT_STICK_DOWN', function() if not keyclaim.take('DOWN') then nav_move(0, 1) end end },
-    { 'GAMEPAD_LEFT_STICK_LEFT', function() if not keyclaim.take('LEFT') then nav_move(-1, 0) end end },
-    { 'GAMEPAD_LEFT_STICK_RIGHT', function() if not keyclaim.take('RIGHT') then nav_move(1, 0) end end },
-    { 'GAMEPAD_ACTION_DOWN', function() if not keyclaim.take('ENTER') then nav_activate() end end },
-    { 'GAMEPAD_ACTION_RIGHT', function() mp.commandv('keypress', 'ESC') end },
-    { 'GAMEPAD_START', function() nav_context() end },
-    { 'GAMEPAD_LEFT_SHOULDER', function() if not keyclaim.take('PGUP') then key_scroll('PGUP') end end },
-    { 'GAMEPAD_RIGHT_SHOULDER', function() if not keyclaim.take('PGDWN') then key_scroll('PGDWN') end end },
 }
 
 -- Every key in NAV_KEYS is already force-bound, so claiming one only changes
@@ -5797,7 +5796,100 @@ end)
 -- Move*/Select here because keypresses would hit mpv defaults (only
 -- the configured wake key is grabbed). 'select' = wake + pause/play,
 -- anything else = plain wake.
-mp.register_script_message('mpvtk-hud-summon', function(kind)
+-- Game controller bindings, pushed by Python (gamepad.py) and re-pushed
+-- when the layout setting changes, so swapping the face buttons takes
+-- effect without a restart.
+--
+-- **Bound here rather than in NAV_KEYS**, which is where they started and
+-- where they were wrong: those bindings are torn down by `ui_suspend` the
+-- moment a video starts, because playback wants the arrows back. The
+-- controller does not share that problem -- it has a whole second stick --
+-- so it must not share the teardown, and the first version of this went
+-- completely dead the moment anything played.
+--
+-- **add_key_binding, NOT add_forced_key_binding**: a non-forced binding is
+-- one the user's own input.conf overrides just by naming the key, which is
+-- the whole remapping story and costs nothing to provide. Forced bindings
+-- would have to be disabled before a remap could be written.
+--
+-- Safe to bind on a build with no SDL2 gamepad support: the GAMEPAD_* names
+-- live in mpv's keycode table either way, so these resolve and simply never
+-- fire. Whether events arrive at all is `--input-gamepad`, which the shim
+-- only passes when the user asks for it.
+mp.register_script_message('mpvtk-gamepad', function(json)
+    local list = utils.parse_json(json) or {}
+    -- The keys that WAKE a hidden playback HUD instead of being delivered.
+    -- Same set the remote's Move*/Select summon path uses, and the same
+    -- reason: with hud_grab_keys off (the default) only the wake key is
+    -- bound during playback, so a keypress here would fall through to
+    -- mpv's own arrows and the left stick would seek. It is the RIGHT
+    -- stick that seeks; the left one drives the UI in every mode, which is
+    -- the whole point of there being two.
+    local wake = { UP = true, DOWN = true, LEFT = true, RIGHT = true,
+                   ENTER = true }
+    for key in pairs(state.gp_bound or {}) do
+        mp.remove_key_binding('mpvtk_gp_' .. key)
+    end
+    state.gp_bound = {}
+    state.gp_last = {}
+    for _, b in ipairs(list) do
+        local key, kind, arg = b[1], b[2], b[3]
+        local rate = tonumber(b[4]) or 0
+        if type(key) == 'string' and type(kind) == 'string'
+            and type(arg) == 'string' then
+            state.gp_bound[key] = true
+            mp.add_key_binding(key, 'mpvtk_gp_' .. key, function(e)
+                -- `complex`, so an auto-repeat is distinguishable from a
+                -- press and a release does nothing. Held controls are
+                -- thinned to `rate` because mpv repeats at
+                -- --input-ar-rate, 40 a second, which on a stick is forty
+                -- library rows a second and unaimable.
+                if type(e) == 'table' and e.event == 'up' then return end
+                if rate > 0 then
+                    -- Every event, not just the ones marked 'repeat': an
+                    -- analog axis resting near its threshold chatters
+                    -- across it, and each crossing arrives as a fresh
+                    -- press. A first press after a pause is always
+                    -- through, because the gap is what is measured.
+                    local now = mp.get_time()
+                    if now - (state.gp_last[key] or -1e9) < rate then
+                        return
+                    end
+                    state.gp_last[key] = now
+                end
+                if kind == 'seek' then
+                    -- Python's kb_seek: the distance out of the user's own
+                    -- input.conf, use_web_seek applied, and a seek the
+                    -- SyncPlay group hears about. A `seek 5` from here
+                    -- would be none of those.
+                    send({ t = 'gpseek', dir = arg })
+                elseif kind == 'nav' then
+                    send({ t = 'gpnav', a = arg })
+                elseif wake[arg] and state.phud.mode
+                    and not state.phud.shown then
+                    state.phud_wake(arg == 'ENTER' and 'select' or 'nav')
+                else
+                    -- Whatever is bound to this key RIGHT NOW answers: the
+                    -- browser's spatial nav while the library is up, the
+                    -- summoned HUD's, a page's own claim, mpv's default
+                    -- when nothing else wants it.
+                    mp.commandv('keypress', arg)
+                end
+            end, { repeatable = rate > 0, complex = true })
+        end
+    end
+end)
+
+-- What Select or a direction means while the bar is HIDDEN. One
+-- function, three callers -- the remote's mpvtk-hud-summon below, the
+-- controller's confirm and direction buttons, and the skip overlay's own
+-- ENTER binding is the keyboard's copy of the first branch.
+--
+-- A field on `state` rather than a local: this chunk is at LuaJIT's
+-- 200-local ceiling. The controller had its own copy of the middle branch
+-- and only that one, so pressing A over a showing Skip Intro button
+-- summoned the bar while the keyboard and the remote both skipped.
+state.phud_wake = function(kind)
     if not state.phud.mode or state.phud.shown then return end
     if state.phud.skip_show and kind == 'select' then
         -- overlay showing: Select accepts the skip, like local ENTER
@@ -5808,6 +5900,10 @@ mp.register_script_message('mpvtk-hud-summon', function(kind)
     else
         phud_summon('key')
     end
+end
+
+mp.register_script_message('mpvtk-hud-summon', function(kind)
+    state.phud_wake(kind)
 end)
 
 -- Skippable-segment label ('' = no segment). Pushed by the browser

--- a/jellyfin_mpv_shim/mpvtk/renderer.lua
+++ b/jellyfin_mpv_shim/mpvtk/renderer.lua
@@ -4579,6 +4579,36 @@ local NAV_KEYS = {
     { 'PGDWN', function() if not keyclaim.take('PGDWN') then key_scroll('PGDWN') end end },
     { 'HOME', function() if not keyclaim.take('HOME') then key_scroll('HOME') end end },
     { 'END', function() if not keyclaim.take('END') then key_scroll('END') end end },
+
+    -- Game controller. Aliases, not a second input model: each one runs the
+    -- handler its keyboard equivalent runs and claims under the keyboard
+    -- name, so a page that claimed 'UP' gets the d-pad too and nothing has
+    -- to learn about controllers.
+    --
+    -- Bound unconditionally, and that is safe: the GAMEPAD_* names live in
+    -- mpv's keycode table whether or not SDL2 gamepad support was compiled
+    -- in, so on a build without it these resolve and simply never fire.
+    -- Whether events arrive at all is `--input-gamepad`, which the shim only
+    -- sets when the user asks (mpv_options.GAMEPAD_OPTION).
+    --
+    -- ACTION_DOWN is A/cross and ACTION_RIGHT is B/circle -- mpv names them
+    -- by position, so this is the same physical pair on every pad. B routes
+    -- through a synthetic ESC for the reason the mouse back button does:
+    -- ESC already steps out exactly one layer, and a second implementation
+    -- of that ladder would drift from it.
+    { 'GAMEPAD_DPAD_UP', function() if not keyclaim.take('UP') then nav_move(0, -1) end end },
+    { 'GAMEPAD_DPAD_DOWN', function() if not keyclaim.take('DOWN') then nav_move(0, 1) end end },
+    { 'GAMEPAD_DPAD_LEFT', function() if not keyclaim.take('LEFT') then nav_move(-1, 0) end end },
+    { 'GAMEPAD_DPAD_RIGHT', function() if not keyclaim.take('RIGHT') then nav_move(1, 0) end end },
+    { 'GAMEPAD_LEFT_STICK_UP', function() if not keyclaim.take('UP') then nav_move(0, -1) end end },
+    { 'GAMEPAD_LEFT_STICK_DOWN', function() if not keyclaim.take('DOWN') then nav_move(0, 1) end end },
+    { 'GAMEPAD_LEFT_STICK_LEFT', function() if not keyclaim.take('LEFT') then nav_move(-1, 0) end end },
+    { 'GAMEPAD_LEFT_STICK_RIGHT', function() if not keyclaim.take('RIGHT') then nav_move(1, 0) end end },
+    { 'GAMEPAD_ACTION_DOWN', function() if not keyclaim.take('ENTER') then nav_activate() end end },
+    { 'GAMEPAD_ACTION_RIGHT', function() mp.commandv('keypress', 'ESC') end },
+    { 'GAMEPAD_START', function() nav_context() end },
+    { 'GAMEPAD_LEFT_SHOULDER', function() if not keyclaim.take('PGUP') then key_scroll('PGUP') end end },
+    { 'GAMEPAD_RIGHT_SHOULDER', function() if not keyclaim.take('PGDWN') then key_scroll('PGDWN') end end },
 }
 
 -- Every key in NAV_KEYS is already force-bound, so claiming one only changes

--- a/jellyfin_mpv_shim/mpvtk/renderer.lua
+++ b/jellyfin_mpv_shim/mpvtk/renderer.lua
@@ -5868,6 +5868,21 @@ mp.register_script_message('mpvtk-gamepad', function(json)
                 elseif wake[arg] and state.phud.mode
                     and not state.phud.shown then
                     state.phud_wake(arg == 'ENTER' and 'select' or 'nav')
+                elseif wake[arg] and state.phud.mode
+                    and not state.phud.kbd then
+                    -- The bar is UP but the MOUSE owns it: a pointer
+                    -- summon with hud_grab_keys off (the default) leaves
+                    -- the arrows to mpv deliberately, so `shown` is not
+                    -- the same question as "does the UI hold the keys".
+                    -- Asking only `shown` sent the left stick straight to
+                    -- mpv's own arrows -- i.e. seeking, over a visible HUD
+                    -- with no focus ring on it, which is the exact thing
+                    -- the wake set above exists to prevent.
+                    --
+                    -- Same function the keyboard's own wake binding uses
+                    -- in this state, so confirm and the directions behave
+                    -- here as ENTER and the arrows do.
+                    phud_kbd_take()
                 else
                     -- Whatever is bound to this key RIGHT NOW answers: the
                     -- browser's spatial nav while the library is up, the

--- a/jellyfin_mpv_shim/mpvtk/widgets.py
+++ b/jellyfin_mpv_shim/mpvtk/widgets.py
@@ -29,7 +29,7 @@ class Element:
     def __init__(self, id=None, w=None, h=None, flex=0,
                  anchor=None, dx=0, dy=0, occlude=False, tip=None,
                  min_w=None, max_w=None, min_h=None, max_h=None,
-                 autofocus=False, disabled=False):
+                 autofocus=False, disabled=False, nav_gravity=False):
         self.id = id
         self.w = w
         self.h = h
@@ -59,6 +59,20 @@ class Element:
         # colours here, because those are baked into child nodes the
         # renderer cannot recognise as parts of a control.
         self.disabled = disabled
+
+        # Where a VERTICAL arrow lands when it arrives at this node's row.
+        # Spatial navigation otherwise picks whichever control in the row
+        # is nearest the x it came from, which is right for a grid of
+        # tiles and wrong for a row of transport buttons: coming DOWN off
+        # a full-width seek bar, "nearest the middle" depends on how many
+        # optional buttons the current width happens to be drawing, so the
+        # same press lands somewhere different at different window sizes.
+        # A row may name the control the user actually meant.
+        #
+        # Vertical only. Horizontal navigation is *stepping along* a row,
+        # and a control that pulled every LEFT/RIGHT to itself could not
+        # be stepped past.
+        self.nav_gravity = nav_gravity
 
 
 class Box(Element):

--- a/jellyfin_mpv_shim/mpvtk_browser/app.py
+++ b/jellyfin_mpv_shim/mpvtk_browser/app.py
@@ -2050,6 +2050,19 @@ class MpvtkBrowser(DialogsMixin, LiveTvDialogsMixin, AuthMixin, SettingsMixin,
             app.on_forward = self._on_mouse_forward
         if hasattr(app, "on_key"):
             app.on_key = self._on_claimed_key
+        if hasattr(app, "on_gamepad_seek"):
+            # The right stick. `kb_seek` and not a distance of ours: it
+            # reads the amount off the user's own input.conf arrow binding,
+            # applies use_web_seek, and seeks in a way a SyncPlay group
+            # hears about.
+            app.on_gamepad_seek = lambda d: self._ctl(
+                lambda c: c.kb_seek(d))
+        if hasattr(app, "on_gamepad_nav"):
+            # A pad button whose meaning differs between the library and a
+            # playing video, handed to the remote control's own ladder
+            # rather than to a second copy of it.
+            app.on_gamepad_nav = lambda a: self._ctl(
+                lambda c: c.remote_action(a))
         app.on_picture_gesture = self._on_picture_gesture
         if hasattr(app, "on_scene_pushed"):
             # The strip cache's clock. Not build(): see StripStore.

--- a/jellyfin_mpv_shim/mpvtk_browser/config.py
+++ b/jellyfin_mpv_shim/mpvtk_browser/config.py
@@ -98,6 +98,15 @@ TAB_SECTIONS = {
         (_("This Device"), ["player_name", "raise_mpv",
                             "discord_presence",
                             "check_updates", "notify_updates"]),
+        # A controller drives the *library* as much as playback -- it is the
+        # couch input for the whole app, not a player control -- so it sits
+        # here rather than under Player Controls on the playback tab.
+        #
+        # `media_keys` deliberately stays uncurated: it is not what most
+        # people are looking for, and on Linux desktops that route media
+        # keys through MPRIS it is likely broken anyway. Promoting it would
+        # be offering a switch we cannot say works.
+        (_("Input"), ["input_gamepad"]),
         # Everything about the window itself, in the order you meet it:
         # how it opens, whether it remembers, what closing it means.
         (_("Window"), ["fullscreen", "browser_fullscreen",
@@ -375,6 +384,7 @@ LABELED_ENUMS = {
 }
 
 LABEL_OVERRIDES = {
+    "input_gamepad": _("Game Controller"),
     "sync_path": _("Download Folder"),
     "prefer_downloaded": _("Prefer Downloaded Copy"),
     "mouse_click_pauses": _("Left Click Pauses Playback"),
@@ -466,6 +476,16 @@ CAST_TARGET_NOTE = _(
 # Explanatory line rendered under a setting, for the ones whose default
 # isn't self-explanatory from the label alone.
 NOTES = {
+    # Both caveats are ones a user would otherwise report as bugs: input
+    # arriving while another window is focused, and the setting appearing to
+    # do nothing at all on an mpv that cannot do it.
+    "input_gamepad": _("Takes effect after a restart. Move with the d-pad "
+                       "or left stick, A to select, B to go back, shoulder "
+                       "buttons to page, Start for the menu. A controller "
+                       "is not focus-aware, so it will reach this app even "
+                       "when another window is in front. Needs an mpv built "
+                       "with SDL2 gamepad support; if yours lacks it this "
+                       "setting is ignored and the log says so."),
     # A blank numeric field meaning "use the setting above" is not
     # guessable from a label, and these three are the ones where leaving
     # them alone is the right answer for almost everybody.

--- a/jellyfin_mpv_shim/mpvtk_browser/config.py
+++ b/jellyfin_mpv_shim/mpvtk_browser/config.py
@@ -106,7 +106,7 @@ TAB_SECTIONS = {
         # people are looking for, and on Linux desktops that route media
         # keys through MPRIS it is likely broken anyway. Promoting it would
         # be offering a switch we cannot say works.
-        (_("Input"), ["input_gamepad"]),
+        (_("Input"), ["input_gamepad", "gamepad_swap_confirm"]),
         # Everything about the window itself, in the order you meet it:
         # how it opens, whether it remembers, what closing it means.
         (_("Window"), ["fullscreen", "browser_fullscreen",
@@ -385,6 +385,7 @@ LABELED_ENUMS = {
 
 LABEL_OVERRIDES = {
     "input_gamepad": _("Game Controller"),
+    "gamepad_swap_confirm": _("Swap Confirm and Back Buttons"),
     "sync_path": _("Download Folder"),
     "prefer_downloaded": _("Prefer Downloaded Copy"),
     "mouse_click_pauses": _("Left Click Pauses Playback"),
@@ -480,12 +481,21 @@ NOTES = {
     # arriving while another window is focused, and the setting appearing to
     # do nothing at all on an mpv that cannot do it.
     "input_gamepad": _("Takes effect after a restart. Move with the d-pad "
-                       "or left stick, A to select, B to go back, shoulder "
+                       "or left stick, seek with the right stick, shoulder "
                        "buttons to page, Start for the menu. A controller "
                        "is not focus-aware, so it will reach this app even "
                        "when another window is in front. Needs an mpv built "
                        "with SDL2 gamepad support; if yours lacks it this "
-                       "setting is ignored and the log says so."),
+                       "setting is ignored and the log says so. Any button "
+                       "can be reassigned in your input.conf."),
+    # The buttons are reported by POSITION, so this is not something the
+    # shim can detect -- see gamepad.py. Worth spelling the layouts out:
+    # somebody with a Switch-style pad is looking for "my A button goes
+    # back", not for the word "swap".
+    "gamepad_swap_confirm": _("Turn this on for a controller whose A button "
+                              "is on the right rather than at the bottom "
+                              "(Switch Pro, most 8BitDo pads). Applies "
+                              "immediately."),
     # A blank numeric field meaning "use the setting above" is not
     # guessable from a label, and these three are the ones where leaving
     # them alone is the right answer for almost everybody.

--- a/jellyfin_mpv_shim/mpvtk_browser/gateway/transport.py
+++ b/jellyfin_mpv_shim/mpvtk_browser/gateway/transport.py
@@ -103,6 +103,24 @@ class TransportMixin(GatewayCore):
             pm.seek(float(secs))
         self._act(do)
 
+    def kb_seek(self, action):
+        """Seek as the keyboard's arrow ``action`` ("up"/"down"/"left"/
+        "right") would, for the game controller's right stick.
+
+        Not `seek_relative`: the distance is not ours to pick. `kb_seek`
+        reads it out of whatever the user has bound that arrow to in their
+        own input.conf, applies use_web_seek, and routes through a seek the
+        SyncPlay group is told about."""
+        self._act(lambda pm: pm.kb_seek(action))
+
+    def remote_action(self, action):
+        """Run a Jellyfin remote-control action ("menu", "home", ...).
+
+        The gateway's door onto `menu_action`, which is the one place that
+        knows a given action means different things with the library up and
+        over a playing video."""
+        self._act(lambda pm: pm.menu_action(action))
+
     def set_volume(self, pct, notify=True):
         self._act(lambda pm: pm.set_volume(float(pct), notify=notify))
 

--- a/jellyfin_mpv_shim/mpvtk_browser/hud.py
+++ b/jellyfin_mpv_shim/mpvtk_browser/hud.py
@@ -824,10 +824,11 @@ def build_hud(b, size):
 
     def tbtn(icon, node_id, cb, autofocus=False, icon_size=HUD_ICON,
              tip=None,
-             repeat=False, fg="eeeeee"):
+             repeat=False, fg="eeeeee", nav_gravity=False):
         return Button("", id=node_id, icon=icon, flat=True, fg=fg,
                       icon_size=sz(icon_size), autofocus=autofocus,
-                      tip=tip, repeat=repeat, on_click=cb)
+                      tip=tip, repeat=repeat, on_click=cb,
+                      nav_gravity=nav_gravity)
 
     # Scrub semantics: 'change' only moves the preview + clock; the seek
     # happens once on 'commit' (drag release / adjust-mode exit), so
@@ -878,9 +879,15 @@ def build_hud(b, size):
             "replay_10", "hud-seek-back",
             lambda: b._ctl(lambda c: c.seek_relative(-10)),
             tip=_("Back 10 Seconds"), repeat=True))
+    # DOWN off the seek bar lands here, whatever else the current width
+    # is drawing beside it. Without the gravity the arrow picks whichever
+    # button happens to sit nearest the middle, and which one that is
+    # changes with the window size as the optional chapter and seek
+    # buttons come and go -- so the same press does something different on
+    # a narrow window than on a wide one.
     controls.append(tbtn(
         pp, "hud-pp", lambda: b._ctl(lambda c: c.toggle_pause()),
-        icon_size=36))
+        icon_size=36, nav_gravity=True))
     if tiers["seek_btns"]:
         controls.append(tbtn(
             "forward_30", "hud-seek-fwd",

--- a/jellyfin_mpv_shim/mpvtk_browser/hud.py
+++ b/jellyfin_mpv_shim/mpvtk_browser/hud.py
@@ -885,9 +885,17 @@ def build_hud(b, size):
     # changes with the window size as the optional chapter and seek
     # buttons come and go -- so the same press does something different on
     # a narrow window than on a wide one.
+    #
+    # **Not on a photo**, which has no seek row at all (see `bar_rows`).
+    # Gravity is a property of arriving in this row from ABOVE, and with
+    # the bar gone the row above is the header -- so every DOWN from the
+    # close button or the SyncPlay button would jump the ring a thousand
+    # pixels left onto play/pause, and UP would not bring it back. The
+    # rationale for the gravity is the full-width seek bar; where there
+    # is no seek bar there is nothing to disambiguate.
     controls.append(tbtn(
         pp, "hud-pp", lambda: b._ctl(lambda c: c.toggle_pause()),
-        icon_size=36, nav_gravity=True))
+        icon_size=36, nav_gravity=not photo))
     if tiers["seek_btns"]:
         controls.append(tbtn(
             "forward_30", "hud-seek-fwd",

--- a/jellyfin_mpv_shim/mpvtk_browser/settings/base.py
+++ b/jellyfin_mpv_shim/mpvtk_browser/settings/base.py
@@ -74,6 +74,15 @@ class SettingsBase:
             # and seeing nothing happen.
             if self.app is not None and hasattr(self.app, "push_scroll_config"):
                 self.app.push_scroll_config()
+        if ok and key == "gamepad_swap_confirm":
+            # Applies live: the renderer just rebinds. Worth doing rather
+            # than adding it to the restart-required pile, because the
+            # setting exists for somebody who has just pressed A and gone
+            # back instead of forward -- pressing it again is how they check
+            # they picked the right switch. (`input_gamepad` beside it does
+            # need a restart; mpv reads that one once, at startup.)
+            if self.app is not None and hasattr(self.app, "push_gamepad"):
+                self.app.push_gamepad()
         if ok and key == "poster_scale":
             # Applies live, unlike the theme's own cover size below: this
             # control is *labelled* Cover Size, so watching it happen is the

--- a/jellyfin_mpv_shim/player.py
+++ b/jellyfin_mpv_shim/player.py
@@ -77,6 +77,35 @@ if settings.mpv_ext or not python_mpv_available:
     is_using_ext_mpv = True
 
 
+def _rejected_option(error):
+    """The mpv option an exception blames, as an mpv_options key, or None.
+
+    Both backends can name it, and neither does so the same way:
+
+    * **libmpv** raises ``AttributeError('mpv option does not exist', -5,
+      (handle, b'input-gamepad', b'yes'))`` -- the name is in the third arg.
+    * **python-mpv-jsonipc >= 1.3.0** raises ``MPVProcessError`` with
+      ``bad_option`` set, having asked mpv why it refused to start. Older
+      versions flattened every start failure into "MPV process retry limit
+      reached." after spending the whole budget, which is why the shim's
+      floor is 1.3.0.
+
+    Returns the *underscored* form, because that is how the option appears
+    in the dict handed to ``mpv.MPV``.
+    """
+    bad = getattr(error, "bad_option", None)
+    if isinstance(bad, str) and bad:
+        return bad.replace("-", "_")
+    args = getattr(error, "args", ())
+    if len(args) >= 3 and isinstance(args[2], tuple) and len(args[2]) >= 2:
+        name = args[2][1]
+        if isinstance(name, bytes):
+            return name.decode("utf-8", "replace").replace("-", "_")
+        if isinstance(name, str):
+            return name.replace("-", "_")
+    return None
+
+
 def _explain_missing_mpv():
     """Say why there is no mpv, before the traceback says something else.
 
@@ -496,6 +525,7 @@ class PlayerManager(AudioMixin, ReportingMixin, WindowMixin):
         self._swept_ptr = None
         #: Whether this mpv can run lua, once asked. See lua_works.
         self._lua_works = None
+        self._gamepad_works = None
         #: An OSC style a fallback forced, or None. Survives mpv
         #: re-creation -- see _init_mpv.
         self._osc_style_override = None
@@ -809,49 +839,81 @@ class PlayerManager(AudioMixin, ReportingMixin, WindowMixin):
         workaround: the OSC being turned off is itself lua, so a build
         without it has none to turn off.
         """
-        from .mpv_options import OSC_OPTION
+        from .mpv_options import GAMEPAD_OPTION, OSC_OPTION
 
-        if self._lua_works is False and OSC_OPTION in mpv_options:
-            # Already discovered, on a previous mpv. Re-learning it costs a
-            # failed construction every time, and on the external backend a
-            # failed construction is the whole start-retry budget --
-            # measured at ~31s with the shipped defaults, paid on every
-            # re-open (idle-quit then a cast, set_browse_window,
-            # force_window) before anything plays.
-            mpv_options = {k: v for k, v in mpv_options.items()
-                           if k != OSC_OPTION}
-            return mpv.MPV(**kwargs, **mpv_options)
+        options = dict(mpv_options)
 
-        try:
-            return mpv.MPV(**kwargs, **mpv_options)
-        except FileNotFoundError:
-            # There is no mpv binary to spawn. Handled ahead of the lua
-            # retry below rather than by it, for two reasons: dropping
-            # --osc cannot conjure one, so the retry only spends the
-            # start-retry budget and then reraises the same error; and the
-            # error it reraises comes from `subprocess`, which reads as
-            # "mpv is not installed" even when nobody was ever asked to
-            # install it. That is how the vulkan-1.dll regression presented
-            # -- libmpv would not load, this backend was chosen for us, and
-            # the traceback named a missing mpv.exe.
-            _explain_missing_mpv()
-            raise
-        except Exception:
-            if OSC_OPTION not in mpv_options:
+        # Already discovered, on a previous mpv. Re-learning either costs a
+        # failed construction every time, and on the external backend a
+        # failed construction used to be the whole start-retry budget --
+        # measured at ~31s with the shipped defaults, paid on every re-open
+        # (idle-quit then a cast, set_browse_window, force_window) before
+        # anything plays.
+        if self._gamepad_works is False:
+            options.pop(GAMEPAD_OPTION, None)
+        if self._lua_works is False:
+            options.pop(OSC_OPTION, None)
+
+        dropped_gamepad = False
+        dropped_osc = False
+
+        while True:
+            try:
+                player = mpv.MPV(**kwargs, **options)
+            except FileNotFoundError:
+                # There is no mpv binary to spawn. Handled ahead of the
+                # retries rather than by them, for two reasons: dropping an
+                # option cannot conjure one, so the retry only spends the
+                # start-retry budget and then reraises the same error; and
+                # the error it reraises comes from `subprocess`, which reads
+                # as "mpv is not installed" even when nobody was ever asked
+                # to install it. That is how the vulkan-1.dll regression
+                # presented -- libmpv would not load, this backend was
+                # chosen for us, and the traceback named a missing mpv.exe.
+                _explain_missing_mpv()
                 raise
-            options = {k: v for k, v in mpv_options.items()
-                       if k != OSC_OPTION}
-            # Retry first, log second. If --osc was not the problem this
-            # raises the real error (chained to the first), and saying
-            # "built without lua" on the way to an unrelated failure would
-            # send the next person reading the log somewhere else entirely.
-            player = mpv.MPV(**kwargs, **options)
-            log.warning("This mpv has no --%s option, so it was built "
-                        "without lua. The library browser, the playback HUD "
-                        "and the on-screen controls all need it; falling "
-                        "back to the command line and the OSD menu.",
-                        OSC_OPTION)
-            self._lua_works = False
+            except Exception as error:
+                # **Which** option was refused, when mpv says so. This used
+                # to rest on "there is only one option this can be", and
+                # that argument retired the moment a second build-gated
+                # option existed. Both backends can be asked -- libmpv puts
+                # the name in the exception, python-mpv-jsonipc >= 1.3.0
+                # sets `bad_option` -- so a gamepad build gate is identified
+                # rather than guessed at.
+                if (_rejected_option(error) == GAMEPAD_OPTION
+                        and GAMEPAD_OPTION in options):
+                    del options[GAMEPAD_OPTION]
+                    dropped_gamepad = True
+                    continue
+
+                # --osc is not identified by name, deliberately: an mpv
+                # built without lua is old enough that the name may not
+                # reach us, and it stays the fallback for *any*
+                # unexplained failure while it is still present. Dropped
+                # once, then a second failure is the real error.
+                if OSC_OPTION in options and not dropped_osc:
+                    del options[OSC_OPTION]
+                    dropped_osc = True
+                    continue
+                raise
+
+            # Log after success, never before. If the option was not the
+            # problem this loop has already reraised, and saying "built
+            # without lua" on the way to an unrelated failure would send the
+            # next person reading the log somewhere else entirely.
+            if dropped_gamepad:
+                log.warning("This mpv has no --%s option, so it was built "
+                            "without SDL2 gamepad support. Game controller "
+                            "input is unavailable; nothing else is "
+                            "affected.", GAMEPAD_OPTION.replace("_", "-"))
+                self._gamepad_works = False
+            if dropped_osc:
+                log.warning("This mpv has no --%s option, so it was built "
+                            "without lua. The library browser, the playback "
+                            "HUD and the on-screen controls all need it; "
+                            "falling back to the command line and the OSD "
+                            "menu.", OSC_OPTION)
+                self._lua_works = False
             return player
 
     def _init_mpv(self):

--- a/jellyfin_mpv_shim/player.py
+++ b/jellyfin_mpv_shim/player.py
@@ -168,6 +168,49 @@ def _rejected_option(error):
     return None
 
 
+def _reap_orphaned_core(error):
+    """Destroy the mpv core a failed ``mpv.MPV(...)`` left running.
+
+    libmpv only, and it is not defensive: python-mpv sets every option
+    inside a ``try`` whose ``finally`` is ``mpv_initialize`` (mpv.py 1.0.8,
+    ``MPV.__init__``), so an option this build does not have raises *after*
+    the core has been brought up. What is left behind is not a stale handle
+    -- it is a **running mpv**, with its window, its scripts and its
+    threads, owned by a half-built object nobody holds a name for. Nothing
+    stops it until the garbage collector reaches the reference cycle the
+    traceback made, and by then the retry's mpv is up: two cores, two VOs on
+    one display, and the process dies in a thread that is not Python's.
+    Measured with ``--input-gamepad`` on a libmpv without it, three runs in
+    three, and the crash lands after the retry has already logged success --
+    which is what made it read as "the retry failed".
+
+    So the orphan is reaped where it is made, not left to the collector.
+    Both the option retries below depend on this: the lua fallback creates
+    one too, and has since it shipped.
+
+    The instance is recovered from the traceback because that is the only
+    place it exists -- the constructor never returned it. It is identified
+    by holding a live handle rather than by its class: ``mpv`` here is
+    whichever backend was imported, and the external one has no core in this
+    process to reap. Read out of ``__dict__`` directly, because libmpv's
+    ``__getattr__`` turns an unknown attribute into a property read on a
+    core that is in no state to answer one.
+    """
+    tb = getattr(error, "__traceback__", None)
+    while tb is not None:
+        owner = tb.tb_frame.f_locals.get("self")
+        handle = getattr(owner, "__dict__", {}).get("handle")
+        stop = getattr(owner, "terminate", None)
+        if handle is not None and callable(stop):
+            try:
+                stop()
+            except Exception:
+                log.debug("could not stop the mpv left by a failed "
+                          "construction", exc_info=True)
+            return
+        tb = tb.tb_next
+
+
 def _explain_missing_mpv():
     """Say why there is no mpv, before the traceback says something else.
 
@@ -940,6 +983,8 @@ class PlayerManager(AudioMixin, ReportingMixin, WindowMixin):
                 _explain_missing_mpv()
                 raise
             except Exception as error:
+                _reap_orphaned_core(error)
+
                 # **Which** option was refused, when mpv says so. This used
                 # to rest on "there is only one option this can be", and
                 # that argument retired the moment a second build-gated

--- a/jellyfin_mpv_shim/player.py
+++ b/jellyfin_mpv_shim/player.py
@@ -77,6 +77,48 @@ if settings.mpv_ext or not python_mpv_available:
     is_using_ext_mpv = True
 
 
+def _disarm_sdl_signal_handlers():
+    """Stop SDL taking SIGTERM off us when gamepad input is on.
+
+    mpv's gamepad support is SDL2, and ``SDL_Init`` installs its own
+    SIGINT/SIGTERM handlers unless ``SDL_NO_SIGNAL_HANDLERS`` says not to.
+    It only replaces a handler that is still ``SIG_DFL`` -- which is why
+    **standalone mpv is unaffected and the shim is not**. mpv installs its
+    handlers before it ever starts the gamepad thread; CPython installs one
+    for SIGINT and leaves SIGTERM at the default, so with libmpv in-process
+    SDL takes SIGTERM, turns it into an ``SDL_QUIT`` event, and mpv's gamepad
+    loop -- which handles controller events and nothing else -- drops it on
+    the floor.
+
+    The result is an app that **cannot be terminated**: ``kill`` does
+    nothing, the window stays up, and SIGKILL is the only thing left. Not a
+    shutdown that hangs, so `exit_watchdog` never sees it either; the
+    shutdown is simply never asked for. Measured on this box with no
+    controller attached -- SDL initialises for hotplug, so a pad is not
+    needed to lose the signal:
+
+        input_gamepad off, SIGTERM -> exit in 0.00s
+        input_gamepad on,  SIGTERM -> ignored, still running after 8s
+        input_gamepad on + this,    -> exit in 0.00s
+
+    SIGINT survives either way (CPython has already claimed it), which is
+    what made this look like a Ctrl-C-only bug in testing.
+
+    An environment variable rather than a hint call because SDL is loaded
+    inside libmpv and there is no SDL handle to call ``SDL_SetHint`` on; SDL
+    reads ``SDL_<HINT>`` from the environment for exactly this case. Set
+    before mpv is constructed, since the gamepad thread starts during its
+    init, and left set afterwards -- mpv is re-created and the second
+    instance needs it just as much.
+
+    Harmless with an external mpv: the variable is inherited by the child,
+    where mpv's own handlers are already installed and SDL would have left
+    them alone anyway.
+    """
+    if os.environ.get("SDL_NO_SIGNAL_HANDLERS") is None:
+        os.environ["SDL_NO_SIGNAL_HANDLERS"] = "1"
+
+
 def _rejected_option(error):
     """The mpv option an exception blames, as an mpv_options key, or None.
 
@@ -853,6 +895,12 @@ class PlayerManager(AudioMixin, ReportingMixin, WindowMixin):
             options.pop(GAMEPAD_OPTION, None)
         if self._lua_works is False:
             options.pop(OSC_OPTION, None)
+
+        # After the pops, not before: an mpv already known to have no
+        # --input-gamepad will load no SDL, so there is nothing to disarm
+        # and no reason to have touched the environment.
+        if GAMEPAD_OPTION in options:
+            _disarm_sdl_signal_handlers()
 
         dropped_gamepad = False
         dropped_osc = False

--- a/jellyfin_mpv_shim/player.py
+++ b/jellyfin_mpv_shim/player.py
@@ -78,75 +78,62 @@ if settings.mpv_ext or not python_mpv_available:
 
 
 def _disarm_sdl_signal_handlers():
-    """Stop SDL taking SIGTERM off us when gamepad input is on.
+    """Keep SDL's signal handlers out of the *external* mpv's child process.
 
     mpv's gamepad support is SDL2, and ``SDL_Init`` installs its own
-    SIGINT/SIGTERM handlers unless ``SDL_NO_SIGNAL_HANDLERS`` says not to.
-    It only replaces a handler that is still ``SIG_DFL`` -- which is why
-    **standalone mpv is unaffected and the shim is not**. mpv installs its
-    handlers before it ever starts the gamepad thread; CPython installs one
-    for SIGINT and leaves SIGTERM at the default, so with libmpv in-process
-    SDL takes SIGTERM, turns it into an ``SDL_QUIT`` event, and mpv's gamepad
-    loop -- which handles controller events and nothing else -- drops it on
-    the floor.
+    SIGINT/SIGTERM handlers unless ``SDL_NO_SIGNAL_HANDLERS`` says not to. It
+    only replaces a handler still at ``SIG_DFL``, which is why standalone mpv
+    is unaffected: it installs its own first.
 
-    The result is an app that **cannot be terminated**: ``kill`` does
-    nothing, the window stays up, and SIGKILL is the only thing left. Not a
-    shutdown that hangs, so `exit_watchdog` never sees it either; the
-    shutdown is simply never asked for. Measured on this box with no
-    controller attached -- SDL initialises for hotplug, so a pad is not
-    needed to lose the signal:
+    **This process is no longer the case that needs it.**
+    ``mpv_shim._claim_sigterm`` installs a real handler before anything can
+    import the player, so SDL finds SIGTERM already taken and leaves it --
+    measured with this variable deliberately unset. That fix is preferable
+    because it does not depend on a ``putenv`` here being visible to a
+    ``getenv`` inside SDL2, which is certain on glibc and unverified on
+    Windows. This stays as the layer under it, and for the case the handler
+    cannot reach:
 
-        input_gamepad off, SIGTERM -> exit in 0.00s
-        input_gamepad on,  SIGTERM -> ignored, still running after 8s
-        input_gamepad on + this,    -> exit in 0.00s
-
-    SIGINT survives either way (CPython has already claimed it), which is
-    what made this look like a Ctrl-C-only bug in testing.
-
-    An environment variable rather than a hint call because SDL is loaded
-    inside libmpv and there is no SDL handle to call ``SDL_SetHint`` on; SDL
-    reads ``SDL_<HINT>`` from the environment for exactly this case. Set
-    before mpv is constructed, since the gamepad thread starts during its
-    init, and left set afterwards -- mpv is re-created and the second
-    instance needs it just as much.
-
-    **Needed on the external backend too**, not merely harmless there. The
-    variable is inherited by the child, and it has to be: jsonipc spawns mpv
-    with ``terminal=no``, and mpv installs its SIGTERM handler from
-    ``terminal_setup_getch`` -- which that skips. So the child's SIGTERM is
-    at ``SIG_DFL`` as well, SDL takes it, and ``MPVProcess.stop()``, which
-    is a ``terminate()``, would be swallowed.
+    **The child mpv of the external backend has no handler of its own.**
+    jsonipc spawns it with ``terminal=no``, and mpv installs its SIGTERM
+    handler from ``terminal_setup_getch``, which that path skips. So the
+    child's SIGTERM is at ``SIG_DFL``, SDL takes it, and
+    ``MPVProcess.stop()`` -- which is a ``terminate()``, i.e. a SIGTERM --
+    would be swallowed, leaving an orphaned mpv window behind. The variable
+    is inherited by the child, which is the only lever this side has.
+    (Sending mpv ``quit`` over the IPC socket instead of signalling it is the
+    better answer and belongs in python-mpv-jsonipc; until then, this.)
 
     **Called unconditionally**, not only when the shim passes the option.
-    ``input-gamepad`` is an ordinary mpv option with no ``M_OPT_NOCFG``, so
-    a line in the user's own ``mpv.conf`` starts the SDL thread with the
-    option absent from anything we built -- and that config is exactly what
+    ``input-gamepad`` is an ordinary mpv option with no ``M_OPT_NOCFG``, so a
+    line in the user's own ``mpv.conf`` starts the SDL thread with the option
+    absent from anything we built -- and that config is exactly what
     ``mpv_ext_no_ovr`` users are told to use. There is no third place to ask
     and no way to ask mpv in time (the thread starts inside
     ``mpv_initialize``), so the only correct gate is no gate. The variable
     does nothing at all in a process that loads no SDL.
 
-    The cost of that is one real side effect: ``os.environ`` is
-    process-wide, and nothing spawns children with a scrubbed environment
+    The cost of that is one real side effect: ``os.environ`` is process-wide,
+    and nothing spawns children with a scrubbed environment
     (``system_open``, the clipboard helpers, the shell-command hooks), so an
     SDL application launched from the shim inherits it and loses SDL's own
-    Ctrl-C handling. Accepted deliberately -- narrower gating buys a
-    silently unkillable app back.
+    Ctrl-C handling. Accepted deliberately -- narrower gating buys a silently
+    orphaned mpv back.
 
     A blank value counts as unset, which is SDL's own reading:
-    ``SDL_GetHintBoolean`` returns the *default* for ``""``, so preserving
-    one would leave the bug in place for anybody whose launcher exports an
-    empty variable. ``"0"`` is honoured -- somebody who wrote that wants
-    SDL's handlers, and quietly reversing them is worse than the bug -- so
-    it is logged rather than silently obeyed.
+    ``SDL_GetHintBoolean`` returns the *default* for ``""``, so preserving one
+    would leave the bug in place for anybody whose launcher exports an empty
+    variable. ``"0"`` is honoured -- somebody who wrote that wants SDL's
+    handlers -- and logged, because on the external backend it is the one
+    value that can still strand an mpv window.
     """
     if os.environ.get("SDL_NO_SIGNAL_HANDLERS"):
         if os.environ["SDL_NO_SIGNAL_HANDLERS"] not in ("1", "true", "yes"):
             log.warning(
                 "SDL_NO_SIGNAL_HANDLERS=%r in the environment, so SDL keeps "
-                "its own signal handlers. With game controller input on, "
-                "that means SIGTERM will not stop this application.",
+                "its own signal handlers. With game controller input and an "
+                "external mpv, that means this application cannot stop its "
+                "mpv process on the way out.",
                 os.environ["SDL_NO_SIGNAL_HANDLERS"])
         return
     os.environ["SDL_NO_SIGNAL_HANDLERS"] = "1"

--- a/jellyfin_mpv_shim/player.py
+++ b/jellyfin_mpv_shim/player.py
@@ -111,12 +111,45 @@ def _disarm_sdl_signal_handlers():
     init, and left set afterwards -- mpv is re-created and the second
     instance needs it just as much.
 
-    Harmless with an external mpv: the variable is inherited by the child,
-    where mpv's own handlers are already installed and SDL would have left
-    them alone anyway.
+    **Needed on the external backend too**, not merely harmless there. The
+    variable is inherited by the child, and it has to be: jsonipc spawns mpv
+    with ``terminal=no``, and mpv installs its SIGTERM handler from
+    ``terminal_setup_getch`` -- which that skips. So the child's SIGTERM is
+    at ``SIG_DFL`` as well, SDL takes it, and ``MPVProcess.stop()``, which
+    is a ``terminate()``, would be swallowed.
+
+    **Called unconditionally**, not only when the shim passes the option.
+    ``input-gamepad`` is an ordinary mpv option with no ``M_OPT_NOCFG``, so
+    a line in the user's own ``mpv.conf`` starts the SDL thread with the
+    option absent from anything we built -- and that config is exactly what
+    ``mpv_ext_no_ovr`` users are told to use. There is no third place to ask
+    and no way to ask mpv in time (the thread starts inside
+    ``mpv_initialize``), so the only correct gate is no gate. The variable
+    does nothing at all in a process that loads no SDL.
+
+    The cost of that is one real side effect: ``os.environ`` is
+    process-wide, and nothing spawns children with a scrubbed environment
+    (``system_open``, the clipboard helpers, the shell-command hooks), so an
+    SDL application launched from the shim inherits it and loses SDL's own
+    Ctrl-C handling. Accepted deliberately -- narrower gating buys a
+    silently unkillable app back.
+
+    A blank value counts as unset, which is SDL's own reading:
+    ``SDL_GetHintBoolean`` returns the *default* for ``""``, so preserving
+    one would leave the bug in place for anybody whose launcher exports an
+    empty variable. ``"0"`` is honoured -- somebody who wrote that wants
+    SDL's handlers, and quietly reversing them is worse than the bug -- so
+    it is logged rather than silently obeyed.
     """
-    if os.environ.get("SDL_NO_SIGNAL_HANDLERS") is None:
-        os.environ["SDL_NO_SIGNAL_HANDLERS"] = "1"
+    if os.environ.get("SDL_NO_SIGNAL_HANDLERS"):
+        if os.environ["SDL_NO_SIGNAL_HANDLERS"] not in ("1", "true", "yes"):
+            log.warning(
+                "SDL_NO_SIGNAL_HANDLERS=%r in the environment, so SDL keeps "
+                "its own signal handlers. With game controller input on, "
+                "that means SIGTERM will not stop this application.",
+                os.environ["SDL_NO_SIGNAL_HANDLERS"])
+        return
+    os.environ["SDL_NO_SIGNAL_HANDLERS"] = "1"
 
 
 def _rejected_option(error):
@@ -896,11 +929,10 @@ class PlayerManager(AudioMixin, ReportingMixin, WindowMixin):
         if self._lua_works is False:
             options.pop(OSC_OPTION, None)
 
-        # After the pops, not before: an mpv already known to have no
-        # --input-gamepad will load no SDL, so there is nothing to disarm
-        # and no reason to have touched the environment.
-        if GAMEPAD_OPTION in options:
-            _disarm_sdl_signal_handlers()
+        # Unconditional, and not gated on GAMEPAD_OPTION being in this
+        # dict: mpv reads `input-gamepad` from the user's own mpv.conf too,
+        # where we cannot see it. See the function.
+        _disarm_sdl_signal_handlers()
 
         dropped_gamepad = False
         dropped_osc = False

--- a/jellyfin_mpv_shim/tray.py
+++ b/jellyfin_mpv_shim/tray.py
@@ -18,6 +18,7 @@ warning and leaves the app running headless-but-functional.
 import logging
 import multiprocessing
 import os
+import signal
 import sys
 import threading
 from multiprocessing import Process, Queue
@@ -295,6 +296,38 @@ def wants_x11_backend(env):
         (env.get("XDG_SESSION_TYPE") or "").lower() == "wayland")
 
 
+def _reset_inherited_signals():
+    """Put this child's signal dispositions back to the default.
+
+    **SIGTERM** is the one that matters, and only a *forked* child has it to
+    undo. ``mpv_shim._claim_sigterm`` installs a handler that sets an
+    ``Event`` the run loop waits on; a fork copies it, and in the child that
+    ``Event`` is a private copy nothing reads -- so ``TrayManager.stop()``,
+    which is a ``terminate()``, i.e. a SIGTERM, is *received and ignored*,
+    and the tray outlives the app until somebody SIGKILLs it. The app asks
+    for ``spawn`` precisely so this cannot happen
+    (``mpv_shim._use_spawn_start_method``); this is the layer under that,
+    because the failure is a stray process and the cause is two files away.
+
+    **SIGINT** is reset in both kinds of child, and is cosmetic. Every child
+    arrives with CPython's ``default_int_handler`` (measured, fork and spawn
+    alike), so a Ctrl-C -- which the terminal sends to the whole process
+    group -- raises ``KeyboardInterrupt`` from wherever the GTK loop happens
+    to be and prints a traceback on the way out. The parent's own shutdown
+    is what stops the tray; the child just needs to go quietly.
+    """
+    for name in ("SIGTERM", "SIGINT"):
+        signum = getattr(signal, name, None)
+        if signum is None:
+            continue
+        try:
+            signal.signal(signum, signal.SIG_DFL)
+        except (ValueError, OSError, RuntimeError):
+            # Not the main thread, or a platform that will not take it.
+            log.debug("could not reset %s in the tray child", name,
+                      exc_info=True)
+
+
 class TrayProcess(Process):
     """The pystray loop. Everything it can do is "put a command name on the
     queue" — it holds no references to the player or the browser, because
@@ -309,6 +342,11 @@ class TrayProcess(Process):
         Process.__init__(self, daemon=True, name="jellyfin-mpv-shim-tray")
 
     def run(self):
+        # First, before anything can be interrupted or asked to stop: a
+        # forked child arrives holding the parent's handlers, and one of
+        # them makes SIGTERM a no-op here. See _reset_inherited_signals.
+        _reset_inherited_signals()
+
         # These variables only mean anything to GTK on Linux/BSD; pystray
         # uses native APIs on Windows and macOS, so leave the env alone.
         if sys.platform.startswith("linux") or sys.platform.startswith("freebsd"):
@@ -538,8 +576,11 @@ class TrayManager:
 
     def _pump(self):
         while not self._halt.is_set():
+            queue = self._queue
+            if queue is None:
+                return              # stop() released it; nothing left to read
             try:
-                command, param = self._queue.get(timeout=0.5)
+                command, param = queue.get(timeout=0.5)
             except Exception:
                 # Empty, or the queue died with the child. Which of those it
                 # was matters: a child that CRASHED sends nothing, and
@@ -598,11 +639,71 @@ class TrayManager:
         except Exception:
             log.error("tray handler %r failed", command, exc_info=True)
 
+    #: How long the child gets to act on the terminate() before it is
+    #: killed. Short on purpose: this runs inside the shutdown sequence,
+    #: which has its own deadline, and there is nothing the child can be
+    #: doing that is worth waiting on -- it holds no state of ours.
+    TERMINATE_GRACE = 2.0
+
     def stop(self):
+        """Terminate the tray child, and make sure it is really gone.
+
+        ``terminate()`` alone is a *request*: it is a SIGTERM, which a child
+        can be holding a handler for -- and one that was forked from this
+        process was, for exactly as long as the start method was not spawn
+        (see ``_reset_inherited_signals``). The parent then ``os._exit``s
+        from ``exit_watchdog.finish`` without reaping it, so what the user
+        is left with is a tray process with no app behind it, surviving
+        until it is SIGKILLed by hand.
+
+        So the request is checked and escalated. Both waits are bounded and
+        neither failure is fatal: a child that outlives even this is worth a
+        line in the log, not a shutdown that stalls.
+        """
         self._halt.set()
-        if self._process is not None:
-            try:
-                self._process.terminate()
-            except Exception:
-                log.debug("tray terminate failed", exc_info=True)
-            self._process = None
+        process, self._process = self._process, None
+        if process is None:
+            self._release_queue()
+            return
+        try:
+            process.terminate()
+            process.join(self.TERMINATE_GRACE)
+            if process.is_alive():
+                log.warning("The system tray process ignored SIGTERM; "
+                            "killing it.")
+                process.kill()
+                process.join(self.TERMINATE_GRACE)
+            if process.is_alive():
+                log.warning("The system tray process (pid %s) could not be "
+                            "stopped.", process.pid)
+        except Exception:
+            log.debug("tray terminate failed", exc_info=True)
+        self._release_queue()
+
+    def _release_queue(self):
+        """Drop the command queue once nothing is left to send on it.
+
+        Its POSIX semaphores are cleaned up by multiprocessing's resource
+        tracker, which then says so on stderr -- and since
+        ``exit_watchdog.finish`` leaves by ``os._exit``, that notice is the
+        last thing printed on every quit. Closing it here is what keeps the
+        end of a normal run quiet.
+
+        ``cancel_join_thread`` because the feeder is not worth waiting on:
+        anything still unsent is a command for a child that is already gone.
+
+        The pump is joined first, bounded by one poll interval: it reads
+        this queue, and closing it under a thread sitting in ``get()`` is a
+        race that costs nothing to remove.
+        """
+        thread, self._thread = self._thread, None
+        if thread is not None:
+            thread.join(1.0)
+        queue, self._queue = self._queue, None
+        if queue is None:
+            return
+        try:
+            queue.cancel_join_thread()
+            queue.close()
+        except Exception:
+            log.debug("tray queue close failed", exc_info=True)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,7 +18,7 @@ dynamic = ["version"]
 dependencies = [
     "python-mpv>=1.0.8",
     "jellyfin-apiclient-python>=1.18.0",
-    "python-mpv-jsonipc>=1.2.2",
+    "python-mpv-jsonipc>=1.3.0",
     "requests",
     # Not optional since the in-player library browser replaced the Tk one:
     # every tile, the playback HUD and the cast screen are rasterized with

--- a/tests/integration/_harness.py
+++ b/tests/integration/_harness.py
@@ -1068,6 +1068,10 @@ def build_player(player_module, video=None):
     pm._lua_works = None
     pm._lua_probe = None
     pm._osc_style_override = None
+    # ...and its sibling, the gamepad build gate. Read by _construct_mpv on
+    # the same path and for the same reason, so a missing one is not a
+    # skipped branch -- it is an AttributeError out of every mpv creation.
+    pm._gamepad_works = None
 
     # Picture processing. Both are read BEFORE they are written -- the
     # deinterlace override on every load, the saved video-sync the first

--- a/tests/integration/test_mpvtk_hud.py
+++ b/tests/integration/test_mpvtk_hud.py
@@ -247,16 +247,18 @@ class TestPlaybackHudLifecycle(h.TmpDirTest):
         self.assertTrue(st.get("active"))
         self.assertIn("refresh", self.ctl.calls)
 
-        # --- DOWN steps off the bar into the transport row (spatial
-        # nav picks the nearest control below); LEFT walks to
-        # play/pause and ENTER activates it
+        # --- DOWN steps off the bar and lands ON play/pause, then
+        # ENTER activates it.
+        #
+        # On it, not merely somewhere in the transport row: the button
+        # declares nav_gravity, so the arrow no longer depends on which
+        # control happens to sit nearest the middle -- which moved with
+        # the window width, because the chapter and seek buttons come and
+        # go with it. This used to press LEFT until it arrived, which is
+        # what a user had to do too.
         self._press_until(
-            "DOWN", lambda: self._state().get("nav")
-            not in (None, "hud-seek"),
-            msg="DOWN never moved focus off the seek bar")
-        self._press_until(
-            "LEFT", lambda: self._state().get("nav") == "hud-pp",
-            msg="LEFT never reached play/pause: %r"
+            "DOWN", lambda: self._state().get("nav") == "hud-pp",
+            msg="DOWN off the seek bar did not land on play/pause: %r"
             % self._state().get("nav"))
         self._press_until(
             "ENTER", lambda: "toggle_pause" in self.ctl.calls,

--- a/tests/integration/test_mpvtk_hud.py
+++ b/tests/integration/test_mpvtk_hud.py
@@ -256,10 +256,19 @@ class TestPlaybackHudLifecycle(h.TmpDirTest):
         # the window width, because the chapter and seek buttons come and
         # go with it. This used to press LEFT until it arrived, which is
         # what a user had to do too.
+        # ONE press, then wait. `_press_until` is the wrong instrument for
+        # a which-node claim: it presses again every 0.6s for six seconds,
+        # so without the gravity a later DOWN can walk out of the row and
+        # `nav_wrap` can bring focus back around to play/pause anyway --
+        # which would weaken "lands on play/pause" to "is reachable by
+        # mashing DOWN". The bind race `_press_until` exists for was
+        # already waited out by the seek-bar focus check above.
         self._press_until(
-            "DOWN", lambda: self._state().get("nav") == "hud-pp",
-            msg="DOWN off the seek bar did not land on play/pause: %r"
-            % self._state().get("nav"))
+            "DOWN", lambda: self._state().get("nav") != "hud-seek",
+            msg="DOWN never moved focus off the seek bar")
+        self.assertEqual(
+            self._state().get("nav"), "hud-pp",
+            "DOWN off the seek bar did not land on play/pause")
         self._press_until(
             "ENTER", lambda: "toggle_pause" in self.ctl.calls,
             msg="ENTER on play/pause never reached the controller")

--- a/tests/lua/fake_mp.lua
+++ b/tests/lua/fake_mp.lua
@@ -17,6 +17,8 @@ M.log = {
     props = {},         -- set_property_native by name
     timers = {},        -- live timers, so a test can fire them
     keybinds = {},
+    forced = {},       -- keybind name -> was it add_FORCED_key_binding?
+    keyopts = {},      -- keybind name -> the flags table it was bound with
     sections = {},      -- set_key_bindings group name -> {key = true}
     enabled = {},       -- section name -> enable_key_bindings state
     section_flags = {}, -- section name -> the flags it was enabled with
@@ -241,15 +243,28 @@ end
 function mp.register_script_message(name, fn) msg_handlers[name] = fn end
 function mp.unregister_script_message(name) msg_handlers[name] = nil end
 
+-- Forced-ness is recorded, not just the handler. It is the whole
+-- difference between a binding the user's own input.conf can override by
+-- naming the key and one they cannot touch without disabling it first --
+-- and with both functions writing the same row, "these are remappable" was
+-- a claim no test could see, let alone fail on.
 function mp.add_key_binding(key, name, fn, opts)
     M.log.keybinds[name or key] = fn
+    M.log.forced[name or key] = false
+    M.log.keyopts[name or key] = opts or {}
 end
 
 function mp.add_forced_key_binding(key, name, fn, opts)
     M.log.keybinds[name or key] = fn
+    M.log.forced[name or key] = true
+    M.log.keyopts[name or key] = opts or {}
 end
 
-function mp.remove_key_binding(name) M.log.keybinds[name] = nil end
+function mp.remove_key_binding(name)
+    M.log.keybinds[name] = nil
+    M.log.forced[name] = nil
+    M.log.keyopts[name] = nil
+end
 -- Whether a section is enabled cannot model mpv's section STACK, but it can
 -- model the flag, which is what a "this group was never turned on" bug looks
 -- like. M.log.enabled[name] is nil until someone enables or disables it.

--- a/tests/lua/fake_mp.lua
+++ b/tests/lua/fake_mp.lua
@@ -19,6 +19,11 @@ M.log = {
     keybinds = {},
     forced = {},       -- keybind name -> was it add_FORCED_key_binding?
     keyopts = {},      -- keybind name -> the flags table it was bound with
+    -- keybind name -> the mpv KEY it was bound for. Everything else here
+    -- is keyed by name, so without this nothing can assert which key
+    -- carries which meaning -- and for the controller that is the whole
+    -- payload: the confirm/back swap changes nothing but that.
+    keykeys = {},
     sections = {},      -- set_key_bindings group name -> {key = true}
     enabled = {},       -- section name -> enable_key_bindings state
     section_flags = {}, -- section name -> the flags it was enabled with
@@ -252,18 +257,21 @@ function mp.add_key_binding(key, name, fn, opts)
     M.log.keybinds[name or key] = fn
     M.log.forced[name or key] = false
     M.log.keyopts[name or key] = opts or {}
+    M.log.keykeys[name or key] = key
 end
 
 function mp.add_forced_key_binding(key, name, fn, opts)
     M.log.keybinds[name or key] = fn
     M.log.forced[name or key] = true
     M.log.keyopts[name or key] = opts or {}
+    M.log.keykeys[name or key] = key
 end
 
 function mp.remove_key_binding(name)
     M.log.keybinds[name] = nil
     M.log.forced[name] = nil
     M.log.keyopts[name] = nil
+    M.log.keykeys[name] = nil
 end
 -- Whether a section is enabled cannot model mpv's section STACK, but it can
 -- model the flag, which is what a "this group was never turned on" bug looks

--- a/tests/lua/test_renderer.lua
+++ b/tests/lua/test_renderer.lua
@@ -2478,6 +2478,281 @@ ok(not did("cycle", "fullscreen"),
    "double-clicking empty library background toggled full screen")
 fake.send("mpvtk-active", "no")
 
+-- ================================================ HUD nav + seek bar
+
+-- Leave HUD mode with a known syncplay answer: `pause_now` hands the
+-- pause to Python inside a group and does it locally otherwise, and the
+-- flag survives until the next engage.
+fake.send("mpvtk-hud", "yes",
+          fake.token({ hide = 4, mode = "hover", syncplay = false }))
+fake.send("mpvtk-hud", "no")
+fake.send("mpvtk-active", "yes")
+
+-- Coming DOWN off the full-width seek bar, spatial nav lands on whichever
+-- control in the row is nearest the x it came from -- and which one that
+-- is changes with the window width, because the chapter and seek buttons
+-- appear and disappear with it. A row may name the control the arrow
+-- actually meant.
+-- The bar spans 100..1180, so the x an arrow leaves it with is 640.
+-- `near` is centred on exactly that and `pp` is nowhere near it: without
+-- the gravity, distance alone picks `near` -- which is the point, because
+-- a version of this row where the play button happens to sit under the
+-- middle proves nothing at all.
+local function hudrow()
+    scene({
+        { id = "bar", t = "slider", x = 100, y = 600, w = 1080, h = 26,
+          min = 0, max = 600, value = 0, aadj = true, ctx = true },
+        { id = "far", t = "rect", x = 300, y = 660, w = 40, h = 40,
+          click = true, ctx = true },
+        { id = "near", t = "rect", x = 620, y = 660, w = 40, h = 40,
+          click = true, ctx = true },
+        { id = "pp", t = "rect", x = 900, y = 660, w = 40, h = 40,
+          click = true, ctx = true, grav = true },
+    })
+end
+
+--- Which node has spatial focus, read the way the rest of this file does:
+--- MENU opens the focused node's context menu and the event names it.
+local function focused()
+    fake.reset_events()
+    navkey("MENU")
+    local e = last_event("context")
+    return e and e.id or nil
+end
+
+hudrow()
+fake.send("mpvtk-focus", fake.token({ id = "bar" }))
+navkey("DOWN")
+eq(focused(), "pp", "DOWN off the bar ignored the row's gravity")
+
+-- ...and gravity is VERTICAL only. Stepping along the row has to be able
+-- to pass the control, or it is a trap rather than a preference.
+navkey("LEFT")
+eq(focused(), "near", "gravity swallowed a sideways step")
+
+-- Select on an always-adjust bar with no scrub pending. Adjust mode is
+-- not a gesture -- the bar is live the moment it is focused -- so a
+-- commit here seeks to where playback already is. It means play/pause.
+hudrow()
+fake.send("mpvtk-focus", fake.token({ id = "bar" }))
+fake.reset_events()
+fake.log.commands = {}
+navkey("ENTER")
+eq(last_event("commit"), nil, "Select on an untouched seek bar seeked")
+local cycled = false
+for _, c in ipairs(fake.log.commands) do
+    if c[1] == "cycle" and c[2] == "pause" then cycled = true end
+end
+ok(cycled, "Select on an untouched seek bar did not play/pause")
+
+-- ...but once something IS pending, Select accepts it. That half is the
+-- whole point of the bar and must not regress.
+navkey("RIGHT")                        -- scrub: a gesture is now in flight
+fake.reset_events()
+navkey("ENTER")
+local done = last_event("commit")
+eq(done and done.id, "bar", "Select did not accept a pending seek")
+
+
+-- ========================================================== game controller
+
+-- The whole point of the mpvtk-gamepad message: these bindings are NOT nav
+-- keys and must not share their lifecycle. NAV_KEYS is torn down by
+-- ui_suspend the moment a video starts, because playback wants the arrows
+-- back -- which is where the first version of this lived, and why every
+-- button on the pad went dead as soon as anything played.
+fake.send("mpvtk-active", "yes")
+fake.send("mpvtk-gamepad", fake.token({
+    { "GAMEPAD_DPAD_UP", "key", "UP", 0.15 },
+    { "GAMEPAD_ACTION_DOWN", "key", "ENTER", 0 },
+    { "GAMEPAD_ACTION_RIGHT", "key", "ESC", 0 },
+    { "GAMEPAD_START", "nav", "menu", 0 },
+    { "GAMEPAD_RIGHT_STICK_LEFT", "seek", "left", 0.4 },
+}))
+ok(fake.log.keybinds["mpvtk_gp_GAMEPAD_DPAD_UP"] ~= nil,
+   "the pushed table did not bind the d-pad")
+
+-- Remappable by the user's own input.conf, which is the whole answer to
+-- "how do I change what a button does" -- and is true only because these
+-- are NON-forced. A forced binding would have to be disabled first.
+eq(fake.log.forced["mpvtk_gp_GAMEPAD_DPAD_UP"], false,
+   "gamepad bindings were forced, so input.conf could not override them")
+
+-- Browse: the button is a synthetic keypress, so whatever owns the keyboard
+-- right now answers it and the pad needs to know about none of them.
+fake.log.commands = {}
+fake.advance(1)
+fake.key("mpvtk_gp_GAMEPAD_DPAD_UP")
+local pressed = nil
+for _, c in ipairs(fake.log.commands) do
+    if c[1] == "keypress" then pressed = c[2] end
+end
+eq(pressed, "UP", "the d-pad did not press the keyboard key it stands for")
+
+-- Now play something. The nav keys go, as they must...
+fake.send("mpvtk-active", "no")
+fake.send("mpvtk-hud", "yes", fake.token({ hide = 4, mode = "hover" }))
+eq(fake.log.keybinds["mpvtk_nav_UP"], nil,
+   "playback left the browser's arrow binding in place")
+-- ...and the controller stays, because it has a second stick and does not
+-- need to give the first one back.
+ok(fake.log.keybinds["mpvtk_gp_GAMEPAD_DPAD_UP"] ~= nil,
+   "playback tore down the gamepad bindings with the nav keys")
+
+-- With the bar hidden the left stick WAKES the HUD rather than being
+-- delivered: with hud_grab_keys off only the wake key is bound, so a
+-- keypress would fall through to mpv's own arrows and the left stick would
+-- seek. Seeking is the right stick's job.
+fake.log.commands = {}
+fake.advance(1)
+fake.key("mpvtk_gp_GAMEPAD_DPAD_UP")
+local fellthrough = false
+for _, c in ipairs(fake.log.commands) do
+    if c[1] == "keypress" then fellthrough = true end
+end
+ok(not fellthrough,
+   "the left stick fell through to mpv's arrows over a hidden HUD")
+
+-- The right stick asks Python, because the distance is the user's own
+-- input.conf number and the seek has to be one a SyncPlay group hears
+-- about -- neither of which a `seek 5` from here would be.
+fake.reset_events()
+fake.advance(1)
+fake.key("mpvtk_gp_GAMEPAD_RIGHT_STICK_LEFT")
+local sk = last_event("gpseek")
+eq(sk and sk.dir, "left", "the right stick did not ask Python to seek")
+
+-- START is a 'nav', not a keypress: the MENU *key* is a browser nav
+-- binding, so over a playing video it is bound to nothing at all and a
+-- keypress would go nowhere.
+fake.reset_events()
+fake.key("mpvtk_gp_GAMEPAD_START")
+local nv = last_event("gpnav")
+eq(nv and nv.a, "menu", "Start did not reach the remote-control ladder")
+
+-- Over a showing Skip Intro button, confirm SKIPS -- it does not summon
+-- the bar. The keyboard's ENTER and the remote's Select both did this
+-- already; the pad had its own copy of the summon and only that, so A did
+-- the one thing the button on screen said it would not.
+-- Re-engage first: the direction press above SUMMONED the bar, and the
+-- skip button is only an offer while it is down.
+fake.send("mpvtk-hud", "no")
+fake.send("mpvtk-hud", "yes", fake.token({ hide = 4, mode = "hover" }))
+fake.send("mpvtk-hud-skip", "Skip Intro")
+fake.advance(1)
+fake.reset_events()
+fake.key("mpvtk_gp_GAMEPAD_ACTION_DOWN")
+ok(last_event("hudskip") ~= nil, "A over the Skip button summoned instead")
+
+-- ...and a DIRECTION over the same button still brings the bar up, which
+-- is the way back to the rest of the controls.
+fake.send("mpvtk-hud", "no")
+fake.send("mpvtk-hud", "yes", fake.token({ hide = 4, mode = "hover" }))
+fake.send("mpvtk-hud-skip", "Skip Intro")
+fake.advance(1)
+fake.reset_events()
+fake.key("mpvtk_gp_GAMEPAD_DPAD_UP")
+eq(last_event("hudskip"), nil, "a direction accepted the skip")
+fake.send("mpvtk-hud-skip", "")
+
+-- Auto-repeat. mpv repeats a held key at --input-ar-rate -- 40 a second by
+-- default -- which on a stick is forty library rows a second and is not
+-- something anybody can aim. Held controls are thinned to their own rate.
+--
+-- Each block counts from a RESET, not cumulatively: "3" as a running total
+-- of a limit that let one through reads exactly like a limit that let three
+-- through, and the failure message would be lying either way.
+local function seeks_sent()
+    local n = 0
+    for _, e in ipairs(fake.log.events) do
+        if type(e) == "table" and e.t == "gpseek" then n = n + 1 end
+    end
+    return n
+end
+
+fake.advance(1)
+fake.reset_events()
+fake.key("mpvtk_gp_GAMEPAD_RIGHT_STICK_LEFT")           -- lands
+fake.key("mpvtk_gp_GAMEPAD_RIGHT_STICK_LEFT", { event = "repeat" })
+fake.key("mpvtk_gp_GAMEPAD_RIGHT_STICK_LEFT", { event = "repeat" })
+eq(seeks_sent(), 1, "a held stick fired every repeat mpv sent")
+
+-- ...and it is a THINNING, not a lockout: past the interval it fires again.
+fake.advance(1)
+fake.reset_events()
+fake.key("mpvtk_gp_GAMEPAD_RIGHT_STICK_LEFT", { event = "repeat" })
+eq(seeks_sent(), 1, "the stick stayed muted after waiting out the interval")
+
+-- An analog axis resting on its threshold chatters across it, and each
+-- crossing arrives as a fresh PRESS rather than a repeat -- so limiting
+-- only the events mpv marks as repeats would leave the sticks as bad as
+-- they were.
+fake.advance(1)
+fake.reset_events()
+fake.key("mpvtk_gp_GAMEPAD_RIGHT_STICK_LEFT")
+fake.key("mpvtk_gp_GAMEPAD_RIGHT_STICK_LEFT")
+fake.key("mpvtk_gp_GAMEPAD_RIGHT_STICK_LEFT")
+eq(seeks_sent(), 1, "stick chatter was delivered press for press")
+
+-- A release is not an action. With `complex` bindings mpv reports it, and
+-- acting on it would double every press.
+fake.advance(1)
+fake.reset_events()
+fake.key("mpvtk_gp_GAMEPAD_RIGHT_STICK_LEFT", { event = "up" })
+eq(seeks_sent(), 0, "letting go of the stick counted as a seek")
+
+-- Confirm does not repeat AT ALL, and that is mpv's flag rather than a
+-- rate: holding a button is not a request to press it again, and an
+-- auto-repeating Select activates whatever it lands on over and over.
+eq(fake.log.keyopts["mpvtk_gp_GAMEPAD_ACTION_DOWN"].repeatable, false,
+   "the confirm button was left auto-repeating")
+eq(fake.log.keyopts["mpvtk_gp_GAMEPAD_DPAD_UP"].repeatable, true,
+   "the d-pad cannot be held to scroll")
+-- ...and a rate of 0 must not become a rate limit, or a double press of
+-- Select would be swallowed.
+fake.log.commands = {}
+fake.key("mpvtk_gp_GAMEPAD_ACTION_DOWN")
+fake.key("mpvtk_gp_GAMEPAD_ACTION_DOWN")
+local enters = 0
+for _, c in ipairs(fake.log.commands) do
+    if c[1] == "keypress" and c[2] == "ENTER" then enters = enters + 1 end
+end
+eq(enters, 2, "a second press of Select was swallowed as a repeat")
+
+-- Re-pushing rebinds, which is what makes the confirm/back swap apply
+-- without a restart. The keys that LEAVE the table have to go with it, or
+-- the old meaning survives underneath the new one.
+fake.send("mpvtk-gamepad", fake.token({
+    { "GAMEPAD_ACTION_RIGHT", "key", "ENTER", 0 },
+}))
+eq(fake.log.keybinds["mpvtk_gp_GAMEPAD_DPAD_UP"], nil,
+   "a re-push left a binding the new table does not have")
+fake.log.commands = {}
+fake.advance(1)
+fake.key("mpvtk_gp_GAMEPAD_ACTION_RIGHT")
+local swapped = nil
+for _, c in ipairs(fake.log.commands) do
+    if c[1] == "keypress" then swapped = c[2] end
+end
+eq(swapped, "ENTER", "the re-pushed table kept the old meaning of the key")
+
+-- Malformed rows are skipped rather than binding something that errors on
+-- press. This arrives from another process, so "cannot happen" is not a
+-- property of this file.
+fake.send("mpvtk-gamepad", fake.token({
+    { "GAMEPAD_ACTION_UP" }, { 1, 2, 3 }, "nonsense",
+    { "GAMEPAD_BACK", "key", "ESC", 0 },
+}))
+eq(fake.log.keybinds["mpvtk_gp_GAMEPAD_ACTION_UP"], nil,
+   "a row with no kind was bound anyway")
+ok(fake.log.keybinds["mpvtk_gp_GAMEPAD_BACK"] ~= nil,
+   "a bad row stopped the good ones after it being bound")
+
+-- Leave the renderer browsing for the teardown block below.
+fake.send("mpvtk-gamepad", fake.token({}))
+fake.send("mpvtk-hud", "no")
+fake.send("mpvtk-active", "yes")
+
 -- ========================================================== teardown
 
 scene({})

--- a/tests/lua/test_renderer.lua
+++ b/tests/lua/test_renderer.lua
@@ -2525,10 +2525,18 @@ fake.send("mpvtk-focus", fake.token({ id = "bar" }))
 navkey("DOWN")
 eq(focused(), "pp", "DOWN off the bar ignored the row's gravity")
 
--- ...and gravity is VERTICAL only. Stepping along the row has to be able
--- to pass the control, or it is a trap rather than a preference.
+-- ...and gravity is VERTICAL only. Two presses, because the honest test
+-- is the one that steps TOWARD the gravity node: leaving it can be
+-- satisfied by ordinary distance, but arriving has to stop at `near`
+-- rather than being pulled past it to `pp`. (The leaving direction is
+-- kept as well -- it is the one a user notices.)
 navkey("LEFT")
-eq(focused(), "near", "gravity swallowed a sideways step")
+eq(focused(), "near", "gravity swallowed a sideways step away from it")
+navkey("LEFT")
+eq(focused(), "far", "...and the step after that")
+navkey("RIGHT")
+eq(focused(), "near", "a sideways step was pulled past its neighbour to "
+                      .. "the gravity node")
 
 -- Select on an always-adjust bar with no scrub pending. Adjust mode is
 -- not a gesture -- the bar is live the moment it is focused -- so a
@@ -2612,6 +2620,36 @@ for _, c in ipairs(fake.log.commands) do
 end
 ok(not fellthrough,
    "the left stick fell through to mpv's arrows over a hidden HUD")
+-- ...and it WOKE the bar. Asserting only the absence of a keypress cannot
+-- tell "drives the UI" from "swallowed the press", and swallowing it is
+-- the likelier bug -- so the negative alone guards the headline behaviour
+-- of the whole asymmetric-stick design with a message that would lie.
+eq(fake.log.props["user-data/mpvtk/active"], true,
+   "the left stick swallowed the press instead of waking the HUD")
+
+-- A pointer summon with hud_grab_keys off leaves the arrows to mpv on
+-- purpose, so the bar is SHOWN while the renderer holds no nav keys --
+-- `shown` is not the same question as "the UI has the keyboard". Asking
+-- only `shown` sent the stick to mpv's arrows over a visible HUD.
+fake.send("mpvtk-hud", "no")
+fake.send("mpvtk-hud", "yes", fake.token({ hide = 4, mode = "hover" }))
+fake.observe("mouse-pos", { x = 600, y = 300, hover = true })
+fake.observe("mouse-pos", { x = 600, y = 312, hover = true })   -- summons
+ok(fake.log.keybinds["mpvtk_nav_UP"] == nil,
+   "the mouse summon took the arrows, so this case cannot be tested")
+fake.log.commands = {}
+fake.advance(1)
+fake.key("mpvtk_gp_GAMEPAD_DPAD_UP")
+local seeped = false
+for _, c in ipairs(fake.log.commands) do
+    if c[1] == "keypress" then seeped = true end
+end
+ok(not seeped,
+   "over a MOUSE-summoned HUD the left stick reached mpv's own arrows")
+ok(fake.log.keybinds["mpvtk_nav_UP"] ~= nil,
+   "the pad did not take the keyboard from the pointer")
+fake.send("mpvtk-hud", "no")
+fake.send("mpvtk-hud", "yes", fake.token({ hide = 4, mode = "hover" }))
 
 -- The right stick asks Python, because the distance is the user's own
 -- input.conf number and the seek has to be one a SyncPlay group hears
@@ -2653,6 +2691,8 @@ fake.advance(1)
 fake.reset_events()
 fake.key("mpvtk_gp_GAMEPAD_DPAD_UP")
 eq(last_event("hudskip"), nil, "a direction accepted the skip")
+eq(fake.log.props["user-data/mpvtk/active"], true,
+   "a direction over the Skip button did not bring the bar up")
 fake.send("mpvtk-hud-skip", "")
 
 -- Auto-repeat. mpv repeats a held key at --input-ar-rate -- 40 a second by
@@ -2735,6 +2775,13 @@ for _, c in ipairs(fake.log.commands) do
     if c[1] == "keypress" then swapped = c[2] end
 end
 eq(swapped, "ENTER", "the re-pushed table kept the old meaning of the key")
+-- ...and it is bound for the mpv key the table names. Every other log
+-- here is keyed by BINDING NAME, which the renderer derives from the key
+-- itself -- so a renderer that bound one fixed key under all the right
+-- names would satisfy the whole suite, and the confirm/back swap is
+-- nothing but a change of which key carries which meaning.
+eq(fake.log.keykeys["mpvtk_gp_GAMEPAD_ACTION_RIGHT"], "GAMEPAD_ACTION_RIGHT",
+   "the binding was made for a different key than the table named")
 
 -- Malformed rows are skipped rather than binding something that errors on
 -- press. This arrives from another process, so "cannot happen" is not a

--- a/tests/snapshots/settings.jsonl
+++ b/tests/snapshots/settings.jsonl
@@ -26,7 +26,7 @@
 {"align": "center", "c": "e8e8e8", "h": 21.2, "id": "r.1.0.0.5.0", "size": 17, "t": "text", "text": "Downloads", "w": 84.5, "x": 569.8, "y": 82.0}
 {"click": true, "fill": "2e3138", "h": 41.2, "hover": {"fill": "3a3e46"}, "id": "stab-logs", "radius": 6, "t": "rect", "w": 56.7, "x": 672.3, "y": 72.0}
 {"align": "center", "c": "e8e8e8", "h": 21.2, "id": "r.1.0.0.6.0", "size": 17, "t": "text", "text": "Logs", "w": 36.7, "x": 682.3, "y": 82.0}
-{"axis": "y", "bar": true, "ch": 701.6, "cw": 1270.0, "h": 594.8, "id": "settings", "t": "scroll", "w": 1280.0, "x": 0.0, "y": 125.2}
+{"axis": "y", "bar": true, "ch": 773.8, "cw": 1270.0, "h": 594.8, "id": "settings", "t": "scroll", "w": 1280.0, "x": 0.0, "y": 125.2}
 {"align": "left", "bold": true, "c": "e8e8e8", "h": 23.8, "id": "r.1.1.0.0", "sc": "settings", "size": 19, "t": "text", "text": "This Device", "w": 1238.0, "x": 16.0, "y": 141.2}
 {"align": "left", "c": "9aa0a6", "h": 21.2, "id": "r.1.1.0.1.0", "sc": "settings", "size": 17, "t": "text", "text": "Player Name", "w": 340.0, "x": 16.0, "y": 178.5}
 {"h": 32.3, "id": "set-player_name", "ph": "", "sc": "settings", "size": 17, "t": "textbox", "text": "izzie-pc", "w": 340.0, "x": 368.0, "y": 173.0}
@@ -50,32 +50,37 @@
 {"click": true, "h": 21.2, "hover": {"c": "747474"}, "id": "set-input_gamepad", "sc": "settings", "t": "rect", "w": 1238.0, "x": 16.0, "y": 387.6}
 {"bc": "3a3d42", "bw": 1, "fill": "2a2d33", "h": 20.0, "id": "r.1.1.0.8.0", "radius": 5, "sc": "settings", "t": "rect", "w": 20.0, "x": 16.0, "y": 388.2}
 {"align": "left", "c": "e8e8e8", "h": 21.2, "id": "r.1.1.0.8.1", "sc": "settings", "size": 17, "t": "text", "text": "Game Controller", "w": 121.9, "x": 46.0, "y": 387.6}
-{"align": "left", "c": "9aa0a6", "h": 17.5, "id": "r.1.1.0.9", "sc": "settings", "size": 14, "t": "text", "text": "Takes effect after a restart. Move with the d-pad or left stick, A to select, B to go back, shoulder buttons to page, Start for the menu. A controller is not focus-aware, so it will reach this app", "w": 1238.0, "x": 16.0, "y": 416.8}
-{"align": "left", "c": "9aa0a6", "h": 17.5, "id": "r.1.1.0.9.l1", "sc": "settings", "size": 14, "t": "text", "text": "even when another window is in front. Needs an mpv built with SDL2 gamepad support; if yours lacks it this setting is ignored and the log says so.", "w": 1238.0, "x": 16.0, "y": 434.3}
-{"align": "left", "bold": true, "c": "e8e8e8", "h": 23.8, "id": "r.1.1.0.10", "sc": "settings", "size": 19, "t": "text", "text": "Window", "w": 1238.0, "x": 16.0, "y": 459.8}
-{"click": true, "h": 21.2, "hover": {"c": "747474"}, "id": "set-fullscreen", "sc": "settings", "t": "rect", "w": 1238.0, "x": 16.0, "y": 491.6}
-{"bc": "3a3d42", "bw": 1, "fill": "2a2d33", "h": 20.0, "id": "r.1.1.0.11.0", "radius": 5, "sc": "settings", "t": "rect", "w": 20.0, "x": 16.0, "y": 492.2}
-{"align": "left", "c": "e8e8e8", "h": 21.2, "id": "r.1.1.0.11.1", "sc": "settings", "size": 17, "t": "text", "text": "Fullscreen", "w": 81.6, "x": 46.0, "y": 491.6}
-{"click": true, "h": 21.2, "hover": {"c": "747474"}, "id": "set-browser_fullscreen", "sc": "settings", "t": "rect", "w": 1238.0, "x": 16.0, "y": 520.8}
-{"bc": "3a3d42", "bw": 1, "fill": "2a2d33", "h": 20.0, "id": "r.1.1.0.12.0", "radius": 5, "sc": "settings", "t": "rect", "w": 20.0, "x": 16.0, "y": 521.4}
-{"align": "left", "c": "e8e8e8", "h": 21.2, "id": "r.1.1.0.12.1", "sc": "settings", "size": 17, "t": "text", "text": "Fullscreen Library Browser", "w": 208.6, "x": 46.0, "y": 520.8}
-{"click": true, "h": 21.2, "hover": {"c": "747474"}, "id": "set-remember_window_size", "sc": "settings", "t": "rect", "w": 1238.0, "x": 16.0, "y": 550.0}
-{"fill": "00a4dc", "h": 20.0, "id": "r.1.1.0.13.0", "radius": 5, "sc": "settings", "t": "rect", "w": 20.0, "x": 16.0, "y": 550.7}
-{"align": "center", "c": "ffffff", "h": 18.8, "id": "r.1.1.0.13.0.0", "sc": "settings", "size": 15, "t": "text", "text": "\u2713", "w": 20.0, "x": 16.0, "y": 551.3}
-{"align": "left", "c": "e8e8e8", "h": 21.2, "id": "r.1.1.0.13.1", "sc": "settings", "size": 17, "t": "text", "text": "Remember Window Size", "w": 186.3, "x": 46.0, "y": 550.0}
-{"align": "left", "c": "9aa0a6", "h": 21.2, "id": "r.1.1.0.14.0", "sc": "settings", "size": 17, "t": "text", "text": "Window Buttons in the Top Bar", "w": 340.0, "x": 16.0, "y": 584.8}
-{"force": true, "h": 32.3, "id": "set-window_controls", "items": ["Only when the window has no title bar", "Always", "Never"], "sc": "settings", "sel": 0, "size": 17, "t": "dropdown", "w": 340.0, "x": 368.0, "y": 579.3}
-{"align": "left", "c": "9aa0a6", "h": 17.5, "id": "r.1.1.0.15", "sc": "settings", "size": 14, "t": "text", "text": "Some desktops \u2014 GNOME on Wayland in particular \u2014 draw no title bar on the player window, leaving no way to move or close it. This puts minimize, maximize and close in the top bar instead,", "w": 1238.0, "x": 16.0, "y": 619.6}
-{"align": "left", "c": "9aa0a6", "h": 17.5, "id": "r.1.1.0.15.l1", "sc": "settings", "size": 14, "t": "text", "text": "and lets you drag the window by it. Left on \"Only when the window has no title bar\", MPV is asked whether this window got one, so desktops that do decorate it are left alone.", "w": 1238.0, "x": 16.0, "y": 637.1}
-{"click": true, "h": 21.2, "hover": {"c": "747474"}, "id": "set-allow_background", "sc": "settings", "t": "rect", "w": 1238.0, "x": 16.0, "y": 662.6}
-{"bc": "3a3d42", "bw": 1, "fill": "2a2d33", "h": 20.0, "id": "r.1.1.0.16.0", "radius": 5, "sc": "settings", "t": "rect", "w": 20.0, "x": 16.0, "y": 663.2}
-{"align": "left", "c": "e8e8e8", "h": 21.2, "id": "r.1.1.0.16.1", "sc": "settings", "size": 17, "t": "text", "text": "Keep Running in Background", "w": 216.2, "x": 46.0, "y": 662.6}
-{"align": "left", "c": "9aa0a6", "h": 17.5, "id": "r.1.1.0.17", "sc": "settings", "size": 14, "t": "text", "text": "With \"Start Minimized\" and \"Fullscreen\" this is the classic cast-target setup: the app waits out of the way, plays fullscreen when something casts to it, and goes back to waiting when the", "w": 1238.0, "x": 16.0, "y": 691.8}
-{"align": "left", "c": "9aa0a6", "h": 17.5, "id": "r.1.1.0.17.l1", "sc": "settings", "size": 14, "t": "text", "text": "video ends or you press Q.", "w": 1238.0, "x": 16.0, "y": 709.3}
-{"click": true, "h": 21.2, "hover": {"c": "747474"}, "id": "set-display_mirror_summon", "sc": "settings", "t": "rect", "w": 1238.0, "x": 16.0, "y": 734.8}
+{"align": "left", "c": "9aa0a6", "h": 17.5, "id": "r.1.1.0.9", "sc": "settings", "size": 14, "t": "text", "text": "Takes effect after a restart. Move with the d-pad or left stick, seek with the right stick, shoulder buttons to page, Start for the menu. A controller is not focus-aware, so it will reach this app", "w": 1238.0, "x": 16.0, "y": 416.8}
+{"align": "left", "c": "9aa0a6", "h": 17.5, "id": "r.1.1.0.9.l1", "sc": "settings", "size": 14, "t": "text", "text": "even when another window is in front. Needs an mpv built with SDL2 gamepad support; if yours lacks it this setting is ignored and the log says so. Any button can be reassigned in your", "w": 1238.0, "x": 16.0, "y": 434.3}
+{"align": "left", "c": "9aa0a6", "h": 17.5, "id": "r.1.1.0.9.l2", "sc": "settings", "size": 14, "t": "text", "text": "input.conf.", "w": 1238.0, "x": 16.0, "y": 451.8}
+{"click": true, "h": 21.2, "hover": {"c": "747474"}, "id": "set-gamepad_swap_confirm", "sc": "settings", "t": "rect", "w": 1238.0, "x": 16.0, "y": 477.3}
+{"bc": "3a3d42", "bw": 1, "fill": "2a2d33", "h": 20.0, "id": "r.1.1.0.10.0", "radius": 5, "sc": "settings", "t": "rect", "w": 20.0, "x": 16.0, "y": 477.9}
+{"align": "left", "c": "e8e8e8", "h": 21.2, "id": "r.1.1.0.10.1", "sc": "settings", "size": 17, "t": "text", "text": "Swap Confirm and Back Buttons", "w": 243.4, "x": 46.0, "y": 477.3}
+{"align": "left", "c": "9aa0a6", "h": 17.5, "id": "r.1.1.0.11", "sc": "settings", "size": 14, "t": "text", "text": "Turn this on for a controller whose A button is on the right rather than at the bottom (Switch Pro, most 8BitDo pads). Applies immediately.", "w": 1238.0, "x": 16.0, "y": 506.6}
+{"align": "left", "bold": true, "c": "e8e8e8", "h": 23.8, "id": "r.1.1.0.12", "sc": "settings", "size": 19, "t": "text", "text": "Window", "w": 1238.0, "x": 16.0, "y": 532.0}
+{"click": true, "h": 21.2, "hover": {"c": "747474"}, "id": "set-fullscreen", "sc": "settings", "t": "rect", "w": 1238.0, "x": 16.0, "y": 563.8}
+{"bc": "3a3d42", "bw": 1, "fill": "2a2d33", "h": 20.0, "id": "r.1.1.0.13.0", "radius": 5, "sc": "settings", "t": "rect", "w": 20.0, "x": 16.0, "y": 564.4}
+{"align": "left", "c": "e8e8e8", "h": 21.2, "id": "r.1.1.0.13.1", "sc": "settings", "size": 17, "t": "text", "text": "Fullscreen", "w": 81.6, "x": 46.0, "y": 563.8}
+{"click": true, "h": 21.2, "hover": {"c": "747474"}, "id": "set-browser_fullscreen", "sc": "settings", "t": "rect", "w": 1238.0, "x": 16.0, "y": 593.0}
+{"bc": "3a3d42", "bw": 1, "fill": "2a2d33", "h": 20.0, "id": "r.1.1.0.14.0", "radius": 5, "sc": "settings", "t": "rect", "w": 20.0, "x": 16.0, "y": 593.7}
+{"align": "left", "c": "e8e8e8", "h": 21.2, "id": "r.1.1.0.14.1", "sc": "settings", "size": 17, "t": "text", "text": "Fullscreen Library Browser", "w": 208.6, "x": 46.0, "y": 593.0}
+{"click": true, "h": 21.2, "hover": {"c": "747474"}, "id": "set-remember_window_size", "sc": "settings", "t": "rect", "w": 1238.0, "x": 16.0, "y": 622.3}
+{"fill": "00a4dc", "h": 20.0, "id": "r.1.1.0.15.0", "radius": 5, "sc": "settings", "t": "rect", "w": 20.0, "x": 16.0, "y": 622.9}
+{"align": "center", "c": "ffffff", "h": 18.8, "id": "r.1.1.0.15.0.0", "sc": "settings", "size": 15, "t": "text", "text": "\u2713", "w": 20.0, "x": 16.0, "y": 623.5}
+{"align": "left", "c": "e8e8e8", "h": 21.2, "id": "r.1.1.0.15.1", "sc": "settings", "size": 17, "t": "text", "text": "Remember Window Size", "w": 186.3, "x": 46.0, "y": 622.3}
+{"align": "left", "c": "9aa0a6", "h": 21.2, "id": "r.1.1.0.16.0", "sc": "settings", "size": 17, "t": "text", "text": "Window Buttons in the Top Bar", "w": 340.0, "x": 16.0, "y": 657.1}
+{"force": true, "h": 32.3, "id": "set-window_controls", "items": ["Only when the window has no title bar", "Always", "Never"], "sc": "settings", "sel": 0, "size": 17, "t": "dropdown", "w": 340.0, "x": 368.0, "y": 651.5}
+{"align": "left", "c": "9aa0a6", "h": 17.5, "id": "r.1.1.0.17", "sc": "settings", "size": 14, "t": "text", "text": "Some desktops \u2014 GNOME on Wayland in particular \u2014 draw no title bar on the player window, leaving no way to move or close it. This puts minimize, maximize and close in the top bar instead,", "w": 1238.0, "x": 16.0, "y": 691.8}
+{"align": "left", "c": "9aa0a6", "h": 17.5, "id": "r.1.1.0.17.l1", "sc": "settings", "size": 14, "t": "text", "text": "and lets you drag the window by it. Left on \"Only when the window has no title bar\", MPV is asked whether this window got one, so desktops that do decorate it are left alone.", "w": 1238.0, "x": 16.0, "y": 709.3}
+{"click": true, "h": 21.2, "hover": {"c": "747474"}, "id": "set-allow_background", "sc": "settings", "t": "rect", "w": 1238.0, "x": 16.0, "y": 734.8}
 {"bc": "3a3d42", "bw": 1, "fill": "2a2d33", "h": 20.0, "id": "r.1.1.0.18.0", "radius": 5, "sc": "settings", "t": "rect", "w": 20.0, "x": 16.0, "y": 735.5}
-{"align": "left", "c": "e8e8e8", "h": 21.2, "id": "r.1.1.0.18.1", "sc": "settings", "size": 17, "t": "text", "text": "Casting Opens the Library Browser", "w": 264.7, "x": 46.0, "y": 734.8}
-{"click": true, "h": 21.2, "hover": {"c": "747474"}, "id": "set-adv", "sc": "settings", "t": "rect", "w": 1238.0, "x": 16.0, "y": 764.1}
-{"bc": "3a3d42", "bw": 1, "fill": "2a2d33", "h": 20.0, "id": "r.1.1.0.19.0", "radius": 5, "sc": "settings", "t": "rect", "w": 20.0, "x": 16.0, "y": 764.7}
-{"align": "left", "c": "e8e8e8", "h": 21.2, "id": "r.1.1.0.19.1", "sc": "settings", "size": 17, "t": "text", "text": "Show advanced settings", "w": 188.9, "x": 46.0, "y": 764.1}
-{"align": "left", "c": "9aa0a6", "h": 17.5, "id": "r.1.1.0.20", "sc": "settings", "size": 14, "t": "text", "text": "Some changes take effect after restarting.", "w": 1238.0, "x": 16.0, "y": 793.3}
+{"align": "left", "c": "e8e8e8", "h": 21.2, "id": "r.1.1.0.18.1", "sc": "settings", "size": 17, "t": "text", "text": "Keep Running in Background", "w": 216.2, "x": 46.0, "y": 734.8}
+{"align": "left", "c": "9aa0a6", "h": 17.5, "id": "r.1.1.0.19", "sc": "settings", "size": 14, "t": "text", "text": "With \"Start Minimized\" and \"Fullscreen\" this is the classic cast-target setup: the app waits out of the way, plays fullscreen when something casts to it, and goes back to waiting when the", "w": 1238.0, "x": 16.0, "y": 764.1}
+{"align": "left", "c": "9aa0a6", "h": 17.5, "id": "r.1.1.0.19.l1", "sc": "settings", "size": 14, "t": "text", "text": "video ends or you press Q.", "w": 1238.0, "x": 16.0, "y": 781.6}
+{"click": true, "h": 21.2, "hover": {"c": "747474"}, "id": "set-display_mirror_summon", "sc": "settings", "t": "rect", "w": 1238.0, "x": 16.0, "y": 807.1}
+{"bc": "3a3d42", "bw": 1, "fill": "2a2d33", "h": 20.0, "id": "r.1.1.0.20.0", "radius": 5, "sc": "settings", "t": "rect", "w": 20.0, "x": 16.0, "y": 807.7}
+{"align": "left", "c": "e8e8e8", "h": 21.2, "id": "r.1.1.0.20.1", "sc": "settings", "size": 17, "t": "text", "text": "Casting Opens the Library Browser", "w": 264.7, "x": 46.0, "y": 807.1}
+{"click": true, "h": 21.2, "hover": {"c": "747474"}, "id": "set-adv", "sc": "settings", "t": "rect", "w": 1238.0, "x": 16.0, "y": 836.3}
+{"bc": "3a3d42", "bw": 1, "fill": "2a2d33", "h": 20.0, "id": "r.1.1.0.21.0", "radius": 5, "sc": "settings", "t": "rect", "w": 20.0, "x": 16.0, "y": 837.0}
+{"align": "left", "c": "e8e8e8", "h": 21.2, "id": "r.1.1.0.21.1", "sc": "settings", "size": 17, "t": "text", "text": "Show advanced settings", "w": 188.9, "x": 46.0, "y": 836.3}
+{"align": "left", "c": "9aa0a6", "h": 17.5, "id": "r.1.1.0.22", "sc": "settings", "size": 14, "t": "text", "text": "Some changes take effect after restarting.", "w": 1238.0, "x": 16.0, "y": 865.6}

--- a/tests/snapshots/settings.jsonl
+++ b/tests/snapshots/settings.jsonl
@@ -26,7 +26,7 @@
 {"align": "center", "c": "e8e8e8", "h": 21.2, "id": "r.1.0.0.5.0", "size": 17, "t": "text", "text": "Downloads", "w": 84.5, "x": 569.8, "y": 82.0}
 {"click": true, "fill": "2e3138", "h": 41.2, "hover": {"fill": "3a3e46"}, "id": "stab-logs", "radius": 6, "t": "rect", "w": 56.7, "x": 672.3, "y": 72.0}
 {"align": "center", "c": "e8e8e8", "h": 21.2, "id": "r.1.0.0.6.0", "size": 17, "t": "text", "text": "Logs", "w": 36.7, "x": 682.3, "y": 82.0}
-{"axis": "y", "bar": true, "ch": 597.6, "cw": 1270.0, "h": 594.8, "id": "settings", "t": "scroll", "w": 1280.0, "x": 0.0, "y": 125.2}
+{"axis": "y", "bar": true, "ch": 701.6, "cw": 1270.0, "h": 594.8, "id": "settings", "t": "scroll", "w": 1280.0, "x": 0.0, "y": 125.2}
 {"align": "left", "bold": true, "c": "e8e8e8", "h": 23.8, "id": "r.1.1.0.0", "sc": "settings", "size": 19, "t": "text", "text": "This Device", "w": 1238.0, "x": 16.0, "y": 141.2}
 {"align": "left", "c": "9aa0a6", "h": 21.2, "id": "r.1.1.0.1.0", "sc": "settings", "size": 17, "t": "text", "text": "Player Name", "w": 340.0, "x": 16.0, "y": 178.5}
 {"h": 32.3, "id": "set-player_name", "ph": "", "sc": "settings", "size": 17, "t": "textbox", "text": "izzie-pc", "w": 340.0, "x": 368.0, "y": 173.0}
@@ -46,30 +46,36 @@
 {"fill": "00a4dc", "h": 20.0, "id": "r.1.1.0.6.0", "radius": 5, "sc": "settings", "t": "rect", "w": 20.0, "x": 16.0, "y": 327.2}
 {"align": "center", "c": "ffffff", "h": 18.8, "id": "r.1.1.0.6.0.0", "sc": "settings", "size": 15, "t": "text", "text": "\u2713", "w": 20.0, "x": 16.0, "y": 327.8}
 {"align": "left", "c": "e8e8e8", "h": 21.2, "id": "r.1.1.0.6.1", "sc": "settings", "size": 17, "t": "text", "text": "Notify Updates", "w": 110.8, "x": 46.0, "y": 326.6}
-{"align": "left", "bold": true, "c": "e8e8e8", "h": 23.8, "id": "r.1.1.0.7", "sc": "settings", "size": 19, "t": "text", "text": "Window", "w": 1238.0, "x": 16.0, "y": 355.8}
-{"click": true, "h": 21.2, "hover": {"c": "747474"}, "id": "set-fullscreen", "sc": "settings", "t": "rect", "w": 1238.0, "x": 16.0, "y": 387.6}
+{"align": "left", "bold": true, "c": "e8e8e8", "h": 23.8, "id": "r.1.1.0.7", "sc": "settings", "size": 19, "t": "text", "text": "Input", "w": 1238.0, "x": 16.0, "y": 355.8}
+{"click": true, "h": 21.2, "hover": {"c": "747474"}, "id": "set-input_gamepad", "sc": "settings", "t": "rect", "w": 1238.0, "x": 16.0, "y": 387.6}
 {"bc": "3a3d42", "bw": 1, "fill": "2a2d33", "h": 20.0, "id": "r.1.1.0.8.0", "radius": 5, "sc": "settings", "t": "rect", "w": 20.0, "x": 16.0, "y": 388.2}
-{"align": "left", "c": "e8e8e8", "h": 21.2, "id": "r.1.1.0.8.1", "sc": "settings", "size": 17, "t": "text", "text": "Fullscreen", "w": 81.6, "x": 46.0, "y": 387.6}
-{"click": true, "h": 21.2, "hover": {"c": "747474"}, "id": "set-browser_fullscreen", "sc": "settings", "t": "rect", "w": 1238.0, "x": 16.0, "y": 416.8}
-{"bc": "3a3d42", "bw": 1, "fill": "2a2d33", "h": 20.0, "id": "r.1.1.0.9.0", "radius": 5, "sc": "settings", "t": "rect", "w": 20.0, "x": 16.0, "y": 417.4}
-{"align": "left", "c": "e8e8e8", "h": 21.2, "id": "r.1.1.0.9.1", "sc": "settings", "size": 17, "t": "text", "text": "Fullscreen Library Browser", "w": 208.6, "x": 46.0, "y": 416.8}
-{"click": true, "h": 21.2, "hover": {"c": "747474"}, "id": "set-remember_window_size", "sc": "settings", "t": "rect", "w": 1238.0, "x": 16.0, "y": 446.1}
-{"fill": "00a4dc", "h": 20.0, "id": "r.1.1.0.10.0", "radius": 5, "sc": "settings", "t": "rect", "w": 20.0, "x": 16.0, "y": 446.7}
-{"align": "center", "c": "ffffff", "h": 18.8, "id": "r.1.1.0.10.0.0", "sc": "settings", "size": 15, "t": "text", "text": "\u2713", "w": 20.0, "x": 16.0, "y": 447.3}
-{"align": "left", "c": "e8e8e8", "h": 21.2, "id": "r.1.1.0.10.1", "sc": "settings", "size": 17, "t": "text", "text": "Remember Window Size", "w": 186.3, "x": 46.0, "y": 446.1}
-{"align": "left", "c": "9aa0a6", "h": 21.2, "id": "r.1.1.0.11.0", "sc": "settings", "size": 17, "t": "text", "text": "Window Buttons in the Top Bar", "w": 340.0, "x": 16.0, "y": 480.8}
-{"force": true, "h": 32.3, "id": "set-window_controls", "items": ["Only when the window has no title bar", "Always", "Never"], "sc": "settings", "sel": 0, "size": 17, "t": "dropdown", "w": 340.0, "x": 368.0, "y": 475.3}
-{"align": "left", "c": "9aa0a6", "h": 17.5, "id": "r.1.1.0.12", "sc": "settings", "size": 14, "t": "text", "text": "Some desktops \u2014 GNOME on Wayland in particular \u2014 draw no title bar on the player window, leaving no way to move or close it. This puts minimize, maximize and close in the top bar instead,", "w": 1238.0, "x": 16.0, "y": 515.6}
-{"align": "left", "c": "9aa0a6", "h": 17.5, "id": "r.1.1.0.12.l1", "sc": "settings", "size": 14, "t": "text", "text": "and lets you drag the window by it. Left on \"Only when the window has no title bar\", MPV is asked whether this window got one, so desktops that do decorate it are left alone.", "w": 1238.0, "x": 16.0, "y": 533.1}
-{"click": true, "h": 21.2, "hover": {"c": "747474"}, "id": "set-allow_background", "sc": "settings", "t": "rect", "w": 1238.0, "x": 16.0, "y": 558.6}
-{"bc": "3a3d42", "bw": 1, "fill": "2a2d33", "h": 20.0, "id": "r.1.1.0.13.0", "radius": 5, "sc": "settings", "t": "rect", "w": 20.0, "x": 16.0, "y": 559.2}
-{"align": "left", "c": "e8e8e8", "h": 21.2, "id": "r.1.1.0.13.1", "sc": "settings", "size": 17, "t": "text", "text": "Keep Running in Background", "w": 216.2, "x": 46.0, "y": 558.6}
-{"align": "left", "c": "9aa0a6", "h": 17.5, "id": "r.1.1.0.14", "sc": "settings", "size": 14, "t": "text", "text": "With \"Start Minimized\" and \"Fullscreen\" this is the classic cast-target setup: the app waits out of the way, plays fullscreen when something casts to it, and goes back to waiting when the", "w": 1238.0, "x": 16.0, "y": 587.9}
-{"align": "left", "c": "9aa0a6", "h": 17.5, "id": "r.1.1.0.14.l1", "sc": "settings", "size": 14, "t": "text", "text": "video ends or you press Q.", "w": 1238.0, "x": 16.0, "y": 605.4}
-{"click": true, "h": 21.2, "hover": {"c": "747474"}, "id": "set-display_mirror_summon", "sc": "settings", "t": "rect", "w": 1238.0, "x": 16.0, "y": 630.9}
-{"bc": "3a3d42", "bw": 1, "fill": "2a2d33", "h": 20.0, "id": "r.1.1.0.15.0", "radius": 5, "sc": "settings", "t": "rect", "w": 20.0, "x": 16.0, "y": 631.5}
-{"align": "left", "c": "e8e8e8", "h": 21.2, "id": "r.1.1.0.15.1", "sc": "settings", "size": 17, "t": "text", "text": "Casting Opens the Library Browser", "w": 264.7, "x": 46.0, "y": 630.9}
-{"click": true, "h": 21.2, "hover": {"c": "747474"}, "id": "set-adv", "sc": "settings", "t": "rect", "w": 1238.0, "x": 16.0, "y": 660.1}
-{"bc": "3a3d42", "bw": 1, "fill": "2a2d33", "h": 20.0, "id": "r.1.1.0.16.0", "radius": 5, "sc": "settings", "t": "rect", "w": 20.0, "x": 16.0, "y": 660.7}
-{"align": "left", "c": "e8e8e8", "h": 21.2, "id": "r.1.1.0.16.1", "sc": "settings", "size": 17, "t": "text", "text": "Show advanced settings", "w": 188.9, "x": 46.0, "y": 660.1}
-{"align": "left", "c": "9aa0a6", "h": 17.5, "id": "r.1.1.0.17", "sc": "settings", "size": 14, "t": "text", "text": "Some changes take effect after restarting.", "w": 1238.0, "x": 16.0, "y": 689.4}
+{"align": "left", "c": "e8e8e8", "h": 21.2, "id": "r.1.1.0.8.1", "sc": "settings", "size": 17, "t": "text", "text": "Game Controller", "w": 121.9, "x": 46.0, "y": 387.6}
+{"align": "left", "c": "9aa0a6", "h": 17.5, "id": "r.1.1.0.9", "sc": "settings", "size": 14, "t": "text", "text": "Takes effect after a restart. Move with the d-pad or left stick, A to select, B to go back, shoulder buttons to page, Start for the menu. A controller is not focus-aware, so it will reach this app", "w": 1238.0, "x": 16.0, "y": 416.8}
+{"align": "left", "c": "9aa0a6", "h": 17.5, "id": "r.1.1.0.9.l1", "sc": "settings", "size": 14, "t": "text", "text": "even when another window is in front. Needs an mpv built with SDL2 gamepad support; if yours lacks it this setting is ignored and the log says so.", "w": 1238.0, "x": 16.0, "y": 434.3}
+{"align": "left", "bold": true, "c": "e8e8e8", "h": 23.8, "id": "r.1.1.0.10", "sc": "settings", "size": 19, "t": "text", "text": "Window", "w": 1238.0, "x": 16.0, "y": 459.8}
+{"click": true, "h": 21.2, "hover": {"c": "747474"}, "id": "set-fullscreen", "sc": "settings", "t": "rect", "w": 1238.0, "x": 16.0, "y": 491.6}
+{"bc": "3a3d42", "bw": 1, "fill": "2a2d33", "h": 20.0, "id": "r.1.1.0.11.0", "radius": 5, "sc": "settings", "t": "rect", "w": 20.0, "x": 16.0, "y": 492.2}
+{"align": "left", "c": "e8e8e8", "h": 21.2, "id": "r.1.1.0.11.1", "sc": "settings", "size": 17, "t": "text", "text": "Fullscreen", "w": 81.6, "x": 46.0, "y": 491.6}
+{"click": true, "h": 21.2, "hover": {"c": "747474"}, "id": "set-browser_fullscreen", "sc": "settings", "t": "rect", "w": 1238.0, "x": 16.0, "y": 520.8}
+{"bc": "3a3d42", "bw": 1, "fill": "2a2d33", "h": 20.0, "id": "r.1.1.0.12.0", "radius": 5, "sc": "settings", "t": "rect", "w": 20.0, "x": 16.0, "y": 521.4}
+{"align": "left", "c": "e8e8e8", "h": 21.2, "id": "r.1.1.0.12.1", "sc": "settings", "size": 17, "t": "text", "text": "Fullscreen Library Browser", "w": 208.6, "x": 46.0, "y": 520.8}
+{"click": true, "h": 21.2, "hover": {"c": "747474"}, "id": "set-remember_window_size", "sc": "settings", "t": "rect", "w": 1238.0, "x": 16.0, "y": 550.0}
+{"fill": "00a4dc", "h": 20.0, "id": "r.1.1.0.13.0", "radius": 5, "sc": "settings", "t": "rect", "w": 20.0, "x": 16.0, "y": 550.7}
+{"align": "center", "c": "ffffff", "h": 18.8, "id": "r.1.1.0.13.0.0", "sc": "settings", "size": 15, "t": "text", "text": "\u2713", "w": 20.0, "x": 16.0, "y": 551.3}
+{"align": "left", "c": "e8e8e8", "h": 21.2, "id": "r.1.1.0.13.1", "sc": "settings", "size": 17, "t": "text", "text": "Remember Window Size", "w": 186.3, "x": 46.0, "y": 550.0}
+{"align": "left", "c": "9aa0a6", "h": 21.2, "id": "r.1.1.0.14.0", "sc": "settings", "size": 17, "t": "text", "text": "Window Buttons in the Top Bar", "w": 340.0, "x": 16.0, "y": 584.8}
+{"force": true, "h": 32.3, "id": "set-window_controls", "items": ["Only when the window has no title bar", "Always", "Never"], "sc": "settings", "sel": 0, "size": 17, "t": "dropdown", "w": 340.0, "x": 368.0, "y": 579.3}
+{"align": "left", "c": "9aa0a6", "h": 17.5, "id": "r.1.1.0.15", "sc": "settings", "size": 14, "t": "text", "text": "Some desktops \u2014 GNOME on Wayland in particular \u2014 draw no title bar on the player window, leaving no way to move or close it. This puts minimize, maximize and close in the top bar instead,", "w": 1238.0, "x": 16.0, "y": 619.6}
+{"align": "left", "c": "9aa0a6", "h": 17.5, "id": "r.1.1.0.15.l1", "sc": "settings", "size": 14, "t": "text", "text": "and lets you drag the window by it. Left on \"Only when the window has no title bar\", MPV is asked whether this window got one, so desktops that do decorate it are left alone.", "w": 1238.0, "x": 16.0, "y": 637.1}
+{"click": true, "h": 21.2, "hover": {"c": "747474"}, "id": "set-allow_background", "sc": "settings", "t": "rect", "w": 1238.0, "x": 16.0, "y": 662.6}
+{"bc": "3a3d42", "bw": 1, "fill": "2a2d33", "h": 20.0, "id": "r.1.1.0.16.0", "radius": 5, "sc": "settings", "t": "rect", "w": 20.0, "x": 16.0, "y": 663.2}
+{"align": "left", "c": "e8e8e8", "h": 21.2, "id": "r.1.1.0.16.1", "sc": "settings", "size": 17, "t": "text", "text": "Keep Running in Background", "w": 216.2, "x": 46.0, "y": 662.6}
+{"align": "left", "c": "9aa0a6", "h": 17.5, "id": "r.1.1.0.17", "sc": "settings", "size": 14, "t": "text", "text": "With \"Start Minimized\" and \"Fullscreen\" this is the classic cast-target setup: the app waits out of the way, plays fullscreen when something casts to it, and goes back to waiting when the", "w": 1238.0, "x": 16.0, "y": 691.8}
+{"align": "left", "c": "9aa0a6", "h": 17.5, "id": "r.1.1.0.17.l1", "sc": "settings", "size": 14, "t": "text", "text": "video ends or you press Q.", "w": 1238.0, "x": 16.0, "y": 709.3}
+{"click": true, "h": 21.2, "hover": {"c": "747474"}, "id": "set-display_mirror_summon", "sc": "settings", "t": "rect", "w": 1238.0, "x": 16.0, "y": 734.8}
+{"bc": "3a3d42", "bw": 1, "fill": "2a2d33", "h": 20.0, "id": "r.1.1.0.18.0", "radius": 5, "sc": "settings", "t": "rect", "w": 20.0, "x": 16.0, "y": 735.5}
+{"align": "left", "c": "e8e8e8", "h": 21.2, "id": "r.1.1.0.18.1", "sc": "settings", "size": 17, "t": "text", "text": "Casting Opens the Library Browser", "w": 264.7, "x": 46.0, "y": 734.8}
+{"click": true, "h": 21.2, "hover": {"c": "747474"}, "id": "set-adv", "sc": "settings", "t": "rect", "w": 1238.0, "x": 16.0, "y": 764.1}
+{"bc": "3a3d42", "bw": 1, "fill": "2a2d33", "h": 20.0, "id": "r.1.1.0.19.0", "radius": 5, "sc": "settings", "t": "rect", "w": 20.0, "x": 16.0, "y": 764.7}
+{"align": "left", "c": "e8e8e8", "h": 21.2, "id": "r.1.1.0.19.1", "sc": "settings", "size": 17, "t": "text", "text": "Show advanced settings", "w": 188.9, "x": 46.0, "y": 764.1}
+{"align": "left", "c": "9aa0a6", "h": 17.5, "id": "r.1.1.0.20", "sc": "settings", "size": 14, "t": "text", "text": "Some changes take effect after restarting.", "w": 1238.0, "x": 16.0, "y": 793.3}

--- a/tests/test_child_process_teardown.py
+++ b/tests/test_child_process_teardown.py
@@ -1,0 +1,240 @@
+"""The tray child has to die when the app does.
+
+The whole of this file is one property -- *quitting leaves no process
+behind* -- asked at the three places it was broken at once.
+
+`mpv_shim._claim_sigterm` installs a SIGTERM handler so `kill` runs the
+orderly shutdown. `TrayManager.stop()` stops the tray child with
+`terminate()`, which **is** a SIGTERM. Those two are only compatible while
+the child does not inherit the handler, i.e. while the start method is
+``spawn`` -- and it silently was not: ``run.py`` calls
+``multiprocessing.freeze_support()``, whose first act is to *read* the start
+method, which resolves the context to the platform default. The later
+``set_start_method("spawn")`` then raised "context has already been set" into
+an ``except RuntimeError: pass``, so the tray was forked, took a copy of the
+handler, ignored every terminate(), and outlived the app.
+
+Each test drives a real child process. They are seconds, not milliseconds,
+and that is the point: nothing short of a real fork/terminate can fail the
+way this failed.
+"""
+
+import multiprocessing
+import os
+import signal
+import subprocess
+import sys
+import textwrap
+import time
+import unittest
+from unittest import mock
+
+REPO_ROOT = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+
+
+def _run_python(source):
+    """Run a script in a fresh interpreter and return its stdout.
+
+    A subprocess because every one of these is about process-global state --
+    the resolved multiprocessing context, the main thread's signal
+    dispositions -- which cannot be set up or undone inside a test runner
+    that has to keep working afterwards.
+    """
+    result = subprocess.run(
+        [sys.executable, "-c", textwrap.dedent(source)],
+        cwd=REPO_ROOT, capture_output=True, text=True, timeout=120)
+    if result.returncode != 0:
+        raise AssertionError(
+            "child interpreter failed (%s):\n%s\n%s"
+            % (result.returncode, result.stdout, result.stderr))
+    return result.stdout
+
+
+class StartMethodTest(unittest.TestCase):
+    """What `run.py` actually ends up with, not what it asks for."""
+
+    def test_freeze_support_does_not_pin_the_start_method(self):
+        # The regression, exactly as run.py sequences it: freeze_support()
+        # first, then main()'s choice. Before the fix this printed the
+        # platform default ("fork" on Linux) and nothing anywhere said so.
+        out = _run_python("""
+            import multiprocessing
+            multiprocessing.freeze_support()      # run.py, before main()
+            from jellyfin_mpv_shim.mpv_shim import _use_spawn_start_method
+            _use_spawn_start_method()
+            print(multiprocessing.get_start_method())
+        """)
+        self.assertEqual(out.strip(), "spawn")
+
+    def test_it_is_spawn_from_a_clean_interpreter_too(self):
+        # The installed console script's path -- no freeze_support() call.
+        # It was already right, and force=True must not have broken it.
+        out = _run_python("""
+            import multiprocessing
+            from jellyfin_mpv_shim.mpv_shim import _use_spawn_start_method
+            _use_spawn_start_method()
+            print(multiprocessing.get_start_method())
+        """)
+        self.assertEqual(out.strip(), "spawn")
+
+
+class InheritedSignalTest(unittest.TestCase):
+    """A forked child must not answer to the parent's handlers."""
+
+    def test_a_forked_child_inherits_the_sigterm_handler(self):
+        # Not a test of our code -- a test of the premise the other two
+        # rest on. If this ever stops holding, the reset below is dead
+        # weight and should be reconsidered rather than kept on faith.
+        if "fork" not in multiprocessing.get_all_start_methods():
+            self.skipTest("no fork start method on this platform")
+        out = _run_python("""
+            import multiprocessing, os, signal, threading, time
+            ctx = multiprocessing.get_context("fork")
+            halt = threading.Event()
+            signal.signal(signal.SIGTERM, lambda s, f: halt.set())
+            def loop():
+                while True:
+                    time.sleep(0.05)
+            p = ctx.Process(target=loop, daemon=True)
+            p.start()
+            time.sleep(1)
+            p.terminate()
+            p.join(3)
+            print("alive" if p.is_alive() else "dead")
+            p.kill()
+        """)
+        self.assertEqual(out.strip(), "alive")
+
+    def test_the_tray_child_puts_sigterm_back(self):
+        # _reset_inherited_signals is what makes terminate() mean terminate
+        # again. Driven in a forked child holding a live handler, because
+        # in-process the assertion is just "signal.signal did what it says".
+        if "fork" not in multiprocessing.get_all_start_methods():
+            self.skipTest("no fork start method on this platform")
+        out = _run_python("""
+            import multiprocessing, signal, threading, time
+            from jellyfin_mpv_shim.tray import _reset_inherited_signals
+            ctx = multiprocessing.get_context("fork")
+            halt = threading.Event()
+            signal.signal(signal.SIGTERM, lambda s, f: halt.set())
+            def loop():
+                _reset_inherited_signals()
+                while True:
+                    time.sleep(0.05)
+            p = ctx.Process(target=loop, daemon=True)
+            p.start()
+            time.sleep(1)
+            p.terminate()
+            p.join(5)
+            print("alive" if p.is_alive() else "dead")
+            p.kill()
+        """)
+        self.assertEqual(out.strip(), "dead")
+
+
+def _deaf_child():
+    """A tray child that will not die for a SIGTERM, whatever the reason.
+
+    Module level so it survives pickling to a spawned child.
+    """
+    signal.signal(signal.SIGTERM, signal.SIG_IGN)
+    while True:
+        time.sleep(0.05)
+
+
+class DeafTrayProcess(multiprocessing.Process):
+    def __init__(self, queue):
+        self.queue = queue
+        multiprocessing.Process.__init__(self, daemon=True)
+
+    def run(self):
+        _deaf_child()
+
+
+class TrayStopEscalationTest(unittest.TestCase):
+    """`stop()` is the last line of defence, so it may not merely ask."""
+
+    def _deaf_manager(self):
+        """A TrayManager whose child cannot be stopped by a SIGTERM.
+
+        The cleanup is not tidiness. multiprocessing's own atexit hook
+        terminates each daemon child and then **joins** it, so a deaf child
+        that survives the test does not merely linger -- it wedges the test
+        runner's exit, turning a failing assertion into a hung suite and
+        hiding the result these tests exist to report.
+        """
+        from jellyfin_mpv_shim import tray
+
+        manager = tray.TrayManager({})
+        with mock.patch.object(tray, "TrayProcess", DeafTrayProcess):
+            self.assertTrue(manager.start())
+        self.addCleanup(_hard_kill, manager._process)
+        return manager
+
+    def test_it_kills_a_child_that_ignores_sigterm(self):
+        from jellyfin_mpv_shim import tray
+
+        manager = self._deaf_manager()
+        pid = manager._process.pid
+        # Long enough to be sure the child reached its own signal(), so a
+        # pass cannot come from having killed it before it was deaf.
+        time.sleep(1.5)
+        started = time.monotonic()
+        manager.stop()
+        elapsed = time.monotonic() - started
+
+        self.assertFalse(_alive(pid),
+                         "the tray child outlived TrayManager.stop()")
+        # Bounded: this runs inside the shutdown sequence, which has its own
+        # deadline, and a stop that takes minutes is its own bug.
+        self.assertLess(elapsed, 3 * tray.TrayManager.TERMINATE_GRACE)
+
+    def test_it_releases_the_queue(self):
+        # os._exit skips multiprocessing's own cleanup, so an unclosed queue
+        # is what puts the resource tracker's "leaked semaphore" warning
+        # after "Shutdown complete." on every quit.
+        manager = self._deaf_manager()
+        manager.stop()
+        self.assertIsNone(manager._queue)
+
+    def test_stopping_twice_is_harmless(self):
+        # The shutdown sequence can reach it more than once (ui.stop, then a
+        # caller that stops the UI again), and a second stop that raised
+        # would strand every step after it.
+        manager = self._deaf_manager()
+        manager.stop()
+        manager.stop()
+
+
+def _hard_kill(process):
+    """SIGKILL a child and reap it, whatever state it is in."""
+    if process is None:
+        return
+    try:
+        if process.is_alive():
+            process.kill()
+        process.join(5)
+    except Exception:
+        pass
+
+
+def _alive(pid):
+    """Whether ``pid`` is a live process, as opposed to a reaped one.
+
+    ``os.kill(pid, 0)`` alone answers yes for a zombie, which is exactly the
+    state a child left unjoined ends up in -- so it would report the bug as
+    fixed while the process was still in the table.
+    """
+    try:
+        os.kill(pid, 0)
+    except OSError:
+        return False
+    try:
+        with open("/proc/%d/stat" % pid) as handle:
+            return handle.read().rsplit(")", 1)[1].split()[0] != "Z"
+    except OSError:
+        return True
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_gamepad.py
+++ b/tests/test_gamepad.py
@@ -1,0 +1,184 @@
+"""Game controller support: the option, and surviving an mpv without it.
+
+mpv has SDL2 gamepad input built in, but `sdl2-gamepad` is
+``value: 'disabled'`` in mpv's own ``meson.options`` -- not ``auto`` -- so
+most builds simply do not have ``--input-gamepad``, and an mpv without it
+does not ignore the flag, it **refuses to start**. That is the whole risk of
+this feature: a user ticks a box, updates mpv, and the application will not
+launch, with the box inside the application they can no longer open.
+
+So the tests here are mostly about the failure, not the feature.
+"""
+
+import unittest
+from unittest import mock
+
+from jellyfin_mpv_shim import mpv_options
+from jellyfin_mpv_shim.conf import settings
+
+from test_mpv_options import SettingsCase
+
+
+class GamepadOptionTest(SettingsCase):
+    def test_it_is_absent_unless_the_user_asks(self):
+        # The default path must never carry a build-gated option: somebody
+        # who leaves this alone cannot be affected by any of it.
+        self.set(input_gamepad=False)
+        self.assertNotIn(mpv_options.GAMEPAD_OPTION, self.build("mpvtk"))
+
+    def test_it_is_added_when_enabled(self):
+        self.set(input_gamepad=True)
+        self.assertIs(self.build("mpvtk")[mpv_options.GAMEPAD_OPTION], True)
+
+    def test_the_option_name_is_the_one_mpv_knows(self):
+        # Underscored in the dict python-mpv is called with, dashed on the
+        # command line. Getting this wrong is silent: mpv would reject a
+        # name it does not have and the feature would look build-gated
+        # everywhere.
+        self.assertEqual(mpv_options.GAMEPAD_OPTION, "input_gamepad")
+        self.assertEqual(mpv_options.GAMEPAD_OPTION.replace("_", "-"),
+                         "input-gamepad")
+
+
+def _libmpv_error(name=b"input-gamepad", value=b"yes"):
+    """What python-mpv raises for an option this mpv does not have."""
+    return AttributeError("mpv option does not exist", -5,
+                          (object(), name, value))
+
+
+def _jsonipc_error(bad_option="input-gamepad"):
+    """What python-mpv-jsonipc >= 1.3.0 raises, which names the option.
+
+    Older releases flattened every start failure into "MPV process retry
+    limit reached." after spending the whole retry budget on it, which is
+    why the shim's floor is 1.3.0.
+    """
+    error = Exception("MPV rejected the option --{0}.".format(bad_option))
+    error.bad_option = bad_option
+    return error
+
+
+class RejectedOptionTest(unittest.TestCase):
+    """Reading the option name back out of two very different exceptions."""
+
+    def setUp(self):
+        from jellyfin_mpv_shim import player
+        self.rejected = player._rejected_option
+
+    def test_libmpv_puts_the_name_in_the_exception_args(self):
+        self.assertEqual(self.rejected(_libmpv_error()), "input_gamepad")
+
+    def test_jsonipc_names_it_outright(self):
+        self.assertEqual(self.rejected(_jsonipc_error()), "input_gamepad")
+
+    def test_an_unrelated_failure_blames_nothing(self):
+        # The important negative. Answering with a guess here would drop an
+        # option over a failure that had nothing to do with it, and hide
+        # the real error behind a retry.
+        self.assertIsNone(self.rejected(ValueError("something else")))
+        self.assertIsNone(self.rejected(AttributeError("no args")))
+
+    def test_a_short_or_odd_argument_tuple_is_not_indexed_blindly(self):
+        self.assertIsNone(self.rejected(AttributeError("a", -5)))
+        self.assertIsNone(self.rejected(AttributeError("a", -5, ("x",))))
+
+
+class GamepadConstructRetryTest(unittest.TestCase):
+    """`_construct_mpv` against an mpv that refuses --input-gamepad.
+
+    Called unbound against a stand-in, as the lua tests do: importing
+    `player` for real opens a window.
+    """
+
+    def _construct(self, factory, options, lua_works=None, gamepad_works=None):
+        from jellyfin_mpv_shim import player
+
+        me = mock.Mock()
+        me._lua_works = lua_works
+        me._gamepad_works = gamepad_works
+        with mock.patch.object(player, "mpv") as fake_mpv:
+            fake_mpv.MPV.side_effect = factory
+            got = player.PlayerManager._construct_mpv(me, options)
+        return got, fake_mpv.MPV.call_args_list, me
+
+    @staticmethod
+    def _rejects(option, exc):
+        def factory(**kw):
+            if option in kw:
+                raise exc
+            return "player"
+        return factory
+
+    def test_it_retries_without_the_option_and_starts(self):
+        for label, error in (("libmpv", _libmpv_error()),
+                             ("jsonipc", _jsonipc_error())):
+            with self.subTest(backend=label):
+                got, calls, me = self._construct(
+                    self._rejects("input_gamepad", error),
+                    {"input_gamepad": True, "vo": "gpu"})
+                self.assertEqual(got, "player")
+                self.assertEqual(len(calls), 2)
+                self.assertNotIn("input_gamepad", calls[1].kwargs)
+                self.assertEqual(calls[1].kwargs["vo"], "gpu")
+
+    def test_it_records_the_answer_so_the_next_mpv_does_not_pay_again(self):
+        _got, _calls, me = self._construct(
+            self._rejects("input_gamepad", _libmpv_error()),
+            {"input_gamepad": True})
+        self.assertIs(me._gamepad_works, False)
+
+    def test_a_remembered_answer_skips_the_failed_construction(self):
+        got, calls, _me = self._construct(
+            self._rejects("input_gamepad", _libmpv_error()),
+            {"input_gamepad": True, "vo": "gpu"}, gamepad_works=False)
+        self.assertEqual(got, "player")
+        self.assertEqual(len(calls), 1, "paid for a construction it knew would fail")
+        self.assertNotIn("input_gamepad", calls[0].kwargs)
+
+    def test_dropping_the_gamepad_does_not_claim_lua_is_missing(self):
+        # Two build gates, two independent answers. Conflating them would
+        # drop the whole UI to the CLI because a controller option was
+        # unavailable.
+        _got, _calls, me = self._construct(
+            self._rejects("input_gamepad", _libmpv_error()),
+            {"input_gamepad": True, "osc": False})
+        self.assertIs(me._gamepad_works, False)
+        self.assertIsNone(me._lua_works)
+
+    def test_an_mpv_missing_both_gated_options_still_starts(self):
+        # The case the old "there is only one option this can be" reasoning
+        # could not express: a minimal build with neither SDL2 gamepad nor
+        # lua. It must end up running, not raising.
+        def factory(**kw):
+            if "input_gamepad" in kw:
+                raise _libmpv_error()
+            if "osc" in kw:
+                raise _libmpv_error(b"osc", b"no")
+            return "player"
+
+        got, calls, me = self._construct(
+            factory, {"input_gamepad": True, "osc": False, "vo": "gpu"})
+        self.assertEqual(got, "player")
+        self.assertEqual(len(calls), 3)
+        self.assertIs(me._gamepad_works, False)
+        self.assertIs(me._lua_works, False)
+
+    def test_an_unrelated_failure_is_not_blamed_on_the_gamepad(self):
+        # It still falls back to dropping --osc, which is the pre-existing
+        # behaviour for any unexplained failure, and then surfaces.
+        def factory(**kw):
+            raise RuntimeError("the display is on fire")
+
+        from jellyfin_mpv_shim import player
+        me = mock.Mock()
+        me._lua_works = None
+        me._gamepad_works = None
+        with mock.patch.object(player, "mpv") as fake_mpv:
+            fake_mpv.MPV.side_effect = factory
+            with self.assertRaises(RuntimeError):
+                player.PlayerManager._construct_mpv(me, {"input_gamepad": True})
+        self.assertIsNot(me._gamepad_works, False)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_gamepad.py
+++ b/tests/test_gamepad.py
@@ -182,3 +182,226 @@ class GamepadConstructRetryTest(unittest.TestCase):
 
 if __name__ == "__main__":
     unittest.main()
+
+
+class BindingTableTest(unittest.TestCase):
+    """`gamepad.bindings` -- the table itself."""
+
+    def test_swap_moves_the_two_face_buttons_and_nothing_else(self):
+        from jellyfin_mpv_shim import gamepad
+
+        plain = {k: rest for k, *rest in gamepad.bindings()}
+        swapped = {k: rest
+                   for k, *rest in gamepad.bindings(swap_confirm=True)}
+        self.assertEqual(set(plain), set(swapped))
+        moved = {k for k in plain if plain[k] != swapped[k]}
+        self.assertEqual(moved, {gamepad.CONFIRM_BUTTON, gamepad.BACK_BUTTON})
+        # ...and they trade, rather than both becoming one thing. A swap
+        # that assigned instead of exchanging would leave the pad with two
+        # back buttons and no way to select anything.
+        self.assertEqual(swapped[gamepad.CONFIRM_BUTTON],
+                         plain[gamepad.BACK_BUTTON])
+        self.assertEqual(swapped[gamepad.BACK_BUTTON],
+                         plain[gamepad.CONFIRM_BUTTON])
+
+    def test_every_key_is_bound_once(self):
+        from jellyfin_mpv_shim import gamepad
+
+        for swap in (False, True):
+            keys = [row[0] for row in gamepad.bindings(swap)]
+            self.assertEqual(len(keys), len(set(keys)), swap)
+
+    def test_the_seek_directions_are_ones_kb_seek_answers(self):
+        # The renderer hands these straight to PlayerManager.kb_seek, which
+        # sends anything it does not recognise to the OSD menu instead --
+        # so a typo here is a stick that silently opens a menu rather than
+        # seeking, and nothing else would notice.
+        from jellyfin_mpv_shim import gamepad
+        from jellyfin_mpv_shim.player import PlayerManager
+
+        known = set(PlayerManager._DEFAULT_SEEK)
+        got = {arg for _k, kind, arg, _r in gamepad.bindings()
+               if kind == gamepad.SEEK}
+        self.assertTrue(got)
+        self.assertLessEqual(got, known)
+
+    def test_the_nav_actions_are_ones_menu_action_answers(self):
+        # Same shape of risk one door along: menu_action's final fallback
+        # is kb_seek, so an action it does not know reaches the OSD menu.
+        from jellyfin_mpv_shim import gamepad
+        from jellyfin_mpv_shim.player import PlayerManager
+
+        known = (set(PlayerManager._NAV_KEYPRESS)
+                 | set(PlayerManager._NAV_COMMANDS) | {"menu"})
+        got = {arg for _k, kind, arg, _r in gamepad.bindings()
+               if kind == gamepad.NAV}
+        self.assertTrue(got)
+        self.assertLessEqual(got, known)
+
+    def test_the_right_stick_seeks_and_the_left_one_does_not(self):
+        # The asymmetry IS the feature: a controller has two sticks and
+        # does not have to share one set of directions the way a keyboard
+        # does. Binding the left stick to a seek is the bug this replaced.
+        from jellyfin_mpv_shim import gamepad
+
+        for key, kind, _arg, _rate in gamepad.bindings():
+            if "RIGHT_STICK" in key:
+                self.assertEqual(kind, gamepad.SEEK, key)
+            elif "LEFT_STICK" in key or "DPAD" in key:
+                self.assertEqual(kind, gamepad.KEY, key)
+
+    def test_nothing_a_press_MEANS_auto_repeats(self):
+        # Holding a button is not a request to press it again. An
+        # auto-repeating Select activates whatever it lands on over and
+        # over, and an auto-repeating Back walks out of the app.
+        from jellyfin_mpv_shim import gamepad
+
+        held = {"UP", "DOWN", "LEFT", "RIGHT", "PGUP", "PGDWN"}
+        for key, kind, arg, rate in gamepad.bindings():
+            repeats = rate > 0
+            wanted = kind == gamepad.SEEK or arg in held
+            self.assertEqual(repeats, wanted, key)
+
+    def test_a_held_control_is_slower_than_mpvs_own_repeat(self):
+        # mpv's --input-ar-rate default is 40 a second. Anything at or
+        # near that is the bug: [iw] "it spams inputs way faster than I can
+        # control them".
+        from jellyfin_mpv_shim import gamepad
+
+        for key, _kind, _arg, rate in gamepad.bindings():
+            if rate:
+                self.assertGreaterEqual(rate, 1 / 15.0, key)
+
+    def test_a_seek_repeats_more_slowly_than_a_selection_moves(self):
+        # A direction repeat moves one row; a seek repeat moves real time,
+        # so at the same rate a resting thumb crosses a film in seconds.
+        from jellyfin_mpv_shim import gamepad
+
+        self.assertGreater(gamepad.SEEK_REPEAT, gamepad.DIRECTION_REPEAT)
+
+    def test_it_is_json_safe(self):
+        # It is sent to the renderer as JSON; a tuple would arrive as a
+        # list anyway, so the table says so here rather than round-tripping
+        # into a different shape than the tests assert on.
+        import json
+
+        from jellyfin_mpv_shim import gamepad
+
+        table = gamepad.bindings()
+        self.assertEqual(json.loads(json.dumps(table)), table)
+
+
+class SdlSignalHandlerTest(unittest.TestCase):
+    """SIGTERM survives having gamepad input on.
+
+    SDL installs its own SIGINT/SIGTERM handlers, but only over a handler
+    still at SIG_DFL -- which is why standalone mpv is fine and the shim is
+    not: mpv installs its handlers first, and CPython leaves SIGTERM at the
+    default. In process, SDL took it and turned it into an SDL_QUIT that
+    mpv's gamepad loop drops, so the app could not be killed by anything
+    short of SIGKILL. Measured, with no controller attached.
+    """
+
+    def setUp(self):
+        import os
+
+        self.env = dict(os.environ)
+        self.addCleanup(lambda: (os.environ.clear(),
+                                 os.environ.update(self.env)))
+        os.environ.pop("SDL_NO_SIGNAL_HANDLERS", None)
+
+    def _construct(self, options):
+        from jellyfin_mpv_shim import player
+
+        me = mock.Mock()
+        me._lua_works = None
+        me._gamepad_works = None
+        with mock.patch.object(player, "mpv") as fake_mpv:
+            fake_mpv.MPV.return_value = "player"
+            player.PlayerManager._construct_mpv(me, options)
+
+    def test_it_is_set_before_an_mpv_that_has_gamepad_input(self):
+        import os
+
+        self._construct({"input_gamepad": True, "vo": "gpu"})
+        self.assertEqual(os.environ.get("SDL_NO_SIGNAL_HANDLERS"), "1")
+
+    def test_it_is_left_alone_when_no_sdl_will_be_loaded(self):
+        # Nothing in the process initialises SDL without this option, so
+        # there is nothing to disarm and no reason to touch the
+        # environment a user handed us.
+        import os
+
+        self._construct({"vo": "gpu"})
+        self.assertIsNone(os.environ.get("SDL_NO_SIGNAL_HANDLERS"))
+
+    def test_an_mpv_already_known_to_lack_gamepad_input_is_left_alone(self):
+        # The option is dropped before mpv is constructed, so no SDL is
+        # loaded and there is nothing to disarm. Ordering, which is the
+        # only way this can be wrong: reading `options` before the pops
+        # passes every other test in this class.
+        import os
+
+        from jellyfin_mpv_shim import player
+
+        me = mock.Mock()
+        me._lua_works = None
+        me._gamepad_works = False
+        with mock.patch.object(player, "mpv") as fake_mpv:
+            fake_mpv.MPV.return_value = "player"
+            player.PlayerManager._construct_mpv(me, {"input_gamepad": True})
+        self.assertIsNone(os.environ.get("SDL_NO_SIGNAL_HANDLERS"))
+
+    def test_an_explicit_value_from_the_user_is_not_overwritten(self):
+        # Including "0". Somebody who set this deliberately wants SDL's
+        # handlers, and quietly reversing them is worse than the bug.
+        import os
+
+        os.environ["SDL_NO_SIGNAL_HANDLERS"] = "0"
+        self._construct({"input_gamepad": True})
+        self.assertEqual(os.environ.get("SDL_NO_SIGNAL_HANDLERS"), "0")
+
+
+class ControllerReachesThePlayerTest(unittest.TestCase):
+    """The two buttons that are not synthetic keypresses, end to end from
+    the renderer's event to the player.
+
+    Everything else on the pad is a keypress the renderer issues itself, so
+    these two are the whole of the wiring -- and a handler left unwired is
+    silent: the stick simply does nothing.
+    """
+
+    def _browser(self):
+        from jellyfin_mpv_shim.mpvtk_browser.app import MpvtkBrowser
+        from tests._shell_harness import FakeSource
+
+        app = mock.Mock()
+        controller = mock.Mock()
+        b = MpvtkBrowser(app=None, source=FakeSource(), controller=controller)
+        b.set_app(app)
+        return app, controller
+
+    def test_the_right_stick_seeks_the_way_the_arrow_keys_do(self):
+        app, controller = self._browser()
+        app.on_gamepad_seek("left")
+        controller.kb_seek.assert_called_once_with("left")
+        # NOT seek_relative: the distance is the user's own input.conf
+        # number, which only kb_seek reads.
+        controller.seek_relative.assert_not_called()
+
+    def test_start_goes_through_the_remote_controls_ladder(self):
+        app, controller = self._browser()
+        app.on_gamepad_nav("menu")
+        controller.remote_action.assert_called_once_with("menu")
+
+    def test_the_gateway_hands_both_to_the_player(self):
+        from jellyfin_mpv_shim.mpvtk_browser.gateway import PlayerGateway
+
+        for method, target, arg in (("kb_seek", "kb_seek", "up"),
+                                    ("remote_action", "menu_action", "menu")):
+            with self.subTest(method=method):
+                gateway = PlayerGateway.__new__(PlayerGateway)
+                pm = mock.Mock()
+                gateway._act = lambda fn, pm=pm: fn(pm)
+                getattr(gateway, method)(arg)
+                getattr(pm, target).assert_called_once_with(arg)

--- a/tests/test_gamepad.py
+++ b/tests/test_gamepad.py
@@ -180,8 +180,6 @@ class GamepadConstructRetryTest(unittest.TestCase):
         self.assertIsNot(me._gamepad_works, False)
 
 
-if __name__ == "__main__":
-    unittest.main()
 
 
 class BindingTableTest(unittest.TestCase):
@@ -231,8 +229,13 @@ class BindingTableTest(unittest.TestCase):
         from jellyfin_mpv_shim import gamepad
         from jellyfin_mpv_shim.player import PlayerManager
 
+        # No literal for "menu" in here. It is already in _NAV_KEYPRESS,
+        # and whitelisting it would make this a set-theory identity: `got`
+        # is exactly {"menu"}, so `got <= known` would hold however
+        # menu_action changed, including if the action stopped being
+        # handled at all.
         known = (set(PlayerManager._NAV_KEYPRESS)
-                 | set(PlayerManager._NAV_COMMANDS) | {"menu"})
+                 | set(PlayerManager._NAV_COMMANDS))
         got = {arg for _k, kind, arg, _r in gamepad.bindings()
                if kind == gamepad.NAV}
         self.assertTrue(got)
@@ -273,11 +276,35 @@ class BindingTableTest(unittest.TestCase):
                 self.assertGreaterEqual(rate, 1 / 15.0, key)
 
     def test_a_seek_repeats_more_slowly_than_a_selection_moves(self):
-        # A direction repeat moves one row; a seek repeat moves real time,
-        # so at the same rate a resting thumb crosses a film in seconds.
+        """A direction repeat moves one row; a seek repeat moves real time,
+        so at the same rate a resting thumb crosses a film in seconds.
+
+        Asserted on the TABLE, not on the two constants. Comparing
+        `SEEK_REPEAT > DIRECTION_REPEAT` says nothing about what the rows
+        actually carry -- putting DIRECTION_REPEAT on the right stick
+        satisfies it, and satisfies every other rate test here too
+        (`test_nothing_a_press_MEANS_auto_repeats` only asks for > 0, and
+        the mpv-rate one only for >= 1/15).
+        """
         from jellyfin_mpv_shim import gamepad
 
-        self.assertGreater(gamepad.SEEK_REPEAT, gamepad.DIRECTION_REPEAT)
+        rates = {}
+        for key, kind, arg, rate in gamepad.bindings():
+            if kind == gamepad.SEEK:
+                rates.setdefault("seek", set()).add(rate)
+            elif arg in ("UP", "DOWN", "LEFT", "RIGHT"):
+                rates.setdefault("direction", set()).add(rate)
+            elif arg in ("PGUP", "PGDWN"):
+                rates.setdefault("page", set()).add(rate)
+        # One rate per class, or "the seek is slower than a direction" is
+        # not a statement about the table.
+        for name, seen in rates.items():
+            self.assertEqual(len(seen), 1, "%s rows disagree: %r"
+                             % (name, seen))
+        self.assertGreater(min(rates["seek"]), min(rates["direction"]))
+        # A page is a jump, so it sits between them.
+        self.assertGreater(min(rates["page"]), min(rates["direction"]))
+        self.assertLess(min(rates["page"]), min(rates["seek"]))
 
     def test_it_is_json_safe(self):
         # It is sent to the renderer as JSON; a tuple would arrive as a
@@ -320,46 +347,65 @@ class SdlSignalHandlerTest(unittest.TestCase):
             fake_mpv.MPV.return_value = "player"
             player.PlayerManager._construct_mpv(me, options)
 
-    def test_it_is_set_before_an_mpv_that_has_gamepad_input(self):
+    def test_it_is_set_before_mpv_is_constructed(self):
         import os
 
         self._construct({"input_gamepad": True, "vo": "gpu"})
         self.assertEqual(os.environ.get("SDL_NO_SIGNAL_HANDLERS"), "1")
 
-    def test_it_is_left_alone_when_no_sdl_will_be_loaded(self):
-        # Nothing in the process initialises SDL without this option, so
-        # there is nothing to disarm and no reason to touch the
-        # environment a user handed us.
+    def test_it_is_set_even_when_the_shim_passes_no_gamepad_option(self):
+        """Unconditional, and it has to be.
+
+        `input-gamepad` is an ordinary mpv option with no M_OPT_NOCFG, so a
+        line in the user's own mpv.conf starts the SDL thread with the
+        option absent from anything the shim built -- and that config file
+        is exactly what `mpv_ext_no_ovr` users are told to use. There is no
+        third place to ask, and no way to ask mpv in time: the gamepad
+        thread starts inside mpv_initialize.
+
+        This is the test the first version of this failed. It gated on the
+        option and read as obviously correct.
+        """
         import os
 
         self._construct({"vo": "gpu"})
-        self.assertIsNone(os.environ.get("SDL_NO_SIGNAL_HANDLERS"))
+        self.assertEqual(os.environ.get("SDL_NO_SIGNAL_HANDLERS"), "1")
 
-    def test_an_mpv_already_known_to_lack_gamepad_input_is_left_alone(self):
-        # The option is dropped before mpv is constructed, so no SDL is
-        # loaded and there is nothing to disarm. Ordering, which is the
-        # only way this can be wrong: reading `options` before the pops
-        # passes every other test in this class.
+    def test_a_blank_value_counts_as_unset(self):
+        """SDL's own reading: `SDL_GetHintBoolean` returns the DEFAULT for
+        an empty string, so `""` means "install handlers" exactly as unset
+        does. Preserving one -- which an `is None` guard does -- leaves the
+        unkillable-app bug in place for anybody whose launcher or systemd
+        unit exports the variable empty.
+        """
         import os
 
-        from jellyfin_mpv_shim import player
-
-        me = mock.Mock()
-        me._lua_works = None
-        me._gamepad_works = False
-        with mock.patch.object(player, "mpv") as fake_mpv:
-            fake_mpv.MPV.return_value = "player"
-            player.PlayerManager._construct_mpv(me, {"input_gamepad": True})
-        self.assertIsNone(os.environ.get("SDL_NO_SIGNAL_HANDLERS"))
+        os.environ["SDL_NO_SIGNAL_HANDLERS"] = ""
+        self._construct({"input_gamepad": True})
+        self.assertEqual(os.environ.get("SDL_NO_SIGNAL_HANDLERS"), "1")
 
     def test_an_explicit_value_from_the_user_is_not_overwritten(self):
-        # Including "0". Somebody who set this deliberately wants SDL's
-        # handlers, and quietly reversing them is worse than the bug.
+        # Somebody who wrote "0" wants SDL's handlers, and quietly
+        # reversing them is worse than the bug.
         import os
 
         os.environ["SDL_NO_SIGNAL_HANDLERS"] = "0"
         self._construct({"input_gamepad": True})
         self.assertEqual(os.environ.get("SDL_NO_SIGNAL_HANDLERS"), "0")
+
+    def test_honouring_it_says_so_in_the_log(self):
+        """...and it is the one value where the shim knows the user is
+        about to lose SIGTERM. Obeying it silently turns a choice into a
+        mystery for whoever reads the bug report."""
+        import os
+
+        os.environ["SDL_NO_SIGNAL_HANDLERS"] = "0"
+        with self.assertLogs("player", level="WARNING") as caught:
+            self._construct({"input_gamepad": True})
+        self.assertTrue(
+            any("SIGTERM" in line for line in caught.output),
+            "the warning does not say what the user loses: %r"
+            % (caught.output,))
 
 
 class ControllerReachesThePlayerTest(unittest.TestCase):
@@ -394,6 +440,22 @@ class ControllerReachesThePlayerTest(unittest.TestCase):
         app.on_gamepad_nav("menu")
         controller.remote_action.assert_called_once_with("menu")
 
+    def test_the_handler_names_are_the_ones_a_real_app_offers(self):
+        """`set_app` guards each wire with `hasattr`, so a rename on the
+        MpvtkApp side does not fail -- it silently skips the wiring and the
+        stick goes dead.
+
+        `_browser` above builds the app as a Mock, where every hasattr is
+        true, so it cannot see this. Asserted against the real class.
+        """
+        from jellyfin_mpv_shim.mpvtk.app import MpvtkApp
+
+        for name in ("on_gamepad_seek", "on_gamepad_nav"):
+            with self.subTest(handler=name):
+                self.assertIn(name, MpvtkApp.__init__.__code__.co_names,
+                              "MpvtkApp.__init__ no longer sets %r, so "
+                              "set_app's hasattr guard will skip it" % name)
+
     def test_the_gateway_hands_both_to_the_player(self):
         from jellyfin_mpv_shim.mpvtk_browser.gateway import PlayerGateway
 
@@ -405,3 +467,12 @@ class ControllerReachesThePlayerTest(unittest.TestCase):
                 gateway._act = lambda fn, pm=pm: fn(pm)
                 getattr(gateway, method)(arg)
                 getattr(pm, target).assert_called_once_with(arg)
+
+
+# At the END of the file, deliberately. It used to sit mid-file with later
+# test classes appended below it, so `python3 tests/test_gamepad.py` ran 13
+# of 29 and reported OK. `discover` was unaffected, which is what made it
+# invisible. See the "uncollected" shape in the notes on tests that cannot
+# fail.
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_gamepad.py
+++ b/tests/test_gamepad.py
@@ -394,18 +394,99 @@ class SdlSignalHandlerTest(unittest.TestCase):
         self.assertEqual(os.environ.get("SDL_NO_SIGNAL_HANDLERS"), "0")
 
     def test_honouring_it_says_so_in_the_log(self):
-        """...and it is the one value where the shim knows the user is
-        about to lose SIGTERM. Obeying it silently turns a choice into a
-        mystery for whoever reads the bug report."""
+        """...and says what it costs.
+
+        Since `mpv_shim._claim_sigterm` took the signal for this process,
+        the remaining exposure is the EXTERNAL backend's child mpv, which
+        has no handler of its own -- so the warning has to name that, not
+        this process. Obeying the value silently turns a choice into a
+        mystery for whoever reads the bug report.
+        """
         import os
 
         os.environ["SDL_NO_SIGNAL_HANDLERS"] = "0"
         with self.assertLogs("player", level="WARNING") as caught:
             self._construct({"input_gamepad": True})
-        self.assertTrue(
-            any("SIGTERM" in line for line in caught.output),
-            "the warning does not say what the user loses: %r"
-            % (caught.output,))
+        blob = " ".join(caught.output)
+        self.assertIn("external mpv", blob)
+        self.assertIn("cannot stop", blob)
+
+
+class SigtermClaimTest(unittest.TestCase):
+    """`mpv_shim._claim_sigterm` -- the primary fix, and an improvement that
+    stands on its own.
+
+    Two properties: SIGTERM asks for the orderly shutdown instead of killing
+    the process mid-report, and claiming it is what stops SDL taking it (SDL
+    only replaces a handler still at SIG_DFL). Pinned here rather than in a
+    subprocess because the interesting half is *which* signal is claimed and
+    *what* the handler does; that SDL then leaves it alone is a property of
+    SDL, measured once and recorded in the docstring.
+    """
+
+    def setUp(self):
+        import signal
+
+        was = signal.getsignal(signal.SIGTERM)
+        self.addCleanup(signal.signal, signal.SIGTERM, was)
+
+    def test_it_sets_the_event_the_run_loop_waits_on(self):
+        import signal
+        import threading
+
+        from jellyfin_mpv_shim import mpv_shim
+
+        halt = threading.Event()
+        mpv_shim._claim_sigterm(halt)
+        handler = signal.getsignal(signal.SIGTERM)
+        self.assertTrue(callable(handler),
+                        "SIGTERM was left at its default")
+        handler(signal.SIGTERM, None)
+        self.assertTrue(halt.is_set(),
+                        "SIGTERM did not ask for a shutdown")
+
+    def test_it_does_not_exit_the_process_itself(self):
+        """Everything that makes a shutdown orderly is in main's `finally`.
+        A handler that exited would skip the final progress report, the
+        window geometry and the credential flush -- which is the bug, not
+        the fix."""
+        import signal
+        import threading
+
+        from jellyfin_mpv_shim import mpv_shim
+
+        mpv_shim._claim_sigterm(threading.Event())
+        # Would raise SystemExit / never return if the handler exited.
+        signal.getsignal(signal.SIGTERM)(signal.SIGTERM, None)
+
+    def test_it_is_installed_before_anything_can_create_mpv(self):
+        """Ordering is the whole point: SDL initialises inside mpv, and
+        `playerManager` is a module-level singleton whose import creates it.
+        So the claim has to happen above every import that reaches the
+        player -- checked as source order, because a runtime test would need
+        a real mpv to be meaningful."""
+        import inspect
+        import re
+
+        from jellyfin_mpv_shim import mpv_shim
+
+        src = inspect.getsource(mpv_shim.main)
+        claim = src.index("_claim_sigterm(halt)")
+        player_imports = [m.start() for m in
+                          re.finditer(r"from \.player import", src)]
+        self.assertTrue(player_imports, "main no longer imports the player")
+        self.assertLess(claim, min(player_imports),
+                        "the player is imported before SIGTERM is claimed, "
+                        "so SDL gets the signal first")
+
+    def test_a_platform_without_sigterm_does_not_break_startup(self):
+        import threading
+        from unittest import mock
+
+        from jellyfin_mpv_shim import mpv_shim
+
+        with mock.patch("signal.signal", side_effect=ValueError("no")):
+            mpv_shim._claim_sigterm(threading.Event())
 
 
 class ControllerReachesThePlayerTest(unittest.TestCase):

--- a/tests/test_gamepad.py
+++ b/tests/test_gamepad.py
@@ -180,6 +180,128 @@ class GamepadConstructRetryTest(unittest.TestCase):
         self.assertIsNot(me._gamepad_works, False)
 
 
+class _FakeLibmpv:
+    """python-mpv's shape in the one respect that bites.
+
+    ``MPV.__init__`` sets the options inside a ``try`` whose ``finally`` is
+    ``mpv_initialize``, so a rejected option raises with the core already
+    **up** -- a running mpv owned by an object the constructor never
+    returned. Anything that models the failure by raising *instead of*
+    building cannot express that, and the retry looks fine right up to the
+    segfault.
+    """
+
+    def __init__(self, journal, reject, boom=None, **options):
+        self.handle = object()
+        self.journal = journal
+        self.stops = 0
+        journal.append(("start", self))
+        if boom is not None:
+            raise boom
+        if reject is not None and reject in options:
+            raise _libmpv_error(reject.replace("_", "-").encode())
+
+    def terminate(self):
+        self.stops += 1
+        self.handle = None
+        self.journal.append(("stop", self))
+
+
+class OrphanedCoreTest(unittest.TestCase):
+    """A construction that fails must not leave an mpv behind.
+
+    The crash this is about arrives *after* the retry has already logged
+    success, so it reads as the retry having failed. It is the previous
+    core: nothing holds it, so it runs until the collector reaches the
+    reference cycle the traceback made, and by then there are two of them on
+    one display.
+    """
+
+    def _construct(self, options, reject, stop_error=None):
+        from jellyfin_mpv_shim import player
+
+        journal = []
+
+        def factory(**kw):
+            core = _FakeLibmpv(journal, reject, **kw)
+            if stop_error is not None:
+                core.terminate = mock.Mock(side_effect=stop_error)
+            return core
+
+        me = mock.Mock()
+        me._lua_works = None
+        me._gamepad_works = None
+        with mock.patch.object(player, "mpv") as fake_mpv:
+            fake_mpv.MPV.side_effect = factory
+            got = player.PlayerManager._construct_mpv(me, options)
+        return got, journal
+
+    def test_the_orphan_is_stopped_before_the_retry_starts_another(self):
+        got, journal = self._construct(
+            {"input_gamepad": True, "vo": "gpu"}, "input_gamepad")
+
+        self.assertEqual([event for event, _core in journal],
+                         ["start", "stop", "start"])
+        orphan = journal[0][1]
+        self.assertIsNot(got, orphan)
+        self.assertIsNone(orphan.handle)
+        self.assertIs(journal[2][1], got)
+
+    def test_the_survivor_is_left_alone(self):
+        got, _journal = self._construct(
+            {"input_gamepad": True}, "input_gamepad")
+        self.assertEqual(got.stops, 0, "reaped the mpv it just started")
+
+    def test_the_lua_fallback_reaps_its_orphan_too(self):
+        # Older than the gamepad option and the same mistake: this path has
+        # been leaving a core behind since it shipped.
+        _got, journal = self._construct({"osc": False, "vo": "gpu"}, "osc")
+        self.assertEqual([event for event, _core in journal],
+                         ["start", "stop", "start"])
+
+    def test_a_failure_nobody_can_retry_still_reaps_on_the_way_out(self):
+        # The error leaves this method, and what it reaches is crash
+        # recovery -- which constructs another mpv. Raising with the last
+        # one still running is the two-cores state by another route.
+        from jellyfin_mpv_shim import player
+
+        journal = []
+
+        def factory(**kw):
+            # Raised from inside the constructor, which is where every real
+            # one comes from: `self` has to be a local of a frame in the
+            # traceback, because that is the only reference to it there is.
+            return _FakeLibmpv(journal, None,
+                               boom=RuntimeError("the display is on fire"),
+                               **kw)
+
+        me = mock.Mock()
+        me._lua_works = None
+        me._gamepad_works = None
+        with mock.patch.object(player, "mpv") as fake_mpv:
+            fake_mpv.MPV.side_effect = factory
+            with self.assertRaises(RuntimeError):
+                player.PlayerManager._construct_mpv(me, {"vo": "gpu"})
+
+        self.assertEqual([event for event, _core in journal], ["start", "stop"])
+
+    def test_a_core_that_will_not_stop_does_not_take_the_retry_with_it(self):
+        got, _journal = self._construct(
+            {"input_gamepad": True}, "input_gamepad",
+            stop_error=RuntimeError("mpv is wedged"))
+        self.assertIsInstance(got, _FakeLibmpv)
+
+    def test_an_error_holding_no_core_is_not_something_to_reap(self):
+        # Every jsonipc failure looks like this -- its mpv is a process, not
+        # a handle in here -- as does any error raised before the core came
+        # up. Walking the traceback must find nothing rather than terminate
+        # whatever `self` happened to be in frame.
+        from jellyfin_mpv_shim import player
+
+        try:
+            raise _libmpv_error()
+        except AttributeError as error:
+            player._reap_orphaned_core(error)
 
 
 class BindingTableTest(unittest.TestCase):

--- a/tests/test_mpvtk_adopt.py
+++ b/tests/test_mpvtk_adopt.py
@@ -255,3 +255,79 @@ class DisabledControlsAbsorbThePointer(unittest.TestCase):
                                  on_click=lambda: None))
         self.assertTrue(node.get("click"))
         self.assertFalse(node.get("dis"))
+
+
+class TestGamepadPush(unittest.TestCase):
+    """The controller binding table on its way to the renderer."""
+
+    def _push(self, **settings):
+        import json
+
+        from jellyfin_mpv_shim import conf
+
+        app = MpvtkApp.attach(FakeMPV(), ext=False)
+        saved = {k: getattr(conf.settings, k) for k in settings}
+        for key, value in settings.items():
+            setattr(conf.settings, key, value)
+        try:
+            app.push_gamepad()
+        finally:
+            for key, value in saved.items():
+                setattr(conf.settings, key, value)
+        payload = next(c for c in app.backend.mpv.commands
+                       if c[0] == "script-message" and c[1] == "mpvtk-gamepad")
+        return json.loads(payload[2])
+
+    def test_it_sends_the_table_the_settings_ask_for(self):
+        from jellyfin_mpv_shim import gamepad
+
+        self.assertEqual(self._push(gamepad_swap_confirm=False),
+                         gamepad.bindings(False))
+        self.assertEqual(self._push(gamepad_swap_confirm=True),
+                         gamepad.bindings(True))
+
+    def test_the_swap_actually_changes_what_is_sent(self):
+        # Guards the assertion above against both calls resolving to the
+        # same thing: a payload built from a captured or defaulted flag
+        # would satisfy it and change nothing on the pad.
+        self.assertNotEqual(self._push(gamepad_swap_confirm=False),
+                            self._push(gamepad_swap_confirm=True))
+
+    def test_a_fresh_renderer_is_told_without_being_asked(self):
+        # mpv is re-created (idle-quit, a cast, force_window), and each new
+        # handle gets a brand-new renderer with no bindings at all. If the
+        # table only ever went out on a settings change, the controller
+        # would work until the first re-open and then stop.
+        #
+        # `_push_metrics` is stubbed out, and has to be: it measures the
+        # real font stack and installs the result through layout.set_metrics,
+        # which is a MODULE GLOBAL. Letting a `ready` land for real here
+        # leaves every later test in the process laying text out against
+        # measured widths instead of the heuristic table -- which is not an
+        # error anywhere, it just silently moves every scene snapshot in the
+        # suite by a few percent. (Found exactly that way: seven snapshot
+        # tests failed in the full run and passed on their own.)
+        from unittest import mock
+
+        app = MpvtkApp.attach(FakeMPV(), ext=False)
+        with mock.patch.object(app, "_push_metrics"):
+            app._dispatch({"t": "ready", "w": 1280, "h": 720})
+        self.assertTrue(any(c[0] == "script-message"
+                            and c[1] == "mpvtk-gamepad"
+                            for c in app.backend.mpv.commands))
+
+    def test_the_sticks_report_through_their_own_handlers(self):
+        # The renderer sends these two rather than a keypress, so a missing
+        # dispatch arm is a stick that does nothing at all.
+        app = MpvtkApp.attach(FakeMPV(), ext=False)
+        seen = []
+        app.on_gamepad_seek = lambda d: seen.append(("seek", d))
+        app.on_gamepad_nav = lambda a: seen.append(("nav", a))
+        app._dispatch({"t": "gpseek", "dir": "left"})
+        app._dispatch({"t": "gpnav", "a": "menu"})
+        self.assertEqual(seen, [("seek", "left"), ("nav", "menu")])
+
+    def test_an_unwired_app_ignores_them(self):
+        app = MpvtkApp.attach(FakeMPV(), ext=False)
+        app._dispatch({"t": "gpseek", "dir": "left"})
+        app._dispatch({"t": "gpnav", "a": "menu"})

--- a/tests/test_python_lua_constants.py
+++ b/tests/test_python_lua_constants.py
@@ -91,6 +91,89 @@ class TestCharWidthTable(unittest.TestCase):
                          set())
 
 
+class TestGamepadWireContract(unittest.TestCase):
+    """The gamepad table crosses the mpv boundary as JSON, and each side
+    pins its own end with its own literal.
+
+    `gamepad.py` names the kinds symbolically (`gamepad.SEEK`) and every
+    Python test uses those names; `renderer.lua` branches on the bare
+    strings. So renaming one of those constants leaves BOTH suites green
+    while the renderer's if/elseif chain falls through to its `else` -- and
+    the else is `keypress`, so the right stick would start issuing
+    `keypress up`, which during playback is mpv's own arrow seek: no
+    `use_web_seek`, no SyncPlay awareness, and over a hidden HUD it summons
+    the bar instead. Silent, and exactly the class of bug this file is for.
+
+    Same for the event names and the payload keys: Lua sends
+    `{t='gpseek', dir=...}` and app.py reads `evt.get("dir")`, with the
+    toolkit test feeding a dict of its own.
+
+    Assertions go through `assertTrue(needle in text)` rather than
+    `assertIn`: the haystack is a 265 KB source file and assertIn puts the
+    whole of it in the failure message.
+    """
+
+    renderer = _read(RENDERER)
+    app = _read(os.path.join(PKG, "mpvtk", "app.py"))
+
+    def _has(self, needle, where, why):
+        self.assertTrue(needle in where, "%s (looked for %r)" % (why, needle))
+
+    def test_the_dispatched_kinds_are_the_strings_the_renderer_matches(self):
+        from jellyfin_mpv_shim import gamepad
+
+        # SEEK and NAV have arms of their own. KEY deliberately does NOT --
+        # it is the `else`, which is why a *typo* in any kind silently
+        # becomes "treat the third field as a key name" rather than an
+        # error. That is the reason this test exists at all.
+        for const, name in ((gamepad.SEEK, "SEEK"), (gamepad.NAV, "NAV")):
+            with self.subTest(kind=name):
+                self._has("kind == '%s'" % const, self.renderer,
+                          "renderer.lua has no arm for gamepad.%s == %r"
+                          % (name, const))
+
+    def test_the_key_kind_is_the_fallthrough_and_nothing_else(self):
+        # If someone gives KEY an arm of its own, the else stops being
+        # unreachable-by-design and a mistyped kind starts doing nothing
+        # instead of something wrong. Either is fine -- but the comment in
+        # gamepad.py says which one this is, so pin it.
+        from jellyfin_mpv_shim import gamepad
+
+        self.assertFalse("kind == '%s'" % gamepad.KEY in self.renderer,
+                         "gamepad.KEY grew an explicit arm in renderer.lua; "
+                         "the fall-through reasoning in gamepad.py and in "
+                         "test_the_dispatched_kinds... needs revisiting")
+
+    def test_every_kind_in_the_table_is_one_of_the_three(self):
+        from jellyfin_mpv_shim import gamepad
+
+        kinds = {kind for _k, kind, _a, _r in gamepad.bindings()}
+        self.assertEqual(kinds, {gamepad.KEY, gamepad.SEEK, gamepad.NAV},
+                         "a kind was added or dropped without review")
+
+    def test_the_event_names_and_payload_keys_match(self):
+        # Lua: send({ t = 'gpseek', dir = arg })  /  { t = 'gpnav', a = arg }
+        for t, key in (("gpseek", "dir"), ("gpnav", "a")):
+            with self.subTest(event=t):
+                self._has("t = '%s', %s = arg" % (t, key), self.renderer,
+                          "renderer.lua does not send %r carrying %r"
+                          % (t, key))
+                self._has('if t == "%s":' % t, self.app,
+                          "mpvtk/app.py does not dispatch %r" % t)
+                self._has('evt.get("%s")' % key, self.app,
+                          "mpvtk/app.py does not read %r" % key)
+
+    def test_the_repeat_interval_is_read_from_the_field_python_writes(self):
+        # Python appends the interval as the FOURTH element; Lua reads b[4].
+        from jellyfin_mpv_shim import gamepad
+
+        row = gamepad.bindings()[0]
+        self.assertEqual(len(row), 4)
+        self._has("tonumber(b[4])", self.renderer,
+                  "renderer.lua does not read the repeat interval from the "
+                  "position gamepad.bindings() writes it to")
+
+
 class TestSkipButtonGeometry(unittest.TestCase):
     """hud.py's _SKIP_* vs renderer.lua's PHUD_SKIP_*.
 

--- a/tests/test_shell_playback.py
+++ b/tests/test_shell_playback.py
@@ -53,6 +53,25 @@ class TestPlaybackHudLayout(unittest.TestCase):
         self.assertEqual(seek.get("marks"), [0.4, 0.8],
                          "chapter slits should be the interior chapters")
 
+    def test_play_pause_is_where_a_vertical_arrow_lands(self):
+        """DOWN off the seek bar has to reach play/pause at every width.
+
+        The renderer otherwise takes whichever control in the row is
+        nearest the x the arrow left the bar with -- and which one that is
+        moves with the window, because the chapter and seek buttons come
+        and go with it. `nav_gravity` names the control instead, and this
+        asserts the *scene* carries it: the renderer half is pinned in
+        tests/lua/test_renderer.lua, and it is pinned against a
+        hand-written node, so nothing there would notice this attribute
+        never being emitted.
+        """
+        b, _ctl = self._browser()
+        for size in ((1280, 720), (900, 520), (640, 400)):
+            with self.subTest(size=size):
+                nodes, _handlers = build_scene(b, size)
+                grav = [n.get("id") for n in nodes if n.get("grav")]
+                self.assertEqual(grav, ["hud-pp"], size)
+
     def _episode(self, b, **kw):
         st = dict(b.hud.state)
         st.update({"title": "Pilot", "series_name": "The Show",

--- a/tests/test_shell_playback.py
+++ b/tests/test_shell_playback.py
@@ -72,6 +72,28 @@ class TestPlaybackHudLayout(unittest.TestCase):
                 grav = [n.get("id") for n in nodes if n.get("grav")]
                 self.assertEqual(grav, ["hud-pp"], size)
 
+    def test_a_photo_has_no_gravity_at_all(self):
+        """A photo HUD draws no seek row, so the transport row sits directly
+        under the top bar -- and gravity applies to any vertical arrival
+        into the row, not just one off the bar. With it on, every DOWN from
+        the close button or the SyncPlay button threw the ring a thousand
+        pixels left onto play/pause, and UP did not bring it back (play/
+        pause's UP goes to the top-LEFT).
+
+        The whole argument for the gravity is disambiguating a full-width
+        seek bar. Where there is no seek bar there is nothing to
+        disambiguate, so there is nothing to pull.
+        """
+        b, _ctl = self._browser()
+        b.hud.state = dict(b.hud.state, is_photo=True)
+        for size in ((1280, 720), (900, 520), (640, 400)):
+            with self.subTest(size=size):
+                nodes, _handlers = build_scene(b, size)
+                self.assertIn("hud-pp", ids(nodes),
+                              "a photo lost its play/pause button")
+                self.assertEqual(
+                    [n.get("id") for n in nodes if n.get("grav")], [], size)
+
     def _episode(self, b, **kw):
         st = dict(b.hud.state)
         st.update({"title": "Pilot", "series_name": "The Show",

--- a/tests/test_shell_settings.py
+++ b/tests/test_shell_settings.py
@@ -723,6 +723,40 @@ class TestWorkOfflineToggle(unittest.TestCase):
         b._set_setting("player_name", "Bud")
         self.assertIs(b.source, before)
 
+class TestGamepadSwapAppliesLive(unittest.TestCase):
+    """The confirm/back swap re-pushes the binding table.
+
+    It has to apply without a restart, because the setting exists for
+    somebody who has just pressed A and gone *back*: pressing it again is
+    how they find out whether they picked the right switch. (`input_gamepad`
+    beside it genuinely does need one -- mpv reads that option at startup.)
+    """
+
+    def _browser(self):
+        from unittest import mock
+
+        cfg = FakeConfig()
+        cfg.schema["gamepad_swap_confirm"] = "bool"
+        cfg.values["gamepad_swap_confirm"] = False
+        cfg.schema["player_name"] = "str"
+        cfg.values["player_name"] = "x"
+        b = MpvtkBrowser(app=mock.Mock(), source=FakeSource(),
+                         controller=mock.Mock(), config=cfg)
+        b._pool = _SyncPool()
+        b.app.push_gamepad.reset_mock()
+        return b
+
+    def test_saving_it_re_pushes_the_table(self):
+        b = self._browser()
+        b._set_setting("gamepad_swap_confirm", True)
+        b.app.push_gamepad.assert_called_once_with()
+
+    def test_an_unrelated_setting_does_not(self):
+        b = self._browser()
+        b._set_setting("player_name", "Bud")
+        b.app.push_gamepad.assert_not_called()
+
+
 class TestPinStartupSeeding(unittest.TestCase):
     """Changing a PIN silently cleared "require at startup": the dialog
     always opened with the box unticked and saved that back."""


### PR DESCRIPTION
Adds gamepad support and associated error handling (gamepad support is not always compiled into mpv, it isn't by default in mpv-build). This is very useful for people who want to control MPV Shim's UI in an HTPC.