### PR TITLE
Filter bug fixes + Lazy Trickplay

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -21,6 +21,7 @@ the line you are about to add, so an inline comment cannot warn you.
 | Anything about startup, shutdown, the tray, single-instance or the gamepad | [docs/architecture.md](docs/architecture.md) |
 | Adding a config key, or moving one between settings tabs | [docs/settings-curation.md](docs/settings-curation.md) |
 | Touching watched/played state, or the download catalog (`sync/`) | [docs/offline-sync.md](docs/offline-sync.md) |
+| Trickplay, the seek-preview bubble, or anything handing mpv a file to `overlay-add` (`trickplay.py`, `bifdecode.py`, `thumbfast.lua`) | [docs/artwork-pipeline.md](docs/artwork-pipeline.md) §11 |
 | Writing a test, or adding/extending a fake | [docs/testing.md](docs/testing.md) |
 
 **`docs/mpv-backends.md` is essential before any player work.** Three examples of
@@ -319,7 +320,7 @@ discards every existing translation of it. Known cases: `Record`, `Channels`,
 | [docs/architecture.md](docs/architecture.md) | the process model: primary election, what a launch claims, the tray child process, making the exit finish; the gamepad; users; singleton wiring |
 | [docs/browser-shell.md](docs/browser-shell.md) | the browser shell: mixins/Pages, thread contract, epoch, lock policy, refresh-in-place, scroll parking, pollers, live-applied settings |
 | [docs/mpv-backends.md](docs/mpv-backends.md) | libmpv vs jsonipc, construction failures, mpv versions, SDL/signals, input sections, options that outlive a queue item, `wait_property`, video-setting defaults |
-| [docs/artwork-pipeline.md](docs/artwork-pipeline.md) | strips and the cache, transparent-artwork plating, tile shapes, Cover Size, badges, header baking, grid centring |
+| [docs/artwork-pipeline.md](docs/artwork-pipeline.md) | strips and the cache, transparent-artwork plating, tile shapes, Cover Size, badges, header baking, grid centring; trickplay's windowed frame file (§11) |
 | [docs/jellyfin-api-notes.md](docs/jellyfin-api-notes.md) | how the server actually behaves: DisplayPreferences/CustomPrefs, UserData, dropped parameters, Live TV query shapes |
 | [docs/readers.md](docs/readers.md) | books, audiobooks, the epub reader and the comic reader |
 | [docs/live-tv.md](docs/live-tv.md) | the Live TV screens, guide, timers and self-refresh |

--- a/docs/artwork-pipeline.md
+++ b/docs/artwork-pipeline.md
@@ -548,3 +548,150 @@ can never be drawn wider than ~570**, and since `_banner_poster` sizes its
 to draw it at 214px (19 KB)**. Nothing inset there is wider than a 16:9 still, so
 `banner.poster_box` caps the width against the slot's own height
 (`MAX_INSET_ASPECT`) as well as against the banner's width.
+
+## 11. Trickplay: the seek-preview frames
+
+The seek bar's preview thumbnails do not go through the store above at all.
+They are the only images the app hands to **mpv** rather than drawing itself:
+`trickplay.py` writes them to a file as raw BGRA and tells the OSC where it is,
+and mpv `overlay-add`s a rectangle out of that file at a byte offset. Nothing
+decodes anything per hover, which is what lets the bubble track the pointer at
+render cadence (§13 of `docs/browser-shell.md`, #618).
+
+**Older mpv MMAPS the file, and everything awkward here follows from that.** An
+offset past EOF was a SIGBUS *in the mpv process* rather than a missing
+thumbnail, so a frame count must be what was written and never what a manifest
+promised; and `open(path, "wb")` over a live mapping truncates the inode under
+it, which is why every generation gets its own path and the previous one is
+unlinked only after the renderer has been pointed at the new one.
+
+**mpv dropped the mmap in March 2026** (`3cd66d2fd7`, "command: avoid crashing
+the player with mmap", after 0.40 — for the same reason, reached from the other
+side). `cmd_overlay_add` now `open`s the file, `fread_pic`s the one rectangle
+into its own `mp_image_alloc(IMGFMT_BGRA, w, h)` and closes it. Every rule above
+stays, because the shim supports the builds that still map — but on a current
+mpv an over-reported count is a failed `overlay-add` with a log line, not a
+crash. **Do not weaken the discipline on the strength of the newer behaviour**;
+do not restate the SIGBUS as unconditional either.
+
+### 11.0 Where the memory actually goes
+
+Measured, because "trickplay uses a lot of RAM" has three candidates and only
+one of them was true:
+
+| | cost |
+|---|---|
+| mpv's copy of a live overlay | `w * h * 4` — 171 KB at 320px. Flat across 30 window swaps; the *file's* size never reaches RSS on a post-`3cd66d2fd7` mpv, and on an older one only the touched pages are resident. |
+| the frame file | one window, ≤ `WINDOW_BUDGET_BYTES`; the previous generation is unlinked as the new one is published. |
+| **decoding a tile in Python** | **this was the expensive one.** |
+
+A mosaic is 3200×1340 at the default preview width and 6400×2680 at 640px, so a
+whole-tile `convert("RGBA")` → `split()` → `merge()` → `tobytes()` held four
+tile-sized buffers at once. `decompress_tiles` crops each frame out of the
+opened tile and converts only the crop instead. Peak RSS for one tile, output
+byte-identical: **86 → 18 MB** at 320×134 and **207 → 71 MB** at 640×268, and
+about 30% faster at the larger size, because it also replaces `height` Python
+slice-and-write calls per frame with one.
+
+### 11.1 Why it is a window and not the video
+
+Trickplay arrives as JPEG mosaics — one per `TileWidth * TileHeight`
+thumbnails, a few hundred KB each. **Decoded, the same tile is 17 MB** at the
+server's default 320px preview width and 68 MB at 640px, and a two-hour film is
+eight of them. Loading the lot cost 130 MB for an ordinary film and, for the
+report this was written for, 800 MB — all of it mapped, for one bubble.
+
+So a fetch loads a *window*: as many frames as fit under
+`trickplay.WINDOW_BUDGET_BYTES` (25 MB), centred on the position asked for and
+clamped to the video. The budget is in **bytes, not minutes**, and that is the
+whole point — memory is what is scarce, so a library configured for large
+previews gets a shorter window rather than a bigger file. At 320×134 that is
+about 24 minutes of video; at 640×268 about six. An item small enough to fit
+entirely is loaded whole and never windows, so ordinary episodes pay nothing.
+
+`trickplay_fast_mode` restores the old behaviour for people who would rather
+spend the memory than ever wait (`docs/settings-curation.md`).
+
+**Tiles are the download unit; frames are the storage unit; they do not
+divide.** A window starts wherever it was centred, so the tile it starts in is
+fetched whole and `bifdecode.decompress_tiles(..., skip=)` throws away the
+frames of it that fall before the window. Fetching from the tile boundary
+instead would be the same bytes off the network and a bigger file.
+
+### 11.2 The message, and why `first` and `total` are on it
+
+    shim-trickplay-bif  <count> <interval_ms> <w> <h> <path> <first> <total>
+
+One message, both consumers: `mpvtk/renderer.lua` for the in-window HUD and
+`thumbfast.lua` for the lua OSCs. Neither can be left out, because they read the
+same file and must not disagree about which one is live.
+
+A consumer turns a position into a frame number against `total` — the cadence is
+the *whole video's* — and then subtracts `first` to reach the file. Without both
+numbers a consumer indexes a 30-frame file with a frame number the film's length
+justifies, which is the read past the end of the file above. Outside
+`[first, first + count)` there is no frame: the bubble reserves the box and
+draws a placeholder, rather than drawing frame 0 under a timestamp from
+somewhere else in the film.
+
+### 11.3 The request comes from the OSC, because only it knows where the pointer is
+
+    script-message  shim-trickplay-need  <seconds>
+
+`player._on_client_message` routes it to `TrickPlay.request_at`, which runs on
+**mpv's event thread** and therefore does nothing but record the position and
+wake the worker. `_want` is a single slot every request overwrites, so a drag
+across the whole seek bar coalesces into one fetch of wherever the pointer ended
+up instead of one per frame boundary it crossed.
+
+Two guards keep that from becoming a storm in the other direction:
+
+- The OSC sends **one message per frame index**, not one per drawn frame — it
+  is called from render, which runs for as long as the pointer sits outside
+  the window. Per *index*, not per window, and the difference is real: one
+  frame is about 1.5 px of a seek bar on a two-hour film, so drifting the
+  pointer across the missing region re-arms the marker repeatedly. What
+  bounds that is the Python side — `_want` is a single slot every request
+  overwrites, and `_covers` drops the ones already answered — so a drag
+  produces one fetch of wherever the pointer stopped, not one per index it
+  crossed. A landing window clears the marker, which re-asks when the
+  position moved on while the fetch was in flight.
+- `TrickPlay._covers` asks whether the loaded window holds the requested
+  **position**, not whether it holds the range a fresh window would have.
+  Ranges answer "no" for every request that is not dead centre, so that
+  spelling re-fetches the neighbours of a file already on disk. Asking about
+  the position is what makes the window hysteretic: one fetch buys half a
+  window of scrubbing in either direction.
+
+### 11.4 Retiring a frame file is deferred, twice over
+
+**A publish holds the previous file one cycle.** `script_message` returns when
+the message is queued to the script's event loop, not when lua has run it, so a
+render timer firing in between still issues `overlay-add` against the *old*
+path. Unlinking as the new file is published is what turns that into a missing
+thumbnail — once per window swap now, where it used to be once per video. So
+`_publish` parks the retired file and a *later* publish removes it. The disk
+holds at most two windows, and teardown (`_retire_current`) drains the held one.
+
+**A refused unlink is retried, not forgotten.** Windows will not unlink a file
+mpv still has open. That was also once-per-video and was left for the next
+run's `cleanup_stale_files()`; windowing makes it once-per-swap, so a long
+session would strand a window's worth of frames for every place the user
+looked. Both cases mean "remove on a later pass", so they share one list.
+
+### 11.5 A failed window is not a downgrade
+
+The bif branch's error handler must **not** fall through to the chapter images.
+Publishing `shim-trickplay-chapters` puts both consumers on the chapter branch,
+where neither can send `shim-trickplay-need` again — `renderer.lua` takes the
+`tp.times` path and `thumbfast.lua` gates the whole window block on
+`img_is_bif`. So one dropped tile mid-film meant chapter stills for the rest of
+the item, with Python still perfectly able to serve windows nothing would ever
+ask for. The fallback belongs to "this item has no trickplay at all", which is
+a different branch. A window that fails leaves the published one live and is
+retried by scrubbing.
+
+This is why `media.Video.get_hls_tile_images` raising rather than truncating is
+the right shape: an online tile failure aborts the window instead of publishing
+a short one. `OfflineVideo`'s returns instead, so a partial download is the one
+source that genuinely runs short.

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -854,15 +854,26 @@ between themes already on disk repaints immediately.
 
 ## Trickplay Thumbnails
 
-MPV will automatically display thumbnail previews. By default it uses the Trickplay images and falls back to chapter images. Please note that this feature will download and
-uncompress all of the chapter images before it becomes available for a video. For a 4 hour movie this
-causes disk usage of about 250 MB, but for the average TV episode it is around 40 MB. It also requires
+MPV will automatically display thumbnail previews. By default it uses the Trickplay images and falls back to chapter images. It also requires
 overriding the default MPV OSC, which may conflict with some custom user script. Trickplay is compatible
 with any OSC that uses [thumbfast](https://github.com/po5/thumbfast), as I have added a [compatibility layer](https://github.com/jellyfin/jellyfin-mpv-shim/blob/master/jellyfin_mpv_shim/thumbfast.lua).
+
+Previews are downloaded as JPEG mosaics and uncompressed to raw bitmaps, which
+is where the size is: a two-hour film is about 130 MB of them at the default
+thumbnail width and over 500 MB if your server generates 640px previews. So
+they are fetched **a window at a time**, a few tens of megabytes around wherever
+you are seeking, and swapped as you move. Scrubbing somewhere the current
+window does not reach shows an empty preview box for one round trip. Items
+short enough to fit under the limit are loaded whole and never wait at all.
+
+`trickplay_fast_mode` turns that off and loads every frame up front, the way
+older versions did — every preview is then instant, at the cost of the full
+download and the full memory.
 
 - `thumbnail_enable` - Enable thumbnail feature. (Default: `true`)
 - `thumbnail_osc_builtin` - Legacy alias: disabling this behaves like `osc_style: default` (use your own OSC but leave trickplay enabled). Prefer `osc_style`. (Default: `true`)
 - `thumbnail_preferred_size` - The ideal size for thumbnails. (Default: `320`)
+- `trickplay_fast_mode` - Load every preview frame at once instead of a window around the seek position. Previews never wait, but a long video costs hundreds of megabytes of memory. Turning it *on* applies to the video you are watching, the next time you scrub outside the part already loaded; turning it *off* applies to the next video. (Default: `false`)
 
 ## SVP Integration
 

--- a/docs/settings-curation.md
+++ b/docs/settings-curation.md
@@ -76,6 +76,24 @@ picked was the wrong one or whether the control does nothing.
 | shader pack directory | read once at startup |
 | several mpv options | mpv reads them at construction — see `docs/mpv-backends.md` |
 
+### Neither, and it is not symmetric: `trickplay_fast_mode`
+
+Read by the TrickPlay worker each time it builds a window, so the two
+directions land differently and the honest phrasing is per-direction:
+
+- **On** applies to the **current** video, at the next scrub the loaded window
+  does not cover — `_covers` says no, `_window_for` returns the whole video,
+  and the rest of the film is fetched then. Not at the moment you flip it, but
+  not next video either.
+- **Off** applies to the **next** video. The whole-video window already covers
+  every position, so `_covers` never says no again and no further fetch is
+  ever issued for the current item.
+
+Worth stating because the obvious summary — "takes effect on the next video" —
+is wrong in the direction a user is more likely to flip it, and wrong towards
+*more* work than they expect rather than less. See `docs/artwork-pipeline.md`
+§11.
+
 ### The two that look inconsistent and are not
 
 **`theme` splits.** Colours apply immediately; sizes do not. A theme change is

--- a/jellyfin_mpv_shim/bifdecode.py
+++ b/jellyfin_mpv_shim/bifdecode.py
@@ -10,24 +10,50 @@ except ImportError:
     Image = None
 
 
-def decompress_tiles(width, height, tile_width, tile_height, count, tiles, fh):
-    """Write `count` BGRA frames from `tiles` into `fh`.
+def decompress_tiles(width, height, tile_width, tile_height, count, tiles, fh,
+                     skip=0):
+    """Write up to `count` BGRA frames from `tiles` into `fh`.
+
+    `skip` drops that many frames off the FRONT of the stream without
+    writing them. The server hands trickplay out one mosaic per
+    `tile_width * tile_height` thumbnails, so a caller that wants a window
+    of the video has to fetch whole tiles either way -- but a decoded frame
+    is `width * height * 4` bytes and a tile of them is tens of megabytes,
+    which is the half worth not keeping. `skip` is what lets the file hold
+    the frames the window asked for rather than everything the tiles it
+    came in happened to carry.
 
     Returns the number of frames ACTUALLY written, which can be fewer than
-    `count` when the tile source runs short (a 404 on a late tile, a
-    truncated body, a server still generating trickplay). The caller must
-    report this rather than the manifest's count: mpv is handed the file to
-    mmap and seeks to `frame * width * height * 4`, so an over-reported count
-    produces an offset past EOF, which is a SIGBUS in the mpv process.
+    `count` when the tile source ends early. Which sources do that is worth
+    being precise about: `OfflineVideo.get_hls_tile_images` returns on a
+    missing file, so a partial download runs short here, but `media.Video`'s
+    RAISES -- an online tile failure aborts the whole window in
+    `TrickPlay.run` and never reaches this return.
+
+    The caller must report this number rather than the one it asked for. A
+    consumer seeks to `frame * width * height * 4` inside the file, so an
+    over-reported count is a read past the end of it: a failed `overlay-add`
+    on a current mpv, and a SIGBUS in the mpv process on one old enough to
+    still mmap what it is handed (docs/artwork-pipeline.md section 11).
     """
     if not PIL_AVAILABLE:
         raise ImportError(
             "Pillow (PIL) is required for trickplay thumbnails. Install with: pip install pillow"
         )
 
+    seen = 0
     image_count = 0
 
-    for image in tiles:
+    # Explicit iterator, so the `count` bound is checked BEFORE the next
+    # tile is pulled. `tiles` is a generator that fetches over the network
+    # one tile per step, so a `for` loop here downloads a whole mosaic to
+    # discover it has already written everything it was asked for.
+    tiles = iter(tiles)
+    while image_count < count:
+        try:
+            image = next(tiles)
+        except StopIteration:
+            break
         # Opened, NOT converted. A mosaic is 3200x1340 at the server's
         # default preview width and twice that per axis at 640px, so every
         # WHOLE-TILE operation costs tens of megabytes -- and converting to
@@ -48,6 +74,10 @@ def decompress_tiles(width, height, tile_width, tile_height, count, tiles, fh):
             for x in range(tile_width):
                 if image_count >= count:
                     return image_count
+                if seen < skip:
+                    seen += 1
+                    continue
+                seen += 1
                 image_count += 1
 
                 frame = image.crop((x * width, y * height,

--- a/jellyfin_mpv_shim/bifdecode.py
+++ b/jellyfin_mpv_shim/bifdecode.py
@@ -28,13 +28,21 @@ def decompress_tiles(width, height, tile_width, tile_height, count, tiles, fh):
     image_count = 0
 
     for image in tiles:
-        image = Image.open(BytesIO(image)).convert("RGBA")
+        # Opened, NOT converted. A mosaic is 3200x1340 at the server's
+        # default preview width and twice that per axis at 640px, so every
+        # WHOLE-TILE operation costs tens of megabytes -- and converting to
+        # RGBA, splitting into four channel images, merging them back and
+        # calling tobytes() on the result is four of them live at once.
+        # Cropping each frame out first and converting only the crop leaves
+        # the decoded tile as the only large buffer. Measured peak RSS for
+        # one tile, byte-identical output: 86 -> 18 MB at 320x134,
+        # 207 -> 71 MB at 640x268, and about 30% faster at the larger size
+        # because it also replaces `height` Python slice-and-write calls per
+        # frame with one.
+        image = Image.open(BytesIO(image))
 
         if height * tile_height != image.height or width * tile_width != image.width:
             raise ValueError("Tile size mismatch.")
-
-        r, g, b, a = image.split()
-        image_data = Image.merge("RGBA", (b, g, r, a)).tobytes()
 
         for y in range(tile_height):
             for x in range(tile_width):
@@ -42,13 +50,12 @@ def decompress_tiles(width, height, tile_width, tile_height, count, tiles, fh):
                     return image_count
                 image_count += 1
 
-                for y_local in range(height):
-                    position = (
-                        y * height * width * tile_width * 4  # seek to correct row
-                        + x * width * 4  # seek to correct column
-                        + y_local * width * tile_width * 4  # seek to correct subrow
-                    )
-                    fh.write(image_data[position : position + width * 4])
+                frame = image.crop((x * width, y * height,
+                                    (x + 1) * width, (y + 1) * height))
+                # mpv is handed this file as BGRA. `raw`/`BGRA` is Pillow's
+                # own channel-swapping packer and is byte-for-byte what the
+                # split/merge/tobytes dance produced.
+                fh.write(frame.convert("RGBA").tobytes("raw", "BGRA"))
 
     return image_count
 

--- a/jellyfin_mpv_shim/conf.py
+++ b/jellyfin_mpv_shim/conf.py
@@ -638,6 +638,20 @@ class Settings(SettingsBase):
     # hidden (mpv key name syntax). ENTER also toggles pause on wake.
     hud_wake_key: str = "ENTER"
     thumbnail_preferred_size: int = 320
+    #: Load every trickplay preview frame at once instead of a window
+    #: around where you are seeking.
+    #:
+    #: Off, the frames are fetched in windows of a few tens of megabytes
+    #: (``trickplay.WINDOW_BUDGET_BYTES``), so scrubbing somewhere the
+    #: window does not reach waits for one round trip. On, the whole video
+    #: is decoded up front, which is what this client always did: every
+    #: preview is then instant, but a two-hour film is about 130 MB of
+    #: decoded BGRA at the server's default thumbnail width and around
+    #: 500 MB at 640px -- written, and decoded through Python to get there.
+    #: Short items are loaded whole either way; the window is a ceiling,
+    #: not a quota. Where that cost actually lands, measured:
+    #: docs/artwork-pipeline.md section 11.
+    trickplay_fast_mode: bool = False
     tls_client_cert: Optional[str] = None
     tls_client_key: Optional[str] = None
     tls_server_ca: Optional[str] = None

--- a/jellyfin_mpv_shim/media.py
+++ b/jellyfin_mpv_shim/media.py
@@ -732,8 +732,14 @@ class Video(object):
             )
             yield data.getvalue()
 
-    def get_hls_tile_images(self, width, count):
-        for i in range(0, count):
+    def get_hls_tile_images(self, width, count, start=0):
+        """``count`` tile mosaics from tile index ``start``.
+
+        A tile carries ``TileWidth * TileHeight`` thumbnails, so a caller
+        after a window of the video asks for the tiles that window falls in
+        rather than for all of them. See ``trickplay.TrickPlay._window_for``.
+        """
+        for i in range(start, start + count):
             data = BytesIO()
             self.client.jellyfin.get_trickplay_tile(
                 data,

--- a/jellyfin_mpv_shim/messages/base.pot
+++ b/jellyfin_mpv_shim/messages/base.pot
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: jellyfin-mpv-shim\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2026-08-18 13:23-0400\n"
+"POT-Creation-Date: 2026-08-19 20:50-0400\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -1577,6 +1577,10 @@ msgid "Player Controls Style"
 msgstr ""
 
 #: jellyfin_mpv_shim/mpvtk_browser/config.py
+msgid "Load All Seek Previews at Once"
+msgstr ""
+
+#: jellyfin_mpv_shim/mpvtk_browser/config.py
 msgid "Show What You're Watching in Discord"
 msgstr ""
 
@@ -1810,6 +1814,16 @@ msgid ""
 "maximize and close in the top bar instead, and lets you drag the window by "
 "it. Left on \"Only when the window has no title bar\", MPV is asked whether "
 "this window got one, so desktops that do decorate it are left alone."
+msgstr ""
+
+#: jellyfin_mpv_shim/mpvtk_browser/config.py
+msgid ""
+"Seek previews are normally fetched a few minutes at a time around where you "
+"are seeking, so scrubbing somewhere new waits briefly. Turn this on to load "
+"them all up front instead: nothing ever waits, but a long film can cost "
+"several hundred MB of memory. Turning it on applies to what you are watching "
+"the next time you seek somewhere new; turning it off applies to the next "
+"video."
 msgstr ""
 
 #: jellyfin_mpv_shim/mpvtk_browser/config.py

--- a/jellyfin_mpv_shim/mpvtk/GUIDE.md
+++ b/jellyfin_mpv_shim/mpvtk/GUIDE.md
@@ -90,8 +90,20 @@ passwords; `on_change`/`on_submit`), `Dropdown` (readonly picker,
 `on_select`), `Slider` (`on_change`, throttled while dragging;
 seek-style sliders add `on_commit` — once, when the drag/adjust
 gesture ends — and `on_cancel` — gesture abandoned via ESC or focus
-moving away, value reverted; `force=True` tracks the scene value but
-never stomps an in-flight gesture), `Busy` (indeterminate spinner).
+moving away, value reverted), `Busy` (indeterminate spinner).
+
+**`force=True` on all three means the same thing: the scene's value wins
+over the renderer's own, but never mid-gesture.** The renderer keeps
+editing state, slider values and dropdown selections across scene pushes,
+keyed by node id, and `force` is how the app overrules that — the Clear All
+button on the filter panel is the case it exists for. The mid-gesture
+exception is what makes it usable: a textbox being typed into, a slider
+being dragged, and a dropdown whose selection has been sent but not yet
+answered all hold their own value until the app says something *different*
+from what it was showing when the gesture began. Without it the reset runs
+from the draw, so the frame after a click shows the pre-click value —
+not a race, every time. The dropdown was the last of the three to get the
+guard; `tests/lua/test_renderer.lua` pins all of it.
 
 Containers: `HScroll`/`VScroll` (optional scrollbar; `on_scroll` for
 windowed/infinite content — fires leading-edge-throttled every 150ms

--- a/jellyfin_mpv_shim/mpvtk/renderer.lua
+++ b/jellyfin_mpv_shim/mpvtk/renderer.lua
@@ -1257,9 +1257,23 @@ end
 
 local function dd_state(node)
     local d = state.dd[node.id]
-    if d == nil or node.force then
+    if d == nil then
         d = { sel = node.sel or 0 }
         state.dd[node.id] = d
+    elseif node.force and d.was == nil then
+        -- `force` means the scene's value wins over the renderer's own --
+        -- EXCEPT mid-gesture. Same shape as the textbox's `not editing`
+        -- guard and sl_state's `not busy`, and the dropdown was the one of
+        -- the three without it.
+        --
+        -- A click flips the selection locally and sends it; the app answers
+        -- by pushing a scene. Until that scene arrives its `sel` is still
+        -- the PRE-CLICK value, and this runs from the DRAW -- so taking it
+        -- redrew the label as the old option on the very next frame, every
+        -- time rather than in a race. `was` is what the app was showing
+        -- when the click happened; the push site below ends the gesture as
+        -- soon as the app says anything different.
+        d.sel = node.sel or 0
     end
     return d
 end
@@ -3339,6 +3353,7 @@ local function on_mouse_down()
         state.dd_open = nil
         if idx ~= nil and node then
             local d = dd_state(node)
+            d.was = node.sel or 0      -- opens the gesture; see dd_state
             d.sel = idx
             send({ t = 'select', id = node.id, index = idx,
                    value = node.items[idx + 1] })
@@ -4354,6 +4369,7 @@ local function nav_activate()
         state.nav_pidx = nil
         if node and idx ~= nil then
             local d = dd_state(node)
+            d.was = node.sel or 0      -- opens the gesture; see dd_state
             d.sel = idx
             send({ t = 'select', id = node.id, index = idx,
                    value = node.items[idx + 1] })
@@ -5032,7 +5048,20 @@ local function reconcile()
     for _, node in ipairs(state.nodes) do
         if node.force then
             if node.t == 'textbox' then state.tb[node.id] = nil end
-            if node.t == 'dropdown' then state.dd[node.id] = nil end
+            if node.t == 'dropdown' then
+                local d = state.dd[node.id]
+                -- A pending selection (see dd_state) ends when the app says
+                -- something DIFFERENT from what it was showing when the
+                -- click happened -- whether that is agreement or a refusal
+                -- that lands on some third value, both are answers.
+                -- Comparing against the value the user picked instead would
+                -- strand the control on their choice forever if the app
+                -- ever answered by keeping the original.
+                if d == nil or d.was == nil
+                        or (node.sel or 0) ~= d.was then
+                    state.dd[node.id] = nil
+                end
+            end
         end
     end
 end
@@ -6185,6 +6214,11 @@ mp.register_script_message('mpvtk-debug', function(json)
             modal_open = modal_active(),
             tb_menu = state.tb_menu ~= nil,
             sliders = state.sl,
+            -- Symmetric with `sliders`, and the omission was load-bearing:
+            -- a dropdown's renderer-local selection is what `force` fights
+            -- over, and with nothing reporting it the whole force path had
+            -- no test. See tests/lua/test_renderer.lua.
+            dropdowns = state.dd,
             has_metrics = measured_widths ~= nil,
             font = ui_font,
             wheel_count = state.wheel_count or 0,

--- a/jellyfin_mpv_shim/mpvtk/renderer.lua
+++ b/jellyfin_mpv_shim/mpvtk/renderer.lua
@@ -201,7 +201,9 @@ local state = {
     -- bar feel slow while it did (#618). Everything the bubble needs is
     -- already local: the tile file is raw BGRA that overlay-add consumes
     -- directly, and mpv owns the chapter list.
-    tp = nil,               -- tiles: {file, iw, ih, count, mult} or {..., times}
+    tp = nil,               -- tiles: {file, iw, ih, count, mult, first, total}
+                            -- or the chapter form {file, iw, ih, times}
+    tp_asked = nil,         -- last frame index requested from Python
     chlist = nil,           -- mpv's chapter-list, for the bubble's caption
     pv_hover = nil,         -- id of the preview slider under the pointer
     pv_secs = 0,            -- the position it is pointing at, in seconds
@@ -2350,7 +2352,11 @@ render = function()
         -- evenly spaced (multiplier ms apart); the chapter-image fallback
         -- carries one frame per chapter start.
         local tp = state.tp
-        local fw, fh, base = 0, 0, 0
+        -- `base` is nil when there is no frame to draw: fw/fh may still be
+        -- set, because the box is reserved while the window loads and a
+        -- base of 0 there would draw the window's FIRST frame under a
+        -- timestamp somewhere else in the film.
+        local fw, fh, base = 0, 0, nil
         local idx
         if tp and (tp.iw or 0) > 0 and (tp.ih or 0) > 0 then
             if tp.times and #tp.times > 0 then
@@ -2359,15 +2365,46 @@ render = function()
                     if tp.times[i] <= pv_secs then idx = i - 1 break end
                 end
                 if idx > #tp.times - 1 then idx = #tp.times - 1 end
+                fw, fh = tp.iw, tp.ih
+                base = idx * tp.iw * tp.ih * 4
             elseif (tp.count or 0) > 0 and (tp.mult or 0) > 0 then
+                -- Against the WHOLE video: the cadence is the video's, and
+                -- `total` is how many frames that cadence covers. The file
+                -- holds [first, first + count) of them.
+                local total = tp.total or tp.count
                 idx = math.floor(pv_secs * 1000 / tp.mult)
-                if idx > tp.count - 1 then idx = tp.count - 1 end
+                if idx > total - 1 then idx = total - 1 end
                 if idx < 0 then idx = 0 end
+                local rel = idx - (tp.first or 0)
+                if rel >= 0 and rel < tp.count then
+                    fw, fh = tp.iw, tp.ih
+                    base = rel * tp.iw * tp.ih * 4
+                else
+                    -- Outside the window. Reserve the space the frame will
+                    -- take so the bubble does not resize under the pointer
+                    -- when it lands, and ask Python for that part of the
+                    -- video. `rel` out of range is exactly the offset that
+                    -- reads past the end of the file, which is a failed
+                    -- overlay-add on a current mpv and a SIGBUS on one old
+                    -- enough to still mmap it (docs/artwork-pipeline.md
+                    -- section 11), so this bound is not cosmetic.
+                    --
+                    -- Inline rather than a helper because renderer.lua's
+                    -- main chunk is at Lua's 200-local ceiling (see
+                    -- tests/test_renderer_lua.py). This runs at render
+                    -- cadence for as long as the pointer sits outside the
+                    -- window, so `tp_asked` is what makes it one message
+                    -- per window instead of one per frame; a landing window
+                    -- clears it, which re-asks when the pointer moved on
+                    -- while the fetch was in flight.
+                    fw, fh = tp.iw, tp.ih
+                    if state.tp_asked ~= idx then
+                        state.tp_asked = idx
+                        mp.commandv('script-message', 'shim-trickplay-need',
+                                    tostring(pv_secs))
+                    end
+                end
             end
-        end
-        if idx then
-            fw, fh = tp.iw, tp.ih
-            base = idx * tp.iw * tp.ih * 4
         end
         local cap
         for _, c in ipairs(state.chlist or {}) do
@@ -2411,11 +2448,19 @@ render = function()
                   { fill = '282828', radius = ui_px(6) })
         local ty = py + pad
         if fh > 0 then
-            -- Native size: overlay-add does not scale, and the worker
-            -- already decoded these at thumbnail_preferred_size.
-            draw_image({ id = 'hud-preview', src = tp.file, base = base,
-                         iw = fw, ih = fh, w = fw, h = fh },
-                       math.floor(px + (bw - fw) / 2), ty)
+            local ix = math.floor(px + (bw - fw) / 2)
+            if base then
+                -- Native size: overlay-add does not scale, and the worker
+                -- already decoded these at thumbnail_preferred_size.
+                draw_image({ id = 'hud-preview', src = tp.file, base = base,
+                             iw = fw, ih = fh, w = fw, h = fh }, ix, ty)
+            else
+                -- The window this position falls in is still being
+                -- fetched. Something has to occupy the reserved box, or
+                -- the caption and the timestamp read as the whole bubble
+                -- and then jump when the frame arrives.
+                draw_rect(ass, ix, ty, fw, fh, { fill = '1a1a1a' })
+            end
             ty = ty + fh + gap
         end
         if cap then
@@ -5977,10 +6022,20 @@ end)
 -- and the two consumers cannot disagree about which file is live. The
 -- worker guarantees the path is unique per generation and only unlinks the
 -- previous one after pointing everybody at the new one.
+--
+-- `first`/`total` make the file a WINDOW of the video rather than all of
+-- it -- the whole thing is hundreds of MB of decoded BGRA. A position
+-- becomes a frame number against `total`, because the cadence is the whole
+-- video's; subtracting `first` reaches the file. Outside
+-- [first, first+count) there is nothing to draw and Python is asked for
+-- that part of the video (the scrub-preview block in render()).
 mp.register_script_message('shim-trickplay-bif',
-    function(count, mult, w, h, path)
+    function(count, mult, w, h, path, first, total)
         state.tp = { file = path, iw = tonumber(w), ih = tonumber(h),
-                     count = tonumber(count), mult = tonumber(mult) }
+                     count = tonumber(count), mult = tonumber(mult),
+                     first = tonumber(first) or 0,
+                     total = tonumber(total) or tonumber(count) }
+        state.tp_asked = nil
         request_render()
     end)
 
@@ -6000,6 +6055,7 @@ mp.register_script_message('shim-trickplay-chapters',
 mp.register_script_message('shim-trickplay-clear', function()
     -- The bytes go away right after this, so forget them first.
     state.tp = nil
+    state.tp_asked = nil
     request_render()
 end)
 

--- a/jellyfin_mpv_shim/mpvtk_browser/config.py
+++ b/jellyfin_mpv_shim/mpvtk_browser/config.py
@@ -160,7 +160,8 @@ TAB_SECTIONS = {
         # applies at all.
         (_("Player Controls"), ["osc_style", "hud_grab_keys", "hud_wake_key",
                                 "hud_scrim", "hud_autohide", "hud_hide_secs",
-                                "mouse_chapter_nav", "mouse_click_pauses"]),
+                                "mouse_chapter_nav", "mouse_click_pauses",
+                                "trickplay_fast_mode"]),
         (_("Playback"), ["auto_play", "hwdec", "always_transcode",
                          "local_kbps", "remote_kbps", "direct_paths",
                          "remote_direct_paths", "playback_timeout"]),
@@ -410,6 +411,7 @@ LABEL_OVERRIDES = {
     "remember_window_size": _("Remember Window Size"),
     "window_controls": _("Window Buttons in the Top Bar"),
     "osc_style": _("Player Controls Style"),
+    "trickplay_fast_mode": _("Load All Seek Previews at Once"),
     "discord_presence": _("Show What You're Watching in Discord"),
     "ui_scale": _("Interface Scale"),
     "ui_text_scale": _("Text Size"),
@@ -570,6 +572,15 @@ NOTES = {
                          "\"Only when the window has no title bar\", MPV is "
                          "asked whether this window got one, so desktops "
                          "that do decorate it are left alone."),
+    "trickplay_fast_mode": _("Seek previews are normally fetched a few "
+                             "minutes at a time around where you are "
+                             "seeking, so scrubbing somewhere new waits "
+                             "briefly. Turn this on to load them all up "
+                             "front instead: nothing ever waits, but a long "
+                             "film can cost several hundred MB of memory. "
+                             "Turning it on applies to what you are watching "
+                             "the next time you seek somewhere new; turning "
+                             "it off applies to the next video."),
     "osc_style": _("Requires restart to change. MPV keybinds are used by "
                    "default. Press ENTER to drive the player controls by "
                    "keyboard. \"No player controls\" leaves playback bare; "

--- a/jellyfin_mpv_shim/mpvtk_browser/dialogs.py
+++ b/jellyfin_mpv_shim/mpvtk_browser/dialogs.py
@@ -809,9 +809,19 @@ class DialogsMixin:
             if value == current or str(value) == str(current):
                 selected = i + 1
                 break
+        # force=True: the renderer keeps a dropdown's selection of its own
+        # (it flips optimistically on click and survives a scene push), so
+        # without this Clear All emptied `_filters` and re-queried while
+        # every picker went on showing the language the user just cleared.
+        #
+        # Safe to force here because `force` does not stomp an in-flight
+        # gesture -- the renderer holds the clicked value until the app
+        # answers with something different (GUIDE.md section 2). It did
+        # not always: the reset ran from the DRAW, so forcing a picker put
+        # its label back to the pre-click option on the very next frame.
         return Dropdown(
             "flt-" + key, [_("Any")] + [lbl for lbl, _v in pairs],
-            selected=selected, w=440, popup_w=440,
+            selected=selected, w=440, popup_w=440, force=True,
             on_select=lambda i, _v, p=pairs, k=key: on_set(
                 k, None if i == 0 else p[i - 1][1]))
 

--- a/jellyfin_mpv_shim/mpvtk_browser/pages/grid.py
+++ b/jellyfin_mpv_shim/mpvtk_browser/pages/grid.py
@@ -532,11 +532,11 @@ class GridPage(Page):
 
     def _bound_query(self):
         """``(sort_by, sort_order, filters, person, srv, image_type,
-        collections)`` read NOW, on the loop thread. The sort/filters a page
-        is fetched with must be the ones it was asked for, not whatever they
-        are when it lands -- and the artwork it asks the server for must be
-        the one the grid is being drawn with, or page two of a Banner view
-        arrives with no banners.
+        collections, ctype)`` read NOW, on the loop thread. The sort/filters
+        a page is fetched with must be the ones it was asked for, not
+        whatever they are when it lands -- and the artwork it asks the server
+        for must be the one the grid is being drawn with, or page two of a
+        Banner view arrives with no banners.
 
         ``collections`` for the same reason as the rest, and it was the one
         thing missing: `_fetch_at` read it live off the route, so a page-in
@@ -554,13 +554,14 @@ class GridPage(Page):
                 self.route.get("person_id"),
                 self.route.get("server") or self.ctx.server,
                 _image_type_of(self.route.get("_view")),
-                bool(self.route.get("_collections")))
+                bool(self.route.get("_collections")),
+                self.route.get("collection_type"))
 
     def _fetch_at(self, start, limit=None, bound=None):
         """One page of results. ``bound`` is a _bound_query() tuple captured
         on the loop thread; omitted only where the caller is already on it."""
         (sort_by, sort_order, filters, person, srv,
-         image_type, collections) = bound or self._bound_query()
+         image_type, collections, ctype) = bound or self._bound_query()
         source = self.ctx.source
         kw = {} if limit is None else {"limit": limit}
         if person:
@@ -576,10 +577,18 @@ class GridPage(Page):
                 srv, start_index=start, sort_by=sort_by,
                 sort_order=sort_order, filters=filters,
                 image_type=image_type, **kw)
+        # collection_type, like every other member of the bound tuple: it
+        # is what makes the query typed and Recursive, and page one is the
+        # only place it used to be passed. Every page after it therefore
+        # asked a DIFFERENT question -- a folder listing of the library
+        # root rather than a recursive query for its Series -- so a filter
+        # the server can only evaluate recursively (AudioLanguages) came
+        # back unapplied, and the total that arrived with it replaced the
+        # filtered one. See docs/browser-shell.md section 13.
         return source.get_library_items(
             srv, self.route["parent_id"], start_index=start,
             sort_by=sort_by, sort_order=sort_order, filters=filters,
-            image_type=image_type, **kw)
+            image_type=image_type, collection_type=ctype, **kw)
 
     def _window(self, first, last):
         """Fetch the items in ``[first, last)`` that are not loaded yet.
@@ -1250,10 +1259,11 @@ class ListPage(GridPage):
         # inherited and unpack what this returns.
         sort_by, sort_order = self._sort_args()
         return (sort_by, sort_order, self.route.get("_filters") or {}, None,
-                self.route.get("server") or self.ctx.server, None, False)
+                self.route.get("server") or self.ctx.server, None, False,
+                None)
 
     def _fetch_at(self, start, limit=None, bound=None):
-        sort_by, sort_order, filters, _person, srv, _itype, _coll = (
+        sort_by, sort_order, filters, _person, srv, _itype, _coll, _ct = (
             bound or self._bound_query())
         kw = {} if limit is None else {"limit": limit}
         return self.ctx.source.get_list(

--- a/jellyfin_mpv_shim/player.py
+++ b/jellyfin_mpv_shim/player.py
@@ -1934,6 +1934,15 @@ class PlayerManager(AudioMixin, ReportingMixin, WindowMixin):
                 self._on_claimed_key(args[1], args[2])
             elif args[0] == self.MENU_MESSAGE and len(args) >= 2:
                 self.menu.menu_action(args[1])
+            elif args[0] == "shim-trickplay-need" and len(args) >= 2:
+                # A preview was asked for at a position the loaded window
+                # does not cover. Only the OSC side knows where the pointer
+                # is, so the request comes from there. This is mpv's event
+                # thread -- request_at records and wakes the worker, and
+                # must keep doing only that.
+                trickplay = self.trickplay
+                if trickplay is not None:
+                    trickplay.request_at(float(args[1]))
             elif args[0] == "jms-lua":
                 if self._lua_probe is not None:
                     self._lua_probe.set()
@@ -2071,8 +2080,9 @@ class PlayerManager(AudioMixin, ReportingMixin, WindowMixin):
             return
         try:
             idle = self._player.core_idle
+            position = self._player.playback_time or 0
             if idle is None:
-                live = (self._player.playback_time or 0) > 0
+                live = position > 0
             else:
                 live = not idle
         except _mpv_errors:
@@ -2085,7 +2095,10 @@ class PlayerManager(AudioMixin, ReportingMixin, WindowMixin):
             return
         self._trickplay_pending = False
         log.debug("Playback is live; starting the trickplay fetch.")
-        self.trickplay.fetch_thumbnails()
+        # Where playback actually is, not zero: the worker loads a window
+        # around it, and on a resumed item the first place anyone scrubs is
+        # where they already are. Whole-video mode ignores it.
+        self.trickplay.fetch_thumbnails(position)
 
     def update(self):
         # Drain queued tasks first, and never let one abort the drain: this

--- a/jellyfin_mpv_shim/sync/offline_media.py
+++ b/jellyfin_mpv_shim/sync/offline_media.py
@@ -299,12 +299,19 @@ class OfflineVideo(Video):
     def get_bif(self, prefer_width=320):
         return self._trickplay["data"] if self._trickplay else None
 
-    def get_hls_tile_images(self, width, count):
+    def get_hls_tile_images(self, width, count, start=0):
+        """``count`` tile mosaics from tile index ``start``.
+
+        Same signature as ``media.Video``'s, and it has to be: the TrickPlay
+        worker asks for the tiles a window falls in, so an offline item whose
+        method still counted from zero answered a mid-film window with the
+        beginning of the film. See docs/artwork-pipeline.md section 11.
+        """
         if not self._trickplay:
             return
         tp_dir = os.path.join(self._item_dir, "trickplay",
                               str(self._trickplay["width"]))
-        for i in range(count):
+        for i in range(start, start + count):
             try:
                 with open(os.path.join(tp_dir, "%d.jpg" % i), "rb") as fh:
                     yield fh.read()

--- a/jellyfin_mpv_shim/thumbfast.lua
+++ b/jellyfin_mpv_shim/thumbfast.lua
@@ -9,6 +9,18 @@ local function dbg(text)
 end
 
 img_count = 0
+-- The file is a WINDOW of the video, not all of it: frames [img_first,
+-- img_first + img_count) of img_total. Decoded BGRA balloons -- a two-hour
+-- film is hundreds of megabytes of it -- so the shim fetches the part you
+-- are looking at and swaps files as you move. Indexing the file with a
+-- frame number the video's length justifies reads past its end: a failed
+-- overlay-add on a current mpv, and a SIGBUS on one old enough to still
+-- mmap the file. So the bounds check below is not cosmetic. A shim old
+-- enough not to send these sends the whole video, which the defaults
+-- describe.
+img_first = 0
+img_total = 0
+img_asked = nil    -- video-relative frame a window was last requested for
 img_multiplier = 0
 img_width = 0
 img_height = 0
@@ -58,6 +70,9 @@ function client_message_handler(event)
         img_width = tonumber(event["args"][4])
         img_height = tonumber(event["args"][5])
         img_file = event["args"][6]
+        img_first = tonumber(event["args"][7]) or 0
+        img_total = tonumber(event["args"][8]) or img_count
+        img_asked = nil
         img_last_frame = -1
         img_enabled = true
         img_is_bif = true
@@ -100,8 +115,34 @@ function client_message_handler(event)
                 end
             end
             should_render_preview = true
-            if img_is_bif and frame >= img_count then
-                frame = img_count -1
+            if img_is_bif then
+                -- Clamp against the VIDEO, then move into the file.
+                if frame >= img_total then frame = img_total - 1 end
+                if frame < 0 then frame = 0 end
+                local want = frame
+                frame = frame - img_first
+                if frame < 0 or frame >= img_count then
+                    -- Not loaded. Ask for it and take the stale thumbnail
+                    -- down: leaving it up labels this position with a
+                    -- picture from somewhere else in the film, which is
+                    -- worse than an empty box.
+                    --
+                    -- Keyed on the FRAME, not on offset_seconds: the OSC
+                    -- sends a `thumb` per pointer position, and dozens of
+                    -- them land on the one frame a single window would
+                    -- answer. img_asked is cleared when a window arrives.
+                    if img_asked ~= want then
+                        img_asked = want
+                        mp.commandv("script-message", "shim-trickplay-need",
+                                    tostring(offset_seconds))
+                    end
+                    if img_is_shown then
+                        mp.commandv("overlay-remove", img_overlay_id)
+                        img_is_shown = false
+                        img_last_frame = -1
+                    end
+                    return
+                end
             end
             -- Re-add only when the frame or position actually changed:
             -- overlay-add re-reads and re-uploads the whole BGRA tile, and

--- a/jellyfin_mpv_shim/trickplay.py
+++ b/jellyfin_mpv_shim/trickplay.py
@@ -1,7 +1,6 @@
 import threading
 import os
 import logging
-import math
 
 from .conf import settings
 from . import conffile
@@ -57,10 +56,49 @@ def _img_path(seq):
     return conffile.get(APP_NAME, "%s.%d%s" % (IMG_PREFIX, seq, IMG_SUFFIX))
 
 
+#: Decoded BGRA one window may occupy.
+#:
+#: A frame is ``Width * Height * 4`` bytes. The download is not the
+#: expensive half -- the server hands trickplay out as JPEG mosaics of
+#: ``TileWidth * TileHeight`` thumbnails, a few hundred KB each -- but
+#: decoded, one of those tiles is 17 MB at the server's default 320px and
+#: 68 MB at 640px, and a two-hour film is eight of them. **[iw]**: "if it's
+#: in ram I would say stay below 25 MB if possible as this is for one
+#: feature, unless the user requests the trickplay fast mode where it just
+#: hands the entire file to mpv where it can seek faster."
+#:
+#: What this bounds is the FILE, the work done before a preview appears,
+#: and -- on an mpv old enough to still mmap what it is handed -- resident
+#: memory too. A current mpv reads out the one rectangle it needs and keeps
+#: `w * h * 4`, so the file's size no longer reaches its RSS; the budget
+#: earns its keep on the other two regardless. The peak this does NOT bound
+#: is Python's, which is per TILE and belongs to `bifdecode`. Both measured:
+#: docs/artwork-pipeline.md section 11.
+#:
+#: Held constant in BYTES rather than in minutes deliberately: what is
+#: scarce scales with the frame, so a library with big thumbnails should get
+#: a shorter window rather than a bigger file. At 320x134 that is about 24
+#: minutes of video, at 640x268 about six.
+WINDOW_BUDGET_BYTES = 25 * 1024 * 1024
+
+# Frame files waiting to be removed, for either of two reasons: a removal
+# Windows refused (it will not unlink a file mpv still has open), or a file
+# `_publish` deliberately held over one cycle so a render that has not yet
+# processed the message pointing it elsewhere still finds its bytes. Both
+# mean "remove on a later pass", so they share one list.
+#
+# Windowed fetching is what makes this worth having: it turns both cases
+# from once-per-video into once-per-window-swap, and a long session would
+# otherwise strand a window's worth of frames for every place the user
+# looked.
+_pending_unlink = []
+_pending_lock = threading.Lock()
+
+
 def _unlink(path):
     """Best-effort removal. On Windows this fails while mpv holds the file
-    mapped; that is harmless — the name is never reused, and the next run's
-    cleanup_stale_files() collects it."""
+    mapped; the name is never reused, so the file is remembered and retried
+    rather than left for the next run's cleanup_stale_files()."""
     if not path:
         return
     try:
@@ -68,6 +106,19 @@ def _unlink(path):
             os.remove(path)
     except OSError:
         log.debug("Could not remove %s", path, exc_info=True)
+        with _pending_lock:
+            if path not in _pending_unlink:
+                _pending_unlink.append(path)
+
+
+def _sweep_unlinks():
+    """Retry the removals that were refused earlier."""
+    with _pending_lock:
+        if not _pending_unlink:
+            return
+        paths, _pending_unlink[:] = list(_pending_unlink), []
+    for path in paths:
+        _unlink(path)
 
 
 def cleanup_stale_files():
@@ -104,6 +155,18 @@ class TrickPlay(threading.Thread):
         # touched by the worker thread and by stop()/clear(), hence the lock.
         self._current = None
         self._file_lock = threading.Lock()
+        # Where the next fetch should centre its window, in seconds. A hint,
+        # not a queue: every request overwrites it, so a drag across the
+        # whole seek bar coalesces into one fetch of wherever the pointer
+        # ended up instead of a fetch per frame boundary it crossed.
+        self._want = 0.0
+        # The manifest for the video the window below belongs to, cached
+        # because get_bif() re-fetches the ITEM when Trickplay was not in
+        # the fields it was loaded with -- a round trip per scrub otherwise.
+        self._bif = None            # (video, manifest) or None
+        # (video, first, count, total) for the published window, so a scrub
+        # into frames already on disk asks the server for nothing.
+        self._window = None
 
         threading.Thread.__init__(self)
         # Daemon so a stop that can't join (see below) never blocks process
@@ -128,7 +191,25 @@ class TrickPlay(threading.Thread):
         if join:
             self.join()
 
-    def fetch_thumbnails(self):
+    def fetch_thumbnails(self, position=0.0):
+        """Load the window around ``position`` (seconds).
+
+        The player passes where playback actually starts, which for a resumed
+        item is not zero -- the first place the user is going to scrub is
+        where they already are.
+        """
+        self._want = max(0.0, position or 0.0)
+        self.trigger.set()
+
+    def request_at(self, seconds):
+        """A preview was asked for at ``seconds`` and the window does not
+        cover it. Sent by the renderer (and by thumbfast.lua for the lua
+        OSCs), which is the only side that knows where the pointer is.
+
+        Runs on mpv's event thread -- see ``player._on_client_message`` --
+        so it must not do anything but record and wake.
+        """
+        self._want = max(0.0, seconds or 0.0)
         self.trigger.set()
 
     def clear(self):
@@ -136,6 +217,8 @@ class TrickPlay(threading.Thread):
         # bytes behind it go away.
         self.player.script_message("shim-trickplay-clear")
         self._retire_current()
+        self._bif = None
+        self._window = None
 
     # -- frame-file lifecycle ---------------------------------------------
 
@@ -145,19 +228,113 @@ class TrickPlay(threading.Thread):
         return _img_path(_next_seq())
 
     def _publish(self, path):
-        """Adopt `path` as the live frame file and drop the previous one.
+        """Adopt `path` as the live frame file and retire the previous one.
 
-        Called only AFTER the renderer has been pointed at `path`, so the
-        file being unlinked is one nothing is being told to read any more.
+        The previous file is dropped **one publish later**, not now.
+        `script_message` returns when the message is queued to the script's
+        event loop, not when lua has run it, so a render timer that fires in
+        between still issues `overlay-add` against the OLD path -- and
+        unlinking it here is what turns that into a missing thumbnail. One
+        cycle of grace costs at most a second window on disk and makes the
+        promise this used to make ("only after the renderer has been pointed
+        elsewhere") actually true. Windowing is why it is worth paying: it
+        turned this from once per video into once per window swap.
         """
         with self._file_lock:
             old, self._current = self._current, path
-        _unlink(old)
+        # Sweep BEFORE queueing, so `old` survives exactly one more publish.
+        _sweep_unlinks()
+        if old:
+            with _pending_lock:
+                if old not in _pending_unlink:
+                    _pending_unlink.append(old)
 
     def _retire_current(self):
         with self._file_lock:
             old, self._current = self._current, None
         _unlink(old)
+        _sweep_unlinks()
+
+    # -- windowing ---------------------------------------------------------
+
+    def _manifest(self, video):
+        """This video's trickplay manifest, fetched once.
+
+        ``get_bif`` re-requests the whole ITEM when ``Trickplay`` was not in
+        the fields it was loaded with, so asking per window would put a round
+        trip in front of every scrub.
+        """
+        cached = self._bif
+        if cached is not None and cached[0] is video:
+            return cached[1]
+        data = video.get_bif(settings.thumbnail_preferred_size)
+        self._bif = (video, data)
+        return data
+
+    @staticmethod
+    def _frame_index(data, seconds):
+        """Which frame of the WHOLE video ``seconds`` falls on.
+
+        The cadence is the video's, not the window's -- ``Interval`` is
+        milliseconds between thumbnails from the start of the file -- so
+        this is the number every consumer computes and then rebases onto
+        whatever part of it is loaded.
+        """
+        total = int(data["ThumbnailCount"])
+        interval = max(1, int(data["Interval"]))
+        return max(0, min(int(seconds * 1000 // interval), total - 1))
+
+    @staticmethod
+    def _window_for(data, seconds):
+        """``(first, count)`` -- the frames to put on disk for a preview at
+        ``seconds``.
+
+        The whole video when the user asked for it (fast mode) or when it
+        fits under WINDOW_BUDGET_BYTES anyway, which is most short content
+        and is why an ordinary episode never pays for windowing. Otherwise a
+        budget's worth centred on the position, clamped to the video so the
+        first and last few minutes are reachable without a window that runs
+        off either end.
+        """
+        total = int(data["ThumbnailCount"])
+        frame = int(data["Width"]) * int(data["Height"]) * 4
+        if total <= 0 or frame <= 0:
+            return 0, total
+        budget = max(1, WINDOW_BUDGET_BYTES // frame)
+        if settings.trickplay_fast_mode or budget >= total:
+            return 0, total
+        centre = TrickPlay._frame_index(data, seconds)
+        first = max(0, min(centre - budget // 2, total - budget))
+        return first, budget
+
+    def _covers(self, video, frame):
+        """Whether the last fetch already answered for ``frame`` of this video.
+
+        Asked about the POSITION, not about the range a fresh window would
+        have: the window is recentred on wherever it was asked for, so
+        comparing ranges answers "no" for every request that is not dead
+        centre and re-fetches the neighbouring frames of a file already on
+        disk. This is what makes the window hysteretic -- one fetch buys
+        half a window of scrubbing in either direction.
+
+        The span recorded is the one that was ASKED for, not the number of
+        frames that arrived. Those differ when the tile source ends early --
+        in practice a partial download, since an online tile failure aborts
+        the window rather than truncating it -- and the difference is a
+        loop: the frames in the shortfall are inside the
+        window every request for them produces, so answering "not covered"
+        re-fetches, re-publishes, clears the consumer's one-ask-per-window
+        marker, and is asked again on the very next frame -- at render
+        cadence, for as long as the pointer sits there. Recording the
+        attempt is what makes a second fetch pointless *and* silent. Nothing
+        is lost by it: a re-fetch would come back equally short, and a new
+        item or a clear() drops this outright.
+        """
+        cur = self._window
+        if cur is None or cur[0] is not video:
+            return False
+        _v, first, asked, _total = cur
+        return first <= frame < first + asked
 
     def run(self):
         if not BIFDECODE_AVAILABLE:
@@ -180,42 +357,70 @@ class TrickPlay(threading.Thread):
                     continue
 
                 video = self.player.get_video()
+                want = self._want
+                # Set once the bif branch owns this pass. A failure AFTER
+                # that point must not fall through to the chapter images
+                # below -- see the handler at the bottom of the block.
+                windowing = False
+                path = None
                 try:
-                    data = video.get_bif(settings.thumbnail_preferred_size)
+                    data = self._manifest(video)
                     if not self.player.has_video() or video != self.player.get_video():
                         # Video changed while we were getting the bif file
                         continue
 
-                    if data:
+                    # A manifest that promises no frames falls through to
+                    # the chapter images below rather than short-circuiting
+                    # here: it is the same "no trickplay" the else branch
+                    # answers, and the fallback is the point of that branch.
+                    if data and int(data.get("ThumbnailCount") or 0) > 0:
+                        windowing = True
+                        if self._covers(video,
+                                        self._frame_index(data, want)):
+                            log.debug("Trickplay window already loaded.")
+                            continue
+                        first, count = self._window_for(data, want)
+
+                        # Tiles are the DOWNLOAD unit and frames are the
+                        # storage unit, and they do not divide: the window
+                        # starts wherever it was centred, so the first tile
+                        # is fetched whole and `skip` throws away the frames
+                        # of it that fall before the window. Fetching from
+                        # the tile boundary instead would be the same bytes
+                        # off the network and a bigger file.
+                        per_tile = (int(data["TileWidth"])
+                                    * int(data["TileHeight"]))
+                        tile_first = first // per_tile
+                        tile_count = (
+                            (first + count - 1) // per_tile - tile_first + 1
+                        )
                         path = self._next_file()
                         with open(path, "wb") as fh:
-                            img_count = math.ceil(
-                                data["ThumbnailCount"]
-                                / data["TileWidth"]
-                                / data["TileHeight"]
-                            )
                             written = bifdecode.decompress_tiles(
                                 data["Width"],
                                 data["Height"],
                                 data["TileWidth"],
                                 data["TileHeight"],
-                                data["ThumbnailCount"],
-                                video.get_hls_tile_images(data["Width"], img_count),
+                                count,
+                                video.get_hls_tile_images(
+                                    data["Width"], tile_count, start=tile_first
+                                ),
                                 fh,
+                                skip=first - tile_first * per_tile,
                             )
 
                         if not written:
                             log.warning("Trickplay produced no frames.")
                             _unlink(path)
                             continue
-                        if written < data["ThumbnailCount"]:
+                        if written < count:
                             # The tile source ran short. Report what is
-                            # actually in the file — mpv seeks to
-                            # frame * w * h * 4 in a mapping of it, so the
-                            # manifest's count would send it past EOF.
+                            # actually in the file — a consumer seeks to
+                            # frame * w * h * 4 inside it, so the count the
+                            # window ASKED for would send it past the end.
                             log.warning(
                                 "Trickplay short: %d of %d frames.",
-                                written, data["ThumbnailCount"],
+                                written, count,
                             )
                         bif_meta = {
                             "count": written,
@@ -236,6 +441,17 @@ class TrickPlay(threading.Thread):
                         # the lua OSCs, and mpvtk's renderer.lua, which
                         # reads the frames out of `path` itself for the
                         # playback HUD's scrub preview.
+                        #
+                        # `first` and `total` are what make the file a
+                        # WINDOW rather than the video: a consumer turns a
+                        # position into a frame number against `total` (the
+                        # cadence is the whole video's), then subtracts
+                        # `first` to reach the file. Without them a
+                        # consumer indexes a 30-frame file with a frame
+                        # number the video's length justifies, which reads
+                        # past the end of it (docs/artwork-pipeline.md
+                        # section 11).
+                        total = int(data["ThumbnailCount"])
                         self.player.script_message(
                             "shim-trickplay-bif",
                             str(bif_meta["count"]),
@@ -243,17 +459,56 @@ class TrickPlay(threading.Thread):
                             str(bif_meta["width"]),
                             str(bif_meta["height"]),
                             path,
+                            str(first),
+                            str(total),
                         )
                         # Both consumers now point at `path`; the previous
-                        # generation is safe to drop.
+                        # generation is safe to drop. The consumers are told
+                        # `written` (what is in the file); `_covers` records
+                        # `count` (what was asked for) -- see its docstring
+                        # for why those must be the different numbers.
+                        self._window = (video, first, count, total)
                         self._publish(path)
                         log.info(
-                            f"Collected {bif_meta['count']} trickplay preview images"
+                            "Collected %d trickplay preview images "
+                            "(frames %d-%d of %d)",
+                            bif_meta["count"], first,
+                            first + written - 1, total,
                         )
                         continue
                     else:
                         log.warning("No trickplay data available")
                 except:
+                    # Only if it never became the live file: `path` is the
+                    # partial write to clean up, and testing that rather
+                    # than the statement order is what keeps a future edit
+                    # between _publish and `continue` from unlinking the
+                    # window it just published.
+                    if path and path != self._current:
+                        _unlink(path)
+                    if windowing:
+                        # This item HAS trickplay and one window of it
+                        # failed -- a dropped tile request, a 504, a TLS
+                        # hiccup. Retry-by-scrubbing, not a downgrade: the
+                        # published window is still live and still correct,
+                        # and the next position the consumer cannot draw
+                        # asks again.
+                        #
+                        # Falling through to the chapter images is what
+                        # this `continue` prevents, and it is not a
+                        # graceful degradation here -- it is a one-way
+                        # door. Publishing `shim-trickplay-chapters` puts
+                        # both consumers on the chapter branch, where
+                        # neither can ever send `shim-trickplay-need`
+                        # again (renderer.lua takes `tp.times`;
+                        # thumbfast.lua gates the whole window block on
+                        # `img_is_bif`). One dropped tile mid-film would
+                        # have meant chapter stills for the rest of the
+                        # item. The fallback belongs to "this item has no
+                        # trickplay at all", which is the branch above.
+                        log.error("Could not load a trickplay window.",
+                                  exc_info=True)
+                        continue
                     log.error(
                         "Could not get trickplay data.",
                         exc_info=True,
@@ -290,6 +545,11 @@ class TrickPlay(threading.Thread):
                     str(path),
                     ",".join(str(x["start"]) for x in chapter_data),
                 )
+                # Not windowed, and it does not need to be: one frame per
+                # chapter is a few dozen at most. Clearing `_window` is what
+                # keeps that honest -- it describes the bif file, and the
+                # live file is now this one.
+                self._window = None
                 self._publish(path)
                 log.info(f"Collected {len(chapter_data)} chapter preview images")
 

--- a/tests/lua/fake_mp.lua
+++ b/tests/lua/fake_mp.lua
@@ -129,6 +129,7 @@ end
 local mp = {}
 local msg_handlers = {}
 local prop_observers = {}
+local event_handlers = {}
 
 --- Seconds an osd update "takes". The renderer times its own frames and
 --- decides from that how fast to schedule them and whether scrolling has to
@@ -308,14 +309,27 @@ function mp.set_key_bindings(list, name, _flags)
         section[entry[1]] = true
     end
 end
-function mp.register_event() end
+-- Recorded, not swallowed. `renderer.lua` reaches Python through
+-- `register_script_message`, but `thumbfast.lua` -- the shim's compatibility
+-- layer for thumbfast-style lua OSCs -- reads the raw `client-message`
+-- EVENT instead, so a no-op here left that whole script undrivable and
+-- therefore untested.
+function mp.register_event(name, fn)
+    event_handlers[name] = event_handlers[name] or {}
+    table.insert(event_handlers[name], fn)
+end
 function mp.register_idle() end
 function mp.get_script_name() return "mpvtk" end
 function mp.osd_message() end
 
+-- `mp.log(level, ...)` is the real primitive (player/lua.c:script_log);
+-- mpv's own defaults.lua builds every mp.msg.* entry on top of it, and
+-- thumbfast.lua calls it directly. Missing here, that was a nil-call the
+-- moment anything logged.
+function mp.log() end
 mp.msg = { error = function() end, warn = function() end,
            info = function() end, verbose = function() end,
-           debug = function() end, log = function() end }
+           debug = function() end, log = mp.log }
 mp.utils = utils
 
 -- assdraw: only ass_new() and the builder methods the renderer chains.
@@ -403,6 +417,24 @@ function M.send(name, ...)
 end
 
 function M.has_handler(name) return msg_handlers[name] ~= nil end
+
+--- Deliver an mpv EVENT, as mpv would. See mp.register_event.
+function M.emit(name, ev)
+    local fired = false
+    for _, fn in ipairs(event_handlers[name] or {}) do
+        fired = true
+        fn(ev)
+    end
+    if not fired then error("no handler for event: " .. name) end
+end
+
+--- The `client-message` an mpv `script-message` command arrives as: the
+--- command name is args[1], exactly as the real event carries it. Scripts
+--- that take this route see every script-message sent to anyone, which is
+--- why they all switch on args[1] rather than registering by name.
+function M.client_message(...)
+    M.emit("client-message", { event = "client-message", args = { ... } })
+end
 
 --- Fire a property observer, as mpv would.
 function M.observe(name, value)

--- a/tests/lua/test_renderer.lua
+++ b/tests/lua/test_renderer.lua
@@ -2800,6 +2800,85 @@ fake.send("mpvtk-gamepad", fake.token({}))
 fake.send("mpvtk-hud", "no")
 fake.send("mpvtk-active", "yes")
 
+-- ------------------------------------------------- force on a dropdown
+
+-- `force` means "the scene's value wins over the renderer's own", and the
+-- renderer keeps a selection per dropdown across scene pushes. There was no
+-- coverage of the pair at all, and the gap hid a real bug: dd_state ran the
+-- force reset from the DRAW, so the frame after a click redrew the label as
+-- the pre-click option -- every time, not in a race -- until the app pushed
+-- a scene agreeing. The textbox and the slider both guard their force reset
+-- against an in-flight gesture; the dropdown did not.
+
+--- A dropdown's renderer-local selection, after actually painting.
+---
+--- The paint is the point: `dd_state` materializes from the draw, so a
+--- scene push alone leaves nothing to read -- and the draw is also where
+--- the bug lived, so a helper that skipped it could not see it.
+local function dd_sel(id)
+    fake.advance(0.1)
+    fake.fire_timers()
+    fake.reset_events()
+    fake.send("mpvtk-debug", fake.token({ cmd = "state" }))
+    local dd = (last_event("debug_state") or {}).dropdowns or {}
+    return dd[id] and dd[id].sel
+end
+
+local function forced_dd(sel)
+    scene({ { id = "fdd", t = "dropdown", x = 40, y = 40, w = 200, h = 30,
+              size = 18, items = { "Any", "English", "German" },
+              sel = sel, force = true } })
+end
+
+forced_dd(0)
+eq(dd_sel("fdd"), 0, "the forced dropdown did not take the scene's value")
+
+click("fdd")                            -- open the popup
+fake.send("mpvtk-debug", fake.token({ cmd = "popup", index = 1 }))
+-- Read the event BEFORE dd_sel, which resets the log to find its own reply.
+eq((last_event("select") or {}).index, 1, "the app was not told")
+eq(dd_sel("fdd"), 1, "the click did not move the selection")
+
+-- The frame before the app has answered. This is the bug: it runs from the
+-- draw, so an unguarded force put the label back to "Any" immediately.
+fake.advance(0.1)
+fake.fire_timers()
+eq(dd_sel("fdd"), 1, "the selection snapped back before the app answered")
+
+-- ...and so does a scene push that still carries the old value, which is
+-- any unrelated repaint landing in the same window (a poller, the filter
+-- panel's own match-count spinner).
+forced_dd(0)
+eq(dd_sel("fdd"), 1, "a stale repaint reverted the click")
+
+-- The app agrees: the gesture ends and the scene is authoritative again.
+forced_dd(1)
+eq(dd_sel("fdd"), 1, "the agreed value was lost")
+
+-- ...which is what makes THIS work -- the case force exists for. Clear All
+-- empties the filters and re-queries; without force the picker went on
+-- showing the language the user just cleared.
+forced_dd(0)
+eq(dd_sel("fdd"), 0, "the scene could not move the picker back to Any")
+
+-- An answer that is neither the old value nor the picked one still ends the
+-- gesture, or a rejected selection would be shown as accepted forever.
+click("fdd")
+fake.send("mpvtk-debug", fake.token({ cmd = "popup", index = 1 }))
+eq(dd_sel("fdd"), 1, "sanity: the click moved it")
+forced_dd(2)
+eq(dd_sel("fdd"), 2, "a third answer did not end the gesture")
+
+-- Without force the renderer keeps its own selection, which is the
+-- behaviour every unforced dropdown relies on.
+scene({ { id = "udd", t = "dropdown", x = 40, y = 40, w = 200, h = 30,
+          size = 18, items = { "Any", "English" }, sel = 0 } })
+click("udd")
+fake.send("mpvtk-debug", fake.token({ cmd = "popup", index = 1 }))
+scene({ { id = "udd", t = "dropdown", x = 40, y = 40, w = 200, h = 30,
+          size = 18, items = { "Any", "English" }, sel = 0 } })
+eq(dd_sel("udd"), 1, "an unforced dropdown was reset by a scene push")
+
 -- ========================================================== teardown
 
 scene({})

--- a/tests/lua/test_renderer.lua
+++ b/tests/lua/test_renderer.lua
@@ -1836,6 +1836,76 @@ hud_pointer(1100, 672)
 pv_paint()
 eq(preview().frame, 9, "a position past the last tile clamps to it")
 
+-- ...and so does a position the loaded WINDOW does not reach, which is the
+-- same hazard from the other direction. The file holds frames
+-- [first, first + count) of a video `total` frames long, so a position has
+-- to be turned into a frame against the video and then rebased onto the
+-- file. Indexing a 20-frame mapping with frame 50 is exactly the read past
+-- EOF that mpv answers with SIGBUS.
+local function trickplay_request()
+    for _, c in ipairs(fake.log.commands) do
+        if c[1] == "script-message" and c[2] == "shim-trickplay-need" then
+            return tonumber(c[3])
+        end
+    end
+end
+
+local function trickplay_asks()
+    local n = 0
+    for _, c in ipairs(fake.log.commands) do
+        if c[1] == "script-message" and c[2] == "shim-trickplay-need" then
+            n = n + 1
+        end
+    end
+    return n
+end
+
+-- 10s cadence, 100 frames of video (the seek bar's whole 10 minutes), file
+-- holds frames 40..59 -- 6:40 to 9:50.
+fake.send("shim-trickplay-bif", "20", "10000", "32", "18", "/tiles.bin",
+          "40", "100")
+fake.log.commands = {}
+hud_pointer(640, 672)                   -- 5:00 -> frame 30, before the window
+pv_paint()
+ok(preview() ~= nil, "the bubble went away outside the window")
+ok(preview_overlay() == nil,
+   "a frame outside the window was composited anyway -- that offset is "
+   .. "past the end of the mapping")
+eq(trickplay_request(), 300, "no window was asked for at the gap")
+
+-- The ask is once per FRAME INDEX, not once per drawn frame: it sits in the
+-- draw path and runs for as long as the pointer stays outside the window.
+--
+-- The pointer has to actually move, and the repaints have to actually
+-- happen. One frame is 10s, which is ~17.7px of this bar, so 645 and 650
+-- are both still frame 30 -- two renders, same index, and the guard is the
+-- only thing that can suppress the second ask. Two bare pv_paint()s in a
+-- row render ZERO times (a one-shot timer self-disables and nothing
+-- invalidated), so a test built on those passes with the guard deleted.
+fake.log.commands = {}
+hud_pointer(645, 672)
+pv_paint()
+hud_pointer(650, 672)
+pv_paint()
+eq(trickplay_asks(), 0, "the request repeats for every render of one frame")
+
+-- ...but a different frame index is a different question, and must ask.
+-- Without this the test above would also pass if nothing ever asked at all.
+fake.log.commands = {}
+hud_pointer(700, 672)                   -- ~5:33 -> frame 33, still outside
+pv_paint()
+eq(trickplay_asks(), 1, "moving to another missing frame asked nothing")
+
+-- 7:30 is frame 45, which the file holds as its frame 5.
+fake.log.commands = {}
+hud_pointer(906, 672)
+pv_paint()
+local win_ov = preview_overlay()
+ok(win_ov ~= nil, "a frame inside the window was not drawn")
+eq(win_ov and tonumber(win_ov[6]), (45 - 40) * 32 * 18 * 4,
+   "the overlay offset was not rebased onto the window")
+eq(trickplay_request(), nil, "asked for a window it already had")
+
 -- The chapter-image fallback indexes by chapter start instead of a cadence.
 fake.send("shim-trickplay-chapters", "32", "18", "/tiles.bin", "0,120,480")
 hud_pointer(640, 673)

--- a/tests/lua/test_thumbfast.lua
+++ b/tests/lua/test_thumbfast.lua
@@ -1,0 +1,211 @@
+-- Unit tests for thumbfast.lua, run against a faked mpv (see fake_mp.lua).
+--
+-- This is the shim's compatibility layer for thumbfast-style lua OSCs: it
+-- receives the TrickPlay worker's `shim-trickplay-*` messages and answers a
+-- `thumb` request by compositing one frame out of the frame file. It had no
+-- tests at all, which mattered once the frame file became a WINDOW of the
+-- video rather than the whole of it — the bounds check added for that is the
+-- thing standing between an old (mmapping) mpv and a SIGBUS, and
+-- `mpv_options.mpv_scripts` loads this script under every OSC style.
+--
+-- It reaches mpv through the raw `client-message` EVENT rather than through
+-- `register_script_message`, so everything here is driven with
+-- `fake.client_message(...)` — the same route the real script has.
+--
+-- Prints "ok N" / "not ok N - why" (TAP-ish); the Python wrapper asserts on
+-- the exit status and shows this output on failure.
+
+local here = arg[0]:match("^(.*)/[^/]*$") or "."
+package.path = here .. "/?.lua;" .. package.path
+
+local fake = require("fake_mp")
+fake.install()
+
+local SCRIPT = arg[1]
+assert(SCRIPT, "usage: test_thumbfast.lua <path to thumbfast.lua>")
+assert(loadfile(SCRIPT))()
+
+-- ------------------------------------------------------------ harness
+
+local passed, failed = 0, 0
+local n = 0
+
+local function ok(cond, name, detail)
+    n = n + 1
+    if cond then
+        passed = passed + 1
+        print(string.format("ok %d - %s", n, name))
+    else
+        failed = failed + 1
+        print(string.format("not ok %d - %s", n, name))
+        if detail then print("    # " .. tostring(detail)) end
+    end
+end
+
+local function eq(got, want, name)
+    ok(got == want, name,
+       string.format("got %s, want %s", tostring(got), tostring(want)))
+end
+
+-- ------------------------------------------------------------ helpers
+
+local W, H = 32, 18
+local FRAME = W * H * 4
+
+--- The last overlay-add issued, as {x, y, file, offset}, or nil.
+local function overlay()
+    local found
+    for _, c in ipairs(fake.log.commands) do
+        if c[1] == "overlay-add" then
+            found = { x = tonumber(c[3]), y = tonumber(c[4]), file = c[5],
+                      offset = tonumber(c[6]) }
+        end
+    end
+    return found
+end
+
+local function removed()
+    for _, c in ipairs(fake.log.commands) do
+        if c[1] == "overlay-remove" then return true end
+    end
+    return false
+end
+
+--- Positions a window was requested for, in order.
+local function asks()
+    local out = {}
+    for _, c in ipairs(fake.log.commands) do
+        if c[1] == "script-message" and c[2] == "shim-trickplay-need" then
+            out[#out + 1] = tonumber(c[3])
+        end
+    end
+    return out
+end
+
+--- The whole video in one file, which is what a shim too old to send
+--- `first`/`total` produces — and what fast mode still produces.
+local function whole(count)
+    fake.client_message("shim-trickplay-bif", tostring(count), "10000",
+                        tostring(W), tostring(H), "/tiles.bin")
+end
+
+--- Frames [first, first+count) of a video `total` frames long.
+local function window(first, count, total)
+    fake.client_message("shim-trickplay-bif", tostring(count), "10000",
+                        tostring(W), tostring(H), "/tiles.bin",
+                        tostring(first), tostring(total))
+end
+
+local function thumb(secs, x, y)
+    fake.log.commands = {}
+    fake.client_message("thumb", tostring(secs), tostring(x or 0),
+                        tostring(y or 0))
+end
+
+-- ------------------------------------------------- the whole-video case
+
+-- The five-argument message is what every shim before windowing sent, and
+-- what fast mode still sends. It must keep behaving exactly as it did:
+-- `first` defaults to 0 and `total` to `count`, so the arithmetic collapses
+-- to what it always was.
+whole(60)
+thumb(300, 10, 20)
+local ov = overlay()
+ok(ov ~= nil, "no overlay for a frame that is present")
+eq(ov and ov.offset, 30 * FRAME, "the legacy 5-arg message moved the offset")
+eq(#asks(), 0, "a whole-video file asked for a window")
+
+-- Past the end clamps rather than reading off it. This is the guard that
+-- predates windowing, and it has to keep working: an offset past EOF is a
+-- failed overlay-add on a current mpv and a SIGBUS on an mmapping one.
+thumb(9999, 10, 20)
+eq(overlay().offset, 59 * FRAME, "a position past the end did not clamp")
+
+-- ------------------------------------------------------ the window case
+
+-- Frames 40..59 of a 100-frame video: 6:40 to 9:50 of a ten-minute film.
+window(40, 20, 100)
+
+-- 7:30 is frame 45, which the FILE holds as its frame 5. Indexing the file
+-- with 45 would read 45 * w * h * 4 into a 20-frame mapping.
+thumb(450, 10, 20)
+ov = overlay()
+ok(ov ~= nil, "a frame inside the window was not drawn")
+eq(ov and ov.offset, 5 * FRAME, "the offset was not rebased onto the window")
+eq(#asks(), 0, "asked for a window it already had")
+
+-- Below the window: nothing to draw, and a request for that part.
+thumb(60, 10, 20)
+eq(overlay(), nil, "composited a frame the file does not hold")
+eq(asks()[1], 60, "no window was requested for the gap below")
+
+-- Above the window, likewise. 800s is frame 80; the window ends at 59, and
+-- the VIDEO runs to 99, so this is outside the file and inside the film.
+thumb(800, 10, 20)
+eq(overlay(), nil, "composited a frame past the end of the window")
+eq(asks()[1], 800, "no window was requested for the gap above")
+
+-- Clamping happens against the VIDEO first: 9999s is frame 99, which is
+-- outside this window, so it must ask rather than clamp into the file.
+thumb(9999, 10, 20)
+eq(overlay(), nil, "clamped into the window instead of asking")
+eq(#asks(), 1, "a position past the end of the video asked for nothing")
+
+-- The stale thumbnail comes DOWN. Leaving it up labels this position with a
+-- picture from somewhere else in the film, which is worse than an empty box.
+thumb(450, 10, 20)                      -- draw something first
+ok(overlay() ~= nil, "nothing was drawn to go stale")
+thumb(60, 10, 20)
+ok(removed(), "a frame from elsewhere in the film was left on screen")
+
+-- One ask per frame index, not one per `thumb`. The OSC sends a thumb per
+-- pointer position and dozens of them land on the one frame a single window
+-- would answer, so keying the guard on the seconds would ask on nearly
+-- every one. 300 and 305 are both frame 30, and neither has been asked for
+-- yet -- an index this run has already requested would make the assertion
+-- pass for the wrong reason.
+fake.log.commands = {}
+fake.client_message("thumb", "300", "10", "20")
+fake.client_message("thumb", "305", "10", "20")
+eq(#asks(), 1, "the request repeats for every pointer position in one frame")
+
+-- ...but a different frame index is a different question. Without this the
+-- assertion above would also pass if nothing ever asked at all.
+fake.log.commands = {}
+fake.client_message("thumb", "200", "10", "20")   -- frame 20, still missing
+eq(#asks(), 1, "moving to another missing frame asked nothing")
+
+-- A window landing re-arms the guard, so a position that is STILL missing is
+-- asked for again -- the pointer moves on while a fetch is in flight, and
+-- without this the bubble would sit empty with nothing pending.
+window(40, 20, 100)
+thumb(60, 10, 20)
+eq(asks()[1], 60, "a landing window did not re-arm the request")
+
+-- ------------------------------------------------------- other branches
+
+-- The chapter fallback indexes by chapter start, and carries no window: the
+-- bounds check must not fire on it (there is nothing to be outside of).
+fake.client_message("shim-trickplay-chapters", tostring(W), tostring(H),
+                    "/tiles.bin", "0,120,480")
+thumb(300, 10, 20)
+ov = overlay()
+ok(ov ~= nil, "the chapter fallback drew nothing")
+eq(ov and ov.offset, 1 * FRAME, "chapter tiles index by start time")
+eq(#asks(), 0, "the chapter fallback asked for a window")
+
+-- Clearing takes the overlay down and stops answering.
+window(40, 20, 100)
+thumb(450, 10, 20)
+ok(overlay() ~= nil, "nothing was shown to clear")
+fake.log.commands = {}
+fake.client_message("shim-trickplay-clear")
+ok(removed(), "clear left the overlay pointing at bytes about to be unlinked")
+thumb(450, 10, 20)
+eq(overlay(), nil, "kept compositing after a clear")
+eq(#asks(), 0, "asked for a window while disabled")
+
+-- ------------------------------------------------------------ summary
+
+print(string.format("1..%d", n))
+if failed > 0 then os.exit(1) end

--- a/tests/test_offline_media.py
+++ b/tests/test_offline_media.py
@@ -110,6 +110,83 @@ class FactoryFileExistsGateTest(unittest.TestCase):
         self.assertIsInstance(video, offline_media.OfflineVideo)
 
 
+class OfflineTrickplayTest(unittest.TestCase):
+    """``OfflineVideo`` is a drop-in for ``media.Video``, and the trickplay
+    worker calls it through exactly the same names.
+
+    It stopped being one when the worker learned to fetch a *window* of the
+    tiles: ``Video.get_hls_tile_images`` grew a ``start`` and this one did
+    not, so every downloaded item raised TypeError and lost its previews
+    while the online path was fine. That is the repo's recurring shape --
+    the right mechanism applied to one of two implementations.
+    """
+
+    def setUp(self):
+        self.tmp = tempfile.TemporaryDirectory()
+        self.root = self.tmp.name
+        self.db = make_db(os.path.join(self.root, "cat.db"))
+        self.sync = FakeSync(self.db, self.root)
+        self._patch = mock.patch.object(offline_media, "syncManager",
+                                        self.sync)
+        self._patch.start()
+        self.item_dir = os.path.join(self.root, "a")
+        os.makedirs(self.item_dir)
+        with open(os.path.join(self.item_dir, "file.mkv"), "wb") as fh:
+            fh.write(b"x")
+        add_row(self.db, "a", "a/file.mkv")
+
+    def tearDown(self):
+        self._patch.stop()
+        self.db.close()
+        self.tmp.cleanup()
+
+    def _video(self, tiles=4):
+        with open(os.path.join(self.item_dir, "trickplay.json"), "w") as fh:
+            json.dump({"width": 320,
+                       "data": {"Width": 320, "Height": 180, "TileWidth": 2,
+                                "TileHeight": 2, "ThumbnailCount": tiles * 4,
+                                "Interval": 10000}}, fh)
+        tp_dir = os.path.join(self.item_dir, "trickplay", "320")
+        os.makedirs(tp_dir)
+        for i in range(tiles):
+            with open(os.path.join(tp_dir, "%d.jpg" % i), "wb") as fh:
+                fh.write(b"tile%d" % i)
+        return offline_media.OfflineVideo("a", FakeParent(client=None))
+
+    def test_the_trickplay_surface_matches_the_online_one(self):
+        """Signatures, not a call: this is the check that generalises to the
+        next parameter the worker starts passing."""
+        import inspect
+
+        from jellyfin_mpv_shim.media import Video
+
+        for name in ("get_bif", "get_hls_tile_images", "get_chapters"):
+            self.assertEqual(
+                inspect.signature(getattr(offline_media.OfflineVideo, name)),
+                inspect.signature(getattr(Video, name)),
+                "OfflineVideo.%s has drifted from media.Video.%s -- the "
+                "trickplay worker calls whichever it is handed" % (name, name))
+
+    def test_a_window_reads_the_tiles_it_asked_for(self):
+        """``start`` is the whole point: without it a mid-film window is
+        answered with the beginning of the film."""
+        video = self._video()
+        self.assertEqual(list(video.get_hls_tile_images(320, 2, start=2)),
+                         [b"tile2", b"tile3"])
+
+    def test_a_missing_tile_ends_the_run_rather_than_raising(self):
+        """A partial download is a short run, which the decoder reports as
+        frames written -- an over-reported count is a read past EOF in mpv."""
+        video = self._video(tiles=3)
+        self.assertEqual(list(video.get_hls_tile_images(320, 4, start=2)),
+                         [b"tile2"])
+
+    def test_no_downloaded_trickplay_yields_nothing(self):
+        video = offline_media.OfflineVideo("a", FakeParent(client=None))
+        self.assertIsNone(video.get_bif())
+        self.assertEqual(list(video.get_hls_tile_images(320, 2, start=1)), [])
+
+
 class OfflineSegmentsTest(unittest.TestCase):
     """Skip Intro/Credits over a downloaded file.
 

--- a/tests/test_renderer_lua.py
+++ b/tests/test_renderer_lua.py
@@ -20,6 +20,7 @@ import unittest
 ROOT = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
 LUA_DIR = os.path.join(ROOT, "tests", "lua")
 RENDERER = os.path.join(ROOT, "jellyfin_mpv_shim", "mpvtk", "renderer.lua")
+THUMBFAST = os.path.join(ROOT, "jellyfin_mpv_shim", "thumbfast.lua")
 
 # luajit first: it is what mpv itself usually embeds, so it is the dialect
 # the renderer actually has to run under.
@@ -40,9 +41,9 @@ LUA = find_lua()
 @unittest.skipIf(LUA is None,
                  "no Lua interpreter (tried: %s)" % ", ".join(INTERPRETERS))
 class TestRendererLua(unittest.TestCase):
-    def _run(self, script, env=None):
+    def _run(self, script, env=None, target=None):
         return subprocess.run(
-            [LUA, os.path.join(LUA_DIR, script), RENDERER],
+            [LUA, os.path.join(LUA_DIR, script), target or RENDERER],
             cwd=LUA_DIR, capture_output=True, text=True, timeout=120,
             env=env)
 
@@ -80,6 +81,27 @@ class TestRendererLua(unittest.TestCase):
         self._assert_suite_passed(
             self._run("test_renderer.lua",
                       env=self._session_env(WAYLAND_DISPLAY="wayland-0")))
+
+    def test_the_thumbfast_suite_passes(self):
+        """`thumbfast.lua` is the other consumer of the trickplay frame
+        file — the compatibility layer every thumbfast-style lua OSC talks
+        to, and `mpv_options.mpv_scripts` loads it under every OSC style.
+
+        It had no tests at all while renderer.lua had a suite, which is this
+        repo's recurring shape: the right mechanism applied to one of two
+        implementations. It matters here because the bounds check in it is
+        what stands between a windowed frame file and a read past the end of
+        it — a failed overlay-add on a current mpv, a SIGBUS on one old
+        enough to still mmap what it is handed.
+        """
+        self._assert_suite_passed(
+            self._run("test_thumbfast.lua", target=THUMBFAST))
+
+    def test_thumbfast_parses_under_this_interpreter(self):
+        proc = subprocess.run(
+            [LUA, "-e", "assert(loadfile(%r))" % THUMBFAST],
+            capture_output=True, text=True, timeout=60)
+        self.assertEqual(proc.returncode, 0, proc.stderr)
 
     def test_the_renderer_parses_under_this_interpreter(self):
         """Cheap syntax gate, separate from the behavioural run: a parse

--- a/tests/test_shell_library.py
+++ b/tests/test_shell_library.py
@@ -1877,6 +1877,24 @@ class TestYearFilter(unittest.TestCase):
         dd = next(n for n in nodes if n.get("id") == "flt-year")
         self.assertEqual(dd["sel"], 2)
 
+    def test_clear_all_moves_the_pickers_not_just_the_route(self):
+        """The renderer keeps a dropdown's selection of its own -- it flips
+        optimistically on click and survives a scene push -- so a rebuild
+        that merely *says* "Any" leaves the control reading the value the
+        user cleared. ``force`` is what lets the scene outvote it, and
+        `sel` alone is the assertion that could not see this.
+        """
+        route = self._route(_filters={"year": 2021})
+        _n, handlers = self._panel()
+        handlers["flt-clear"]["click"]()
+        nodes, _h = build_scene(self.b)
+        dd = next(n for n in nodes if n.get("id") == "flt-year")
+        self.assertEqual(route["_filters"].get("year"), None)
+        self.assertEqual(dd["sel"], 0)
+        self.assertTrue(dd.get("force"),
+                        "the picker leaves its renderer-local selection in "
+                        "place, so Clear All does not move it")
+
 class TestCollections(unittest.TestCase):
     """Collections were missing from mpvtk entirely: no Movies-library
     toggle, no add-to-collection, no remove-from-collection."""

--- a/tests/test_shell_paging.py
+++ b/tests/test_shell_paging.py
@@ -1217,5 +1217,74 @@ class TestAReturningScrollContainerStartsAtTheTop(unittest.TestCase):
         self.assertIn("music-0-al0", self._tiles(b, "music-"))
 
 
+class TestPagedQueriesMatchTheFirstOne(unittest.TestCase):
+    """Every page of a grid must ask the *same question* page one asked.
+
+    ``collection_type`` is what makes a library query typed and Recursive
+    (``IncludeItemTypes=Series&Recursive=True``). Only the initial load
+    passed it, so page two was a plain folder listing of the library root
+    -- a different result set, in a different order, with a different total.
+    It looked fine unfiltered, because a TV library's direct children are
+    its Series anyway. Under ``AudioLanguages=eng`` it was the bug the
+    tester saw: the recursive query filters, the folder listing does not,
+    so scrolling spliced unfiltered shows into a filtered grid and the
+    unfiltered total came with them.
+
+    **Only the first test below fails against that bug**, and the other two
+    are not covering it: they guard the rest of the bound tuple, and guard
+    against over-correcting into typing a query that must stay untyped. The
+    distinction is worth stating, because three tests under one docstring
+    about one bug read as three times the coverage.
+    """
+
+    def _grid(self, ctype="tvshows", total=500):
+        src = FakeSource()
+        src.grid_items = [{"Id": "s%d" % i, "Name": "Show %d" % i,
+                           "Type": "Series",
+                           "PrimaryImageAspectRatio": 2 / 3}
+                          for i in range(total)]
+        b = MpvtkBrowser(app=None, source=src)
+        b._pool = _SyncPool()
+        b.server = "srv1"
+        route = {"kind": "grid", "server": "srv1", "parent_id": "lib1",
+                 "collection_type": ctype,
+                 "_filters": {"audio_languages": "eng"}}
+        b.nav_stack = [route]
+        b._load_route(route)
+        return b, route, src
+
+    def test_every_page_carries_the_collection_type(self):
+        b, route, src = self._grid()
+        grid_scroll(b, route, 20_000, 40_000)
+        self.assertGreater(len(src.queries), 1, "nothing paged")
+        self.assertTrue(
+            all(q["collection_type"] == "tvshows" for q in src.queries),
+            "a page asked an untyped, non-recursive query: %r"
+            % [(q["start_index"], q["collection_type"])
+               for q in src.queries])
+
+    def test_every_page_carries_the_filters(self):
+        """The other half of the same tuple, and the reason it matters --
+        a filter the server can only evaluate recursively is silently
+        dropped by the untyped query rather than rejected."""
+        b, route, src = self._grid()
+        grid_scroll(b, route, 20_000, 40_000)
+        self.assertTrue(
+            all(q["filters"] == {"audio_languages": "eng"}
+                for q in src.queries),
+            "a page dropped the filters: %r"
+            % [q["filters"] for q in src.queries])
+
+    def test_a_folder_inside_a_library_still_sends_none(self):
+        """A folder route has no collection_type and must not invent one --
+        that is what makes it a plain listing of its own children."""
+        b, route, src = self._grid(ctype=None)
+        grid_scroll(b, route, 20_000, 40_000)
+        self.assertTrue(
+            all(q["collection_type"] is None for q in src.queries),
+            "a folder listing was typed: %r"
+            % [q["collection_type"] for q in src.queries])
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_trickplay_files.py
+++ b/tests/test_trickplay_files.py
@@ -46,6 +46,13 @@ class FrameFileLifetimeTest(unittest.TestCase):
         self.tp._seq = 0
         self.tp._current = None
         self.tp._file_lock = threading.Lock()
+        # Module-level, and _publish now parks a file in it -- so without
+        # this a test inherits the previous one's deferred removal and the
+        # counts below stop meaning what they say.
+        with trickplay._pending_lock:
+            trickplay._pending_unlink[:] = []
+        self.addCleanup(lambda: trickplay._pending_unlink.__setitem__(
+            slice(None), []))
 
     def _write(self, path, data=b"x" * 16):
         with open(path, "wb") as fh:
@@ -57,17 +64,55 @@ class FrameFileLifetimeTest(unittest.TestCase):
         b = self.tp._next_file()
         self.assertNotEqual(a, b)
 
-    def test_publishing_retires_only_the_previous_file(self):
-        a = self.tp._next_file()
+    def _bins(self):
+        return sorted(f for f in os.listdir(self.dir.name)
+                      if f.endswith(".bin"))
+
+    def test_a_retired_file_survives_exactly_one_more_publish(self):
+        """The grace period, and why it is not a leak.
+
+        ``script_message`` returns when the message is queued to lua, not
+        when lua has run it, so a render firing in between still reads the
+        OLD path. Unlinking as the new file is published is what turns that
+        into a missing thumbnail -- once per window swap now, rather than
+        once per video. So a retired file goes one publish later, and the
+        disk holds at most two.
+        """
+        # Written as each is published, not up front: the point of the
+        # assertions below is what is ON DISK, so a file that exists before
+        # anything published it is noise in every one of them.
+        a, b, c = (self.tp._next_file() for _ in range(3))
+
         self._write(a)
         self.tp._publish(a)
-        self.assertTrue(os.path.exists(a), "the live file was removed")
+        self.assertEqual(self._bins(), [os.path.basename(a)])
 
-        b = self.tp._next_file()
         self._write(b)
         self.tp._publish(b)
+        self.assertTrue(os.path.exists(a),
+                        "the previous window went before lua could have "
+                        "been told to stop reading it")
+        self.assertTrue(os.path.exists(b), "the live file was removed")
+
+        self._write(c)
+        self.tp._publish(c)
         self.assertFalse(os.path.exists(a), "the old generation leaked")
-        self.assertTrue(os.path.exists(b))
+        self.assertEqual(self._bins(),
+                         sorted(map(os.path.basename, (b, c))),
+                         "more than one window is being held over")
+
+    def test_retiring_the_current_file_takes_the_held_one_with_it(self):
+        """Teardown has to drain the grace period, or the last two windows
+        of every session are left for the next run's cleanup."""
+        a, b = (self.tp._next_file() for _ in range(2))
+        self._write(a)
+        self.tp._publish(a)
+        self._write(b)
+        self.tp._publish(b)
+        self.assertEqual(len(self._bins()), 2)
+
+        self.tp._retire_current()
+        self.assertEqual(self._bins(), [], "a window survived teardown")
 
     def test_clear_tells_the_renderer_before_removing_the_file(self):
         """overlay-remove has to land before the bytes behind it go away."""
@@ -123,12 +168,35 @@ class ShortTileRunTest(unittest.TestCase):
     """decompress_tiles must report frames WRITTEN, not frames promised: mpv
     seeks to frame * w * h * 4 inside a mapping of the file."""
 
-    def _tile(self, w, h):
+    def _tile(self, w, h, cells=None):
+        """A mosaic whose every cell is filled with its own index.
+
+        A solid colour would let `skip` be ignored and still pass: the
+        assertions would be counting bytes, which is not the field these
+        tests are named after. `cells` is (tile_width, tile_height); the
+        red channel of a cell carries its position in the tile.
+        """
         from PIL import Image
 
+        img = Image.new("RGBA", (w, h), (0, 0, 0, 255))
+        if cells:
+            tw, th = cells
+            cw, ch = w // tw, h // th
+            for i in range(tw * th):
+                y, x = divmod(i, tw)
+                img.paste((i + 1, 2, 3, 255),
+                          (x * cw, y * ch, (x + 1) * cw, (y + 1) * ch))
+        else:
+            img.paste((1, 2, 3, 255), (0, 0, w, h))
         buf = io.BytesIO()
-        Image.new("RGBA", (w, h), (1, 2, 3, 255)).save(buf, format="PNG")
+        img.save(buf, format="PNG")
         return buf.getvalue()
+
+    @staticmethod
+    def _first_bytes(data, frame_bytes):
+        """The red channel of each written frame's first pixel (BGRA)."""
+        return [data[i * frame_bytes + 2]
+                for i in range(len(data) // frame_bytes)]
 
     def setUp(self):
         try:
@@ -163,6 +231,56 @@ class ShortTileRunTest(unittest.TestCase):
 
         self.assertEqual(
             bifdecode.decompress_tiles(4, 4, 2, 2, 8, [], io.BytesIO()), 0)
+
+    def test_skip_drops_frames_off_the_front(self):
+        """A window rarely starts on a tile boundary, and the frames before
+        it are the ones not worth keeping -- decoded, a tile is tens of
+        megabytes.
+
+        Asserts WHICH frames landed, not how many: a count alone passes
+        with `skip` ignored, since the same number of frames comes out
+        either way.
+        """
+        from jellyfin_mpv_shim import bifdecode
+
+        fh = io.BytesIO()
+        written = bifdecode.decompress_tiles(
+            4, 4, 2, 2, 2, [self._tile(8, 8, cells=(2, 2))], fh, skip=1)
+        self.assertEqual(written, 2)
+        self.assertEqual(self._first_bytes(fh.getvalue(), 4 * 4 * 4), [2, 3],
+                         "the file starts at the wrong frame")
+
+    def test_skip_spans_a_tile_boundary(self):
+        """`skip` counts frames of the STREAM, not of the first tile: a
+        window can start in the second tile it was handed."""
+        from jellyfin_mpv_shim import bifdecode
+
+        tile = self._tile(8, 8, cells=(2, 2))
+        fh = io.BytesIO()
+        written = bifdecode.decompress_tiles(
+            4, 4, 2, 2, 3, [tile] * 2, fh, skip=5)
+        self.assertEqual(written, 3)
+        # Stream frames 5,6,7 -> cells 2,3,4 of the second tile.
+        self.assertEqual(self._first_bytes(fh.getvalue(), 4 * 4 * 4),
+                         [2, 3, 4],
+                         "skip did not carry across the tile boundary")
+
+    def test_a_tile_past_the_count_is_never_FETCHED(self):
+        """`tiles` is a generator that downloads one mosaic per step, so the
+        `count` bound has to be checked before the next one is pulled -- a
+        plain `for` loop asks the server for a tile to discover it has
+        already written every frame it was asked for."""
+        from jellyfin_mpv_shim import bifdecode
+
+        seen = []
+
+        def tiles():
+            for i in range(4):
+                seen.append(i)
+                yield self._tile(8, 8)
+
+        bifdecode.decompress_tiles(4, 4, 2, 2, 4, tiles(), io.BytesIO())
+        self.assertEqual(seen, [0], "decoded tiles the window does not need")
 
 
 class StripCounterRaceTest(unittest.TestCase):
@@ -293,6 +411,418 @@ class _WorkerPlayer:
     def script_message(self, *args):
         with self.lock:
             self.messages.append(args)
+
+
+class _BifVideo:
+    """A video whose server HAS trickplay, modelled down to the tile shape.
+
+    The manifest fields are the ones the worker reads and the tile mosaics
+    are real images of the size the manifest promises, because the whole
+    question here is which tiles were asked for and which frames of them
+    reached the file -- a stand-in that answered with bytes would make every
+    assertion below a proxy for itself. Each frame is filled with its own
+    GLOBAL index, so the file says what it holds.
+    """
+
+    def __init__(self, width=4, height=4, tile_w=2, tile_h=2, count=16,
+                 interval=10000):
+        self.width, self.height = width, height
+        self.tile_w, self.tile_h = tile_w, tile_h
+        self.count, self.interval = count, interval
+        #: (start, count) of every tile request, in order.
+        self.requested = []
+
+    def get_bif(self, *_a, **_kw):
+        return {"Width": self.width, "Height": self.height,
+                "TileWidth": self.tile_w, "TileHeight": self.tile_h,
+                "ThumbnailCount": self.count, "Interval": self.interval}
+
+    def get_chapters(self):
+        return []
+
+    def get_chapter_images(self, *_a, **_kw):
+        return iter(())
+
+    def _tile(self, index):
+        from PIL import Image
+
+        per = self.tile_w * self.tile_h
+        img = Image.new("RGBA", (self.width * self.tile_w,
+                                 self.height * self.tile_h))
+        for cell in range(per):
+            y, x = divmod(cell, self.tile_w)
+            frame = index * per + cell
+            img.paste((frame % 256, 0, 0, 255),
+                      (x * self.width, y * self.height,
+                       (x + 1) * self.width, (y + 1) * self.height))
+        buf = io.BytesIO()
+        img.save(buf, format="PNG")
+        return buf.getvalue()
+
+    def get_hls_tile_images(self, width, count, start=0):
+        self.requested.append((start, count))
+        for i in range(start, start + count):
+            yield self._tile(i)
+
+
+class WindowedTrickplayTest(unittest.TestCase):
+    """Only the frames around the seek position reach disk.
+
+    A decoded frame is `width * height * 4` bytes, so a two-hour film at the
+    server's default thumbnail width is ~130 MB of them and one at 640px is
+    around 500 MB, all for one preview bubble. The worker fetches the tiles
+    the window falls in and writes only the window's frames out of them.
+
+    (Not "and mpv mmaps it, so that is resident memory": mpv reads out the
+    one rectangle it needs on any build since 3cd66d2fd7. The file is disk
+    and the decode is RAM -- see docs/artwork-pipeline.md section 11.)
+    """
+
+    #: 4x4 frames -> 64 bytes each, tiles of 2x2 -> 4 frames per tile.
+    FRAME_BYTES = 4 * 4 * 4
+
+    def setUp(self):
+        try:
+            import PIL  # noqa: F401
+        except ImportError:
+            self.skipTest("Pillow not available")
+        self.dir = tempfile.TemporaryDirectory()
+        self.addCleanup(self.dir.cleanup)
+        orig = trickplay._img_path
+        trickplay._img_path = lambda seq: os.path.join(
+            self.dir.name, "raw_images.%d.bin" % seq)
+        self.addCleanup(lambda: setattr(trickplay, "_img_path", orig))
+        # Five frames' worth, so a 16-frame video has to be windowed.
+        orig_budget = trickplay.WINDOW_BUDGET_BYTES
+        trickplay.WINDOW_BUDGET_BYTES = 5 * self.FRAME_BYTES
+        self.addCleanup(lambda: setattr(trickplay, "WINDOW_BUDGET_BYTES",
+                                        orig_budget))
+        orig_fast = trickplay.settings.trickplay_fast_mode
+        trickplay.settings.trickplay_fast_mode = False
+        self.addCleanup(lambda: setattr(trickplay.settings,
+                                        "trickplay_fast_mode", orig_fast))
+
+    def _worker(self, video):
+        player = _WorkerPlayer(video)
+        tp = trickplay.TrickPlay(player)
+        self.addCleanup(lambda: tp.stop(join=False))
+        tp.start()
+        return tp, player
+
+    def _fetch(self, tp, player, position, timeout=5.0):
+        """Ask for a window and wait for the message it publishes, if any."""
+        before = len(player.messages)
+        tp.request_at(position)
+        deadline = time.monotonic() + timeout
+        while len(player.messages) == before and time.monotonic() < deadline:
+            time.sleep(0.005)
+        with player.lock:
+            if len(player.messages) == before:
+                return None
+            return player.messages[-1]
+
+    def _frames(self, path):
+        """The global frame index written into each frame of the file.
+
+        Frames are BGRA, so the red channel this fixture fills with the frame
+        number is the third byte of the first pixel.
+        """
+        with open(path, "rb") as fh:
+            data = fh.read()
+        self.assertEqual(len(data) % self.FRAME_BYTES, 0,
+                         "the file is not a whole number of frames")
+        return [data[i * self.FRAME_BYTES + 2]
+                for i in range(len(data) // self.FRAME_BYTES)]
+
+    def test_only_the_window_is_written_and_it_says_where_it_starts(self):
+        video = _BifVideo()
+        tp, player = self._worker(video)
+        # 90s at a 10s cadence is frame 9; a five-frame budget centres on it.
+        msg = self._fetch(tp, player, 90)
+        self.assertIsNotNone(msg, "the window was never published")
+        kind, count, mult, w, h, path, first, total = msg
+        self.assertEqual(kind, "shim-trickplay-bif")
+        self.assertEqual((int(count), int(first), int(total)), (5, 7, 16))
+        self.assertEqual(self._frames(path), [7, 8, 9, 10, 11],
+                         "the file does not hold the frames it claims")
+
+    def test_the_tiles_fetched_are_the_ones_the_window_falls_in(self):
+        """Tiles are the download unit and do not divide the window: frames
+        7..11 live in tiles 1 and 2, and tile 1 is fetched whole for the one
+        frame of it that is wanted."""
+        video = _BifVideo()
+        tp, player = self._worker(video)
+        self._fetch(tp, player, 90)
+        self.assertEqual(video.requested, [(1, 2)],
+                         "the whole video was downloaded, or the wrong part")
+
+    def test_the_window_boundary_is_half_open(self):
+        """`first <= frame < first + asked`, both ends.
+
+        A `<=` on the upper bound claims a frame the file does not hold, so
+        the consumer draws nothing there and never gets a window that would
+        fix it. Asserted directly, because every other test in this class
+        works comfortably inside the window and none of them moves if the
+        comparison slips.
+        """
+        video = _BifVideo()
+        tp, _player = self._worker(video)
+        tp._window = (video, 7, 5, 16)          # frames 7..11
+        self.assertFalse(tp._covers(video, 6), "reached below the window")
+        self.assertTrue(tp._covers(video, 7))
+        self.assertTrue(tp._covers(video, 11))
+        self.assertFalse(tp._covers(video, 12), "claimed a frame past the end")
+        self.assertFalse(tp._covers(object(), 9),
+                         "another video's window counted as this one's")
+
+    def test_a_position_already_loaded_asks_the_server_for_nothing(self):
+        video = _BifVideo()
+        tp, player = self._worker(video)
+        self._fetch(tp, player, 90)                 # frames 7..11
+        self.assertEqual(len(video.requested), 1)
+        # 100s is frame 10, inside the window. Nothing to fetch and nothing
+        # to publish -- the renderer is already pointed at these bytes.
+        self.assertIsNone(self._fetch(tp, player, 100, timeout=0.5),
+                          "a covered position published a new file")
+        self.assertEqual(video.requested, [(1, 2)],
+                         "a covered position went back to the server")
+
+    def test_moving_out_of_the_window_loads_the_new_part(self):
+        video = _BifVideo()
+        tp, player = self._worker(video)
+        self._fetch(tp, player, 90)
+        msg = self._fetch(tp, player, 10)           # frame 1, well before it
+        self.assertIsNotNone(msg, "scrubbing out of the window loaded nothing")
+        self.assertEqual(int(msg[6]), 0, "the window did not move")
+        self.assertEqual(self._frames(msg[5]), [0, 1, 2, 3, 4])
+
+    def test_the_window_is_clamped_to_the_video(self):
+        """Centring alone would run off both ends -- and a first frame below
+        zero is a negative offset into the tile stream."""
+        video = _BifVideo()
+        tp, player = self._worker(video)
+        self.assertEqual(int(self._fetch(tp, player, 0)[6]), 0)
+        # 150s is frame 15, the last one; the window ends there rather than
+        # promising frames 13..17 of a 16-frame video.
+        msg = self._fetch(tp, player, 150)
+        self.assertEqual((int(msg[6]), int(msg[1])), (11, 5))
+        self.assertEqual(self._frames(msg[5]), [11, 12, 13, 14, 15])
+
+    def test_a_video_that_fits_is_loaded_whole(self):
+        """The budget is a ceiling, not a quota: an ordinary episode never
+        pays for windowing, and its previews are all instant."""
+        video = _BifVideo(count=4)
+        tp, player = self._worker(video)
+        msg = self._fetch(tp, player, 20)
+        self.assertEqual((int(msg[1]), int(msg[6]), int(msg[7])), (4, 0, 4))
+        self.assertEqual(video.requested, [(0, 1)])
+
+    def test_fast_mode_loads_the_whole_video(self):
+        """**[iw]**: "unless the user requests the trickplay fast mode where
+        it just hands the entire file to mpv where it can seek faster"."""
+        trickplay.settings.trickplay_fast_mode = True
+        video = _BifVideo()
+        tp, player = self._worker(video)
+        msg = self._fetch(tp, player, 90)
+        self.assertEqual((int(msg[1]), int(msg[6]), int(msg[7])), (16, 0, 16))
+        self.assertEqual(video.requested, [(0, 4)],
+                         "fast mode did not fetch every tile")
+        self.assertEqual(self._frames(msg[5]), list(range(16)))
+
+    def test_a_short_tile_run_is_not_asked_for_again(self):
+        """The loop this closes: the frames a short run did not deliver sit
+        inside the window every request for them produces, so treating them
+        as "not covered" re-fetches and re-publishes -- which clears the
+        consumer's one-ask-per-window marker, so it asks again on the next
+        rendered frame, at render cadence, forever.
+
+        Three requests, not one: a single-step test cannot see a loop.
+        """
+        video = _BifVideo()
+        # The last tile 404s, so frames 12..15 never arrive.
+        real = video.get_hls_tile_images
+
+        def short(width, count, start=0):
+            for i, tile in enumerate(real(width, count, start=start)):
+                if start + i >= 3:
+                    return
+                yield tile
+
+        video.get_hls_tile_images = short
+
+        tp, player = self._worker(video)
+        # 150s is frame 15 -- inside the window [11, 16), missing from it.
+        msg = self._fetch(tp, player, 150)
+        self.assertIsNotNone(msg, "nothing was published at all")
+        self.assertEqual(int(msg[1]), 1, "the short run over-reported")
+        self.assertEqual(self._frames(msg[5]), [11])
+        fetches = len(video.requested)
+
+        for attempt in range(3):
+            self.assertIsNone(
+                self._fetch(tp, player, 150, timeout=0.5),
+                "the short window was re-published on attempt %d -- that is "
+                "the loop" % attempt)
+        self.assertEqual(len(video.requested), fetches,
+                         "the shortfall was re-fetched: %r" % video.requested)
+
+    def test_a_failed_window_does_not_downgrade_the_item_to_chapters(self):
+        """A dropped tile mid-film used to be a one-way door.
+
+        The bif block's ``except`` fell through to the chapter images, which
+        publish ``shim-trickplay-chapters`` -- and on that branch NEITHER
+        consumer can ask for a window again (renderer.lua takes ``tp.times``;
+        thumbfast.lua gates the whole window block on ``img_is_bif``). So one
+        504 on one tile meant chapter stills for the rest of the item, with
+        Python still perfectly able to serve windows that nothing would ever
+        request. Before windowing this path could only run at playback start,
+        where falling back to chapters IS the design.
+        """
+        video = _BifVideo()
+        video.get_chapters = lambda: [{"start": 0}, {"start": 60}]
+        real = video.get_hls_tile_images
+        boom = []
+
+        def flaky(width, count, start=0):
+            if boom:
+                raise OSError("504 on a tile")
+            for tile in real(width, count, start=start):
+                yield tile
+
+        video.get_hls_tile_images = flaky
+
+        tp, player = self._worker(video)
+        self.assertEqual(self._fetch(tp, player, 20)[0], "shim-trickplay-bif")
+        live = tp._current
+
+        boom.append(True)
+        self.assertIsNone(self._fetch(tp, player, 150, timeout=0.7),
+                          "the failed window published something")
+        self.assertNotIn(
+            "shim-trickplay-chapters",
+            [m[0] for m in player.messages],
+            "a failed window downgraded the item to chapter previews")
+        self.assertEqual(tp._current, live,
+                         "the live window was replaced by the failure")
+        self.assertEqual(
+            [f for f in os.listdir(self.dir.name) if f.endswith(".bin")],
+            [os.path.basename(live)],
+            "the half-written window was left on disk")
+
+        # And it recovers: the next request after the server comes back is
+        # served normally. Three, because the failure this pins is permanent.
+        boom.clear()
+        for attempt in range(3):
+            msg = self._fetch(tp, player, 150)
+            self.assertIsNotNone(msg, "no window after failure #%d" % attempt)
+            self.assertEqual(msg[0], "shim-trickplay-bif")
+            tp._window = None      # force the next pass to re-fetch
+
+    def test_the_first_fetch_lands_on_the_resume_position(self):
+        """`fetch_thumbnails` takes where playback actually starts. On a
+        resumed item that is not zero, and it is the first place anybody
+        scrubs."""
+        video = _BifVideo()
+        tp, player = self._worker(video)
+        before = len(player.messages)
+        tp.fetch_thumbnails(90)
+        deadline = time.monotonic() + 5
+        while len(player.messages) == before and time.monotonic() < deadline:
+            time.sleep(0.005)
+        self.assertEqual(int(player.messages[-1][6]), 7,
+                         "the first window ignored the resume position")
+
+
+class WindowMathTest(unittest.TestCase):
+    """`_window_for` on its own, at the sizes a real server produces."""
+
+    def setUp(self):
+        orig = trickplay.settings.trickplay_fast_mode
+        trickplay.settings.trickplay_fast_mode = False
+        self.addCleanup(lambda: setattr(trickplay.settings,
+                                        "trickplay_fast_mode", orig))
+
+    #: Measured off a real library: a 128-minute film at the server's
+    #: default trickplay width. 770 frames * 320 * 134 * 4 = 132 MB.
+    REAL = {"Width": 320, "Height": 134, "TileWidth": 10, "TileHeight": 10,
+            "ThumbnailCount": 770, "Interval": 10000}
+
+    def test_the_window_shrinks_as_the_thumbnails_grow(self):
+        """The budget is bytes, not minutes, and that is the point: what is
+        scarce is the memory mpv maps, so a library configured for 640px
+        previews gets a shorter window rather than a bigger file."""
+        small = dict(self.REAL)
+        big = dict(self.REAL, Width=640, Height=268)
+        _f1, c1 = trickplay.TrickPlay._window_for(small, 3600)
+        _f2, c2 = trickplay.TrickPlay._window_for(big, 3600)
+        self.assertLess(c2, c1)
+        for data, count in ((small, c1), (big, c2)):
+            self.assertLessEqual(
+                count * data["Width"] * data["Height"] * 4,
+                trickplay.WINDOW_BUDGET_BYTES,
+                "the window is over budget")
+
+    def test_a_degenerate_manifest_does_not_divide_by_zero(self):
+        self.assertEqual(
+            trickplay.TrickPlay._window_for(
+                dict(self.REAL, ThumbnailCount=0), 10), (0, 0))
+        self.assertEqual(
+            trickplay.TrickPlay._window_for(
+                dict(self.REAL, Width=0), 10)[1], 770)
+
+
+class DeferredUnlinkTest(unittest.TestCase):
+    """Windows refuses to unlink a file mpv still has mapped. Windowing turns
+    that from a once-per-video event into a once-per-scrub one, so a refused
+    removal is remembered and retried instead of being left for the next
+    run's cleanup."""
+
+    def setUp(self):
+        self.dir = tempfile.TemporaryDirectory()
+        self.addCleanup(self.dir.cleanup)
+        with trickplay._pending_lock:
+            trickplay._pending_unlink[:] = []
+        self.addCleanup(lambda: trickplay._pending_unlink.__setitem__(
+            slice(None), []))
+
+    def test_a_refused_removal_is_retried_on_the_next_publish(self):
+        path = os.path.join(self.dir.name, "raw_images.1.bin")
+        with open(path, "wb") as fh:
+            fh.write(b"x")
+
+        real_remove = os.remove
+        refuse = [True]
+
+        def maybe_remove(p):
+            if refuse[0] and p == path:
+                raise OSError(32, "in use")
+            real_remove(p)
+
+        os.remove = maybe_remove
+        self.addCleanup(lambda: setattr(os, "remove", real_remove))
+
+        trickplay._unlink(path)
+        self.assertTrue(os.path.isfile(path), "the fixture did not refuse")
+        self.assertIn(path, trickplay._pending_unlink)
+
+        refuse[0] = False
+        trickplay._sweep_unlinks()
+        self.assertFalse(os.path.isfile(path),
+                         "the refused removal was never retried")
+        self.assertEqual(trickplay._pending_unlink, [])
+
+    def test_a_removal_that_keeps_failing_is_kept_not_dropped(self):
+        path = os.path.join(self.dir.name, "raw_images.2.bin")
+        with open(path, "wb") as fh:
+            fh.write(b"x")
+        real_remove = os.remove
+        os.remove = lambda p: (_ for _ in ()).throw(OSError(32, "in use"))
+        self.addCleanup(lambda: setattr(os, "remove", real_remove))
+        trickplay._unlink(path)
+        for _ in range(3):
+            trickplay._sweep_unlinks()
+        self.assertEqual(trickplay._pending_unlink, [path],
+                         "a still-mapped file was forgotten, or duplicated")
 
 
 class WorkerSurvivesAVideoChangeTest(unittest.TestCase):


### PR DESCRIPTION
Changes:
- Make trickplay stop writing up to 800 MB to disk for no reason
- Fix an issue where the language filter didn't set or clear correctly