### PR TITLE
Speed up unit tests

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -60,8 +60,17 @@ means **the mouse cursor never hides again** for the rest of the session.
   every pinned sha256 in seconds — pass it the Flathub manifest, which is usually the
   one that has drifted. See `docs/packaging.md`.
 - Tests: `xvfb-run -a python3 -m unittest discover tests` (stdlib unittest, no extra
-  deps). Integration matrix:
-  `xvfb-run -a python3 tests/integration/run_integration.py`.
+  deps) — **~7 minutes**. Integration matrix:
+  `xvfb-run -a python3 tests/integration/run_integration.py` — ~6.5 minutes.
+- Faster unit runs: `xvfb-run -a python3 tools/run_tests_parallel.py` — the same
+  4,900 tests one process per module, **~64s**. Same import semantics as
+  `discover`; a per-module timeout means a hang is a reported failure, and each
+  worker gets its own process group so a kill cannot orphan an mpv. Put
+  `xvfb-run` in front of *it*, not the workers. Do not parallelize the
+  integration matrix — its legs are serial on purpose (docs/testing.md §9).
+- **Tee a full run to a file** rather than piping it through `tail`/`grep`. At
+  these runtimes, one look at a failure you did not keep costs another run, and
+  `run_integration.py`'s summary prints only a return code per leg.
 - Profile a server's artwork handling: `tools/bench_image_loading.py`. Read-only; uses
   the saved credentials. See `docs/artwork-pipeline.md`.
 - There is no linter config.

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -187,3 +187,62 @@ Anything a scheduler, poller, health check or websocket can re-run gets a **loop
 Firing `MpvtkApp`'s ready dispatch in a test installs measured font metrics
 *globally*, so seven unrelated scene snapshots fail — and only in the full run, never
 when the module is selected alone.
+
+## 9. Running the unit suite in parallel
+
+`tools/run_tests_parallel.py` runs the same tests as `discover tests`, one
+process per module:
+
+```
+xvfb-run -a python3 tools/run_tests_parallel.py
+```
+
+**~64s against ~7 minutes**, same 4,905 tests. It is stdlib-only, like the
+suite, and it exists because the suite got slow enough that re-running it to
+see a failure you did not keep costs more than the failure did.
+
+`xvfb-run` goes in front of *this script*, not around the workers: `-a` picks
+a display by probing for a free one, and sixteen of those probing at once race
+for the same number. The workers inherit `DISPLAY` and share one server.
+
+### What it has to get right
+
+- **`sys.argv` is cleared before anything under `jellyfin_mpv_shim` is
+  imported** (§2). A worker that takes arguments of its own would otherwise
+  die on the app's usage line.
+- **The repo root goes on `sys.path` explicitly.** A script in `tools/` has
+  `tools/` as `sys.path[0]`, so `jellyfin_mpv_shim` resolves to whatever is
+  pip-installed — silently, and it *runs*, against the previous release. This
+  is the "run from the repo root" rule reached from a direction the rule does
+  not cover, and it cost an hour here.
+- **Selection is `TestLoader.discover(start_dir, pattern=…)`**, not a module
+  name, so each module is imported exactly as `discover tests` imports it.
+- **The result comes from a line the worker prints, not from its exit
+  status.** A module holding a real libmpv can abort with "pure virtual method
+  called" during interpreter teardown when several dozen are torn down at
+  once — after passing. The worker reports, then `os._exit`s. A worker that
+  dies *before* reporting is still a hard failure.
+- **Each worker is its own process group, and a timeout kills the group.** A
+  killed run that leaves mpv and Xvfb children behind is how a machine
+  accumulates a graveyard of them; one on the dev box outlived its run by five
+  days.
+
+### Jobs, and why the default is half the CPUs
+
+Every worker that imports `player.py` creates a real mpv window (§1), and they
+share one single-threaded Xvfb. Measured on a 32-CPU box: `-j32` finished in
+50s idle and **starved** under ambient load — four modules that normally take
+12-17s were unfinished at 90s. `-j16` is 64s and has not wobbled. Raise it on
+a quiet machine; the floor is the slowest single module (~43s), because that
+is one process and nothing splits it.
+
+`tests/test_parallel_runner.py` pins the one invariant the runner cannot check
+about itself: the modules it would run are the modules discover collects. A
+module it silently skips reports exactly like a module that passed.
+
+### The integration matrix stays serial
+
+`run_integration.py` runs its legs one at a time deliberately, and its last leg
+runs everything in one process specifically to catch cross-module interference.
+Parallelizing it would remove the thing it is for — and it drives real mpv
+through the keyboard, which is where contention bites hardest.

--- a/tests/test_parallel_runner.py
+++ b/tests/test_parallel_runner.py
@@ -1,0 +1,75 @@
+"""``tools/run_tests_parallel.py`` must run the same tests as discover.
+
+The whole value of the parallel runner is that its result means what
+``python3 -m unittest discover tests`` means. The way that quietly stops
+being true is not a crash -- it is a module the runner never launches, which
+looks exactly like a module whose tests all passed.
+
+So this pins the one invariant a runner cannot check about itself: the set
+of modules it would run is the set discover would collect. It does not run
+anything (that would be the suite running itself), and it deliberately
+compares FILENAMES rather than counts -- a count is the thing that silently
+agrees when two modules are swapped for each other.
+"""
+
+import os
+import sys
+import unittest
+
+sys.argv = [sys.argv[0]]      # importing the shim reaches args.get_args()
+
+ROOT = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+
+
+def _runner():
+    """``tools/run_tests_parallel.py`` as a module, without installing it.
+
+    It lives in ``tools/`` rather than in a package, so there is nothing to
+    import normally -- and adding it to the path permanently would put
+    ``tools/`` ahead of the repo root, which is the exact shadowing hazard
+    the runner's own docstring is about.
+    """
+    import importlib.util
+
+    path = os.path.join(ROOT, "tools", "run_tests_parallel.py")
+    spec = importlib.util.spec_from_file_location("_jms_par_runner", path)
+    mod = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(mod)
+    return mod
+
+
+class ParallelRunnerCoversTheSuiteTest(unittest.TestCase):
+    #: unittest's default. The runner matches on ``test_``; if a module ever
+    #: lands that discover would take and the runner would not, that is a
+    #: silently skipped module.
+    DISCOVER_PATTERN = "test*.py"
+
+    def _discovered(self):
+        import fnmatch
+
+        return {n for n in os.listdir(os.path.join(ROOT, "tests"))
+                if fnmatch.fnmatch(n, self.DISCOVER_PATTERN)}
+
+    def test_it_would_run_every_module_discover_collects(self):
+        missing = self._discovered() - set(_runner()._modules())
+        self.assertEqual(
+            missing, set(),
+            "tools/run_tests_parallel.py would skip these, and a skipped "
+            "module reports as a passing one:\n  " + "\n  ".join(sorted(missing)))
+
+    def test_it_would_not_invent_a_module(self):
+        """The mirror image: a file the runner launches and discover does
+        not is a worker that fails on an empty suite, or worse, runs
+        something the real suite never does."""
+        extra = set(_runner()._modules()) - self._discovered()
+        self.assertEqual(extra, set(),
+                         "not part of `discover tests`: %s" % sorted(extra))
+
+    def test_the_module_list_is_not_empty(self):
+        """Guard on the guard: both assertions above pass against a runner
+        that collects nothing at all."""
+        self.assertGreater(len(_runner()._modules()), 100)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_win_fribidi.py
+++ b/tests/test_win_fribidi.py
@@ -14,10 +14,25 @@ we look, that it happens once, and that it cannot be skipped by a stale
 measurement cache.
 """
 
+import ctypes  # noqa: F401  -- see below
 import os
 import sys
 import unittest
 from unittest import mock
+
+# `ctypes` is imported here for its SIDE EFFECT, not for its API.
+#
+# These tests patch `win_fribidi.os.name` to "nt", and `win_fribidi.os` is
+# the one shared `os` module -- so the patch is global while it is in
+# effect. `preload()` does `import ctypes` inside the function, and
+# `ctypes/__init__.py` branches on `os.name`: reached for the first time
+# under the patch, it takes the Windows path and dies on
+# `from _ctypes import FormatError`.
+#
+# It never bit in a full `discover tests` run because something earlier had
+# always imported ctypes already, so the import was a cache hit. Running
+# this module on its own -- which is what tools/run_tests_parallel.py does
+# to every module -- is where it surfaces.
 
 sys.argv = [sys.argv[0]]      # importing the shim reaches args.get_args()
 

--- a/tools/run_tests_parallel.py
+++ b/tools/run_tests_parallel.py
@@ -1,0 +1,232 @@
+#!/usr/bin/env python3
+"""Run the unit suite across processes, one process per test module.
+
+    xvfb-run -a python3 tools/run_tests_parallel.py
+
+Same tests as ``python3 -m unittest discover tests``, same import semantics,
+in a fraction of the wall clock. Stdlib only, like the suite it runs.
+
+**One xvfb for the whole run, not one per worker.** Put `xvfb-run -a` in
+front of THIS script rather than around the workers: `-a` picks a free
+display by probing, and thirty-two of them probing at once race for the same
+number. The workers inherit `DISPLAY` and share one server. (They still need
+one — importing `player.py` opens a real mpv window; see
+`docs/testing.md`.)
+
+Why a process per module rather than threads: the suite is full of
+module-level singletons, `sys.modules` eviction and a real mpv per process.
+Threads would share all of it.
+
+Two things this has to get right, and both have cost a session before:
+
+* **`sys.argv` is neutralised before anything under `jellyfin_mpv_shim` is
+  imported.** Importing almost anything there reaches `args.get_args()` at
+  import time, which parses the real argv and exits with the app's usage
+  line. `discover tests` gets away with it because unittest rewrites argv
+  first; a worker taking arguments of its own does not.
+* **The repo root goes on `sys.path` explicitly.** A script run from
+  `tools/` has `tools/` as `sys.path[0]`, so `jellyfin_mpv_shim` resolves to
+  whatever is pip-installed in `~/.venv` — silently, and it *runs*, just
+  against the previous release. That is the trap in CLAUDE.md's "run tests
+  from the repo root" rule, reached from a direction the rule does not
+  cover.
+
+Selection is by `TestLoader.discover(start_dir, pattern=...)` rather than by
+module name, so each worker imports the module exactly as `discover tests`
+would -- as a top-level `test_foo`, with `tests/` on the path. Loading it as
+`tests.test_foo` instead would give it a different identity in `sys.modules`
+than the serial run gives it.
+"""
+
+import argparse
+import os
+import signal
+import subprocess
+import sys
+import time
+
+ROOT = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+TESTS = os.path.join(ROOT, "tests")
+
+
+#: What a worker prints once its tests are done. The parent reads THIS, not
+#: the exit status -- see _worker.
+RESULT = "JMS-RESULT"
+
+
+def _worker(pattern):
+    """Run one module's tests and report on stdout. Never returns."""
+    # Before importing anything under jellyfin_mpv_shim -- see the module
+    # docstring. Both lines are load-bearing.
+    sys.argv = [sys.argv[0]]
+    sys.path.insert(0, ROOT)
+
+    import unittest
+
+    suite = unittest.TestLoader().discover(TESTS, pattern=pattern)
+    total = suite.countTestCases()
+    result = unittest.TextTestRunner(verbosity=1).run(suite)
+    print("%s %d %d %d" % (RESULT, total, len(result.failures),
+                           len(result.errors)))
+    sys.stdout.flush()
+
+    # os._exit, deliberately: skip interpreter teardown entirely.
+    #
+    # A module that imported player.py has a real libmpv in this process,
+    # and tearing several dozen of those down at once -- which is what
+    # running the suite in parallel does -- aborts with "pure virtual method
+    # called" *after* the tests have passed. Both of the modules it hit are
+    # green alone and green in the serial suite; the crash is in the exit
+    # path, which is not what any of these tests are about.
+    #
+    # This is the reason the parent trusts the line above rather than the
+    # exit status. A worker that dies BEFORE printing it is still a hard
+    # failure -- that is a real crash mid-test, and it is reported as one.
+    sys.stderr.flush()
+    os._exit(0 if result.wasSuccessful() else 1)
+
+
+def _default_jobs():
+    """Half the CPUs, not all of them, and that is measured rather than
+    cautious.
+
+    Every worker that imports `player.py` creates a real mpv window, and
+    they all share one Xvfb, which is single-threaded. On this 32-CPU box
+    `-j32` finished in 50s on an idle machine and **starved** on a busy one:
+    four modules that take 12-17s were still unfinished at 90s. `-j16` is
+    64s and has not wobbled. The extra 14s buys a result you can trust
+    while something else is running, which is most of the time.
+
+    Raise it with `-j` on an otherwise idle machine; the ceiling is the
+    slowest single module (~43s here), because that is one process and
+    nothing splits it.
+    """
+    return max(2, (os.cpu_count() or 4) // 2)
+
+
+def _modules():
+    """Every module `discover tests` would collect, biggest file first.
+
+    Size is a rough proxy for cost, and it only has to be rough: workers
+    pull from a queue, so a bad guess costs one slot for one module rather
+    than unbalancing a fixed split. Starting the big ones first is what
+    keeps the tail short.
+
+    `tests/integration` and `tests/e2e` are NOT included, for the same
+    reason `discover tests` does not reach them -- neither is a package, and
+    they have their own runners.
+    """
+    names = [n for n in os.listdir(TESTS)
+             if n.startswith("test_") and n.endswith(".py")]
+    return sorted(names, key=lambda n: -os.path.getsize(os.path.join(TESTS, n)))
+
+
+def main():
+    ap = argparse.ArgumentParser(description=__doc__.splitlines()[0])
+    ap.add_argument("-j", "--jobs", type=int, default=0,
+                    help="worker processes (default: half the CPUs -- see "
+                         "DEFAULT_JOBS)")
+    ap.add_argument("-q", "--quiet", action="store_true",
+                    help="only print the summary and any failures")
+    ap.add_argument("-t", "--timeout", type=float, default=300.0,
+                    help="seconds a single module may take before it is "
+                         "killed and reported as failed (default: 300)")
+    ap.add_argument("--worker", metavar="PATTERN",
+                    help=argparse.SUPPRESS)   # internal
+    args = ap.parse_args()
+
+    if args.worker:
+        return _worker(args.worker)
+
+    modules = _modules()
+    jobs = args.jobs or _default_jobs()
+    if not os.environ.get("DISPLAY") and not os.environ.get("WAYLAND_DISPLAY"):
+        print("warning: no DISPLAY. Importing player.py opens a real mpv "
+              "window, so run this under `xvfb-run -a`.", file=sys.stderr)
+
+    pending = list(modules)
+    running = {}          # Popen -> (module, started)
+    done = []             # (module, rc, seconds, output, count)
+    started = time.time()
+
+    def launch():
+        while pending and len(running) < jobs:
+            mod = pending.pop(0)
+            proc = subprocess.Popen(
+                [sys.executable, os.path.abspath(__file__), "--worker", mod],
+                cwd=ROOT, stdout=subprocess.PIPE, stderr=subprocess.STDOUT,
+                text=True,
+                # Its own process group, so killing a worker takes the mpv
+                # it started with it. A killed run that leaves mpv and Xvfb
+                # children behind is how a machine accumulates a graveyard
+                # of them across sessions -- one on this box outlived its
+                # run by five days -- and the waste is what made a *serial*
+                # suite look like it needed OOM headroom.
+                start_new_session=True)
+            running[proc] = (mod, time.time())
+
+    def reap(proc):
+        """Kill a worker and everything it started."""
+        try:
+            os.killpg(os.getpgid(proc.pid), signal.SIGKILL)
+        except (ProcessLookupError, PermissionError):
+            proc.kill()
+
+    launch()
+    while running:
+        for proc in list(running):
+            if proc.poll() is None:
+                if time.time() - running[proc][1] > args.timeout:
+                    # A module that hangs must not hang the run. This is a
+                    # real hazard here rather than a theoretical one:
+                    # importing player.py starts a real mpv, and enough of
+                    # them racing for one X server can block in creation.
+                    reap(proc)
+                continue
+            mod, t0 = running.pop(proc)
+            out = proc.stdout.read()
+            proc.stdout.close()
+            count, bad, reported = 0, 0, False
+            for line in out.splitlines():
+                if line.startswith(RESULT + " "):
+                    _tag, n, fails, errs = line.split()
+                    count, bad, reported = int(n), int(fails) + int(errs), True
+            # No result line means the worker died before it could report:
+            # a crash during the tests, an import that exited, a kill. That
+            # is a failure however the process happened to exit.
+            rc = 1 if (not reported or bad) else 0
+            if not reported and time.time() - t0 >= args.timeout:
+                out += ("\n*** killed after %.0fs (--timeout). It passes "
+                        "alone; suspect contention for the X server or for "
+                        "mpv.\n" % args.timeout)
+            done.append((mod, rc, time.time() - t0, out, count))
+            if not args.quiet:
+                print("%-4s %5.1fs %4d  %s"
+                      % ("FAIL" if rc else "ok",
+                         time.time() - t0, count, mod), flush=True)
+            launch()
+        if running:
+            time.sleep(0.02)
+
+    elapsed = time.time() - started
+    failed = [d for d in done if d[1]]
+    total = sum(d[4] for d in done)
+    slowest = sorted(done, key=lambda d: -d[2])[:5]
+
+    for mod, _rc, secs, out, _n in failed:
+        print("\n" + "=" * 70 + "\nFAILED: %s (%.1fs)\n" % (mod, secs) + "=" * 70)
+        print(out.rstrip())
+
+    print("\n%d tests in %d modules, %d workers, %.1fs wall clock"
+          % (total, len(done), jobs, elapsed))
+    print("slowest: " + ", ".join("%s %.1fs" % (m, s) for m, _r, s, _o, _n
+                                  in slowest))
+    if failed:
+        print("FAILED modules: " + " ".join(sorted(m for m, *_ in failed)))
+        return 1
+    print("OK")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
This PR updates the test runner to run in parallel so it takes 1/7th the amount of time it used to.