### PR TITLE
State lifecycle bugfixes

### DIFF
--- a/docs/testing.md
+++ b/docs/testing.md
@@ -246,3 +246,54 @@ module it silently skips reports exactly like a module that passed.
 runs everything in one process specifically to catch cross-module interference.
 Parallelizing it would remove the thing it is for — and it drives real mpv
 through the keyboard, which is where contention bites hardest.
+
+## 10. Driving real mouse input against a real mpv
+
+Five things that cost a session each, none of which has a line in the tests to
+sit on — they are all about the test you are *about* to write.
+
+**A click is `keydown MBTN_LEFT` + `keyup MBTN_LEFT`, not `mouse <x> <y> 0`.**
+That last form delivers the button with neither state bit set, which mpv reports
+as a *press* — and `defaults.lua` routes a press to the **release** half of a
+`set_key_bindings` pair, so it fires `on_mouse_up` with no press before it. That
+does nothing at rest (it bails without `state.pressed`), so the test clicks
+nothing and passes; mid-drag it is worse than nothing, because it takes the
+slider/scrollbar branch and commits a gesture the test never made. Position the
+pointer with `mouse <x> <y>` first: the press is resolved against mpv's own idea
+of where the pointer is.
+
+**Going through mpv is the point, when the question is which binding wins.**
+`app.debug(cmd="click", id=...)` calls the renderer's handlers directly, so it
+answers yes however the input sections were left. Only a real button press walks
+mpv's section stack — which is what
+`test_mpvtk_hud.py:test_the_console_gives_back_the_hud_it_left_with` is for.
+
+**`mouse <x> <y>` repairs `mouse-pos.hover` on the way past**: mpv synthesizes
+MOUSE_ENTER for an artificial move that lands inside the window (`command.c`,
+`cmd_mouse`). A stranded hover flag — the #700 state, where mpv believes the
+pointer is outside a window it is sitting in the middle of — therefore *cannot*
+be reached from outside the process. That half is pinned in `tests/lua/`, driving
+the real observer; from an integration test you can only pin the rest of the
+path. (An out-of-bounds `mouse <x> <y>` synthesizes MOUSE_**LEAVE** by the same
+rule, which is a second way to leave from outside the process.)
+
+**A real leave does not look like the one your test writes.** `keypress
+MOUSE_LEAVE`, and the Lua fake's `{same x, same y, hover=false}`, both produce a
+leave whose position is unchanged — which is the *rare* shape. mpv clears the
+flag when the LeaveNotify is fed but commits a motion's position when the
+command is dequeued, drains the whole input queue per iteration, and reports a
+property once per drain: so an ordinary flick of the pointer out of the window
+arrives as **one** notification carrying the last in-window position *and*
+`hover=false` (measured at 27 of 30 crossings; a fast exit reports a position
+from the middle of the window). Any renderer logic that keys off "the position
+changed" is testing a shape X11 almost never sends. What the renderer does
+instead — treat one such event as provisional and let a grace timer decide — is
+in the `mouse-pos` observer.
+
+**Writing a user-data flag: python-mpv sends every scalar as a string.**
+`handle._set_property("user-data/...", True)` stores the *string* `"yes"`, and a
+string node reads back as nil under `MPV_FORMAT_FLAG` — which is the format
+`renderer.lua` observes mpv-console's flag in, because that is what the console
+writes. A test that sets it the obvious way sets nothing the renderer can see and
+then passes whatever the code does (§7). Write it with `MPV_FORMAT_FLAG` through
+ctypes on libmpv; jsonipc's JSON `true` arrives as a bool already.

--- a/jellyfin_mpv_shim/mpvtk/app.py
+++ b/jellyfin_mpv_shim/mpvtk/app.py
@@ -287,6 +287,11 @@ class MpvtkApp:
         self.on_picture_gesture = None
         #: Last pan model pushed, so an unchanged one costs no message.
         self._picture_pan = None
+        #: Guards BOTH compare-and-skip pushes below (the pan model and the
+        #: key claim). One lock rather than two: they are the same mechanism
+        #: with the same two callers -- a build() on the loop thread, and a
+        #: yield or minimize reached from the player's thread -- and neither
+        #: is ever taken while the other is held.
         self._pan_lock = threading.Lock()
         # The mouse's forward button, windowless because history belongs to
         # the app (GUIDE.md section 4). Its counterpart the back button
@@ -868,8 +873,11 @@ class MpvtkApp:
         claim that no longer exists — and a reader would come back with
         LEFT/RIGHT walking the focus ring and SPACE toggling mpv's pause.
         """
-        self._claimed_keys = ()
-        self._picture_pan = None
+        # Under the same lock the two pushes use, so a claim or a pan model
+        # already in flight cannot store itself over the forgetting.
+        with self._pan_lock:
+            self._claimed_keys = ()
+            self._picture_pan = None
         self.backend.command(
             "script-message", "mpvtk-active", "yes" if active else "no"
         )
@@ -911,12 +919,33 @@ class MpvtkApp:
         the renderer drops on its own, are in GUIDE.md section 3.
         """
         keys = tuple(keys or ())
-        if keys == self._claimed_keys:
-            return
-        self._claimed_keys = keys
-        self.backend.command(
-            "script-message", "mpvtk-keys", json.dumps({"keys": list(keys)}),
-        )
+        # Under the lock, and stored only once the push has actually gone.
+        #
+        # The STORE ORDER is about failure: a compare-and-skip cache that
+        # records a send which RAISED answers "already pushed" for every retry
+        # after it -- and the browser retries this every frame, catching and
+        # logging the failure (mpvtk_browser/app.py `_claim_page_keys`), so
+        # the page stays up with its keys silently dropped for as long as it
+        # is on screen. Same shape as the caches `set_active` has to forget.
+        #
+        # The LOCK is about the two threads: `_claim_page_keys` pushes from
+        # build() on the loop thread while `_release_page_grabs` drops the
+        # claim from a yield or a minimize, which arrive on the player's
+        # thread (docs/browser-shell.md section 2). Unlocked, the compare, the
+        # send and the store interleave: both callers can pass the compare
+        # against the same old value, and then whichever stores last owns the
+        # cache while the other owned the wire -- so the cache says "already
+        # pushed" about a claim the renderer does not have, which is the same
+        # silently-dead-keys failure by a different route. `set_picture_pan`
+        # has always been locked for exactly this.
+        with self._pan_lock:
+            if keys == self._claimed_keys:
+                return
+            self.backend.command(
+                "script-message", "mpvtk-keys",
+                json.dumps({"keys": list(keys)}),
+            )
+            self._claimed_keys = keys
 
     def set_picture_pan(self, config=None):
         """Hand the renderer the gesture model for a displayed picture.
@@ -939,10 +968,12 @@ class MpvtkApp:
         with self._pan_lock:
             if payload == self._picture_pan:
                 return
-            self._picture_pan = payload
+            # Sent before it is stored, for the reason `claim_keys` gives:
+            # a cache that remembers a failed send stops retrying it.
             self.backend.command(
                 "script-message", "mpvtk-vpan", json.dumps(payload),
             )
+            self._picture_pan = payload
 
     def summon_hud(self):
         """Wake an idle HUD as if a nav key were pressed (no pause

--- a/jellyfin_mpv_shim/mpvtk/renderer.lua
+++ b/jellyfin_mpv_shim/mpvtk/renderer.lua
@@ -4738,7 +4738,20 @@ function keyclaim.set(list)
     state.keys = want
 end
 
+-- **While mpv's console has the keyboard on loan, binding is recording an
+-- INTENT, not taking a key.** The lifecycle moves during a loan -- a pointer
+-- movement summons the HUD, playback starts, browse resumes -- and each of
+-- those re-asserts its own input. Doing that for real reaches straight past
+-- the console and takes back the keys it is being typed into: ENTER ran a
+-- summon instead of the command, which is the whole reason the loan exists.
+-- The snapshot is what the close replays, so writing the intent there loses
+-- nothing. (`mpvtk-active` has done this for `nav` since it was written;
+-- these are the other two paths that needed it.)
 local function bind_nav_keys()
+    if state.kb_saved then
+        state.kb_saved.nav = true
+        return
+    end
     for _, k in ipairs(NAV_KEYS) do
         mp.add_forced_key_binding(k[1], 'mpvtk_nav_' .. k[1], k[2],
             { repeatable = true })
@@ -5547,6 +5560,10 @@ local phud_skip_hide, phud_skip_unbind  -- fwd: summon/hide retune them
 -- skips on the button / summons elsewhere. While the HUD is up, ENTER
 -- and clicks belong to the scene, whose Skip button is a real node.
 local function phud_skip_bind()
+    if state.kb_saved then            -- see bind_nav_keys
+        state.kb_saved.skip = true
+        return
+    end
     -- ENTER skips while the button is up and nothing else owns it
     -- (deterministically: any ENTER summon/wake binding is removed,
     -- not merely shadowed)
@@ -5627,6 +5644,10 @@ local function phud_bind_wake()
 end
 
 function phud_bind_summon()
+    if state.kb_saved then            -- see bind_nav_keys
+        state.kb_saved.summon = true
+        return
+    end
     phud_bind_wake()
     if state.phud.grab then
         for _, key in ipairs(PHUD_SUMMON_KEYS) do
@@ -5802,9 +5823,17 @@ function phud_summon(src)
     phud_unbind_summon()
     ui_resume(not state.phud.kbd)
     if not state.phud.kbd then
-        -- the wake key still upgrades to keyboard driving
-        mp.add_forced_key_binding(phud_wake_key(), 'mpvtk_wake',
-            phud_kbd_take)
+        -- the wake key still upgrades to keyboard driving -- unless mpv's
+        -- console has the keyboard, in which case this is an intent for the
+        -- close to replay, like every other bind during a loan. Guarded HERE
+        -- rather than in a helper because this is the only caller: it is the
+        -- one binding that says "the bar is up and the pointer raised it".
+        if state.kb_saved then
+            state.kb_saved.wake = true
+        else
+            mp.add_forced_key_binding(phud_wake_key(), 'mpvtk_wake',
+                phud_kbd_take)
+        end
     end
     -- ESC steps back out one layer at a time: popup -> menu/dialog ->
     -- the HUD itself. (A scene-driven dialog also binds
@@ -6430,11 +6459,20 @@ end)
 mp.observe_property('user-data/mpv/console/open', 'bool', function(_, open)
     if open then
         if state.kb_saved then return end
+        -- `wake` is not one of the kb_* flags, and that is the point: a HUD
+        -- summoned by the POINTER keeps the wake key bound to the
+        -- upgrade-to-keyboard handler, while `phud_unbind_summon` cleared
+        -- kb_summon on the way in. So the three flags all read false with
+        -- ENTER still ours, and the console was typed into a key that raised
+        -- the HUD instead of running the command -- the exact theft this
+        -- handler exists to stop, in the one state nothing described.
+        local wake = state.phud.shown and not state.phud.kbd
         state.kb_saved = { nav = state.kb_nav, summon = state.kb_summon,
-                           skip = state.kb_skip }
+                           skip = state.kb_skip, wake = wake }
         if state.kb_nav then unbind_nav_keys() end
         if state.kb_summon then phud_unbind_summon() end
         if state.kb_skip then phud_skip_unbind() end
+        if wake then mp.remove_key_binding('mpvtk_wake') end
     elseif state.kb_saved then
         local was = state.kb_saved
         state.kb_saved = nil
@@ -6467,5 +6505,11 @@ mp.observe_property('user-data/mpv/console/open', 'bool', function(_, open)
             phud_bind_summon()
         end
         if was.skip then phud_skip_bind() end
+        -- ...and the pointer-summoned HUD's upgrade key, if that is still
+        -- what is on screen.
+        if was.wake and state.phud.shown and not state.phud.kbd then
+            mp.add_forced_key_binding(phud_wake_key(), 'mpvtk_wake',
+                                      phud_kbd_take)
+        end
     end
 end)

--- a/jellyfin_mpv_shim/mpvtk/renderer.lua
+++ b/jellyfin_mpv_shim/mpvtk/renderer.lua
@@ -6438,8 +6438,34 @@ mp.observe_property('user-data/mpv/console/open', 'bool', function(_, open)
     elseif state.kb_saved then
         local was = state.kb_saved
         state.kb_saved = nil
-        if was.nav then bind_nav_keys() end
-        if was.summon then phud_bind_summon() end
+        -- Replayed against what the lifecycle is doing NOW, not against what
+        -- it was doing when the console opened: it moves underneath the loan.
+        -- A pointer movement while the console is up summons the HUD, and
+        -- browse can resume (the `mpvtk-active` handler updates the snapshot
+        -- for that one, which is where this rule started).
+        --
+        -- The SUMMON surface is the one that costs the mouse. It is the idle
+        -- HUD's, and re-binding it over a shown HUD -- or over the library --
+        -- takes `mbtn_left` back for click-to-pause, so the bar's own buttons
+        -- and every tile stop responding until the next ESC or auto-hide,
+        -- with nothing on screen to say why. It also replaces the wake key's
+        -- upgrade-to-keyboard binding with a summon that is already a no-op.
+        -- `phud_skip_bind` asks the same question for itself.
+        --
+        -- The nav keys belong to BROWSE, and to a HUD somebody is driving
+        -- from the keyboard. Not to "anything that is not a mouse-driven
+        -- HUD": `phud.mode` is only ever true under osc_style mpvtk, so with
+        -- any other OSC a suspended player looks exactly like the library --
+        -- and the arrows, ENTER and TAB would be taken as forced bindings
+        -- over a video nobody could seek any more. This is the predicate the
+        -- binders themselves use.
+        if was.nav and ((state.active and not state.phud.mode)
+                        or (state.phud.mode and state.phud.kbd)) then
+            bind_nav_keys()
+        end
+        if was.summon and state.phud.mode and not state.phud.shown then
+            phud_bind_summon()
+        end
         if was.skip then phud_skip_bind() end
     end
 end)

--- a/jellyfin_mpv_shim/mpvtk/renderer.lua
+++ b/jellyfin_mpv_shim/mpvtk/renderer.lua
@@ -209,7 +209,10 @@ local state = {
     pv_secs = 0,            -- the position it is pointing at, in seconds
     pv_rect = nil,          -- last drawn bubble rect (nil = not shown)
     ready_sent = false,
-    mouse = { x = -1, y = -1, hover = false },
+    -- `lost`: a leave has been accepted, so the next in-window
+    -- position is mpv's hover flag being wrong rather than a leave
+    -- (see the mouse-pos observer).
+    mouse = { x = -1, y = -1, hover = false, lost = nil },
     hover_id = nil,
     hover_region = nil,     -- id of the hovered node that asked to be told
     pressed = nil,          -- node id armed by mbtn down
@@ -4849,42 +4852,120 @@ mp.add_forced_key_binding('F12', 'mpvtk_hud', function()
     request_render()
 end)
 
+-- The pointer really has gone: drop everything that was tracking it. A FIELD
+-- on `state` rather than a local, because this chunk is at LuaJIT's 200-local
+-- ceiling (tests/test_renderer_lua.py reports the headroom) -- the same reason
+-- `state.pause_now` is one.
+state.mouse_left = function()
+    if state.mouse.leave_timer then
+        state.mouse.leave_timer:kill()
+        state.mouse.leave_timer = nil
+    end
+    state.mouse.hover = false
+    state.mouse.prov = nil
+    -- and forget WHERE it was. The coordinates outlive the pointer
+    -- otherwise, and phud_busy would go on reading a mouse that had left the
+    -- window as resting on the controls.
+    state.mouse.x, state.mouse.y = -1, -1
+    state.tip = nil
+    if state.tip_timer then
+        state.tip_timer:kill()
+        state.tip_timer = nil
+    end
+    update_slider_hover(nil)
+    if state.hover_id then
+        state.hover_id = nil
+        request_render()
+    end
+end
+
 mp.observe_property('mouse-pos', 'native', function(_, pos)
     if not pos then return end
+    -- **mpv can lose a hover and never get it back**, which took the whole
+    -- UI's mouse with it (#700). The flag is set ONLY by MOUSE_ENTER /
+    -- MOUSE_LEAVE, and x11_common.c drops every crossing whose mode is not
+    -- NotifyNormal (mpv 30860f7b1, "x11: ignore mouse enter/leave events due
+    -- to pointer grab"). A WM that grabs the pointer, maximizes the window
+    -- underneath it and ungrabs -- Cinnamon double-clicking the title bar --
+    -- therefore delivers the EnterNotify that would restore hover as
+    -- NotifyUngrab, mpv discards it, and hover stays false for the rest of
+    -- the session with the pointer sitting in the middle of the window.
+    --
+    -- So an in-window position arriving with hover=false is AMBIGUOUS, and
+    -- nothing in the event says which it is:
+    --
+    --   * the pointer really left, and this is the last motion before it --
+    --     mpv clears the flag when the LeaveNotify is fed but commits a
+    --     motion's position when the command is dequeued, drains the queue
+    --     per iteration and reports the property once per drain, so an
+    --     ordinary flick out of the window arrives as ONE event carrying an
+    --     in-window position AND hover=false (measured at 27 of 30
+    --     crossings; a fast exit reports a position mid-window);
+    --   * or the flag is stranded and the pointer is still here.
+    --
+    -- **Resolved by what follows, and biased toward the pointer being
+    -- present.** The first such event is PROVISIONAL: the position is taken,
+    -- the UI stays live -- hover rings, scrolling, clicks -- and a short
+    -- grace timer is armed. Nothing more arrives if the pointer really left
+    -- (X delivers motion to whatever window it is over), so the timer
+    -- commits the leave; another motion re-arms it and the UI never notices.
+    -- The grace is well under the HUD's shortest auto-hide, so "the pointer
+    -- is off the controls" still lands in time to hide them.
+    --
+    -- No "did we see a leave first" gate: an enter can be lost on its own
+    -- (a fresh renderer while the pointer is outside, a crossing eaten by a
+    -- grab), and then there is no leave to have seen -- motion inside the
+    -- window has to be enough on its own.
+    local synth = false
     if pos.hover == false then
-        -- Mid-resize the pointer is OUTSIDE the window for most of the
-        -- gesture -- it has to be, since the corner only reaches it once
-        -- the window has grown -- and hover goes false the instant the
-        -- drag starts. The coordinates are still live: the button is held,
-        -- so the implicit pointer grab keeps motion coming to us (X11) and
-        -- the compositor keeps delivering to the focused surface
-        -- (Wayland). Taking the branch below would both drop the event and
-        -- forget where the pointer was, which stalls the resize on its
-        -- first pixel and then computes a 320x240 window from x,y = -1.
-        if state.wsize then
-            -- Report the truth -- the pointer really is outside -- but keep
-            -- tracking it. Only the coordinates matter to the drag.
+        -- **A gesture owns the pointer.** Mid-resize the pointer is outside
+        -- the window for most of the drag -- it has to be, since the corner
+        -- only reaches it once the window has grown -- and the same is true
+        -- of a scrollbar or slider dragged past the edge. The coordinates
+        -- are still live either way (the held button keeps the pointer
+        -- grabbed), and dropping them strands the gesture: the resize stalls
+        -- on its first pixel and computes a 320x240 window from x,y = -1.
+        -- A gesture in flight is also the one moment a spurious leave costs
+        -- the most, so it is never believed here.
+        if state.wsize or state.drag or state.slider_drag or state.tb_drag
+            or state.dd_bar_drag or state.vpan_drag then
             state.mouse.hover = false
             on_mouse_move(pos.x, pos.y)
             return
         end
-        state.mouse.hover = false
-        -- and forget WHERE it was. The coordinates outlive the pointer
-        -- otherwise, and phud_busy would go on reading a mouse that had
-        -- left the window as resting on the controls.
-        state.mouse.x, state.mouse.y = -1, -1
-        state.tip = nil
-        if state.tip_timer then
-            state.tip_timer:kill()
-            state.tip_timer = nil
+        if state.w and state.h and pos.x >= 0 and pos.y >= 0
+            and pos.x < state.w and pos.y < state.h
+            and (pos.x ~= state.mouse.x or pos.y ~= state.mouse.y) then
+            pos.hover = true   -- a fresh table per notification; ours to fix
+            synth = true
         end
-        update_slider_hover(nil)
-        if state.hover_id then
-            state.hover_id = nil
-            request_render()
-        end
+    end
+    if pos.hover == false then
+        state.mouse_left()
         return
     end
+    -- Provisional (see above): re-arm the grace, so a pointer that really
+    -- left is given up on shortly after it stops reporting. A confirmed
+    -- hover -- mpv's own -- ends the question outright.
+    if synth then
+        if state.mouse.leave_timer then state.mouse.leave_timer:kill() end
+        -- 0.2s: long enough that a moving pointer always re-arms it,
+        -- short enough to be invisible to the HUD's auto-hide, whose own
+        -- floor is 0.5s (PHUD_HIDE.min). A literal rather than a named
+        -- constant because this chunk is at LuaJIT's 200-local ceiling and
+        -- one more is a load error, not a warning.
+        state.mouse.leave_timer = mp.add_timeout(0.2, state.mouse_left)
+    elseif state.mouse.leave_timer then
+        state.mouse.leave_timer:kill()
+        state.mouse.leave_timer = nil
+    end
+    -- Whether the pointer has been seen inside TWICE running: one ambiguous
+    -- event is as likely to be a leave as a stranded flag, and summoning the
+    -- playback HUD from the flick that took the pointer off the window is
+    -- the one place that guess is visible. Everything else stays live on the
+    -- first event, which is the whole point of being provisional.
+    local confirmed = not synth or state.mouse.prov
+    state.mouse.prov = synth
     state.mouse.hover = true
     -- Record it for BOTH branches. The idle-HUD branch below returns
     -- without reaching on_mouse_move, so a mouse summon used to leave
@@ -4901,7 +4982,7 @@ mp.observe_property('mouse-pos', 'native', function(_, pos)
             (math.abs(pos.x - state.phud.mx) +
              math.abs(pos.y - state.phud.my)) > 2
         state.phud.mx, state.phud.my = pos.x, pos.y
-        if moved then
+        if moved and confirmed then
             -- Pointer movement summons the full HUD, skippable segment
             -- or not: the scene draws its own Skip button, so there is
             -- nothing to withhold, and a live segment lasting a minute

--- a/jellyfin_mpv_shim/mpvtk_browser/app.py
+++ b/jellyfin_mpv_shim/mpvtk_browser/app.py
@@ -2249,6 +2249,17 @@ class MpvtkBrowser(DialogsMixin, LiveTvDialogsMixin, AuthMixin, SettingsMixin,
                 # they have not read yet.
                 self.invalidate()
                 return
+            if self.load.starting is not None:
+                # ...and a start still IN FLIGHT owns it for the same reason:
+                # the loading screen is on the window and the yield to video
+                # has not happened yet. The player suppresses the incidental
+                # stopped pushes a load produces (player_reporting), so this
+                # is the second lock -- a remote stop, a websocket, anything
+                # that reports one from outside that path. Cancelling and
+                # failing both clear `starting` before they arrive here, so
+                # nothing can be stranded on the loading screen by it.
+                self.invalidate()
+                return
             if self._minimized:
                 # Cast finished and the library was never open: drop back to
                 # the windowless state rather than popping the browser up on

--- a/jellyfin_mpv_shim/player_reporting.py
+++ b/jellyfin_mpv_shim/player_reporting.py
@@ -119,6 +119,22 @@ class ReportingMixin:
                 aborted = self._player.playback_abort
             except _mpv_errors:
                 aborted = True
+            if not stopped and video is None and self._start_in_progress:
+                # **A start in flight is not a stop.** `_video` is assigned
+                # only once the open succeeds and `playback_abort` stays true
+                # until it does, so for the whole of a load every incidental
+                # push here reported "stopped" -- and the browser reads that
+                # as "playback ended", drops its loading screen and returns to
+                # the library, over the start the user is waiting for.
+                #
+                # There is always at least one: `_play_media` writes the
+                # persisted per-type volume before mpv is handed the file, and
+                # the volume observer pushes. A skippable-segment transition
+                # and the now-playing ticker do it too.
+                #
+                # An explicit stopped=True still reports: that is the stop
+                # path, which is exactly how a cancelled or failed start ends.
+                return
             if stopped or video is None or aborted:
                 cb({"stopped": True})
                 return

--- a/tests/integration/test_mpvtk_browser.py
+++ b/tests/integration/test_mpvtk_browser.py
@@ -464,5 +464,129 @@ class TestTableRowContextMenu(unittest.TestCase):
         self.assertNotIn(("context", 3), self.events)
 
 
+@h.require_real_mpv
+class TestRealMousePosPath(unittest.TestCase):
+    """The pointer as MPV reports it, not as the debug hook simulates it.
+
+    Every other mouse test here goes through ``mpvtk-debug``, which calls
+    ``on_mouse_move`` directly. Nothing covered the property the renderer
+    actually listens to -- and that is where #700 lived: mpv sets
+    ``mouse-pos.hover`` only from MOUSE_ENTER/MOUSE_LEAVE and ignores every
+    X11 crossing whose mode is not NotifyNormal, so a WM that grabs the
+    pointer, maximizes the window under it and ungrabs leaves hover false
+    with the pointer sitting in the middle of the window. The renderer then
+    hit-tested every click at -1,-1 and the whole UI stopped responding.
+
+    **The stranded state itself cannot be reached from out here**, and the
+    reason is the same rule the fix uses: mpv's own ``mouse`` command decides
+    hover from the window bounds (command.c synthesizes MOUSE_ENTER for an
+    in-bounds artificial move), so it repairs the flag before the renderer
+    ever sees it. That half is pinned in ``tests/lua/test_renderer.lua``,
+    against the real observer. What only a real mpv can settle is the rest of
+    the path: that a leave is still a leave, that an out-of-window position
+    is not taken for a hover, and that the property reaches the renderer at
+    all on both backends.
+    """
+
+    def setUp(self):
+        from jellyfin_mpv_shim.mpvtk.app import MpvtkApp
+        from jellyfin_mpv_shim.mpvtk.widgets import Button, Column, Spacer
+
+        self.handle, ext = _spawn_handle()
+        self.app = MpvtkApp.attach(self.handle, ext=ext)
+        self.clicks = []
+        self.btn = Button("Press me", id="target-btn", w=240,
+                          on_click=lambda: self.clicks.append(1))
+        self._thread = threading.Thread(
+            target=lambda: self.app.run(
+                lambda size: Column([Spacer(h=60), self.btn])),
+            daemon=True)
+        self._thread.start()
+        self.assertTrue(self.app.ready.wait(15), "renderer never ready")
+        time.sleep(0.6)
+
+    def tearDown(self):
+        try:
+            self.app.quit()
+            self._thread.join(timeout=5)
+        finally:
+            try:
+                self.handle.terminate()
+            except Exception:
+                pass
+
+    def _center(self):
+        """The button's centre in WINDOW pixels, which is what mpv's `mouse`
+        command speaks. Read from the pushed scene rather than node_rect(),
+        which converts back to logical coordinates for widget code."""
+        node = next((n for n in (self.app._nodes or [])
+                     if n.get("id") == "target-btn"), None)
+        self.assertIsNotNone(node, "the button never reached the renderer")
+        return int(node["x"] + node["w"] / 2), int(node["y"] + node["h"] / 2)
+
+    def _mouse(self, x, y):
+        self.handle.command("mouse", int(x), int(y))
+        time.sleep(0.4)
+
+    def _mouse_state(self):
+        st = self.app.debug_state()
+        self.assertIsNotNone(st, "no debug state from renderer")
+        return st
+
+    def test_the_real_pointer_hovers_leaves_and_comes_back(self):
+        cx, cy = self._center()
+        self._mouse(cx, cy)
+        st = self._mouse_state()
+        self.assertEqual(st.get("hover"), "target-btn",
+                         "mpv's own mouse-pos never reached the renderer: %r"
+                         % (st.get("mouse"),))
+        self.assertTrue(st["mouse"]["hover"])
+
+        # A leave is still a leave: the position is forgotten, so nothing is
+        # left hovered and a click cannot land on a control the pointer is
+        # no longer over.
+        self.handle.command("keypress", "MOUSE_LEAVE")
+        time.sleep(0.4)
+        st = self._mouse_state()
+        self.assertIsNone(st.get("hover"), "the leave left the button hovered")
+        self.assertEqual(st["mouse"]["x"], -1,
+                         "the leave kept the last in-window position")
+
+        # An out-of-window position must not be read as a hover. It only
+        # moves at all while a button is held (X keeps delivering to the
+        # grab), and believing it would light up controls under a pointer
+        # that is somewhere else entirely.
+        self._mouse(st["w"] + 50, st["h"] + 50)
+        st = self._mouse_state()
+        self.assertFalse(st["mouse"]["hover"],
+                         "a position outside the window was taken as a hover")
+        self.assertIsNone(st.get("hover"))
+
+        # ...and coming back does come back.
+        self._mouse(cx, cy)
+        self.assertEqual(self._mouse_state().get("hover"), "target-btn",
+                         "the pointer never got back into the window")
+
+    def test_a_real_click_reaches_the_button(self):
+        """A press and a release through mpv's own input stack, section
+        stack included -- which the Lua fake cannot model.
+
+        `keydown`/`keyup`, not `mouse x y 0`: that form delivers the button
+        with neither state bit, which mpv reports as a *press* and which the
+        two-function bindings `mp.set_key_bindings` installs answer to
+        neither half of.
+        """
+        cx, cy = self._center()
+        self._mouse(cx, cy)
+        self.handle.command("keydown", "MBTN_LEFT")
+        time.sleep(0.2)
+        self.handle.command("keyup", "MBTN_LEFT")
+        deadline = time.time() + 4
+        while time.time() < deadline and not self.clicks:
+            time.sleep(0.2)
+        self.assertTrue(self.clicks,
+                        "a real left click never reached the button")
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/tests/integration/test_mpvtk_hud.py
+++ b/tests/integration/test_mpvtk_hud.py
@@ -727,6 +727,90 @@ class TestPlaybackHudLifecycle(h.TmpDirTest):
         self._wait(lambda: not self.browser.hud.shown, timeout=10,
                    msg="the default mode kept the HUD up on a paused video")
 
+    def _set_console(self, open_):
+        """mpv-console's presence flag, as the console script itself sets it.
+
+        Split by backend for the same reason ``_set_pause`` is: libmpv's
+        command() stringifies its arguments, so a bool has to go through the
+        property API to arrive as one -- and the renderer observes this as
+        MPV_FORMAT_FLAG, where a string node simply reads as nil.
+        """
+        name = "user-data/mpv/console/open"
+        if h.BACKEND == "jsonipc":
+            self.handle.command("set_property", name, open_)
+        else:
+            # NOT handle._set_property: python-mpv sends every scalar as a
+            # STRING, and a user-data node holding "yes" reads back as nil
+            # under MPV_FORMAT_FLAG -- which is the format the renderer
+            # observes it in, because that is what mpv's console writes. The
+            # test then sets nothing the renderer can see and passes whatever
+            # the code does.
+            import ctypes
+            from mpv import MpvFormat, _mpv_set_property
+            flag = ctypes.c_int(1 if open_ else 0)
+            _mpv_set_property(self.handle.handle, name.encode("utf-8"),
+                              MpvFormat.FLAG, ctypes.byref(flag))
+        time.sleep(0.4)
+
+    def _real_click(self, node_id):
+        """A press and a release through mpv's own input stack, at the
+        node's real coordinates -- so the SECTION STACK decides who gets the
+        button. ``app.debug(cmd="click")`` calls the handlers directly and
+        would answer yes however the bindings were left."""
+        node = next((n for n in (self.app._nodes or [])
+                     if n.get("id") == node_id), None)
+        self.assertIsNotNone(node, "%s is not in the pushed scene" % node_id)
+        cx = int(node["x"] + node["w"] / 2)
+        cy = int(node["y"] + node["h"] / 2)
+        self.handle.command("mouse", cx, cy)
+        time.sleep(0.3)
+        self.handle.command("keydown", "MBTN_LEFT")
+        time.sleep(0.2)
+        self.handle.command("keyup", "MBTN_LEFT")
+
+    def test_the_console_gives_back_the_hud_it_left_with(self):
+        """The keyboard loan is a snapshot, and the lifecycle moves under it.
+
+        mpv-console wants the keys our forced bindings outrank, so the
+        renderer hands the three groups over for as long as it is up and
+        takes them back on close. But the pointer can summon the HUD while
+        the console is open -- and replaying "the idle summon surface was
+        bound" onto a HUD that is now SHOWN re-takes mbtn_left for
+        click-to-pause and replaces the wake key's upgrade-to-keyboard
+        binding with a cold summon that is already a no-op. The bar is on
+        screen and answers neither the mouse nor the keyboard.
+
+        Only a real mpv can settle this: which binding wins is its section
+        stack, which the Lua fake does not model.
+        """
+        self.ctl.key_opts = {"grab": False, "key": "ENTER",
+                             # long enough that auto-hide cannot clear the
+                             # wedge before the assertions run
+                             "hide": 60, "mode": "hover"}
+        self._play_video()
+        self._wait(lambda: self._state().get("phud_mode"),
+                   msg="never entered HUD-idle")
+
+        self._set_console(True)
+        self.app.debug(cmd="phud", action="mousemove", x=200, y=200)
+        self._wait(lambda: self._state().get("phud_shown"),
+                   msg="pointer movement never summoned the HUD")
+        self._set_console(False)
+
+        self._wait(lambda: any(n.get("id") == "hud-pp"
+                               for n in (self.app._nodes or [])),
+                   msg="the HUD scene never reached the renderer")
+        self.ctl.calls = []
+        self._real_click("hud-pp")
+        self._wait(lambda: "toggle_pause" in self.ctl.calls,
+                   msg="a click on play/pause never reached the button: %r"
+                       % (self.ctl.calls,))
+
+        # ...and the wake key still upgrades this HUD to keyboard driving
+        # rather than trying to summon one that is already up.
+        self._press_until("ENTER", lambda: self._state().get("phud_kbd"),
+                          msg="the wake key stopped taking keyboard control")
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/tests/lua/fake_mp.lua
+++ b/tests/lua/fake_mp.lua
@@ -17,6 +17,10 @@ M.log = {
     props = {},         -- set_property_native by name
     timers = {},        -- live timers, so a test can fire them
     keybinds = {},
+    -- The RELEASE half of a set_key_bindings pair (entry[2]), for the few
+    -- gestures whose whole subject is what the press left behind -- a click
+    -- resolves the node under the pointer twice, once on each half.
+    keybinds_up = {},
     forced = {},       -- keybind name -> was it add_FORCED_key_binding?
     keyopts = {},      -- keybind name -> the flags table it was bound with
     -- keybind name -> the mpv KEY it was bound for. Everything else here
@@ -306,6 +310,7 @@ function mp.set_key_bindings(list, name, _flags)
     M.log.sections[name or "?"] = section
     for _, entry in ipairs(list or {}) do
         M.log.keybinds[entry[1]] = entry[3] or entry[2]
+        if entry[3] then M.log.keybinds_up[entry[1]] = entry[2] end
         section[entry[1]] = true
     end
 end
@@ -444,6 +449,14 @@ end
 function M.key(name, ...)
     local fn = M.log.keybinds[name]
     if not fn then error("no key binding: " .. name) end
+    return fn(...)
+end
+
+--- The release of a down/up pair. M.key fires the DOWN half, which is the
+--- one almost every test wants; this is its other half.
+function M.key_up(name, ...)
+    local fn = M.log.keybinds_up[name]
+    if not fn then error("no key release binding: " .. name) end
     return fn(...)
 end
 

--- a/tests/lua/test_renderer.lua
+++ b/tests/lua/test_renderer.lua
@@ -2211,6 +2211,79 @@ ok(fake.log.keybinds["mpvtk_nav_ENTER"] == nil,
    "closing the console bound nav keys that were not bound before it opened")
 fake.send("mpvtk-active", "yes")
 
+-- ...but "what was bound" is a snapshot, and the LIFECYCLE moves underneath
+-- it: the pointer can summon the HUD while the console is up. Restoring the
+-- idle HUD's summon surface over a HUD that is now SHOWN takes mbtn_left back
+-- for click-to-pause, so the bar's own buttons stop responding -- a mouse
+-- that has gone dead with the controls in plain sight, and nothing on screen
+-- to say why.
+fake.send("mpvtk-hud", "no")
+fake.send("mpvtk-hud", "yes", fake.token({ hide = 4, mode = "hover" }))
+ok(fake.log.keybinds["mpvtk_phud_click"] ~= nil,
+   "sanity: an idle HUD takes the click for click-to-pause")
+fake.observe("user-data/mpv/console/open", true)
+ok(fake.log.keybinds["mpvtk_phud_click"] == nil,
+   "the console is up and the summon surface is still ours")
+fake.observe("mouse-pos", { x = 600, y = 300, hover = true })
+fake.observe("mouse-pos", { x = 600, y = 360, hover = true })
+fake.reset_events()
+fake.send("mpvtk-debug", fake.token({ cmd = "state" }))
+ok((last_event("debug_state") or {}).phud_shown == true,
+   "sanity: pointer movement summons the HUD even with the console up")
+fake.observe("user-data/mpv/console/open", false)
+ok(fake.log.keybinds["mpvtk_phud_click"] == nil,
+   "closing the console gave the shown HUD's clicks back to click-to-pause")
+
+-- The same restore also replaces the wake key's upgrade-to-keyboard binding
+-- with a cold summon, which is already a no-op on a HUD that is up: the bar
+-- can then never be driven from the keyboard at all.
+fake.key("mpvtk_wake")
+fake.reset_events()
+fake.send("mpvtk-debug", fake.token({ cmd = "state" }))
+ok((last_event("debug_state") or {}).phud_kbd == true,
+   "the wake key no longer upgrades a mouse-summoned HUD to keyboard driving")
+
+fake.send("mpvtk-hud", "no")
+fake.send("mpvtk-active", "yes")
+
+-- The NAV half of the same rule, which the cases above cannot reach: the
+-- console can be open across a transition in either direction.
+--
+-- Browse -> suspended, decided while the console holds the keys. Restoring
+-- "nav was bound" here hands the arrows, ENTER and TAB to an invisible
+-- renderer for the whole of playback -- and `phud.mode` does not stand in for
+-- "the UI owns the keyboard", because it is only ever true under osc_style
+-- mpvtk; with a lua OSC a suspended player has no HUD mode at all.
+fake.observe("user-data/mpv/console/open", true)
+fake.send("mpvtk-active", "no")
+fake.observe("user-data/mpv/console/open", false)
+ok(fake.log.keybinds["mpvtk_nav_ENTER"] == nil,
+   "closing the console bound nav keys over suspended playback")
+fake.send("mpvtk-active", "yes")
+
+-- ...and the other way: suspended -> browse, which the `mpvtk-active`
+-- handler records into the snapshot rather than binding behind the console.
+fake.send("mpvtk-active", "no")
+fake.observe("user-data/mpv/console/open", true)
+fake.send("mpvtk-active", "yes")
+fake.observe("user-data/mpv/console/open", false)
+ok(fake.log.keybinds["mpvtk_nav_ENTER"] ~= nil,
+   "browse came back from the console with no arrow, ENTER or TAB")
+
+-- A keyboard-driven HUD owns them too, and it is not browse: `state.active`
+-- alone would refuse them.
+fake.send("mpvtk-hud", "no")
+fake.send("mpvtk-hud", "yes", fake.token({ grab = true, hide = 4,
+                                           mode = "hover" }))
+fake.observe("mouse-pos", { x = 600, y = 300, hover = true })
+fake.observe("mouse-pos", { x = 600, y = 360, hover = true })
+fake.observe("user-data/mpv/console/open", true)
+fake.observe("user-data/mpv/console/open", false)
+ok(fake.log.keybinds["mpvtk_nav_ENTER"] ~= nil,
+   "a keyboard-driven HUD lost its arrows to the console")
+fake.send("mpvtk-hud", "no")
+fake.send("mpvtk-active", "yes")
+
 -- ==================================================== what gets drawn
 --
 -- Two things in this file live entirely in the drawing and are invisible to

--- a/tests/lua/test_renderer.lua
+++ b/tests/lua/test_renderer.lua
@@ -985,6 +985,127 @@ scene({})
 eq(hover_events(), "hover_end:tile-a-play",
    "a hovered node leaving the scene reported no departure")
 
+-- ================= a hover mpv lost, and one it never had (#700)
+--
+-- mpv sets `mouse-pos.hover` only from MOUSE_ENTER / MOUSE_LEAVE and ignores
+-- every X11 crossing whose mode is not NotifyNormal, so a WM that grabs the
+-- pointer, maximizes the window under it and ungrabs -- Cinnamon's title-bar
+-- double click -- strands the flag at false with the pointer in the middle of
+-- the window. That cost the whole UI its mouse: no hover ring, and every
+-- click hit-tested at -1,-1.
+--
+-- An in-window position with hover=false is AMBIGUOUS, and the renderer
+-- resolves it by what follows rather than by guessing (see the observer).
+-- These are the three rules that has to satisfy.
+
+local function mouse_state()
+    fake.reset_events()
+    fake.send("mpvtk-debug", fake.token({ cmd = "state" }))
+    return (last_event("debug_state") or {}).mouse or {}
+end
+
+--- Let the leave grace expire with nothing else arriving.
+local function idle_out()
+    fake.advance(0.3)
+    fake.fire_timers()
+end
+
+-- **The pointer is believed, with no leave needed first.** An enter can be
+-- lost on its own -- a renderer that loads while the pointer is outside, a
+-- crossing eaten by a grab -- and then there is no leave to have seen.
+scene({ tile("tile-a", 0, 0, { hev = true }) })
+point(300, 300)                      -- somewhere else, and clear of the tile
+fake.reset_events()
+fake.observe("mouse-pos", { x = 50, y = 40, hover = false })
+eq(hover_events(), "hover:tile-a",
+   "an in-window pointer was ignored because mpv said hover=false")
+eq(mouse_state().hover, true, "the stranded hover flag was not corrected")
+
+-- ...and it keeps being believed. The flag stays stranded for the rest of the
+-- session, so EVERY event after it is hover=false too; correcting one must
+-- not look like a crossing, or the UI alternates between hovering and
+-- leaving one motion apart.
+for _, xy in ipairs({ { 55, 42 }, { 60, 44 }, { 65, 46 } }) do
+    fake.observe("mouse-pos", { x = xy[1], y = xy[2], hover = false })
+end
+eq(mouse_state().hover, true, "a stranded hover flag was only corrected once")
+
+-- The click that used to go nowhere: it hit-tests state.mouse, the same as
+-- the ring, so it is asserted separately.
+fake.reset_events()
+fake.key("mbtn_left")        -- press...
+fake.key_up("mbtn_left")     -- ...and release
+ok(last_event("click") ~= nil and last_event("click").id == "tile-a",
+   "a click at a stranded-hover position hit nothing")
+
+-- **A real leave still lands** -- which is what the playback HUD's auto-hide
+-- is built on. It usually arrives carrying a MOVED position: mpv clears the
+-- flag when the LeaveNotify is fed but commits a motion's position when the
+-- command is dequeued, drains the queue per iteration and reports the
+-- property once per drain, so an ordinary flick out of the window is ONE
+-- event holding the last in-window position and hover=false. Measured at 27
+-- of 30 crossings on a real mpv. Nothing follows it, and that is the tell.
+point(50, 40)
+fake.reset_events()
+fake.observe("mouse-pos", { x = 60, y = 45, hover = false })
+idle_out()
+eq(hover_events(), "hover_end:tile-a", "a real leave never landed")
+local m = mouse_state()
+ok(m.hover == false and m.x == -1,
+   "a leave that stopped reporting was not committed",
+   string.format("hover=%s x=%s", tostring(m.hover), tostring(m.x)))
+
+-- The same from the middle of the window, which is what a fast exit reports.
+point(50, 40)
+fake.observe("mouse-pos", { x = 640, y = 360, hover = false })
+idle_out()
+eq(mouse_state().hover, false,
+   "a leave reporting a position mid-window was not committed")
+
+-- An unchanged position is not motion at all: nothing to be ambiguous about,
+-- so that leave is taken at once rather than after the grace.
+point(50, 40)
+fake.observe("mouse-pos", { x = 50, y = 40, hover = false })
+eq(mouse_state().hover, false, "an unmoved leave waited for the grace")
+
+-- Out of the window, likewise. The position only moves at all out there
+-- while a button is held (X keeps delivering to the grab), and believing it
+-- would light up controls under a pointer somewhere else entirely.
+point(50, 40)
+fake.observe("mouse-pos", { x = 1400, y = 900, hover = false })
+eq(mouse_state().hover, false, "an out-of-window position was taken as a hover")
+
+-- **A gesture is never interrupted by a leave.** A spurious one mid-drag is
+-- where believing it costs the most: the scroll stops following the pointer
+-- and does not resume, with the button still held.
+scene({ vscroll("body", 400, 4000, { bar = true }) })
+fake.advance(0.1)
+fake.fire_timers()
+local bar = ((function()
+    fake.reset_events()
+    fake.send("mpvtk-debug", fake.token({ cmd = "state" }))
+    return (last_event("debug_state") or {}).bars or {}
+end)())["body"]
+ok(bar ~= nil, "fixture: the scroll container drew no scrollbar")
+if bar then
+    fake.mouse(bar.x + 2, bar.thumb_y + 2)
+    fake.send("mpvtk-debug",
+              fake.token({ cmd = "down", x = bar.x + 2, y = bar.thumb_y + 2 }))
+    local before = offset("body")
+    -- BELOW the window, which is where this actually happens: drag a
+    -- scrollbar past the bottom edge and the pointer is genuinely outside,
+    -- so hover goes false with the button still held. The gesture owns the
+    -- pointer and must keep being fed -- the in-window half needs no rule of
+    -- its own, since a moved in-window position is believed anyway.
+    fake.observe("mouse-pos", { x = bar.x + 2, y = 900, hover = false })
+    ok(offset("body") > before,
+       "a leave mid-drag stopped the scrollbar following the pointer")
+    fake.send("mpvtk-debug", fake.token({ cmd = "up", x = bar.x + 2,
+                                          y = 900 }))
+end
+point(50, 40)
+
+
 -- ===================================================== scroll snapping
 --
 -- Scrolling glides. It quantizes to row boundaries only when the frames a
@@ -1622,6 +1743,28 @@ fake.send("mpvtk-debug", fake.token({ cmd = "click", x = 5, y = 5 }))
 -- The controls' auto-hide is a policy (hud_autohide), and the pointer
 -- resting ON them holds it off in every mode but 'always'. Reaching for a
 -- button must not be a race against the timer.
+
+-- Summoning the HUD is the one place the provisional guess is VISIBLE: the
+-- flick that takes the pointer off the window is an in-window position with
+-- hover=false, and believing it there raises the controls as you move away
+-- from them. So the summon waits for a second such event -- the pointer
+-- demonstrably still moving inside -- while everything else stays live on
+-- the first, which is the whole point of being provisional.
+fake.send("mpvtk-hud", "no")
+fake.send("mpvtk-hud", "yes", fake.token({ hide = 4, mode = "hover" }))
+fake.observe("mouse-pos", { x = 600, y = 300, hover = true })   -- records only
+fake.reset_events()
+fake.observe("mouse-pos", { x = 600, y = 360, hover = false })  -- the flick out
+fake.send("mpvtk-debug", fake.token({ cmd = "state" }))
+ok((last_event("debug_state") or {}).phud_shown ~= true,
+   "moving the pointer OFF the window summoned the playback HUD")
+fake.observe("mouse-pos", { x = 600, y = 420, hover = false })  -- still moving
+fake.reset_events()
+fake.send("mpvtk-debug", fake.token({ cmd = "state" }))
+ok((last_event("debug_state") or {}).phud_shown == true,
+   "a pointer still moving inside never summoned the HUD")
+fake.send("mpvtk-hud", "no")
+fake.send("mpvtk-active", "yes")
 
 local function hud_engage(opts)
     fake.send("mpvtk-hud", "no")

--- a/tests/lua/test_renderer.lua
+++ b/tests/lua/test_renderer.lua
@@ -2246,6 +2246,80 @@ ok((last_event("debug_state") or {}).phud_kbd == true,
 fake.send("mpvtk-hud", "no")
 fake.send("mpvtk-active", "yes")
 
+-- **The state nothing described.** A HUD summoned by the POINTER keeps the
+-- wake key bound to the upgrade-to-keyboard handler, while kb_summon was
+-- cleared on the way in -- so all three tracked flags read false with ENTER
+-- still ours, and the console was typed into a key that raised the HUD.
+fake.send("mpvtk-hud", "no")
+fake.send("mpvtk-hud", "yes", fake.token({ hide = 4, mode = "hover" }))
+fake.observe("mouse-pos", { x = 600, y = 300, hover = true })
+fake.observe("mouse-pos", { x = 600, y = 360, hover = true })
+fake.reset_events()
+fake.send("mpvtk-debug", fake.token({ cmd = "state" }))
+ok((last_event("debug_state") or {}).phud_shown == true,
+   "fixture: the pointer never summoned the HUD")
+ok(fake.log.keybinds["mpvtk_wake"] ~= nil,
+   "fixture: a mouse-summoned HUD should keep the wake key")
+fake.observe("user-data/mpv/console/open", true)
+ok(fake.log.keybinds["mpvtk_wake"] == nil,
+   "the console is up and ENTER still raises the HUD")
+fake.observe("user-data/mpv/console/open", false)
+ok(fake.log.keybinds["mpvtk_wake"] ~= nil,
+   "closing the console left the HUD with no way to take the keyboard")
+fake.send("mpvtk-hud", "no")
+fake.send("mpvtk-active", "yes")
+
+-- **A lifecycle transition during the loan records an intent; it does not
+-- take the keys back.** Playback starting while the console is open used to
+-- re-bind the idle HUD's summon surface straight over it, so ENTER raised the
+-- controls instead of running the command being typed.
+fake.observe("user-data/mpv/console/open", true)
+fake.send("mpvtk-hud", "no")
+fake.send("mpvtk-hud", "yes", fake.token({ hide = 4, mode = "hover" }))
+ok(fake.log.keybinds["mpvtk_wake"] == nil,
+   "a HUD engaged during the loan took the console's ENTER")
+ok(fake.log.keybinds["mpvtk_phud_click"] == nil,
+   "a HUD engaged during the loan took the console's mouse button")
+fake.observe("user-data/mpv/console/open", false)
+ok(fake.log.keybinds["mpvtk_wake"] ~= nil,
+   "the summon surface was never handed back after the console closed")
+fake.send("mpvtk-hud", "no")
+fake.send("mpvtk-active", "yes")
+
+-- **The HUD must still let go while the console is up**, which is what makes
+-- the ESC and F12 it holds a papercut rather than a trap: mpv's console keeps
+-- `ctrl+[` (and a click) to close on, and both of ours come back the moment
+-- the bar hides. The auto-hide is a renderer timer and the loan does not touch
+-- it, so a pointer that stops moving -- and is not resting on the controls --
+-- takes the bar down and hands ESC back.
+fake.send("mpvtk-hud", "no")
+fake.send("mpvtk-hud", "yes", fake.token({ hide = 4, mode = "hover" }))
+fake.observe("user-data/mpv/console/open", true)
+fake.observe("mouse-pos", { x = 600, y = 300, hover = true })
+fake.observe("mouse-pos", { x = 600, y = 360, hover = true })   -- summons
+-- the bars hud.py draws, with the pointer in the gap between them
+scene({ { id = "hud-topbar", t = "rect", x = 0, y = 0, w = 1280, h = 60 },
+        { id = "hud-bar", t = "rect", x = 0, y = 640, w = 1280, h = 80 } })
+ok(fake.log.keybinds["mpvtk_phud_esc"] ~= nil,
+   "fixture: a shown HUD should hold ESC")
+ok(fake.log.keybinds["mpvtk_hud"] ~= nil,
+   "fixture: a shown HUD should hold F12")
+fake.advance(5)
+fake.fire_timers()
+fake.reset_events()
+fake.send("mpvtk-debug", fake.token({ cmd = "state" }))
+ok((last_event("debug_state") or {}).phud_shown ~= true,
+   "the HUD never auto-hid while the console was up")
+ok(fake.log.keybinds["mpvtk_phud_esc"] == nil,
+   "the HUD hid but kept ESC, so the console cannot close on it")
+ok(fake.log.keybinds["mpvtk_hud"] == nil,
+   "the HUD hid but kept F12")
+ok(fake.log.keybinds["mpvtk_wake"] == nil,
+   "hiding under the console took ENTER back for the summon surface")
+fake.observe("user-data/mpv/console/open", false)
+fake.send("mpvtk-hud", "no")
+fake.send("mpvtk-active", "yes")
+
 -- The NAV half of the same rule, which the cases above cannot reach: the
 -- console can be open across a transition in either direction.
 --

--- a/tests/test_last_server_and_load_ui.py
+++ b/tests/test_last_server_and_load_ui.py
@@ -235,6 +235,42 @@ class LoadingAndFailureScreenTest(unittest.TestCase):
         walk(scene)
         return bool(found)
 
+    def test_a_stopped_push_mid_load_keeps_the_window(self):
+        """The flash the user sees as blank -> library -> player.
+
+        `_video` is unset for the whole of a load, so the player reported
+        every incidental push during one as "stopped" -- and this branch read
+        that as "playback ended" and called enter_browse(). The library came
+        back over the start, took the spinner with it, and re-read Home while
+        it was there. The player suppresses those pushes now; this is the
+        second lock, for a stop reported from anywhere else.
+        """
+        b = self.browser
+        b.load.on_load_start({"title": "Some Movie"})
+        b.on_playstate({"stopped": True})
+        self.assertFalse(b._browsing,
+                         "a stopped push mid-load returned to the library")
+        self.assertIsNotNone(b.load.starting,
+                             "the in-flight load was forgotten")
+
+    def test_the_spinner_survives_a_stopped_push(self):
+        """The same, one layer up: what the user is actually looking at."""
+        b = self.browser
+        b.load.on_load_start({"title": "Some Movie"})
+        self._slow()
+        self.assertTrue(self._has_spinner(), "fixture: no spinner to lose")
+        b.on_playstate({"stopped": True})
+        self.assertTrue(self._has_spinner(),
+                        "a stopped push mid-load took the spinner away")
+
+    def test_a_stop_with_no_load_in_flight_still_returns_to_browse(self):
+        """The guard must not swallow the ordinary end of playback."""
+        b = self.browser
+        b.load.reset()
+        b.on_playstate({"stopped": True})
+        self.assertTrue(b._browsing,
+                        "playback ended and the library never came back")
+
     def test_a_load_in_flight_shows_a_spinner(self):
         """Busy animates renderer-side, so it can sit through a 30s stall
         without costing a single repaint from here."""

--- a/tests/test_mpvtk_framework.py
+++ b/tests/test_mpvtk_framework.py
@@ -353,6 +353,90 @@ class TestClickMods(unittest.TestCase):
         self.assertEqual(got, ["x"])
 
 
+class TestPushCachesForgetAFailedSend(unittest.TestCase):
+    """A compare-and-skip cache must not remember a push that never landed.
+
+    Both of these are "only send it when it changed" caches, and both are
+    re-asked every frame by a page that is on screen (``_claim_page_keys``,
+    and the comic reader's clamp). Storing the value before the send means
+    one failed command -- which the browser catches and logs at debug --
+    turns into "already pushed" for every retry after it, and the reader
+    loses its page-turn keys, or the picture its pan model, for as long as
+    that page is up. The failure is silent on both sides.
+    """
+
+    def _app(self):
+        return MpvtkApp.attach(FakeMPV(), ext=False)
+
+    def _flaky(self, app):
+        sent = []
+
+        def command(*args):
+            sent.append(args)
+            if len(sent) == 1:
+                raise RuntimeError("mpv went away")
+
+        app.backend.command = command
+        return sent
+
+    def test_a_failed_key_claim_is_pushed_again(self):
+        app = self._app()
+        sent = self._flaky(app)
+        with self.assertRaises(RuntimeError):
+            app.claim_keys(("LEFT", "RIGHT"))
+        app.claim_keys(("LEFT", "RIGHT"))     # the next frame asks again
+        self.assertEqual(len(sent), 2,
+                         "the failed claim was remembered as sent")
+        app.claim_keys(("LEFT", "RIGHT"))     # ...and now it is cached
+        self.assertEqual(len(sent), 2, "an unchanged claim was re-sent")
+
+    def test_a_claim_and_a_drop_do_not_interleave(self):
+        """The two callers are on different threads: the shell pushes the
+        route's claim from build() on the loop thread, and a yield or a
+        minimize drops it from the player's thread. Unlocked, both pass the
+        compare against the same old value and the cache ends up describing
+        the one that lost the wire -- keys the renderer does not have, or, as
+        here, a claim that outlives the page and takes SPACE and the arrows
+        into playback with it."""
+        import threading
+
+        app = self._app()
+        sent, entered, release = [], threading.Event(), threading.Event()
+
+        def command(*args):
+            sent.append(args)
+            entered.set()
+            release.wait(2)
+
+        app.backend.command = command
+        t = threading.Thread(target=lambda: app.claim_keys(("LEFT", "RIGHT")))
+        t.start()
+        self.assertTrue(entered.wait(2), "the claim never reached the backend")
+        dropper = threading.Thread(target=lambda: app.claim_keys(()))
+        dropper.start()
+        release.set()
+        t.join(5)
+        dropper.join(5)
+        self.assertEqual(len(sent), 2,
+                         "the drop was skipped against a claim still in "
+                         "flight: %r" % (sent,))
+        self.assertEqual(app._claimed_keys, (),
+                         "the cache describes the claim, not the drop")
+
+    def test_a_failed_pan_model_is_pushed_again(self):
+        app = self._app()
+        sent = self._flaky(app)
+        model = {"unitx": 1.0, "unity": 2.0, "minx": 0.0, "maxx": 0.0,
+                 "miny": 0.0, "maxy": 0.0, "step": 120, "page": 0}
+        with self.assertRaises(RuntimeError):
+            app.set_picture_pan(model)
+        app.set_picture_pan(dict(model))
+        self.assertEqual(len(sent), 2,
+                         "the failed pan model was remembered as sent")
+        app.set_picture_pan(dict(model))
+        self.assertEqual(len(sent), 2, "an unchanged model was re-sent")
+
+
 class TestScrollOffsets(unittest.TestCase):
     def test_reads_property_mirror(self):
         app = MpvtkApp.attach(FakeMPV(), ext=False)

--- a/tests/test_playstate_payload.py
+++ b/tests/test_playstate_payload.py
@@ -77,6 +77,53 @@ AUDIOBOOK = {"Name": "The Lantern Keeper", "Type": "AudioBook",
              "Album": "The Lantern Keeper"}
 
 
+class TestAStartInFlightIsNotAStop(unittest.TestCase):
+    """`_video` is assigned only once the open succeeds, so for the whole of a
+    load the player looks stopped from in here. Every incidental push during
+    one therefore reported "stopped" -- and the browser reads that as
+    "playback ended", drops its loading screen and returns to the library over
+    the start the user is waiting for.
+
+    There is always at least one such push: `_play_media` writes the persisted
+    per-type volume before mpv is handed the file, and the volume observer
+    pushes on the change.
+    """
+
+    def _push(self, video=None, starting=False, stopped=False):
+        got = []
+        pm = PlayerManager.__new__(PlayerManager)
+        pm.on_playstate = got.append
+        pm._video = video
+        pm._player = _Player()
+        pm._hud_skip = None
+        pm.repeat_mode = "none"
+        pm._start_in_progress = starting
+        PlayerManager.push_playstate(pm, stopped=stopped)
+        return got
+
+    def test_an_incidental_push_mid_start_reports_nothing(self):
+        self.assertEqual(self._push(starting=True), [],
+                         "a load reported itself stopped")
+
+    def test_an_explicit_stop_mid_start_still_reports(self):
+        """Which is how a cancelled or failed start ends -- the stop path
+        passes stopped=True, and the browser needs it to leave the screen."""
+        self.assertEqual(self._push(starting=True, stopped=True),
+                         [{"stopped": True}])
+
+    def test_a_real_stop_still_reports(self):
+        """No start in flight and no video: playback genuinely ended."""
+        self.assertEqual(self._push(), [{"stopped": True}])
+
+    def test_once_the_video_lands_the_snapshot_is_real(self):
+        """The flag outlives the assignment by a few lines; a push in that
+        window must describe what is playing, not suppress itself."""
+        got = self._push(video=_Video(MOVIE), starting=True)
+        self.assertTrue(got and got[0].get("stopped") is False,
+                        "the snapshot went missing once the video landed: %r"
+                        % (got,))
+
+
 class TestEpisodeContext(unittest.TestCase):
     def test_an_episode_carries_its_series_and_numbering(self):
         st = snapshot(EPISODE)


### PR DESCRIPTION
Fixes a few issues:
- Prevents a lost hover state in mpv making the UI unusable
- Fix HUD console keybinding
- Fix state issue when launching playback that causes the library to briefly flash