### PR TITLE
Fix issues where mouse gets lost with some input devices

### DIFF
--- a/docs/testing.md
+++ b/docs/testing.md
@@ -270,12 +270,33 @@ mpv's section stack — which is what
 
 **`mouse <x> <y>` repairs `mouse-pos.hover` on the way past**: mpv synthesizes
 MOUSE_ENTER for an artificial move that lands inside the window (`command.c`,
-`cmd_mouse`). A stranded hover flag — the #700 state, where mpv believes the
-pointer is outside a window it is sitting in the middle of — therefore *cannot*
-be reached from outside the process. That half is pinned in `tests/lua/`, driving
-the real observer; from an integration test you can only pin the rest of the
-path. (An out-of-bounds `mouse <x> <y>` synthesizes MOUSE_**LEAVE** by the same
-rule, which is a second way to leave from outside the process.)
+`cmd_mouse`). So a stranded hover flag — the #700 state, where mpv believes the
+pointer is outside a window it is sitting in the middle of — cannot be reached
+through *that* command, and an integration test driving the pointer with it can
+only pin the rest of the path. The decision logic is pinned in `tests/lua/`,
+against the real observer. (An out-of-bounds `mouse <x> <y>` synthesizes
+MOUSE_**LEAVE** by the same rule, which is a second way to leave from outside
+the process.)
+
+It **is** reachable with real X input, which is what `tools/probe_hover_strand.py`
+does: grab the pointer, move the window under it with `xdotool`, ungrab, and the
+restoring EnterNotify arrives as NotifyUngrab and is dropped. That is a manual
+probe rather than a test because Xvfb, openbox, xdotool and python-xlib are none
+of them test dependencies, and a suite that skips reports exactly like one that
+passed (§7). Reach for it before shipping another guess at #700 — two attempts
+went to the reporter without anyone here having seen the state, because openbox
+and kwin ungrab before they resize and Cinnamon/muffin does not.
+
+**The repair is `keypress MOUSE_ENTER`, not `mouse <x> <y>`.** Both feed the
+enter artificially, but the latter also rewrites the pointer position — and
+`mouse-pos` reports the *consumer* coordinates, advanced when a queued move is
+dequeued, while the unchanged-position early return compares the *producer*
+ones. Handing back the position just observed can therefore replace a newer
+pending motion, and with built-in dragging live can cross the deadzone into
+`begin-vo-dragging`. Its bounds-derived hover repair is also mpv 0.33+, where
+`keypress` predates 0.29. Note that `mp.commandv` *reports* a rejected command
+(`nil` plus a message) rather than raising it, so a bare `pcall` around it
+proves nothing — read the returned value.
 
 **A real leave does not look like the one your test writes.** `keypress
 MOUSE_LEAVE`, and the Lua fake's `{same x, same y, hover=false}`, both produce a

--- a/jellyfin_mpv_shim/mpvtk/renderer.lua
+++ b/jellyfin_mpv_shim/mpvtk/renderer.lua
@@ -209,10 +209,13 @@ local state = {
     pv_secs = 0,            -- the position it is pointing at, in seconds
     pv_rect = nil,          -- last drawn bubble rect (nil = not shown)
     ready_sent = false,
-    -- `lost`: a leave has been accepted, so the next in-window
-    -- position is mpv's hover flag being wrong rather than a leave
-    -- (see the mouse-pos observer).
-    mouse = { x = -1, y = -1, hover = false, lost = nil },
+    -- `prov`: the last sample was an in-window position mpv called a
+    -- leave, so a second one is the pointer contradicting the flag.
+    -- `down`: a mouse button is believed held (see mouse_pair).
+    -- `nofix`: this mpv rejected the hover repair; stop asking.
+    -- All three: the mouse-pos observer.
+    mouse = { x = -1, y = -1, hover = false,
+              prov = nil, down = nil, nofix = nil },
     hover_id = nil,
     hover_region = nil,     -- id of the hovered node that asked to be told
     pressed = nil,          -- node id armed by mbtn down
@@ -3965,12 +3968,20 @@ end
 -- modifier set before the shared handlers run. The _dbl variants are
 -- bound (as no-ops for modified ones) so they can't fall through to
 -- the player's defaults while browsing.
+--
+-- `state.mouse.down` is tracked HERE and not in on_mouse_down, which the
+-- debug hook also calls and which a right click never reaches. It gates the
+-- hover repair (see the mouse-pos observer): while a button is held, X keeps
+-- delivering motion to us from outside the window, so a moved in-window
+-- sample stops being evidence that the pointer is here. One flag rather than
+-- a count, because mpv itself only holds one down command at a time -- a
+-- second press cancels the first (input/input.c, `release_down_cmd`).
 local function mouse_pair(shift, ctrl)
     local function set()
         state.mods = { shift = shift, ctrl = ctrl }
     end
-    return function() set(); on_mouse_up() end,
-        function() set(); on_mouse_down() end
+    return function() set(); state.mouse.down = nil; on_mouse_up() end,
+        function() set(); state.mouse.down = true; on_mouse_down() end
 end
 
 -- ------------------------------------------- spatial navigation (10ft)
@@ -4777,7 +4788,8 @@ mp.set_key_bindings({
     { 'mbtn_left_dbl', function() on_dbl() end },
     { 'shift+mbtn_left_dbl', function() end },
     { 'ctrl+mbtn_left_dbl', function() end },
-    { 'mbtn_right', function() end, function() on_rclick() end },
+    { 'mbtn_right', function() state.mouse.down = nil end,
+                    function() state.mouse.down = true; on_rclick() end },
 }, 'mpvtk_mouse', 'force')
 -- The thumb buttons, in a section of their OWN so the playback HUD can
 -- decline them (see ui_resume).
@@ -4892,6 +4904,42 @@ state.mouse_left = function()
     end
 end
 
+-- **Give mpv its hover flag back**, instead of running a guess on top of one
+-- that will never be right again. Called once the pointer has contradicted
+-- the flag twice running (see the observer).
+--
+-- `keypress MOUSE_ENTER` feeds the enter artificially, which is what sets
+-- `mouse_hover` (input/input.c `feed_key`) -- for the rest of the session,
+-- so a pointer that then PARKS stays hovered. That is the whole point: no
+-- amount of grace can help a pointer that has stopped producing events.
+--
+-- Not the `mouse` command, which would look like the obvious choice and is
+-- wrong twice. It rewrites the pointer position, and `mouse-pos` reports the
+-- CONSUMER coordinates (advanced when a queued move is dequeued) while the
+-- unchanged-position early return compares the PRODUCER ones -- so handing
+-- back the position just observed can replace a newer pending motion, and
+-- with built-in dragging live can cross the deadzone into begin-vo-dragging.
+-- Its hover repair is also 0.33+, where `keypress` predates 0.29.
+state.mouse_repair = function()
+    if state.mouse.nofix or state.mouse.down then return end
+    -- Touch and pen both emulate the mouse by default, and both end a
+    -- contact WITHOUT a MOUSE_LEAVE -- so two moved samples from either are
+    -- not the pointer contradicting anything. Properties are 0.39 / 0.41;
+    -- missing is not "in contact", so only a positive answer declines.
+    local n = mp.get_property_native('touch-pos/count')
+    if type(n) == 'number' and n > 0 then return end
+    if mp.get_property_native('tablet-pos/tool-in-proximity') == true then
+        return
+    end
+    -- mp.commandv REPORTS a rejected command (nil + message) rather than
+    -- raising it (player/lua.c `check_error`), so the pcall proves nothing
+    -- on its own and the returned value has to be read.
+    local called, ok = pcall(mp.commandv, 'keypress', 'MOUSE_ENTER')
+    if not (called and ok == true) then
+        state.mouse.nofix = true
+    end
+end
+
 mp.observe_property('mouse-pos', 'native', function(_, pos)
     if not pos then return end
     -- **mpv can lose a hover and never get it back**, which took the whole
@@ -4924,6 +4972,14 @@ mp.observe_property('mouse-pos', 'native', function(_, pos)
     -- commits the leave; another motion re-arms it and the UI never notices.
     -- The grace is well under the HUD's shortest auto-hide, so "the pointer
     -- is off the controls" still lands in time to hide them.
+    --
+    -- **A second such event settles it, and then mpv is REPAIRED** rather
+    -- than second-guessed -- `state.mouse_repair`, which is what actually
+    -- fixes #700. The grace alone cannot: in the stranded state mouse-pos
+    -- only fires while the pointer MOVES, so a pointer that comes to rest on
+    -- a tile went dead 0.2s later and every click after that hit-tested at
+    -- -1,-1 again. That is the shape the reporter saw from the first attempt
+    -- -- each element lighting up for about half a second and then dying.
     --
     -- No "did we see a leave first" gate: an enter can be lost on its own
     -- (a fresh renderer while the pointer is outside, a crossing eaten by a
@@ -4977,8 +5033,19 @@ mp.observe_property('mouse-pos', 'native', function(_, pos)
     -- playback HUD from the flick that took the pointer off the window is
     -- the one place that guess is visible. Everything else stays live on the
     -- first event, which is the whole point of being provisional.
+    --
+    -- **Two is also the threshold for repairing mpv**, and for the same
+    -- reason in reverse: a genuine unheld leave produces exactly ONE moved
+    -- in-window sample and then silence, so repairing on the first would
+    -- strand hover TRUE on every ordinary exit -- a hover ring that never
+    -- clears, and phud_busy re-arming the HUD's auto-hide forever.
     local confirmed = not synth or state.mouse.prov
+    local repair = synth and state.mouse.prov
+    -- Recorded BEFORE the repair, not after: the enter mpv feeds notifies
+    -- this same observer back, and a notification that lands while `prov`
+    -- still says "provisional" would have its correction overwritten here.
     state.mouse.prov = synth
+    if repair then state.mouse_repair() end
     state.mouse.hover = true
     -- Record it for BOTH branches. The idle-HUD branch below returns
     -- without reaching on_mouse_move, so a mouse summon used to leave
@@ -5407,6 +5474,10 @@ local function ui_suspend()
     state.nav_rect = nil
     state.nav_pending = nil
     state.pressed = nil
+    -- Our sections go away below, so a release we are still waiting for is
+    -- never going to arrive. Left set, it would refuse the hover repair for
+    -- the rest of the session.
+    state.mouse.down = nil
     state.tip = nil
     if state.tip_timer then
         state.tip_timer:kill()

--- a/tests/lua/fake_mp.lua
+++ b/tests/lua/fake_mp.lua
@@ -192,15 +192,40 @@ function mp.get_time() now = now + 0.001; return now end
 
 function M.advance(dt) now = now + dt end
 
+--- Commands that this mpv does NOT have, by name. `mp.commandv` answers
+--- those the way the real one answers a rejected command -- `nil` plus a
+--- message, NOT an error -- which is the distinction the hover repair reads
+--- (player/lua.c `check_error`); a fake that raised instead would let a
+--- `pcall` alone look like proof the command ran.
+M.no_command = {}
+
 function mp.commandv(...)
     local args = { ... }
     table.insert(M.log.commands, args)
+    if M.no_command[args[1]] then return nil, "command not found" end
     if args[1] == "overlay-add" and M.overlay_cost > 0 then
         M.advance(M.overlay_cost)
     end
     if args[1] == "script-message" and args[2] == "mpvtk-event" then
         table.insert(M.log.events, args[3])
     end
+    -- mpv sets `mouse_hover` from MOUSE_ENTER / MOUSE_LEAVE however they are
+    -- fed, artificially included, and re-notifies mouse-pos observers.
+    -- Modelled because the renderer repairs a stranded hover this way
+    -- (#700) and the notification back is what ends its provisional state.
+    --
+    -- Delivered SYNCHRONOUSLY, where mpv queues a command and notifies from
+    -- the playloop a moment later. Deliberate: re-entering the observer from
+    -- inside its own commandv is the harder ordering, so anything that
+    -- survives here survives the real one. Do not read it as mpv's order.
+    if args[1] == "keypress"
+        and (args[2] == "MOUSE_ENTER" or args[2] == "MOUSE_LEAVE") then
+        M.hover = args[2] == "MOUSE_ENTER"
+        M.observe("mouse-pos",
+                  { x = M.mouse_x or -1, y = M.mouse_y or -1,
+                    hover = M.hover })
+    end
+    return true
 end
 
 function mp.command_native(t)
@@ -443,6 +468,12 @@ end
 
 --- Fire a property observer, as mpv would.
 function M.observe(name, value)
+    -- Remembered so a MOUSE_ENTER fed by `keypress` can report the position
+    -- mpv still has, which is the point of that repair: the flag changes and
+    -- the coordinates do not.
+    if name == "mouse-pos" and type(value) == "table" then
+        M.mouse_x, M.mouse_y, M.hover = value.x, value.y, value.hover
+    end
     for _, fn in ipairs(prop_observers[name] or {}) do fn(name, value) end
 end
 

--- a/tests/lua/test_renderer.lua
+++ b/tests/lua/test_renderer.lua
@@ -1038,6 +1038,80 @@ fake.key_up("mbtn_left")     -- ...and release
 ok(last_event("click") ~= nil and last_event("click").id == "tile-a",
    "a click at a stranded-hover position hit nothing")
 
+-- **And the pointer is allowed to STOP.** The grace timer alone could never
+-- do this: in the stranded state mouse-pos fires only while the pointer
+-- moves, so a pointer coming to rest went dead 0.2s later and every click
+-- after that hit-tested at -1,-1 -- each element lighting up for about half
+-- a second and then dying, which is what #700's reporter saw from the first
+-- attempt. The second contradicting sample repairs mpv's own flag instead.
+local function repairs()
+    local n = 0
+    for _, c in ipairs(fake.log.commands) do
+        if c[1] == "keypress" and c[2] == "MOUSE_ENTER" then n = n + 1 end
+    end
+    return n
+end
+
+scene({ tile("tile-a", 0, 0, { hev = true }) })
+point(300, 300)
+fake.log.commands = {}
+fake.observe("mouse-pos", { x = 50, y = 40, hover = false })
+eq(repairs(), 0, "one ambiguous sample was enough to repair mpv")
+fake.observe("mouse-pos", { x = 55, y = 42, hover = false })
+eq(repairs(), 1, "a second contradicting sample did not repair the flag")
+idle_out()                        -- the pointer parks: nothing more arrives
+eq(mouse_state().hover, true,
+   "a repaired hover did not survive the pointer coming to rest")
+eq(mouse_state().x, 55, "a repaired hover forgot where the pointer was")
+fake.reset_events()
+fake.key("mbtn_left"); fake.key_up("mbtn_left")
+ok(last_event("click") ~= nil and last_event("click").id == "tile-a",
+   "a click from a PARKED pointer went nowhere")
+
+-- Once repaired, mpv answers hover itself and nothing else is synthesized.
+fake.log.commands = {}
+for _, xy in ipairs({ { 60, 44 }, { 65, 46 }, { 70, 48 } }) do
+    fake.observe("mouse-pos", { x = xy[1], y = xy[2], hover = true })
+end
+eq(repairs(), 0, "a hover mpv had already given back was repaired again")
+
+-- **A held button withdraws the evidence.** X keeps delivering motion to us
+-- from outside the window while a button is down, so a moved in-window
+-- sample stops meaning the pointer is here -- and repairing then would
+-- strand hover TRUE with the pointer somewhere else entirely.
+point(50, 40)
+fake.key("mbtn_left")             -- and NOT released
+fake.log.commands = {}
+fake.observe("mouse-pos", { x = 55, y = 42, hover = false })
+fake.observe("mouse-pos", { x = 60, y = 44, hover = false })
+eq(repairs(), 0, "mpv was repaired from under a held button")
+fake.key_up("mbtn_left")
+
+-- Touch and pen emulate the mouse and end a contact without a MOUSE_LEAVE,
+-- so their samples are not evidence either. A build too old to have the
+-- properties reports nothing, which must not read as "in contact".
+point(50, 40)
+fake.log.props["touch-pos/count"] = 1
+fake.log.commands = {}
+fake.observe("mouse-pos", { x = 55, y = 42, hover = false })
+fake.observe("mouse-pos", { x = 60, y = 44, hover = false })
+eq(repairs(), 0, "a touch contact was taken for the pointer")
+fake.log.props["touch-pos/count"] = nil
+
+-- An mpv that rejects the command is asked exactly once, and the provisional
+-- grace goes on being the fallback it always was.
+point(50, 40)
+fake.no_command["keypress"] = true
+fake.log.commands = {}
+for _, xy in ipairs({ { 55, 42 }, { 60, 44 }, { 65, 46 }, { 70, 48 } }) do
+    fake.observe("mouse-pos", { x = xy[1], y = xy[2], hover = false })
+end
+eq(repairs(), 1, "an mpv without the repair was asked more than once")
+idle_out()
+eq(mouse_state().hover, false,
+   "the grace fallback stopped working once the repair was refused")
+fake.no_command["keypress"] = nil
+
 -- **A real leave still lands** -- which is what the playback HUD's auto-hide
 -- is built on. It usually arrives carrying a MOVED position: mpv clears the
 -- flag when the LeaveNotify is fed but commits a motion's position when the

--- a/tools/probe_hover_strand.py
+++ b/tools/probe_hover_strand.py
@@ -1,0 +1,225 @@
+#!/usr/bin/env python3
+"""Reproduce issue #700's stranded ``mouse-pos.hover`` against a real mpv.
+
+Two attempts at #700 shipped to the reporter without anyone here having seen
+the bug, because the window managers on hand (openbox, kwin) ungrab the
+pointer before they resize and Cinnamon/muffin does not. This drives the grab
+directly instead of hoping for a WM that does it, so the state is reachable on
+any machine with an X server.
+
+**What it shows.** mpv sets ``hover`` only from MOUSE_ENTER / MOUSE_LEAVE, and
+``video/out/x11_common.c`` drops every crossing whose mode is not
+NotifyNormal (mpv 30860f7b1). Grab the pointer, bring the window under it,
+ungrab: the EnterNotify that would restore hover arrives as NotifyUngrab and
+is discarded, so ``hover`` stays false for the rest of the session with the
+pointer sitting in the middle of the window -- while the coordinates go on
+updating correctly. Then it checks the repair ``renderer.lua`` issues,
+``keypress MOUSE_ENTER``, and that it holds once the pointer stops moving.
+
+Not part of any suite: it needs Xvfb, openbox, xdotool and python-xlib, and
+none of those is a test dependency. See docs/testing.md section 10.
+
+Usage: python3 tools/probe_hover_strand.py [--display :77]
+Exit status is 0 only if the flag was stranded AND the repair took.
+"""
+
+import argparse
+import json
+import os
+import shutil
+import socket
+import subprocess
+import sys
+import time
+
+#: Where the window is parked before the pointer is let near it, and the
+#: geometry it is given afterwards -- big enough that the pointer, which does
+#: not move during the grab, ends up well inside it.
+START_GEOMETRY = "400x300+900+600"
+MOVED_TO = (40, 40)
+GROWN_TO = (1200, 800)
+
+
+class Ipc:
+    """The three JSON-IPC calls this needs, without adding a dependency."""
+
+    def __init__(self, path):
+        self.sock = socket.socket(socket.AF_UNIX)
+        self.sock.connect(path)
+        self.buf = b""
+
+    def cmd(self, *args):
+        self.sock.sendall(json.dumps({"command": list(args)}).encode() + b"\n")
+        while True:
+            while b"\n" in self.buf:
+                line, self.buf = self.buf.split(b"\n", 1)
+                if not line.strip():
+                    continue
+                msg = json.loads(line)
+                # Events have no `error` key; replies always do.
+                if "error" in msg:
+                    return msg
+            self.buf += self.sock.recv(65536)
+
+    def mouse_pos(self):
+        return self.cmd("get_property", "mouse-pos").get("data")
+
+
+class Session:
+    """Xvfb + openbox + mpv, torn down by PID and never by pattern."""
+
+    def __init__(self, display, sock):
+        self.display = display
+        self.sock = sock
+        self.procs = []
+
+    def _env(self):
+        return dict(os.environ, DISPLAY=self.display)
+
+    def spawn(self, *argv):
+        proc = subprocess.Popen(argv, env=self._env(),
+                                stdout=subprocess.DEVNULL,
+                                stderr=subprocess.DEVNULL)
+        self.procs.append(proc)
+        return proc
+
+    def x(self, *argv):
+        return subprocess.run(argv, env=self._env(),
+                              capture_output=True, text=True)
+
+    def start(self):
+        try:
+            os.unlink(self.sock)
+        except OSError:
+            pass
+        self.spawn("Xvfb", self.display, "-screen", "0", "1600x1000x24")
+        time.sleep(1.5)
+        # A WM is needed only so the window is managed and reparented the way
+        # a real one is; openbox does NOT itself reproduce the bug.
+        self.spawn("openbox")
+        time.sleep(1.0)
+        self.spawn("mpv", "--idle=yes", "--force-window=yes", "--vo=x11",
+                   "--no-config", "--osc=no", "--no-input-default-bindings",
+                   "--geometry=" + START_GEOMETRY,
+                   "--input-ipc-server=" + self.sock)
+        for _ in range(80):
+            if os.path.exists(self.sock):
+                break
+            time.sleep(0.25)
+        else:
+            raise SystemExit("mpv never created its IPC socket")
+        time.sleep(1.5)
+        return Ipc(self.sock)
+
+    def stop(self):
+        for proc in reversed(self.procs):
+            try:
+                proc.terminate()
+                proc.wait(timeout=5)
+            except Exception:
+                try:
+                    proc.kill()
+                except Exception:
+                    pass
+
+
+def strand(session, window_id):
+    """Grab, move the window under the motionless pointer, ungrab."""
+    from Xlib import display as xdisplay, X
+
+    disp = xdisplay.Display(session.display)
+    root = disp.screen().root
+    root.grab_pointer(False,
+                      X.PointerMotionMask | X.ButtonPressMask |
+                      X.ButtonReleaseMask,
+                      X.GrabModeAsync, X.GrabModeAsync, X.NONE, X.NONE,
+                      X.CurrentTime)
+    disp.sync()
+    session.x("xdotool", "windowmove", str(window_id), *map(str, MOVED_TO))
+    session.x("xdotool", "windowsize", str(window_id), *map(str, GROWN_TO))
+    time.sleep(0.8)
+    disp.ungrab_pointer(X.CurrentTime)
+    disp.sync()
+    time.sleep(0.6)
+
+
+def run(display):
+    sock = "/tmp/mpv-hover-strand-%d.sock" % os.getpid()
+    session = Session(display, sock)
+    try:
+        ipc = session.start()
+        window_id = int(ipc.cmd("get_property", "window-id")["data"])
+        print("window-id  :", hex(window_id))
+
+        # Park the pointer clear of the window, so the crossing back in is
+        # the one the grab is about to eat.
+        session.x("xdotool", "mousemove", "100", "100")
+        time.sleep(0.6)
+        print("parked out :", ipc.mouse_pos())
+
+        strand(session, window_id)
+
+        # Move WITHIN the window. The coordinates track; the flag does not.
+        for x, y in ((300, 300), (340, 320), (380, 340)):
+            session.x("xdotool", "mousemove", str(x), str(y))
+            time.sleep(0.35)
+        stranded = ipc.mouse_pos()
+        print("stranded   :", stranded)
+        if not stranded or stranded.get("hover") is not False:
+            print("\nRESULT: the flag was not stranded -- nothing to repair.")
+            return 2
+        if stranded.get("x", -1) <= 0:
+            print("\nRESULT: no coordinates arrived; not the #700 state.")
+            return 2
+
+        reply = ipc.cmd("keypress", "MOUSE_ENTER")
+        print("keypress   :", reply)
+        time.sleep(0.4)
+        repaired = ipc.mouse_pos()
+        print("after fix  :", repaired)
+
+        session.x("xdotool", "mousemove", "420", "360")
+        time.sleep(0.4)
+        moved = ipc.mouse_pos()
+        # Well past the renderer's 0.2s leave grace: a repair that only held
+        # while the pointer moved would be the bug all over again.
+        time.sleep(1.5)
+        parked = ipc.mouse_pos()
+        print("moved on   :", moved)
+        print("parked in  :", parked)
+
+        # mouse-pos is WINDOW-relative, and the window is at MOVED_TO --
+        # comparing it against the screen coordinates xdotool was handed is
+        # how this probe first reported a failure it had not found.
+        want = (420 - MOVED_TO[0], 360 - MOVED_TO[1])
+        good = (repaired.get("hover") is True
+                and moved.get("hover") is True
+                and parked.get("hover") is True
+                and (parked.get("x"), parked.get("y")) == want
+                and parked == moved)
+        print("\nRESULT:", "REPAIRED and held" if good else "FAILED")
+        return 0 if good else 1
+    finally:
+        session.stop()
+
+
+def main():
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--display", default=":77",
+                        help="X display for the throwaway server")
+    args = parser.parse_args()
+
+    missing = [t for t in ("Xvfb", "openbox", "xdotool", "mpv")
+               if not shutil.which(t)]
+    try:
+        import Xlib  # noqa: F401
+    except ImportError:
+        missing.append("python-xlib")
+    if missing:
+        print("missing: " + ", ".join(missing), file=sys.stderr)
+        return 2
+    return run(args.display)
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
This makes the mpvtk hover lifecycle handling more robust, because when the pointer is declared dead it makes click events get lost. Pending verification by filler of issue #700 as there's already been one partial but not successful attempt to fix this.