### PR TITLE
Fix uosc/modernz support

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -539,11 +539,35 @@ You can use the config file to enable and disable features.
     (falls back to `mpv` otherwise). `jellyfin` is accepted as a legacy
     alias.
   - `mpv` - The stock mpv controls, patched with trickplay preview support.
-  - `default` - Whatever OSC is built into your mpv (or your own OSC scripts).
+  - `default` - Whatever OSC is built into your mpv, or your own OSC scripts.
     Thumbnail data is still published for thumbfast-aware OSCs like uosc.
+    - **Running your own OSC:** drop the script in the `scripts/` folder beside
+      `conf.json` (see the paths at the top of this file) and any font it needs
+      in `fonts/`, then put `osc=no` in `mpv.conf` there so mpv's built-in one
+      does not draw underneath it. That line is honoured — `default` is the one
+      style where the shim never overrides the option.
+    - The shim asks the OSC to get out of the way when the library browser
+      opens, and when you choose `none`, with the `osc-visibility` and
+      `osc-idlescreen` script-messages. Mpv's own OSC and the scripts forked
+      from it understand those; an OSC that implements only a private API of
+      its own may not hear them and can keep drawing over the library.
+  - `custom` - You have installed your own OSC script. Turns MPV's built-in
+    controls off (whatever your `mpv.conf` says) and has the library paint a
+    solid background of its own instead of relying on the window colour.
+    - That background is the point. A third-party OSC draws an idle screen —
+      the MPV logo and "Drop files or URLs here to play" — while the library
+      sits on a window with nothing loaded, and it is drawn *over* the window
+      colour, so no colour setting can hide it. Only something the library
+      paints itself can.
+    - This style also lets the library draw above the OSC's own layer, which
+      uosc in particular needs. That is why it is a separate choice rather
+      than something `default` does for everyone: the same layer is used by
+      MPV's console when it is showing a menu.
+    - Trickplay previews still work, the same as under `default`.
   - `none` - No on-screen controls at all. Playback is bare; the library, the
     keyboard shortcuts and the menu key (`kb_menu`, `c` by default) still
     work, and Skip Intro/Credits falls back to its "seek to skip" prompt.
+    Applies to a third-party OSC as well, subject to the same caveat.
   - **Replaces `enable_osc`, and is not migrated from it.** That was a
     separate switch which only ever reached mpv's *own* controls, so turning
     it off did nothing under the default style and then silently took the

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -563,6 +563,19 @@ You can use the config file to enable and disable features.
       uosc in particular needs. That is why it is a separate choice rather
       than something `default` does for everyone: the same layer is used by
       MPV's console when it is showing a menu.
+    - **Two things a third-party OSC cannot do, and will not.** Both apply to
+      `default` as well; trickplay previews are the part that does work.
+      - **Tracks.** Its subtitle and audio pickers see only what MPV has, and
+        Jellyfin's external and burned-in subtitles are not MPV tracks — an
+        external one is added only when you pick it, and a burned-in one needs
+        the server to restart the stream. Choosing from the OSC's own picker
+        misses those, is not reported to Jellyfin, and is not remembered for
+        the next episode. Use the menu key (`kb_menu`, `c` by default), or the
+        library, to change tracks.
+      - **The queue.** It lives in the shim, not in MPV, so MPV's playlist has
+        one entry in it and the OSC's playlist and next/previous buttons do
+        nothing. Handing the queue to MPV would mean keeping two copies of the
+        playback state in step, which is not worth what it would buy.
     - Trickplay previews still work, the same as under `default`.
   - `none` - No on-screen controls at all. Playback is bare; the library, the
     keyboard shortcuts and the menu key (`kb_menu`, `c` by default) still

--- a/docs/mpv-backends.md
+++ b/docs/mpv-backends.md
@@ -771,3 +771,131 @@ Two scope limits, both load-bearing:
 
 The suspend does nothing at all on an mpv without the option (built without
 gpu-next, or too old) — reading it is how we find that out.
+
+## 12. The on-screen controls, and the user's own OSC
+
+`osc_style` has four values and only three of them are ours. `default` means
+"whatever your mpv would normally do, plus your own scripts", and it is the
+supported way to run a third-party OSC (uosc, ModernZ, ModernX) against the
+shim — `mpv_scripts` loads `thumbfast.lua` whenever the TrickPlay worker
+started, regardless of style, so a thumbfast-aware OSC gets Jellyfin's
+trickplay previews for free. Three things about that path are not obvious.
+
+### libmpv turns the OSC off, and the user's mpv.conf outranks us
+
+The `osc` option defaults to **yes** — and libmpv overrides it to **no**,
+where the external backend's `player-operation-mode=cplayer` leaves it alone.
+Measured on 0.41: a bare libmpv reports `osc=False` against an
+`option-info/osc/default-value` of `True`. So under `default` the shim has to
+ask for it, or a libmpv user gets no controls from a setting that promised
+mpv's own.
+
+It asks *at construction*, in `build_mpv_options`, and the reason is
+precedence (measured; see the test named below):
+
+| set at construction | in the shim's `mpv.conf` | mpv ends up with |
+|---|---|---|
+| `osc=True` | *(nothing)* | `True` |
+| `osc=True` | `osc=no` | **`False`** |
+| *(nothing)* | *(nothing)* | `False` (libmpv default) |
+
+**`mpv.conf` wins over an option passed to the constructor** — the opposite of
+the precedence a command-line argument would get. That
+inversion is the whole mechanism: it makes `osc: True` a *default the user can
+decline*, which is what someone running their own OSC out of
+`<config>/scripts/` needs. It is a property of how the binding applies
+options, not something mpv documents, so
+`tests/test_osc_third_party.py::PrecedenceAgainstRealLibmpvTest` measures it
+against a real libmpv rather than trusting it.
+
+Writing the property onto the live player instead — which is what
+`enable_osc` used to do for every style — cannot be declined, and so it loaded
+mpv's built-in OSC underneath the user's. `enable_osc` therefore never writes
+`osc` under `default`. It still writes it for the three styles that answer
+the OSC question themselves, and there the un-decline-ability is the point:
+it is how `osc=yes` in an mpv.conf is held off.
+
+### `osc` reaches mpv's own OSC and nothing else
+
+Setting the property loads and unloads mpv's built-in `osc.lua` at runtime
+(measured: `script-binding osc/visibility` appears and disappears with it). It
+says nothing to a script in `<config>/scripts/`. The lever that reaches those
+is the script-message pair every `osc.lua` fork inherits:
+
+    script-message  osc-visibility   never|auto
+    script-message  osc-idlescreen   no|yes
+
+Broadcast, not `script-message-to`: one send reaches whichever OSC is loaded,
+and a message nobody listens for costs nothing. `enable_osc` sends them for
+every style, which is what makes **"No player controls" silence a third-party
+OSC** and what gets one off the screen when the library browser opens.
+
+A send at construction is not racing the script's registration — a client
+message goes on the target client's queue and lua processes it after its main
+chunk has run (measured 8/8 with the message sent as early as the IPC socket
+existed).
+
+`osc-idlescreen` is the second half because the browse window is
+`force_window` with nothing loaded, so `idle-active` is true and a fork that
+draws the mpv logo draws it over the library. Suppressing visibility alone is
+enough for a fork that wipes every overlay it owns on hide; not every fork
+does (ModernZ keeps a second overlay for the logo and wipes only the first).
+
+**The restore is latched** (`_osc_suppressed`). Sending `auto` whenever the
+controls are wanted would fire at construction too, and overwrite a user who
+put `visibility=never` in their own OSC's config. We un-hide only what we hid,
+and the latch resets on an mpv re-create because the new mpv brings a new OSC
+at its own default.
+
+### The idle screen needs a backdrop, not a message
+
+Suppressing `osc-idlescreen` only works if it lands before the OSC's first
+draw. After that there may be no way back: ModernZ parks the logo on a
+*second* overlay (`state.logo_osd`, z=-1000, where its bar is z=+1000) and
+`render_wipe` on it lives only in `tick()`'s non-idle branches — which
+`osc-visibility never` makes unreachable, because tick returns at the top
+once `state.enabled` is false. So under "No player controls" a logo drawn
+before we spoke survives into playback; under `default` it survives only
+until playback starts, when tick reaches a branch that wipes it. Both were
+reported, and the difference between them is what identified the overlay.
+
+Hence `osc_style: custom`, which is two things, and it took both.
+
+**A backdrop, because mpv's window colour is the wrong layer.**
+`background-color` is a **VO** colour and the idle screen is OSD drawn over
+it, so no colour we hand mpv can cover one. Something of *ours* has to paint
+the window. That is why the one theme shipping a `window_gradient` (jf-wmc)
+hid the logo when nothing else did, and `MpvtkApp._wants_opaque_backdrop`
+generalises it: under `custom` the window gets a flat `WINDOW_BG` fill at the
+bottom of the Stack even when the theme asks for no gradient.
+
+**And a z order, because the backdrop is ASS and so is the OSC.** The
+gradient is not a bitmap — `renderer.lua:draw_gradient` writes ASS events,
+and so does a `Box` — so it does not get the automatic win over OSD that
+`overlay-add` would. It beats ModernZ only because ModernZ parks its logo at
+z=-1000, below our 0. **uosc draws its whole self at z=2000**, and there an
+opaque full-window fill of ours changed nothing: measured against real uosc,
+2.2% of the window stayed inked at z=0 and 0.0% at z=3000. `mpvtk-z` raises
+the renderer's overlay for this one style. Not for the others: 2000 is also
+mpv's console showing a selectable list, and covering that is too much to
+charge everyone for a problem only a foreign OSC has.
+
+Raising it is safe in the directions that would matter. Per mpv's own
+`osd-overlay` docs the builtin OSD — subtitles included — is always *below*
+every script overlay whatever the number, and `overlay-add` bitmaps are
+always *above* every one of them. So the z reorders us against other scripts
+and against nothing else.
+
+The `osc-idlescreen` message is still sent as well: it is cheaper, and on a
+fork that honours it the logo is never drawn at all.
+
+### The `thumbfast-info` payload is deliberately short
+
+Upstream thumbfast publishes `{width, height, scale_factor, disabled,
+available, socket, thumbnail, overlay_id}`. `socket` and `thumbnail` are
+artifacts of its second-mpv-instance design — an IPC socket and an output file
+— and the shim has neither, so it does not fake them. `scale_factor` *is*
+sent, always `1`: `width`/`height` already arrive pre-multiplied exactly as
+upstream sends them, so nothing needs it, but an OSC that divides by it to
+recover a logical size gets an arithmetic error on `nil` rather than a
+thumbnail.

--- a/docs/mpv-backends.md
+++ b/docs/mpv-backends.md
@@ -889,6 +889,29 @@ and against nothing else.
 The `osc-idlescreen` message is still sent as well: it is cheaper, and on a
 fork that honours it the logo is never drawn at all.
 
+### What a third-party OSC does not get, deliberately
+
+Trickplay works. Tracks and the queue do not, under `custom` and `default`
+alike, and neither is going to.
+
+**Tracks.** A foreign OSC's subtitle and audio pickers read mpv's track list,
+and two of Jellyfin's three subtitle flavours are not in it: an external
+track is `sub_add`ed only once chosen (`_ensure_external_sub`), and a
+burn-in one (`video.subtitle_enc`) exists only as a restarted transcode.
+Picking from the OSC's own list therefore cannot see them, bypasses
+`set_streams`, and so is neither reported to Jellyfin nor carried to the next
+episode by `_capture_track_memory`. `osc_bridge` is what has the whole
+picture, and the OSD menu and the HUD are what read it.
+
+**The queue.** `Media` owns the queue in Python; mpv's playlist holds the one
+item that is playing. So `playlist-next`, `${playlist}` and `playlist-pos-1`
+all read a one-entry playlist and every playlist affordance in a foreign OSC
+is inert. Pushing the queue into mpv would mean two copies of the playback
+state kept in step — across transcode restarts, queue edits and SyncPlay
+seeks — which is a large amount of new state for buttons the library and the
+HUD already provide. **[iw]**: "wontfix due to the state hell that would be
+putting our queue into MPV's."
+
 ### The `thumbfast-info` payload is deliberately short
 
 Upstream thumbfast publishes `{width, height, scale_factor, disabled,

--- a/jellyfin_mpv_shim/messages/base.pot
+++ b/jellyfin_mpv_shim/messages/base.pot
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: jellyfin-mpv-shim\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2026-08-22 23:24-0400\n"
+"POT-Creation-Date: 2026-08-29 15:16-0400\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -1329,6 +1329,10 @@ msgid "MPV built-in default"
 msgstr ""
 
 #: jellyfin_mpv_shim/mpvtk_browser/config.py
+msgid "Custom OSC"
+msgstr ""
+
+#: jellyfin_mpv_shim/mpvtk_browser/config.py
 msgid "No player controls"
 msgstr ""
 
@@ -1945,7 +1949,10 @@ msgstr ""
 msgid ""
 "MPV keybinds are used by default. Press ENTER to drive the player controls "
 "by keyboard. \"No player controls\" leaves playback bare; the library, the "
-"keyboard shortcuts and the menu key still work."
+"keyboard shortcuts and the menu key still work. Choose \"Custom OSC\" when "
+"you have installed your own OSC script: it turns MPV's own off and gives the "
+"library a solid background, so the script's idle screen cannot show through "
+"it."
 msgstr ""
 
 #: jellyfin_mpv_shim/mpvtk_browser/config.py

--- a/jellyfin_mpv_shim/mpv_options.py
+++ b/jellyfin_mpv_shim/mpv_options.py
@@ -27,8 +27,13 @@ from .utils import get_resource
 log = logging.getLogger("mpv_options")
 
 #: Styles that must not leave mpv's built-in OSC on: two that replace it
-#: with something of ours, and one that replaces it with nothing.
-_REPLACES_OSC = ("mpv", "mpvtk", "none")
+#: with something of ours, one that replaces it with nothing, and one where
+#: the replacement is a script of the user's that we never see.
+#:
+#: "default" is deliberately absent -- there mpv's own OSC is the answer, and
+#: whether to have it is the user's to say in their mpv.conf (section 12 of
+#: docs/mpv-backends.md).
+REPLACES_OSC = ("mpv", "mpvtk", "none", "custom")
 
 
 #: Config value -> the mpv ``hwdec`` value, where it is a constant.
@@ -522,11 +527,24 @@ def build_mpv_options(osc_style, scripts, ext_mpv, browser_wants_window):
     if hwdec is not None:
         mpv_options["hwdec"] = hwdec
 
-    if osc_style in _REPLACES_OSC:
+    if osc_style in REPLACES_OSC:
         # "mpv" loads the patched stock OSC as a script; "mpvtk" has the
         # in-window playback HUD replace any OSC. Either way mpv's built-in
         # one must be off.
         mpv_options["osc"] = False
+    elif not ext_mpv:
+        # "default" means "whatever mpv would normally do", and under libmpv
+        # that is nothing: libmpv turns the OSC off where cplayer leaves it
+        # on. The external backend already asks for cplayer, so it needs no
+        # help here.
+        #
+        # A construction option, never a write onto the live player, and
+        # that distinction is the whole feature: mpv.conf OVERRIDES an
+        # option set at construction, so this is a default the user can say
+        # `osc=no` to when they run their own OSC out of <config>/scripts/.
+        # Writing the property afterwards instead loaded mpv's built-in OSC
+        # underneath theirs. Both measured; docs/mpv-backends.md section 12.
+        mpv_options["osc"] = True
 
     if scripts:
         if settings.mpv_ext:

--- a/jellyfin_mpv_shim/mpvtk/app.py
+++ b/jellyfin_mpv_shim/mpvtk/app.py
@@ -442,6 +442,31 @@ class MpvtkApp:
                         "m": theme.min_size()})
         )
 
+    def push_overlay_z(self):
+        """Whether our ASS should outrank other scripts'.
+
+        Only "Custom OSC" wants it: there the player UI is a script we never
+        see, and uosc draws its whole self -- idle screen included -- at
+        z=2000 while we sit at 0, so an opaque full-window fill of ours
+        still left its "Drop files or URLs to play here" on screen. Every
+        other style leaves the order alone, because 2000 is also mpv's
+        console with a selectable list up. The z landscape and the
+        measurement are in renderer.lua next to OSD_Z_HOSTILE.
+
+        Resolved rather than read raw -- `osc_style` can hold a legacy alias.
+        Pushed on ready; the setting needs a restart to take effect anyway,
+        since it also decides options mpv is constructed with.
+        """
+        from ..mpv_options import resolve_osc_style
+
+        try:
+            hostile = resolve_osc_style() == "custom"
+        except Exception:
+            hostile = False
+        self.backend.command(
+            "script-message", "mpvtk-z", "yes" if hostile else "no"
+        )
+
     def push_gamepad(self):
         """Forward the game controller binding table to the renderer.
 
@@ -647,6 +672,7 @@ class MpvtkApp:
                 self.push_scale()
                 self.push_scroll_config()
                 self.push_gamepad()
+                self.push_overlay_z()
                 self.ready.set()
             return
         if t == "debug_state":

--- a/jellyfin_mpv_shim/mpvtk/renderer.lua
+++ b/jellyfin_mpv_shim/mpvtk/renderer.lua
@@ -256,6 +256,7 @@ local state = {
     tb_drag = nil,          -- {id, anchor} during click-drag selection
     tb_menu = nil,          -- {id, x, y} textbox context menu
     scale = 1,              -- UI scale (mpvtk-scale); see ui_px()
+    osd_z = 0,              -- ASS z order; see the mpvtk-z handler
     tb_menu_geo = nil,
     modal = nil,            -- 'layer' meta node of the open Dialog
     modal_hidden = false,   -- dismissed locally, awaiting scene push
@@ -2509,6 +2510,7 @@ render = function()
     osd.res_x = state.w
     osd.res_y = state.h
     osd.data = ass.text
+    osd.z = state.osd_z
     osd:update()
     flush_overlays()
 end
@@ -5323,6 +5325,31 @@ local _SCALE_BASE = {
     NAV_TAIL = NAV_TAIL,
     FOLLOW_SLACK = FOLLOW_SLACK,
 }
+
+-- Raise our ASS above a third-party OSC's, or put it back ("Custom OSC"
+-- only -- see push_overlay_z).
+--
+-- Ours only ever has to outrank OTHER SCRIPTS. mpv's builtin OSD, subtitles
+-- included, is always below every script overlay whatever the number, and
+-- overlay-add bitmaps are always above every one of them (mpv
+-- DOCS/man/input.rst, `osd-overlay`), so this reorders us against scripts
+-- and nothing else.
+--
+-- The neighbourhood, measured: mpv's own osc.lua draws its bar at 1000 and
+-- its idle logo at -1000, ModernZ likewise, and **uosc puts its whole self
+-- at 2000**. At 0 the library is under all of it -- an opaque full-window
+-- fill still left uosc's "Drop files or URLs to play here" fully visible,
+-- 2.2% of the window inked either way -- and only a z above uosc's cleared
+-- it. Not the default, because 2000 is also mpv's console showing a
+-- selectable list, and covering that is too much to charge everyone for a
+-- problem only a foreign OSC has.
+--
+-- Literals, not file-scope locals: this file is AT Lua's 200-local ceiling
+-- (tests/test_renderer_lua.py::test_there_is_a_local_budget_left).
+mp.register_script_message('mpvtk-z', function(hostile)
+    state.osd_z = (hostile == 'yes') and 3000 or 0
+    request_render()
+end)
 
 mp.register_script_message('mpvtk-scale', function(json)
     local t = utils.parse_json(json)

--- a/jellyfin_mpv_shim/mpvtk_browser/app.py
+++ b/jellyfin_mpv_shim/mpvtk_browser/app.py
@@ -2633,15 +2633,44 @@ class MpvtkBrowser(DialogsMixin, LiveTvDialogsMixin, AuthMixin, SettingsMixin,
         if grip is not None:
             children.append(grip)
         page = Column(children, w=w, h=h, align="stretch")
+        # A page background, when something needs one. mpv's own
+        # background-color is a flat colour and stays as the base -- it is
+        # what shows before the first scene lands -- so this paints over it
+        # rather than replacing it. Bottom of the Stack, so every bit of
+        # chrome still draws on top.
         stops = theme.window_gradient()
-        if not stops:
+        if stops:
+            back = Gradient(stops=stops, axis="y", w=w, h=h)
+        elif self._wants_opaque_backdrop():
+            back = Box(bg=theme.WINDOW_BG, w=w, h=h)
+        else:
             return page
-        # A themed page background. mpv's own background-color is a flat
-        # colour and stays as the base -- it is what shows before the first
-        # scene lands -- so this paints over it rather than replacing it.
-        # Bottom of the Stack, so every bit of chrome still draws on top.
-        return Stack([Gradient(stops=stops, axis="y", w=w, h=h), page],
-                     w=w, h=h)
+        return Stack([back, page], w=w, h=h)
+
+    def _wants_opaque_backdrop(self):
+        """Whether the library has to paint its own window background.
+
+        Normally it does not: mpv's ``background-color`` is the window, and
+        one flat fill costs nothing to composite. Under "Custom OSC" that is
+        not enough. The controls are then a script we never see, it draws an
+        idle screen while the browse window sits there with nothing loaded,
+        and that screen is OSD *over* the VO background -- so no colour we
+        give mpv can hide it. Ours is a bitmap, which composites above OSD,
+        and is the only thing that can. (Asking the script to stop drawing
+        works too and we do ask, but only a fork that honours
+        ``osc-idlescreen`` hears it, and one that has already drawn may have
+        no path left that wipes it.) docs/mpv-backends.md section 12.
+
+        Through `resolve_osc_style`, never the raw setting, because that can
+        hold a legacy alias. Not through the player, which would cost this
+        module an import of `player` -- and importing that builds its
+        singleton and opens an mpv window.
+        """
+        from ..mpv_options import resolve_osc_style
+        try:
+            return resolve_osc_style() == "custom"
+        except Exception:
+            return False
 
     # How long a status message stays on screen.
     TOAST_SECS = 6.0

--- a/jellyfin_mpv_shim/mpvtk_browser/config.py
+++ b/jellyfin_mpv_shim/mpvtk_browser/config.py
@@ -394,6 +394,7 @@ LABELED_ENUMS = {
         (_("Jellyfin UI"), "mpvtk"),
         (_("MPV UI with thumbnails"), "mpv"),
         (_("MPV built-in default"), "default"),
+        (_("Custom OSC"), "custom"),
         (_("No player controls"), "none"),
     ],
     # Down as well as up. Smaller is useful on a small screen, and it is
@@ -755,7 +756,10 @@ NOTES = {
                    "default. Press ENTER to drive the player controls by "
                    "keyboard. \"No player controls\" leaves playback bare; "
                    "the library, the keyboard shortcuts and the menu key "
-                   "still work."),
+                   "still work. Choose \"Custom OSC\" when you have "
+                   "installed your own OSC script: it turns MPV's own off "
+                   "and gives the library a solid background, so the "
+                   "script's idle screen cannot show through it."),
     "scroll_wheel_pixels": _(
         "Pixels one wheel notch scrolls. Raise it to scroll faster, lower it "
         "for finer control. On a grid the value is rounded so that a whole "

--- a/jellyfin_mpv_shim/player.py
+++ b/jellyfin_mpv_shim/player.py
@@ -37,7 +37,8 @@ from .player_audio import AudioMixin
 from .player_reporting import ReportingMixin
 from . import player_window
 from .player_window import WindowMixin, wlog
-from .mpv_options import build_mpv_options, mpv_scripts, resolve_osc_style
+from .mpv_options import (REPLACES_OSC, build_mpv_options, mpv_scripts,
+                          resolve_osc_style)
 from .session_reporter import SessionReporter
 from . import conf
 from .conf import settings
@@ -575,6 +576,9 @@ class PlayerManager(AudioMixin, ReportingMixin, WindowMixin):
         #: An OSC style a fallback forced, or None. Survives mpv
         #: re-creation -- see _init_mpv.
         self._osc_style_override = None
+        #: Whether we have told the on-screen controls to hide. The latch
+        #: half of enable_osc; see there.
+        self._osc_suppressed = False
         self._lua_probe = None
         self.do_not_handle_pause = False
         # Throttle for periodic offline resume-position persistence on the
@@ -978,6 +982,7 @@ class PlayerManager(AudioMixin, ReportingMixin, WindowMixin):
         # script that is belongs to mpv_scripts; this only records that one
         # was loaded, so the built-in OSC can be held off below.
         self._osc_script_loaded = osc_style == "mpv"
+        self._osc_suppressed = False
 
         # ensure standard mpv configuration directories and files exist
         conffile.get_dir(APP_NAME, "scripts")
@@ -1069,10 +1074,6 @@ class PlayerManager(AudioMixin, ReportingMixin, WindowMixin):
                               exc_info=True)
 
         if hasattr(self._player, "osc"):
-            # Ensure the built-in OSC stays disabled when a shim OSC script
-            # is loaded, even if the user's mpv.conf has osc=yes.
-            if self._osc_script_loaded:
-                self._player.osc = False
             self.enable_osc(self.osc_enabled)
         else:
             log.warning("This mpv version doesn't support on-screen controller.")
@@ -4422,24 +4423,39 @@ class PlayerManager(AudioMixin, ReportingMixin, WindowMixin):
 
         if not self._mpv_alive:
             return
+        style = getattr(self, "_osc_style_resolved", None)
         try:
-            if self._osc_script_loaded:
-                # Both shim OSC scripts register the osc-visibility message.
-                self.script_message(
-                    "osc-visibility", "auto" if enabled else "never", "False"
-                )
-                if hasattr(self._player, "osc"):
-                    self._player.osc = False
-            else:
-                if hasattr(self._player, "osc"):
-                    # The mpvtk playback HUD replaces any OSC and "none"
-                    # asked for no controls — never turn the built-in one
-                    # on under either.
-                    self._player.osc = (
-                        enabled
-                        and getattr(self, "_osc_style_resolved", None)
-                        not in ("mpvtk", "none")
-                    )
+            # Broadcast: mpv's own osc.lua and every fork of it registers
+            # these, while `osc` below reaches mpv's own and nothing else.
+            # So this is the whole of what "No player controls" and the
+            # library browser can say to an OSC that is not ours.
+            #
+            # The idle logo goes unconditionally, in both directions and
+            # from _init_mpv -- it has to land BEFORE the OSC's first draw,
+            # not merely before the library appears. Once a fork has drawn
+            # it, asking again does nothing: ModernZ parks it on a second
+            # overlay that its hide path never wipes, so the mpv logo sits
+            # over the library for the rest of the session (measured: an
+            # untouched OSC inks 2.1% of an idle window, suppressing after
+            # the draw leaves exactly 2.1%, suppressing before leaves 0%).
+            # It is never handed back -- every window the shim is idle in
+            # is one it draws itself.
+            self.script_message("osc-idlescreen", "no", "False")
+            # Visibility IS handed back, and is latched for it: restoring
+            # unconditionally would also fire at construction and undo a
+            # user's own `visibility=never`. docs/mpv-backends.md §12.
+            if not enabled:
+                self.script_message("osc-visibility", "never", "False")
+                self._osc_suppressed = True
+            elif self._osc_suppressed:
+                self.script_message("osc-visibility", "auto", "False")
+                self._osc_suppressed = False
+            # Mpv's own, held off against an mpv.conf `osc=yes` -- which a
+            # construction option cannot do (build_mpv_options). Not keyed
+            # on `enabled`: these styles never want it back. "default" is
+            # the user's option and is never written.
+            if style in REPLACES_OSC and hasattr(self._player, "osc"):
+                self._player.osc = False
         except _mpv_errors:
             self._handle_mpv_disconnect()
 

--- a/jellyfin_mpv_shim/thumbfast.lua
+++ b/jellyfin_mpv_shim/thumbfast.lua
@@ -38,6 +38,10 @@ function send_thumbfast_message()
     local json, err = utils.format_json({
         width = img_width,
         height = img_height,
+        -- Always 1: width/height are already what a consumer should draw,
+        -- the same as upstream thumbfast sends. Present only because an OSC
+        -- that divides by it to recover a logical size errors on nil.
+        scale_factor = 1,
         disabled = not img_enabled,
         available = img_enabled,
         overlay_id = img_overlay_id

--- a/tests/integration/_harness.py
+++ b/tests/integration/_harness.py
@@ -1122,6 +1122,9 @@ def build_player(player_module, video=None):
 
     pm.repeat_mode = "none"
     pm._osc_script_loaded = False
+    # enable_osc's latch: read directly, not via getattr, so a built player
+    # without it raises rather than silently taking the un-suppressed path.
+    pm._osc_suppressed = False
     pm.mpvtk_active = False
     pm._hud_skip = None
     pm._trickplay_pending = False

--- a/tests/integration/run_integration.py
+++ b/tests/integration/run_integration.py
@@ -155,9 +155,10 @@ def _run(modules, *, backend=None, use_xvfb=False, extra_env=None,
     if modules and modules[0] == "discover":
         # `-m unittest -v discover ...` is rejected: -v before the
         # subcommand selects the plain form, which has no `discover`.
-        cmd = [sys.executable, "-m", "unittest", "discover", "-v", *modules[1:]]
+        cmd = [sys.executable, "-u", "-m", "unittest", "discover", "-v",
+               *modules[1:]]
     else:
-        cmd = [sys.executable, "-m", "unittest", "-v", *modules]
+        cmd = [sys.executable, "-u", "-m", "unittest", "-v", *modules]
     if use_xvfb:
         xvfb = shutil.which("xvfb-run")
         if xvfb:
@@ -178,8 +179,14 @@ def _run(modules, *, backend=None, use_xvfb=False, extra_env=None,
     captured = []
     for line in proc.stdout:
         sys.stdout.write(line)
+        # Per line, not per leg. Our stdout is block-buffered whenever it is
+        # redirected, which is every `run_integration.py > log 2>&1`, so
+        # flushing after the loop meant a leg's entire output landed in one
+        # write at the end of it -- ~147s of silence for a whole-suite leg.
+        # A log that stops growing then looks exactly like a hung run, and
+        # twice it got diagnosed as one.
+        sys.stdout.flush()
         captured.append(line)
-    sys.stdout.flush()
     rc = proc.wait()
     return label, rc, _counts("".join(captured))
 

--- a/tests/lua/fake_mp.lua
+++ b/tests/lua/fake_mp.lua
@@ -155,15 +155,27 @@ function M.set_draw_cost(seconds) M.draw_cost = seconds or 0 end
 
 function M.set_overlay_cost(seconds) M.overlay_cost = seconds or 0 end
 
+--- The last overlay `create_osd_overlay` handed out.
+---
+--- Exposed because `z` is a real property of the renderer's output and a
+--- stand-in that dropped it left nothing for a test to assert against: the
+--- ASS z order is what decides whether the library draws over a
+--- third-party OSC (see the mpvtk-z handler). `z` starts nil rather than 0
+--- so "the renderer set it" and "nobody set it" stay distinguishable.
+M.osd = nil
+
 function mp.create_osd_overlay()
-    return {
+    local ov = {
         data = "",
+        z = nil,
         update = function()
             M.log.draws = M.log.draws + 1
             M.advance(M.draw_cost)
         end,
         remove = function() end,
     }
+    M.osd = ov
+    return ov
 end
 
 function mp.add_timeout(timeout, fn)

--- a/tests/lua/test_renderer.lua
+++ b/tests/lua/test_renderer.lua
@@ -3313,6 +3313,30 @@ scene({ { id = "udd", t = "dropdown", x = 40, y = 40, w = 200, h = 30,
           size = 18, items = { "Any", "English" }, sel = 0 } })
 eq(dd_sel("udd"), 1, "an unforced dropdown was reset by a scene push")
 
+-- ================================================== the ASS z order
+
+-- "Custom OSC" is the one style where the library has to outrank another
+-- script's ASS. uosc draws its whole self, idle screen included, at
+-- z=2000, so at our default 0 even an opaque full-window fill leaves its
+-- "Drop files or URLs to play here" on screen. Everyone else keeps 0,
+-- because 2000 is also mpv's console with a selectable list up. See the
+-- mpvtk-z handler in renderer.lua.
+
+scene({ vscroll("zorder", 100, 200) })
+eq(fake.osd.z, 0, "the renderer did not start at the neutral z order")
+
+-- advance() first: the handler asks for a repaint through request_render,
+-- which is rate-limited, so the timer is not due until the clock moves.
+fake.send("mpvtk-z", "yes")
+fake.advance(1)
+fake.fire_timers()
+eq(fake.osd.z, 3000, "mpvtk-z yes left us under uosc's 2000")
+
+fake.send("mpvtk-z", "no")
+fake.advance(1)
+fake.fire_timers()
+eq(fake.osd.z, 0, "mpvtk-z no did not put the z order back")
+
 -- ========================================================== teardown
 
 scene({})

--- a/tests/lua/test_thumbfast.lua
+++ b/tests/lua/test_thumbfast.lua
@@ -205,6 +205,41 @@ thumb(450, 10, 20)
 eq(overlay(), nil, "kept compositing after a clear")
 eq(#asks(), 0, "asked for a window while disabled")
 
+-- --------------------------------------------- the thumbfast-info payload
+
+-- Third-party OSCs read this blob and nothing else to decide whether
+-- previews exist and how big to reserve for them, so its shape is a
+-- published interface. `scale_factor` is the one field carried purely for
+-- them: width/height already arrive pre-multiplied (as upstream thumbfast
+-- sends them), so nothing here needs it -- but an OSC that divides by it to
+-- recover a logical size gets an arithmetic error on nil rather than a
+-- thumbnail. docs/mpv-backends.md section 12.
+
+--- The last thumbfast-info payload, as the table format_json was handed.
+local function info()
+    local found
+    for _, c in ipairs(fake.log.commands) do
+        if c[1] == "script-message" and c[2] == "thumbfast-info" then
+            found = c[3]
+        end
+    end
+    return found
+end
+
+fake.log.commands = {}
+window(0, 20, 100)
+ok(info() ~= nil, "publishing a window announced no thumbfast-info")
+eq(info().scale_factor, 1, "scale_factor missing from thumbfast-info")
+eq(info().width, W, "announced the wrong width")
+eq(info().height, H, "announced the wrong height")
+eq(info().disabled, false, "announced itself disabled with a window loaded")
+eq(info().available, true, "announced itself unavailable with a window loaded")
+
+fake.log.commands = {}
+fake.client_message("shim-trickplay-clear")
+eq(info().scale_factor, 1, "scale_factor dropped on the clear announcement")
+eq(info().disabled, true, "stayed enabled after a clear")
+
 -- ------------------------------------------------------------ summary
 
 print(string.format("1..%d", n))

--- a/tests/test_docs_coverage.py
+++ b/tests/test_docs_coverage.py
@@ -93,7 +93,7 @@ class DocsCoverageTest(unittest.TestCase):
         vocabulary = {
             # audio_mode / osc_style / ui_scale / theme values
             "auto", "stereo", "optical", "hdmi", "mpvtk", "mpv", "default",
-            "none", "null", "jellyfin", "nebula", "superdark",
+            "none", "custom", "null", "jellyfin", "nebula", "superdark",
             # scroll_mode values
             "continuous", "aligned", "row",
             # grid_fill values

--- a/tests/test_integration_runner.py
+++ b/tests/test_integration_runner.py
@@ -79,6 +79,78 @@ class TestLegStatus(unittest.TestCase):
         self.assertEqual(hollow, 0)
 
 
+class _Recorder:
+    """A stdout that remembers the ORDER of writes and flushes."""
+
+    def __init__(self):
+        self.events = []
+
+    def write(self, text):
+        self.events.append(("write", text))
+
+    def flush(self):
+        self.events.append(("flush", None))
+
+
+class TestOutputStreamsWhileTheLegRuns(unittest.TestCase):
+    """A leg's output must reach the log while the leg is still running.
+
+    `_run` tees the child through our own stdout, and that is block-buffered
+    whenever it is redirected -- which is every `run_integration.py > log`.
+    Flushing after the loop instead of inside it meant a whole-suite leg's
+    ~147s of output arrived in a single write when the leg ended, so the log
+    sat unchanged throughout it. A log that stops growing is indistinguishable
+    from a hung run, and twice it was read as one; the second time a
+    stall-watchdog fired during a leg that went on to report `Ran 324 tests
+    ... OK`.
+    """
+
+    LINES = ["first\n", "second\n", "third\n"]
+
+    def _drive(self):
+        import subprocess
+
+        rec = _Recorder()
+        captured = {}
+
+        class FakeProc:
+            def __init__(self):
+                self.stdout = iter(TestOutputStreamsWhileTheLegRuns.LINES)
+
+            def wait(self):
+                return 0
+
+        def fake_popen(cmd, **kwargs):
+            captured["cmd"] = cmd
+            return FakeProc()
+
+        orig_popen, orig_stdout = subprocess.Popen, sys.stdout
+        subprocess.Popen, sys.stdout = fake_popen, rec
+        try:
+            runner._run(["tests.integration.test_example"])
+        finally:
+            subprocess.Popen, sys.stdout = orig_popen, orig_stdout
+        return rec.events, captured["cmd"]
+
+    def test_every_line_is_flushed_as_it_arrives(self):
+        events, _cmd = self._drive()
+        first = next(i for i, (k, v) in enumerate(events)
+                     if k == "write" and v == self.LINES[0])
+        last = next(i for i, (k, v) in enumerate(events)
+                    if k == "write" and v == self.LINES[-1])
+        self.assertTrue(
+            any(k == "flush" for k, _ in events[first:last]),
+            "nothing was flushed between the first line and the last, so a "
+            "running leg would look like a stalled one")
+
+    def test_the_child_is_unbuffered_too(self):
+        """Our flush cannot help if the child is holding the lines."""
+        _events, cmd = self._drive()
+        self.assertIn("-u", cmd)
+        self.assertLess(cmd.index("-u"), cmd.index("-m"),
+                        "-u must reach python, not unittest")
+
+
 class TestStrictIsWired(unittest.TestCase):
     def test_the_flag_exists(self):
         """--strict is what CI should use; a typo'd flag name would make

--- a/tests/test_keysweep.py
+++ b/tests/test_keysweep.py
@@ -199,7 +199,20 @@ class AgainstRealMpvTest(unittest.TestCase):
             import mpv
         except OSError:                                  # pragma: no cover
             self.skipTest("libmpv not loadable")
-        self.mpv = mpv.MPV(vo="null", config=False, idle=True)
+        # input_default_bindings BECAUSE THE SHIM PASSES IT (_init_mpv), and
+        # without it this measures an mpv the shim never builds.
+        #
+        # `input-bindings` reports each binding's `priority` as the index of
+        # its section in the ACTIVE list, or -1 when the section is not
+        # active -- and separately forces -1 onto every builtin binding when
+        # default bindings are off, which libmpv turns off by default. So
+        # omitting it flattened every builtin to -1, `keysweep.winning()`
+        # had nothing left to rank on, and last-defined-wins handed the
+        # arrow keys to the `{discnav}` section mpv master added in
+        # 216e26c871 -- a section that is only ever enabled while a disc
+        # menu is on screen. The shim was never affected; the harness was.
+        self.mpv = mpv.MPV(vo="null", config=False, idle=True,
+                           input_default_bindings=True)
         self.addCleanup(self.mpv.terminate)
 
     def test_it_finds_more_than_the_shim_hard_coded(self):

--- a/tests/test_mpv_options.py
+++ b/tests/test_mpv_options.py
@@ -133,14 +133,36 @@ class OscOptionTest(SettingsCase):
         for style in ("mpv", "mpvtk"):
             self.assertIs(self.build(style)["osc"], False)
 
+    def test_custom_holds_it_off_too(self):
+        """"Custom OSC" says the controls are a script of the user's, so
+        mpv's own would be a second set drawn underneath -- and unlike
+        `default`, here the answer is not the user's mpv.conf to give."""
+        self.assertIs(self.build("custom")["osc"], False)
+
     def test_no_controls_means_mpv_s_own_are_off_too(self):
         """"none" is the only style that replaces the OSC with nothing, so
         it is also the only one where forgetting this would leave mpv's own
         controls as the answer to "no controls please" (#615)."""
         self.assertIs(self.build("none")["osc"], False)
 
-    def test_default_leaves_the_users_osc_alone(self):
-        self.assertNotIn("osc", self.build("default"))
+    def test_default_asks_libmpv_for_the_one_it_turns_off(self):
+        """libmpv defaults `osc` off where cplayer leaves it on, so
+        "whatever your mpv would normally do" has to be asked for.
+
+        As a CONSTRUCTION option, which is the whole point: mpv.conf
+        overrides one of those, so a user running their own OSC out of
+        <config>/scripts/ can still say `osc=no`. Writing the property onto
+        the live player instead loaded mpv's built-in OSC underneath theirs.
+        docs/mpv-backends.md section 12."""
+        self.assertIs(self.build("default")["osc"], True)
+
+    def test_external_mpv_needs_no_help(self):
+        # It already asks for player-operation-mode=cplayer, where the
+        # option defaults on -- and there these become command-line
+        # arguments, which OUTRANK the user's mpv.conf rather than
+        # deferring to it.
+        self.set(mpv_ext=True)
+        self.assertNotIn("osc", self.build("default", ext_mpv=True))
 
 
 class ScriptPassingTest(SettingsCase):

--- a/tests/test_osc_third_party.py
+++ b/tests/test_osc_third_party.py
@@ -1,0 +1,276 @@
+"""Third-party OSCs, and the two levers that reach them.
+
+`osc_style: default` is the supported way to run someone else's OSC (uosc,
+ModernZ, ModernX) against the shim, and `osc_style: none` is the settings
+form's "No player controls". Neither worked, because both went through the
+`osc` property -- which loads and unloads mpv's OWN osc.lua and says nothing
+to a script in `<config>/scripts/`:
+
+- "No player controls" left a third-party OSC drawing, and so did opening the
+  library browser over a playing video.
+- Worse, under `default` the shim WROTE `osc = True` onto the live player at
+  construction and on every browse-leave. libmpv defaults the option off, so
+  the write was needed -- but a property write cannot be declined, so it
+  loaded mpv's built-in OSC underneath the user's, from the first frame.
+
+The fix is two-sided: the enable/disable *message* every osc.lua fork
+inherits goes to everyone, and the `osc` option moves to construction, where
+the user's own mpv.conf outranks it. docs/mpv-backends.md section 12.
+"""
+
+import sys
+import threading
+import unittest
+from unittest import mock
+
+sys.argv = [sys.argv[0]]
+
+from jellyfin_mpv_shim.player import PlayerManager        # noqa: E402
+
+#: Sentinel for "nobody has written this". `None` would not do -- the bug
+#: being pinned is a write, and a write of None reads as untouched.
+UNTOUCHED = object()
+
+
+class FakeMpv:
+    """Records commands. `osc` exists as an attribute because `enable_osc`
+    gates on `hasattr` -- an mpv too old for the option is a separate case
+    (see OldMpvTest)."""
+
+    def __init__(self):
+        self.commands = []
+        self.osc = UNTOUCHED
+
+    def command(self, *args):
+        self.commands.append(args)
+
+
+class OscCase(unittest.TestCase):
+    def setUp(self):
+        patch = mock.patch.multiple(
+            "jellyfin_mpv_shim.player.settings",
+            mpv_ext=False, mpv_ext_no_ovr=False)
+        patch.start()
+        self.addCleanup(patch.stop)
+
+    def pm(self, style, player=None):
+        p = PlayerManager.__new__(PlayerManager)
+        p._lock = threading.RLock()
+        p._mpv_alive = True
+        p._osc_style_resolved = style
+        p._osc_suppressed = False
+        p._player = FakeMpv() if player is None else player
+        return p
+
+    @staticmethod
+    def messages(p, verb):
+        """The arguments every `script-message <verb>` carried, in order."""
+        return [c[2] for c in p._player.commands
+                if c[0] == "script-message" and c[1] == verb]
+
+
+class ItReachesEveryOscTest(OscCase):
+    STYLES = ("mpvtk", "mpv", "default", "custom", "none")
+
+    def test_hiding_is_announced_under_every_style(self):
+        # Broadcast, so one send covers whichever OSC is actually loaded.
+        # Gated behind `_osc_script_loaded` before, it only ever reached
+        # our own trickplay-osc.lua.
+        for style in self.STYLES:
+            with self.subTest(style):
+                p = self.pm(style)
+                p.enable_osc(False)
+                self.assertEqual(self.messages(p, "osc-visibility"),
+                                 ["never"])
+
+    def test_the_idle_logo_is_put_away_under_every_style(self):
+        # The browse window is force_window with nothing loaded, so an OSC
+        # that draws the mpv logo while idle draws it over the library.
+        for style in self.STYLES:
+            with self.subTest(style):
+                p = self.pm(style)
+                p.enable_osc(False)
+                self.assertEqual(self.messages(p, "osc-idlescreen"), ["no"])
+
+    def test_the_idle_logo_goes_even_when_the_controls_stay(self):
+        """`_init_mpv` calls enable_osc(True) under `default`, and that is
+        the only send that happens before the OSC's first draw. Waiting for
+        the library to open is too late -- ModernZ parks the logo on an
+        overlay its hide path never wipes, so it sits over the library for
+        the rest of the session."""
+        for style in self.STYLES:
+            with self.subTest(style):
+                p = self.pm(style)
+                p.enable_osc(True)
+                self.assertEqual(self.messages(p, "osc-idlescreen"), ["no"])
+
+    def test_no_player_controls_silences_someone_elses_osc(self):
+        """The settings form's "No player controls". `osc = False` answers
+        for mpv's own and nothing else, which is why this needs the
+        message."""
+        p = self.pm("none")
+        p.enable_osc(False)
+        self.assertIn("never", self.messages(p, "osc-visibility"))
+        self.assertIs(p._player.osc, False)
+
+
+class TheOscPropertyTest(OscCase):
+    def test_default_never_writes_it(self):
+        """The user's, and set at construction where mpv.conf outranks us.
+        A live write cannot be declined -- it stacked mpv's built-in OSC
+        under theirs."""
+        for enabled in (True, False, True):
+            with self.subTest(enabled=enabled):
+                p = self.pm("default")
+                p.enable_osc(enabled)
+                self.assertIs(p._player.osc, UNTOUCHED)
+
+    def test_the_styles_that_bring_their_own_hold_mpvs_off(self):
+        # Here the un-decline-ability is the point: this is how `osc=yes`
+        # in an mpv.conf is overridden.
+        for style in ("mpv", "mpvtk", "none", "custom"):
+            for enabled in (True, False):
+                with self.subTest(style=style, enabled=enabled):
+                    p = self.pm(style)
+                    p.enable_osc(enabled)
+                    self.assertIs(p._player.osc, False)
+
+
+class TheRestoreIsLatchedTest(OscCase):
+    """Un-hide only what we hid.
+
+    `enable_osc(True)` runs at construction, so restoring unconditionally
+    would broadcast "auto" at every startup and overwrite a user who put
+    `visibility=never` in their own OSC's config."""
+
+    def test_a_restore_with_nothing_suppressed_says_nothing(self):
+        # About visibility only -- the idle logo is suppressed on every
+        # call, deliberately, and is not part of the latch.
+        p = self.pm("default")
+        p.enable_osc(True)
+        self.assertEqual(self.messages(p, "osc-visibility"), [])
+
+    def test_it_restores_what_it_suppressed(self):
+        p = self.pm("default")
+        p.enable_osc(False)
+        p.enable_osc(True)
+        self.assertEqual(self.messages(p, "osc-visibility"),
+                         ["never", "auto"])
+
+    def test_the_idle_logo_is_never_handed_back(self):
+        """Asymmetric on purpose: the controls have to return, the mpv logo
+        has nowhere to belong in a shim session, and sending "yes" would
+        override someone who set `idlescreen=no` themselves."""
+        p = self.pm("default")
+        for _ in range(3):
+            p.enable_osc(False)
+            p.enable_osc(True)
+        self.assertEqual(set(self.messages(p, "osc-idlescreen")), {"no"})
+        self.assertEqual(self.messages(p, "osc-visibility"),
+                         ["never", "auto"] * 3)
+
+    def test_the_latch_does_not_walk_over_repeated_browsing(self):
+        # Enter/leave is a loop: the tray, the queue and `q` all re-run it.
+        # A one-step test cannot see a latch that drifts.
+        p = self.pm("default")
+        for _ in range(4):
+            p.enable_osc(False)      # browse enter
+            p.enable_osc(False)      # and again -- menu.py overlaps it
+            p.enable_osc(True)       # browse leave
+        seen = self.messages(p, "osc-visibility")
+        # Suppressing twice re-sends "never" -- idempotent, and cheaper than
+        # the state a dedup would need. What must not drift is the RESTORE:
+        # one per suppressed period, never one per call, or a doubled hide
+        # would leave a stray "auto" to overwrite the user's own config.
+        self.assertEqual(seen.count("auto"), 4)
+        self.assertEqual(seen[0], "never", "restored before anything was hid")
+        for i, mode in enumerate(seen):
+            self.assertGreaterEqual(
+                seen[:i + 1].count("never"), seen[:i + 1].count("auto"),
+                "restore ran ahead of the suppression it belongs to")
+        self.assertFalse(p._osc_suppressed)
+
+    def test_it_resets_when_mpv_is_re_created(self):
+        """A new mpv brings a new OSC at its own default, so a suppression
+        must not survive the re-create and restore over the user's config.
+        Asserted on the source because reaching the reset means constructing
+        a real player, which opens a window."""
+        import inspect
+
+        src = inspect.getsource(PlayerManager._init_mpv)
+        self.assertIn("self._osc_suppressed = False", src)
+
+
+class OldMpvTest(OscCase):
+    def test_an_mpv_without_the_osc_option_still_gets_the_message(self):
+        """The property is version-gated; the message is not. Falling over
+        here would take the whole browse handoff with it."""
+        class NoOsc:
+            def __init__(self):
+                self.commands = []
+
+            def command(self, *args):
+                self.commands.append(args)
+
+        p = self.pm("none", player=NoOsc())
+        p.enable_osc(False)
+        self.assertEqual(self.messages(p, "osc-visibility"), ["never"])
+
+
+class UserConfigIsLeftAloneTest(OscCase):
+    def test_external_mpv_with_no_ovr_is_not_touched_at_all(self):
+        with mock.patch.multiple("jellyfin_mpv_shim.player.settings",
+                                 mpv_ext=True, mpv_ext_no_ovr=True):
+            p = self.pm("none")
+            p.enable_osc(False)
+            self.assertEqual(p._player.commands, [])
+            self.assertIs(p._player.osc, UNTOUCHED)
+
+
+class PrecedenceAgainstRealLibmpvTest(unittest.TestCase):
+    """The measured fact `build_mpv_options` leans on, pinned.
+
+    Setting `osc` at construction rather than on the live player is only a
+    fix because the user's own `mpv.conf` OUTRANKS it -- the opposite of the
+    precedence a command-line argument would get. That is a property of how
+    the binding applies options, not something mpv documents, so if it ever
+    inverts the shim goes back to loading mpv's built-in OSC underneath
+    someone's uosc with nothing else noticing. docs/mpv-backends.md
+    section 12.
+    """
+
+    def setUp(self):
+        import tempfile
+        try:
+            import mpv                                   # noqa: F401
+        except OSError:                                  # pragma: no cover
+            self.skipTest("libmpv not loadable")
+        self.dir = tempfile.mkdtemp()
+
+    def build(self, conf_text, **opts):
+        import mpv
+        import os
+        with open(os.path.join(self.dir, "mpv.conf"), "w") as fh:
+            fh.write(conf_text)
+        p = mpv.MPV(config=True, config_dir=self.dir, vo="null", **opts)
+        try:
+            return p.osc
+        finally:
+            p.terminate()
+
+    def test_libmpv_leaves_the_osc_off_by_default(self):
+        """Which is why `default` has to ask for it at all -- the option's
+        own default is yes, and libmpv overrides that."""
+        self.assertIs(self.build(""), False)
+
+    def test_a_construction_option_turns_it_on(self):
+        self.assertIs(self.build("", osc=True), True)
+
+    def test_the_users_mpv_conf_overrides_that_option(self):
+        # The whole feature: `osc: True` is a default someone running their
+        # own OSC can decline.
+        self.assertIs(self.build("osc=no\n", osc=True), False)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_shell_library.py
+++ b/tests/test_shell_library.py
@@ -2788,6 +2788,60 @@ class TestThemeGradients(unittest.TestCase):
         self.assertEqual(g["h"], 60)
         self.assertEqual(g["w"], 1280.0)
 
+    def test_custom_osc_gets_a_flat_backdrop_where_the_window_had_none(self):
+        """"Custom OSC" means a script we never see draws the controls, and
+        such a script draws an idle screen while the browse window sits
+        with nothing loaded. That screen is OSD *over* mpv's
+        background-color, so no colour setting hides it -- only a bitmap of
+        ours, composited above OSD, can. Measured: an untouched ModernZ inks
+        2.1% of an idle window. docs/mpv-backends.md section 12."""
+        from jellyfin_mpv_shim.conf import settings
+        before = settings.osc_style
+        try:
+            settings.osc_style = "custom"
+            nodes = self._scene("default")
+        finally:
+            settings.osc_style = before
+        full = [n for n in nodes
+                if n.get("t") == "rect" and (n.get("w"), n.get("h")) ==
+                (1280.0, 720.0) and n.get("fill")]
+        self.assertTrue(full, "no window-sized fill under Custom OSC")
+        # Bottom of the paint order, or it covers the library it is behind.
+        self.assertEqual(nodes.index(full[0]), 0)
+
+    def test_the_other_styles_still_leave_the_window_to_mpv(self):
+        """One flat fill is cheap but not free, and mpv's own
+        background-color is the right answer for every style whose controls
+        we drew ourselves."""
+        from jellyfin_mpv_shim.conf import settings
+        before = settings.osc_style
+        try:
+            for style in ("mpvtk", "mpv", "default", "none"):
+                with self.subTest(style):
+                    settings.osc_style = style
+                    nodes = self._scene("default")
+                    full = [n for n in nodes
+                            if n.get("t") == "rect"
+                            and (n.get("w"), n.get("h")) == (1280.0, 720.0)]
+                    self.assertEqual(full, [])
+        finally:
+            settings.osc_style = before
+
+    def test_a_themed_gradient_is_not_doubled_up_under_custom_osc(self):
+        """The gradient already covers the window; a flat fill under it
+        would be a second full-window composite for nothing."""
+        from jellyfin_mpv_shim.conf import settings
+        before = settings.osc_style
+        try:
+            settings.osc_style = "custom"
+            nodes = self._scene("jf-wmc")
+        finally:
+            settings.osc_style = before
+        self.assertEqual(len([n for n in nodes if n.get("t") == "grad"]), 1)
+        self.assertEqual(
+            [n for n in nodes if n.get("t") == "rect"
+             and (n.get("w"), n.get("h")) == (1280.0, 720.0)], [])
+
     def test_the_bar_drops_its_flat_fill_when_a_gradient_is_behind_it(self):
         """Otherwise the fill simply covers the gradient up."""
         flat = [n for n in self._scene("default")


### PR DESCRIPTION
This adds a "Custom OSC" option to the MPV UI option, which allows custom OSCs placed in the scripts/fonts folders to "just work" with the caveat that playlist queue management and external subtitles are structurally inaccessible to custom oscs without them sending script messages to MPV Shim like the Jellyfin UI option does.