### PR TITLE
Fix scroll wheel input not working when OSC is visible (#711)

### DIFF
--- a/jellyfin_mpv_shim/trickplay-osc.lua
+++ b/jellyfin_mpv_shim/trickplay-osc.lua
@@ -2870,8 +2870,6 @@ mp.set_key_bindings({
     -- alias to shift_mbtn_left for single-handed mouse use
     {"mbtn_mid",            function(e) process_event("shift+mbtn_left", "up") end,
                             function(e) process_event("shift+mbtn_left", "down")  end},
-    {"wheel_up",            function(e) process_event("wheel_up", "press") end},
-    {"wheel_down",          function(e) process_event("wheel_down", "press") end},
     {"mbtn_left_dbl",       "ignore"},
     {"shift+mbtn_left_dbl", "ignore"},
     {"mbtn_right_dbl",      "ignore"},


### PR DESCRIPTION
## Summary

Removes the OSC-owned `WHEEL_UP` / `WHEEL_DOWN` bindings so user-defined scroll wheel bindings in `input.conf` work even while the OSC is displayed.

This closes #711.

## Problem

When the OSC is displayed, its `"input"` input section is enabled with `"force"` priority. That section registered its own `wheel_up` and `wheel_down` bindings, which intercepted scroll events before user-defined `input.conf` bindings could take effect.

The `process_event` handler for wheel events only dispatched volume changes when the mouse was over the volume button element. When the pointer was elsewhere, the event was silently swallowed — making user-defined scroll wheel bindings (e.g. `WHEEL_UP add volume 5`) completely non-functional while the OSC was visible.

When the OSC auto-hid, `mp.disable_key_bindings("input")` was called, and user bindings worked again — matching the reported behavior in #711.

## Fix

By removing the `wheel_up` and `wheel_down` bindings from the forced `"input"` section in `trickplay-osc.lua`, scroll wheel events now fall through to the user's `input.conf` bindings consistently, regardless of whether the OSC is visible or hidden.

## Testing

1. Add to `input.conf`:
   ```
   WHEEL_UP add volume 5
   WHEEL_DOWN add volume -5
   ```
2. Start playing a video
3. Move the mouse to show the OSC
4. Scroll wheel should now adjust volume as expected while the OSC is displayed
5. Verify scroll wheel also works after the OSC auto-hides

Closes #711