### PR TITLE
UI Nits 5

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -68,14 +68,17 @@ means **the mouse cursor never hides again** for the rest of the session.
   every pinned sha256 in seconds — pass it the Flathub manifest, which is usually the
   one that has drifted. See `docs/packaging.md`.
 - Tests: `xvfb-run -a python3 -m unittest discover tests` (stdlib unittest, no extra
-  deps) — **~7 minutes**. Integration matrix:
-  `xvfb-run -a python3 tests/integration/run_integration.py` — ~6.5 minutes.
+  deps) — **~2m15s**. Integration matrix:
+  `xvfb-run -a python3 tests/integration/run_integration.py` — **~10 minutes**.
 - Faster unit runs: `xvfb-run -a python3 tools/run_tests_parallel.py` — the same
-  4,900 tests one process per module, **~64s**. Same import semantics as
+  ~5,500 tests one process per module, **~30s**. Same import semantics as
   `discover`; a per-module timeout means a hang is a reported failure, and each
   worker gets its own process group so a kill cannot orphan an mpv. Put
   `xvfb-run` in front of *it*, not the workers. Do not parallelize the
   integration matrix — its legs are serial on purpose (docs/testing.md §9).
+  (Runtimes measured 2026-09-05 on a 16-core box, and they had drifted in both
+  directions — the unit suite was quoted at 7 minutes and the matrix at 6.5.
+  Treat them as the shape of the wait, not a benchmark.)
 - **Tee a full run to a file** rather than piping it through `tail`/`grep`. At
   these runtimes, one look at a failure you did not keep costs another run, and
   `run_integration.py`'s summary prints only a return code per leg.

--- a/docs/ISSUES_2026-09.md
+++ b/docs/ISSUES_2026-09.md
@@ -81,7 +81,7 @@ Status is kept current; a done row names the commit.
 | 4 | [Cross-cutting B](#cross-cutting-b--cli-overrides-must-not-reach-savedict) (#718 persistence) | `args.py`, `mpv_shim.py`, `settings_base.py`, `restart.py` | **done** `5f39561e` |
 | 5 | [#718 activation](#718--cli---minimized-must-not-become-a-saved-setting) (follow-up 2) | `tests/integration/`, `single_instance.py` | **done** `6a5b3eca` — not pure test work after all; see below |
 | 6 | [#722](#722--only-home-re-reads-user-data) | `app.py`, `ui.py` | **done** `da499b96` |
-| 7 | [Cross-cutting A](#cross-cutting-a--one-suspended-state-for-classic-osc-modality) (#724, #726) | tests + `tools/probe_classic_osc_mouse.py` | **done** `77f9f692` — the repro DID exonerate our code; no production change |
+| 7 | [Cross-cutting A](#cross-cutting-a--one-suspended-state-for-classic-osc-modality) (#724, #726) | tests + `tools/probe_classic_osc_mouse.py` | **done** `a7324740` — the repro DID exonerate our code; no production change |
 | 8 | [#727](#727--window-buttons-and-the-title-bar) | S ×2, `player_window.py`, `mpv_options.py` | two settings; touches the window code 10 will |
 | 9 | [#717](#717--the-hud-enter-key-cannot-be-remapped) | S, `renderer.lua`, `gateway/hud.py`, `gamepad.py`, `player.py` | `renderer.lua` again — after 7 has settled it; and it is three input sources, not one |
 | 10 | [#723](#723--hud-scaling-with-window-size) | S, `hud.py` | independent; grouped with the other settings work |

--- a/docs/ISSUES_2026-09.md
+++ b/docs/ISSUES_2026-09.md
@@ -82,7 +82,7 @@ Status is kept current; a done row names the commit.
 | 5 | [#718 activation](#718--cli---minimized-must-not-become-a-saved-setting) (follow-up 2) | `tests/integration/`, `single_instance.py` | **done** `6a5b3eca` — not pure test work after all; see below |
 | 6 | [#722](#722--only-home-re-reads-user-data) | `app.py`, `ui.py` | **done** `da499b96` |
 | 7 | [Cross-cutting A](#cross-cutting-a--one-suspended-state-for-classic-osc-modality) (#724, #726) | tests + `tools/probe_classic_osc_mouse.py` | **done** `a7324740` — the repro DID exonerate our code; no production change |
-| 8 | [#727](#727--window-buttons-and-the-title-bar) | S ×2, `player_window.py`, `mpv_options.py` | two settings; touches the window code 10 will |
+| 8 | [#727](#727--window-buttons-and-the-title-bar) | S ×2, `player_window.py`, `mpv_options.py`, `player.py` | **done** `73d1236d` |
 | 9 | [#717](#717--the-hud-enter-key-cannot-be-remapped) | S, `renderer.lua`, `gateway/hud.py`, `gamepad.py`, `player.py` | `renderer.lua` again — after 7 has settled it; and it is three input sources, not one |
 | 10 | [#723](#723--hud-scaling-with-window-size) | S, `hud.py` | independent; grouped with the other settings work |
 | 11 | [#725](#725--keepaspect-window) | S, `player.py`, `player_window.py`, integration matrix | the test matrix is the bulk of it; after 8 |

--- a/docs/ISSUES_2026-09.md
+++ b/docs/ISSUES_2026-09.md
@@ -240,8 +240,25 @@ is what the setting was withheld for:
 
 `tests/lua/test_renderer.lua` drives all of that through the real
 script-message boundary; `tests/test_ui_select_key.py` keeps the three
-producers agreeing and pins that the setting is offered. Five mutations of the
-renderer change were each caught by a distinct case.
+producers agreeing. Five mutations of the renderer change were each caught by
+a distinct case.
+
+**Where the row sits [iw]: Advanced, not a curated group.** The requirement is
+that a setting *exists* to point somebody at — *"so anyone who complains about
+it can be pointed at a setting and they'll stop bothering me"* — and key
+remapping is an answer to give on request rather than a control everyone reads
+past. So it is uncurated and falls through to General → Advanced, which is a
+real editable row with a label and a note and is searched like any other
+group. The test asserts `sections()` (reachable at all) and asserts it is
+*not* in `SECTIONS` (curated), which is the placement rather than the
+requirement — two cases, because they can fail for opposite reasons.
+
+Behind a disclosure, **search is how anyone actually arrives**, so the queries
+were measured rather than assumed: `remap`, `rebind`, `keyboard` and
+`shortcut` all returned nothing, and `hud_wake_key` — the other ENTER during
+playback — additionally missed **`enter` itself**, its note never naming the
+key it binds. Both got `SEARCH_ALIASES` entries; answering for one of a pair
+is how the two drift.
 
 **Left alone, deliberately.** `phud_bind_wake`, `phud_bind_summon` and
 `phud_skip_bind` still compare against `'ENTER'` by literal. Those are the

--- a/docs/ISSUES_2026-09.md
+++ b/docs/ISSUES_2026-09.md
@@ -10,6 +10,18 @@ the investigation; everything else is the investigation's own conclusion. A
 section that says "open" names a decision nobody has made yet — it is not a
 thing to guess at while implementing.
 
+**The plan has been through one adversarial review** (a different vendor's
+model, read-only, asked to refute rather than converge). It found eight real
+defects in the *proposals* — not in the diagnoses — and every one is folded in
+above rather than appended: #717's repair would have broken the gamepad and the
+Jellyfin remote, #718's would have discarded deliberate Settings edits, #720's
+would have corrupted "Add to play queue", #722's would have raced pagination and
+refreshed across servers, #727's could not express its own new setting to a
+classic OSC, #723's tier formula was backwards, #721's proposed lint was
+redundant with an existing test, and one claimed ordering dependency was not
+real. Where a refuted idea is instructive it is kept and marked as refuted,
+because the next reader will have the same idea.
+
 The filename carries a `YYYY-MM` date, which is what keeps it out of
 `tests/test_doc_symbols.py` (`PLAN_DOCS`). That matters here: this document
 names config keys and functions that **do not exist yet**, which is exactly
@@ -38,29 +50,54 @@ Two repairs span several issues and are written once, at the bottom:
 ## Proposed work order
 
 Grouped by what they touch, not by issue number, so that two items in the same
-file are not written twice against each other. Ordering rationale, and the one
-place it matters: **#721 lands before #723**, because #723 changes how the HUD's
-scale is computed and #721 changes what that scale is applied to — doing them in
-the other order means writing #723's floor arithmetic against a glyph size that
-is about to start scaling.
+file are not written twice against each other.
+
+**There is no hard ordering dependency between any two items.** An earlier draft
+claimed #721 must precede #723; that was wrong, and the refutation is worth
+keeping because it is the kind of dependency that feels real. #723's floor is
+computed from the trigger's *box* (47 logical px, `widgets.py:902-903`), and the
+box's `w`/`h` already scale correctly today — #721 changes only whether the
+`isz` field emitted at `layout.py:889` is converted at `scaling.py:74`. The two
+touch different fields of the same widget and are independently landable. #721
+is still first below, because it is the smallest and it makes the HUD look right
+while the rest is in flight, but nothing breaks if it is not.
+
+Every row lists **all** the surfaces the item touches, not just the file where
+the logic lives. Four of these add a config key, and `docs/settings-curation.md`
+makes that five files, not one: `conf.py` (the typed default),
+`mpvtk_browser/config.py` (section placement, label, note, and whether it is
+`RESTART_REQUIRED`), `docs/configuration.md` (enforced by
+`tests/test_docs_coverage.py`), and `messages/base.pot` via `./regen_pot.sh` for
+any new user-facing string.
+
+`S` in the Touches column = the five-file settings surface above.
 
 | Order | Item | Touches | Why here |
 |---|---|---|---|
-| 1 | [#721](#721--three-hud-glyphs-ignore-ui_scale) | `mpvtk/scaling.py`, `mpvtk/layout.py` | one table entry, no dependants, unblocks #723 |
-| 2 | [Cross-cutting B](#cross-cutting-b--cli-overrides-must-not-reach-savedict) (#718) | `mpv_shim.py`, `settings_base.py` | self-contained; every later setting inherits the rule |
-| 3 | [#720](#720--play-on-a-season-navigates-instead-of-playing) | `tiles.py`, `repository.py` | self-contained; touches the same file as 4 |
-| 4 | [#719a](#719a--go-to-series-from-any-episode-tile) | `tiles.py` | same file and same method family as 3 |
-| 5 | [#722](#722--only-home-re-reads-user-data) | `app.py`, `ui.py`, `pagination.py` | independent of everything above; collapses two refreshers into one, so size it as a refactor |
-| 6 | [Cross-cutting A](#cross-cutting-a--one-suspended-state-for-classic-osc-modality) (#724, #726) | `renderer.lua`, `app.py` | starts with a repro, so it can run while others land |
-| 7 | [#727](#727--window-buttons-and-the-title-bar) | `conf.py`, `player_window.py`, `mpv_options.py` | two settings; touches the window code #725 will |
-| 8 | [#717](#717--the-hud-enter-key-cannot-be-remapped) | `conf.py`, `renderer.lua`, `gateway/hud.py` | `renderer.lua` again — after 6 has settled it |
-| 9 | [#723](#723--hud-scaling-with-window-size) | `conf.py`, `hud.py` | needs #721's scaling to be correct first |
-| 10 | [#725](#725--keepaspect-window) | `player.py`, `player_window.py`, integration matrix | the test matrix is the bulk of it; after 7 |
-| 11 | [#719b](#719b--clickable-caption-runs-on-a-tile) | `strips.py`, `tile_renderer.py`, `metrics.py` | new capability, and 719a already makes the series reachable |
+| 1 | [#721](#721--three-hud-glyphs-ignore-ui_scale) | `mpvtk/scaling.py`, `mpvtk/layout.py`, `tests/test_ui_scale.py` | smallest; one table entry and one fixture field |
+| 2 | [#720](#720--play-on-a-season-navigates-instead-of-playing) | `tiles.py`, `repository.py` | self-contained; same file as 3 |
+| 3 | [#719a](#719a--go-to-series-from-any-episode-tile) | `tiles.py`, `base.pot` | same file and same method family as 2 |
+| 4 | [Cross-cutting B](#cross-cutting-b--cli-overrides-must-not-reach-savedict) (#718 persistence) | `mpv_shim.py`, `settings_base.py`, `mpvtk_browser/config.py` | every later setting inherits the rule, so before 6-10 |
+| 5 | [#718 activation](#718--cli---minimized-must-not-become-a-saved-setting) (follow-up 2) | `tests/integration/` only | pure test work; independent of 4 despite sharing the issue |
+| 6 | [#722](#722--only-home-re-reads-user-data) | `app.py`, `ui.py`, `pagination.py` | collapses two refreshers into one — size it as a refactor, not a gate change |
+| 7 | [Cross-cutting A](#cross-cutting-a--one-suspended-state-for-classic-osc-modality) (#724, #726) | `renderer.lua`, `app.py`, an mpv-version bisect | starts with a repro that may exonerate our code entirely |
+| 8 | [#727](#727--window-buttons-and-the-title-bar) | S ×2, `player_window.py`, `mpv_options.py` | two settings; touches the window code 10 will |
+| 9 | [#717](#717--the-hud-enter-key-cannot-be-remapped) | S, `renderer.lua`, `gateway/hud.py`, `gamepad.py`, `player.py` | `renderer.lua` again — after 7 has settled it; and it is three input sources, not one |
+| 10 | [#723](#723--hud-scaling-with-window-size) | S, `hud.py` | independent; grouped with the other settings work |
+| 11 | [#725](#725--keepaspect-window) | S, `player.py`, `player_window.py`, integration matrix | the test matrix is the bulk of it; after 8 |
+| 12 | [#719b](#719b--clickable-caption-runs-on-a-tile) | `strips.py`, `tile_renderer.py`, `metrics.py` | new capability, and 3 already makes the series reachable |
 
-Three items collide on a file and are deliberately separated in time:
-`renderer.lua` (6 then 8), `tiles.py` (3 then 4), and the window code (7 then
-10). Nothing else overlaps.
+**Where items genuinely collide.** `renderer.lua` (7 then 9), `tiles.py`
+(2 then 3), the window code (8 then 11), and — the one an earlier draft missed
+— the **settings surface**, which 8, 9, 10 and 11 all touch. Those four each add
+a key to `conf.py` and a row to `mpvtk_browser/config.py`'s section tables and
+`docs/configuration.md`; they need not be one commit, but they must not be
+written in parallel against each other, and `./regen_pot.sh` should run once at
+the end of the group rather than four times.
+
+Item 5 is separated from 4 deliberately: they share issue #718 but nothing else.
+4 is a change to how settings serialize; 5 is regression coverage for
+second-launch activation and touches no production code at all.
 
 ---
 
@@ -91,7 +128,32 @@ remapped properly".
 **Shape.** A new key setting — working name `kb_ui_select`, default `"ENTER"` —
 read by the same path that already carries `hud_wake_key` to the renderer
 (`mpvtk_browser/gateway/hud.py:37`, the `mpvtk-hud` opts blob), and applied to
-the `ENTER` entry of `NAV_KEYS`. Notes on doing it:
+the `ENTER` entry of `NAV_KEYS`.
+
+**The trap, and it is the whole difficulty: ENTER is not only a keyboard key
+here — it is the wire format two other input sources use to mean "Select".**
+Remapping the `NAV_KEYS` entry alone silently kills both of them:
+
+- the **game controller**. `gamepad.py:74` maps Confirm to the literal
+  `"ENTER"`, with a comment saying it is ENTER *because* that is what the
+  browser's nav activates on; the press reaches mpv as `keypress <arg>`
+  (`renderer.lua:6255`).
+- the **Jellyfin remote**. `player.py:_NAV_KEYPRESS` (`:4739`) maps the
+  server's `"ok"` to `"ENTER"`, issued at `player.py:4863`.
+
+So a user who sets `kb_ui_select` to anything else keeps keyboard selection and
+loses gamepad A and phone/web Select. **The setting must move a semantic
+action, not a key**: either all three producers read `kb_ui_select`, or — better,
+because it removes an authority rather than adding a third reader — the two
+synthetic sources stop spelling their intent as a keystroke and send a Select
+message the renderer answers directly, leaving `kb_ui_select` to govern only the
+physical keyboard.
+
+Exit predicate for this item: with `kb_ui_select` set to a non-ENTER key,
+keyboard, gamepad Confirm and remote Select all still activate the same focused
+control. A test that only presses the keyboard cannot fail for this.
+
+Other notes on doing it:
 
 - `NAV_KEYS` is a module-level table consumed by `bind_nav_keys` and by
   `keyclaim.nav_names`. A configurable key means the table can no longer be
@@ -256,11 +318,17 @@ Next Up, and not a resume position.
   filters.
 - `_resolve_play_ids` currently returns ids only, and `_menu_play`'s `done`
   hardcodes `self._play_list(ids, server, 0, …)`. The start index needs the
-  DTOs, so the Season path has to return `(ids, start_index, items)` — or gain a
-  season-specific sibling. `ItemActions.play_list(ids, server, start_index=0,
-  audio=False, items=None, …)` (`item_actions.py:171`) already takes both, and
-  its `items` argument is what supplies the resume offset for the entry actually
-  started, so passing the DTOs is wanted anyway.
+  DTOs. **Give the Season its own resolver rather than widening this one's
+  return type** — `_resolve_play_ids` has a second caller, `_menu_queue`
+  (`tiles.py:562`), which passes the result straight to `_queue_items`
+  (`tiles.py:574`), so a `(ids, start_index, items)` tuple would arrive at
+  "Add to play queue" as though it were the id list and queue three garbage
+  entries. That is not a style preference between two equal options; it is the
+  only safe shape unless both callers move to a typed result together.
+  `ItemActions.play_list(ids, server, start_index=0, audio=False, items=None,
+  …)` (`item_actions.py:171`) already takes the index and the DTOs, and its
+  `items` argument is what supplies the resume offset for the entry actually
+  started, so passing them is wanted anyway.
 - Do **not** copy web's `StartIndex || seasonStartIndex || 0` chain — index 0 is
   falsy there, so a season whose first episode is unplayed falls through the
   `||` and lands on 0 by coincidence rather than by decision. Write the intent.
@@ -325,12 +393,26 @@ scene through `scale_scene` and asserts the glyph tracks the box and the
 axis over. `tests/test_ui_scale.py` is where the `_PX_KEYS` table itself is
 pinned; the new key belongs in whatever enumeration lives there too.
 
-**While in there:** the `_PX_KEYS` comment says the tables were "audited against
-layout.py's emission and renderer.lua's reads". That audit missed `isz`, so it
-is worth re-running rather than trusting — every key `layout.py` emits that
-`renderer.lua` uses as a pixel length must be in exactly one of the tables. A
-lint over `node["…"] =` assignments against the three tables would make this
-enforceable instead of advisory.
+**The general guard already exists, and it has a fixture gap — do not build a
+new lint.** `tests/test_ui_scale.py:ScaleSceneDriftTest.test_no_pixel_field_escapes_the_conversion`
+(`:93`) is exactly the invariant this needs: it lays a scene out at 1.0 and 2.0
+and requires every numeric node field to have either scaled or be known not to.
+It misses `isz` only because its fixture builds an icon-trigger `Dropdown`
+*without* `icon_size` (`tests/test_ui_scale.py:67-68`, added to exercise `pw`), so
+the field never appears in the scene at all.
+
+**Adding `icon_size=30` to that one fixture line makes the existing test catch
+this exact regression** — and every future one of the same shape. That is the
+whole repair on the test side. A source lint over `node["…"] =` assignments was
+the earlier proposal here and it is worse: it is syntactic where this is
+behavioural, and it would need its own allowlist for booleans, colours, slider
+domain values, indexes and the physical bitmap dimensions that must *not* scale
+— i.e. it would reproduce `_PX_KEYS`' exception list in a second place.
+
+This is also the "a stand-in that omits a field" rule from `CLAUDE.md` in its
+purest form: the fixture did not leave a path uncovered, it made the path
+unreachable while reporting a pass, because the field the guard is about had
+nowhere to live.
 
 ---
 
@@ -408,6 +490,23 @@ dropped from the Live TV one:
 this issue adds are `series` and `season`; `grid`, `favorites` and `detail` are
 candidates and each needs the pagination question answered before it is added,
 because that is where the missing marker starts to matter.
+
+**And the event has to be filtered by server, which it is not today.**
+`_user_data_changed(self, _client=None)` (`ui.py:120`) discards the client and
+refreshes whatever is on screen, with a docstring justifying it: "the event only
+ever comes from a server this client is logged into". That is a fair argument
+for **Home**, which is assembled from every logged-in server anyway. It stops
+being fair the moment a per-server route is admitted: in a two-server session,
+activity on server A would re-fetch a Series route belonging to server B — a
+wasted round trip at best, and at worst an unrelated event driving the current
+route into the offline fallback (`app.py:1360`) when B is unreachable.
+
+The lookup already exists three functions up: `_display_content` (`ui.py:96`)
+resolves a client to a server UUID against `clientManager.clients`. The
+generalized refresher should take the emitting server and skip a route whose
+`route["server"]` is a different one — with Home exempt, because Home is
+genuinely cross-server. **This is a pre-existing latent bug that #722 promotes
+into a real one**, so it belongs in this item rather than in a separate one.
 
 **Do not** reach for a per-item optimistic patch of the parent's
 `UnplayedItemCount` on the client. `ItemActions.toggle_watched`
@@ -510,12 +609,25 @@ first is what the metric governs.
 **Open — the tiers.** `tiers` (`hud.py:786-796`) is a set of absolute pixel
 breakpoints (`w >= 500`, `w >= 560`, `w >= 700`, `w >= 760`, `w >= 1000`) tuned
 against the current 0.72 floor. With a lower floor the controls fit in less
-width, so the breakpoints should fall with the scale rather than firing at the
-same window width regardless — otherwise the bar shrinks and *still* drops the
-quality picker at 560px. Whether that means dividing each breakpoint by the
-scale, or re-tuning them, is the decision. This is the part that will bite: the
-tiers and the scale currently answer to the same `w` and are tuned against each
-other.
+width, so a breakpoint should fall as the controls shrink — otherwise the bar
+shrinks and *still* drops the quality picker at 560px.
+
+**Do not "divide the breakpoint by the scale".** An earlier draft suggested
+that and it is backwards: `560 / 0.5 = 1120` moves the threshold *up*, dropping
+controls twice as early, which is the opposite of the goal. The scale is ≤ 1, so
+dividing by it can only ever raise a threshold.
+
+The two candidate spellings, both of which move it the right way:
+
+- **compare against a scaled width** — `w / scale >= 560`, i.e. ask "how much
+  room would this be at full size", which keeps the tuned numbers meaningful;
+- **multiply the breakpoint** — `w >= 560 * scale`, arithmetically the same
+  thing rearranged, and easier to read wrong later.
+
+The first is the honest spelling; either way the decision is which, plus whether
+the numbers still want re-tuning once the floor moves. This is the part that
+will bite: the tiers and the scale currently answer to the same `w` and are
+tuned against each other.
 
 ---
 
@@ -552,8 +664,44 @@ and the only mouse-binding difference is a *removal*, the
 `window-controls-title` drag section. Its `input` section handling is stock, so
 right-click pauses there exactly as in plain mpv.
 
-**What is not established** is what leaves `mpvtk_mouse` enabled during
-classic-OSC playback. On paper the suspend path is correct:
+**Before any of that: `MBTN_RIGHT` does not mean "pause" on the mpv we ship.**
+mpv changed its own default between 0.40 and 0.41:
+
+| mpv | builtin `MBTN_RIGHT` (`etc/input.conf:33`) |
+|---|---|
+| 0.38 | `cycle pause` |
+| 0.40 | `cycle pause` |
+| 0.41 | `script-binding select/context-menu` |
+
+Both shipped pins are past that change — the Flatpak pin was `v0.41.0` in pre13
+and a master commit in pre14, and the Windows pin moved from shinchiro
+`20260610` to `20260828` in the same commit (`16ad0bb4`). So on the reporter's
+build, right-click's *default* is the context menu, and "right click should
+pause" was already untrue in pre13.
+
+Two consequences, and the second is the one that matters:
+
+- **The acceptance test cannot assert "MBTN_RIGHT toggles pause"** — that fails
+  on ≥0.41 even after a perfectly correct handoff. It must assert that the
+  *resolved* binding fires, i.e. that whatever `input-bindings` says MBTN_RIGHT
+  means is what happens.
+- **The regression window contains an mpv version bump**, and this plan
+  originally attributed the whole of issue 1 to shim code. pre13 → pre14 changed
+  the mpv binary as well as the shim. `select.lua` is a builtin script and the
+  shim does not disable script loading on the player path (only the standalone
+  `mpvtk/app.py:_SPAWN_OPTS` sets `load_scripts: no`), and
+  `input_default_bindings=True` is set at `player.py:1022` — so the context menu
+  *should* work; but "should" is what a bisect is for.
+
+**So step 0 of the repro is a bisect on mpv, not on us:** run the pre14 shim
+against the `20260610` build and then the `20260828` build, unchanged, and see
+whether classic-OSC right-click behaves differently. If it does, the shim is
+exonerated and this becomes an upstream note plus possibly a pin decision. That
+experiment is cheap, it is decisive, and skipping it means every subsequent hour
+is spent on the assumption that our code is at fault.
+
+**What is not established** — assuming the bisect points back at us — is what
+leaves `mpvtk_mouse` enabled during classic-OSC playback. On paper the suspend path is correct:
 `LoadFeedback.clear()` → `_hand_off` → `MpvtkBrowser._yield()` →
 `hud.available()` is False → `_set_renderer_active(False)` → `mpvtk-active no`
 → `ui_suspend()`. Worth noting while looking: `app.py:2371`'s
@@ -741,6 +889,28 @@ script options with it, which is the same class of mistake as writing over their
 scripts with their own option namespace (uosc and friends) are out of scope, and
 "where possible" is doing real work in the verdict.
 
+**But three values cannot carry two policy axes, so the bridge is its own
+change.** `window_controls_enabled()` (`trickplay-osc.lua:473-480`) consults
+`user_opts.windowcontrols` and `state.border` and **never asks about
+fullscreen**. So once `window_controls_fullscreen` exists there is no stock value
+meaning "show them windowed, hide them fullscreen":
+
+| our state | best `osc-windowcontrols` | what the OSC then does |
+|---|---|---|
+| `window_controls=always`, fullscreen off | `yes` | correct |
+| `window_controls=always`, fullscreen **off** | `yes` | **wrong** — shows them fullscreen too |
+| `window_controls=auto` + `hide_title_bar` | `auto` | **wrong** — same, shows them fullscreen |
+| "windowed yes, fullscreen no" | — | inexpressible |
+
+Two honest ways out, and this is a decision rather than a detail: teach the fork
+a second option (it is our fork, so `osc-windowcontrols-fullscreen` is
+available), or **scope `window_controls_fullscreen` explicitly to the mpvtk UI**
+and say so in its note, leaving classic OSCs on their own two-value policy. The
+second is smaller and does not fork the option namespace further; the first is
+the only one that makes the setting mean the same thing everywhere. Either way,
+**land the two settings first and the OSC bridge as a separate commit** — they
+are independent, and the bridge is the half with the open question.
+
 **Docs.** Both new keys need entries in `docs/configuration.md` —
 `tests/test_docs_coverage.py` fails a setting without one — and a placement
 decision in `docs/settings-curation.md`. Neither is `RESTART_REQUIRED` if both
@@ -785,7 +955,11 @@ Three things to establish, in this order:
 **Then pin it.** An integration leg that asserts, in classic-OSC modality with a
 video playing: `mpvtk_mouse` / `mpvtk_thumb` / `mpvtk_wheel` are all disabled,
 `input-builtin-dragging` is back to what the user had, and a synthesized
-`MBTN_RIGHT` toggles pause. `tests/integration/test_keyboard_controls.py` and
+`MBTN_RIGHT` reaches **whatever `input-bindings` resolves it to** — not
+specifically pause, for the version reason above. The property read is the
+assertion; the observable effect is not portable across mpv versions and a test
+that hardcodes "pause" is a test that will fail on the next pin move for a
+reason that has nothing to do with this bug. `tests/integration/test_keyboard_controls.py` and
 `test_mpvtk_hud.py` are the neighbours. Derive the failing case from the issue's
 words and watch it fail **before** writing the fix — an assertion written after
 the fix is structurally unable to fail.
@@ -819,21 +993,42 @@ Per `CLAUDE.md`'s applying-review-findings rule: count the sites before the
 first patch, and prefer the repair that removes an authority. Three more
 comments is the shape that does not hold.
 
-**Shape.** One `apply_cli_overrides(args)` in `mpv_shim.py` that records the
-overridden field names alongside the value loaded from disk, and a `dict()` that
-writes the **loaded** value for those fields. Where the record lives is the
-design choice — a set on the settings object that `dict()` consults is the
-smallest thing that works, and it puts the rule at the one place that
-serialises rather than at each of the four places that assign.
+**Shape — and `dict()` is the wrong place to put it.** The obvious repair is
+one `apply_cli_overrides(args)` that records the overridden field names with
+their on-disk values, and a `dict()` that writes the **loaded** value for those
+fields. That is where an earlier draft landed, and it is broken:
 
-`ui_scale`'s existing comment then describes the mechanism instead of standing
-in for it, and a fifth CLI override added later is covered by construction
-rather than by remembering.
+**`dict()` is not the persistence boundary — it is also how the Settings screen
+reads the config.** `config.get_settings()` (`mpvtk_browser/config.py:1116`)
+returns `settings.dict()` to populate the form, and `config.set_setting`
+(`:1148`) handles an explicit user edit by assigning the field and calling
+`save()` immediately. `settings_base.dict()` (`:67`) cannot tell that assignment
+apart from the CLI's.
 
-**Test.** Assert `dict()` — not just `save()` — returns the on-disk value for
-every overridden field, for all four flags, with the override in place. Then the
-integration case from #718 follow-up 2 item 2: launch with `--minimized`,
-provoke a save, and read `conf.json` back.
+The failure that produces: disk says `ui_scale: 1`, the app is launched with
+`--ui-scale 2`, and the user then deliberately picks `1.5` in Settings. `dict()`
+substitutes the loaded `1`, and the edit they just made is discarded — a
+strictly worse bug than the one being fixed, because it silently reverts a
+deliberate action rather than persisting an accidental one.
+
+So the override record needs a **lifetime**, not just a membership test: an
+explicit `set_setting` on an overridden key must drop it from the record (the
+user has now stated an intent for that key, which outranks the flag), and only
+then assign and save. Equivalently, persistence gets its own serialization entry
+point distinct from the one the UI reads — which is the version that removes an
+authority, since it stops one method answering two questions.
+
+Whichever is chosen, the **exit predicate has two halves and a test that checks
+only the first is the trap**:
+
+1. an unrelated save (window geometry, audio device) leaves an overridden key at
+   its on-disk value;
+2. an explicit Settings edit of that same overridden key **persists the new
+   value**.
+
+**Test.** Both halves above, for all four flags, asserted against `dict()` and
+not only against `save()`. Then the integration case from #718 follow-up 2 item
+2: launch with `--minimized`, provoke a save, read `conf.json` back.
 
 ---
 

--- a/docs/ISSUES_2026-09.md
+++ b/docs/ISSUES_2026-09.md
@@ -81,7 +81,7 @@ Status is kept current; a done row names the commit.
 | 4 | [Cross-cutting B](#cross-cutting-b--cli-overrides-must-not-reach-savedict) (#718 persistence) | `args.py`, `mpv_shim.py`, `settings_base.py`, `restart.py` | **done** `5f39561e` |
 | 5 | [#718 activation](#718--cli---minimized-must-not-become-a-saved-setting) (follow-up 2) | `tests/integration/`, `single_instance.py` | **done** `6a5b3eca` — not pure test work after all; see below |
 | 6 | [#722](#722--only-home-re-reads-user-data) | `app.py`, `ui.py` | **done** `da499b96` |
-| 7 | [Cross-cutting A](#cross-cutting-a--one-suspended-state-for-classic-osc-modality) (#724, #726) | `renderer.lua`, `app.py`, an mpv-version bisect | starts with a repro that may exonerate our code entirely |
+| 7 | [Cross-cutting A](#cross-cutting-a--one-suspended-state-for-classic-osc-modality) (#724, #726) | tests + `tools/probe_classic_osc_mouse.py` | **done** `77f9f692` — the repro DID exonerate our code; no production change |
 | 8 | [#727](#727--window-buttons-and-the-title-bar) | S ×2, `player_window.py`, `mpv_options.py` | two settings; touches the window code 10 will |
 | 9 | [#717](#717--the-hud-enter-key-cannot-be-remapped) | S, `renderer.lua`, `gateway/hud.py`, `gamepad.py`, `player.py` | `renderer.lua` again — after 7 has settled it; and it is three input sources, not one |
 | 10 | [#723](#723--hud-scaling-with-window-size) | S, `hud.py` | independent; grouped with the other settings work |
@@ -680,6 +680,35 @@ mpv 0.38's `osc.lua` — 637 diff lines against `src/v0.38/player/lua/osc.lua`,
 and the only mouse-binding difference is a *removal*, the
 `window-controls-title` drag section. Its `input` section handling is stock, so
 right-click pauses there exactly as in plain mpv.
+
+> **RESOLVED — measured, and the answer is that our code is already
+> correct.** `tools/probe_classic_osc_mouse.py` reads mpv's own
+> `input-bindings` through the browse -> classic-OSC-playback -> browse cycle
+> on a real mpv. Told `mpvtk-active no`, the renderer drops `mpvtk_mouse`,
+> `mpvtk_thumb` and `mpvtk_wheel` to priority -1 (mpv's word for "the owning
+> section is not active") **and hands `input-builtin-dragging` back**, and
+> the app sends that message on every video start. `trickplay-osc.lua`'s own
+> `input` section is inactive while the OSC is hidden, so it is not a
+> claimant either.
+>
+> What is left over the video is mpv's own default section: `MBTN_LEFT` is
+> `ignore` -- it has never paused, on any version -- and `MBTN_RIGHT` is
+> `script-binding select/context-menu` since 0.41. **So "neither button
+> pauses" in classic-OSC modality is upstream behaviour, not a shim
+> regression**, and the "neutralize all mouse bindings" verdict was already
+> satisfied by the code.
+>
+> No production change. What landed is the protection, because the property
+> is invisible from the Python side (every call "succeeds" whether or not mpv
+> let go): a real-mpv guard on both backends
+> (`test_mpvtk_browser.ClassicOscReleasesTheMouseTest`, mutation-checked
+> against a `ui_suspend` that skips the disable) and a Python-side guard on
+> the transitions a video actually takes (`tests/test_classic_osc_mouse.py`).
+>
+> **Still unexplained: why the reporter calls it a pre13 regression.** Both
+> pins are past 0.41, so right-click was already the context menu in pre13.
+> Worth asking them what pre13 did that pre14 does not, rather than assuming.
+> The rest of this section is kept as the reasoning that got there.
 
 **Before any of that: `MBTN_RIGHT` does not mean "pause" on the mpv we ship.**
 mpv changed its own default between 0.40 and 0.41:

--- a/docs/ISSUES_2026-09.md
+++ b/docs/ISSUES_2026-09.md
@@ -36,7 +36,7 @@ what a planning document is for.
 | [720](#720--play-on-a-season-navigates-instead-of-playing) | Play on a season opens it | bug | match web **[iw]** |
 | [721](#721--three-hud-glyphs-ignore-ui_scale) | HUD icons don't scale, then overlap | **regression** + latent bug | scale `isz`; floor the trigger; measured fit |
 | [722](#722--only-home-re-reads-user-data) | Watched status stale | bug | collapse two refreshers |
-| [723](#723--hud-scaling-with-window-size) | Scale HUD with window | enhancement | new setting **[iw]** |
+| [723](#723--hud-scaling-with-window-size) | Scale HUD with window | enhancement | measured fit + `hud_auto_scale` **[iw]** |
 | [724](#724--the-mouse-in-classic-osc-modality) | Mouse play/pause broken | **regression** | neutralize **[iw]** |
 | [725](#725--keepaspect-window) | Keep window aspect ratio | enhancement | **won't fix** **[iw]** |
 | [726](#726--window-drag-with-left-click-pause-on) | Drag keybind not swapped | bug | **won't fix (JF UI)** [iw] |
@@ -84,7 +84,7 @@ Status is kept current; a done row names the commit.
 | 7 | [Cross-cutting A](#cross-cutting-a--one-suspended-state-for-classic-osc-modality) (#724, #726) | tests + `tools/probe_classic_osc_mouse.py` | **done** `a7324740` — the repro DID exonerate our code; no production change |
 | 8 | [#727](#727--window-buttons-and-the-title-bar) | S ×2, `player_window.py`, `mpv_options.py`, `player.py` | **done** `73d1236d` |
 | 9 | [#717](#717--the-hud-enter-key-cannot-be-remapped) | S, `renderer.lua`, `gateway/hud.py`, `gamepad.py`, `player.py` | `renderer.lua` again — after 7 has settled it; and it is three input sources, not one |
-| 10 | [#723](#723--hud-scaling-with-window-size) | S, `hud.py` | the *fit* half landed with #721; what is left is the accessibility floor |
+| 10 | [#723](#723--hud-scaling-with-window-size) | S, `hud.py` | **done** — fit with #721, floor after it |
 | 11 | ~~[#725](#725--keepaspect-window)~~ | — | **dropped [iw]**; see the section |
 | 12 | [#719b](#719b--clickable-caption-runs-on-a-tile) | `strips.py`, `tile_renderer.py`, `metrics.py` | new capability, and 3 already makes the series reachable |
 
@@ -737,10 +737,59 @@ Two things the rewrite turned up that the breakpoints had hidden:
   and fixed by giving the box the width of `_clock(dur) / -_clock(dur)`, which
   also stops the bar shifting once a second.
 
-**Still open — the accessibility floor**, which is the `hud_auto_scale` checkbox
-above and the only part of #723 not yet built. The fit composes with it: a lower
-floor means the controls shrink further before anything is shed, and `_shed`
-needs no change to benefit.
+### DONE: the accessibility floor
+
+`hud_auto_scale`, default on, in the Player Controls group and in `HUD_ONLY`
+(it is inert under a classic OSC). Off is `LEGACY_SCALE_FLOOR = 0.72`, the
+literal number the bar shipped with; on is `MIN_TARGET_PX / trigger_box(HUD_ICON)`
+= 24/47 ≈ **0.51**, asked of `widgets.trigger_box` rather than copying the
+ratio, so changing `HUD_ICON` moves the floor instead of breaking a test.
+
+**The `ui_scale` divisor in the formula above is wrong, and this is the
+correction.** [iw] chose the logical-unit spelling once the two readings were
+laid out. `ui_scale` is either mpv's `display-hidpi-scale` (the default) or a
+number the user forced, and dividing by it fails in both:
+
+- **HiDPI.** Logical px are *already* density-independent — that is what
+  `ui_scale` is for — so a 47-logical-px box is ~47 CSS px of apparent size at
+  any DPI. Dividing would let the bar shrink to a quarter size with ~12 CSS px
+  targets: below the AA minimum the constant exists to enforce, on exactly the
+  kind of machine #721 was reported from ("UI scale: 2x" in the reporter's log).
+- **A forced value.** `docs/configuration.md`'s own example for setting it is
+  "to make the UI readable on a TV across the room". Someone who asks for
+  bigger is stating an accessibility need, and shrinking back to a 24px target
+  undoes precisely that.
+
+Expressed in logical units the physical target comes out right on every
+display, which is the DPI-dependence that was actually wanted. Pinned by a test
+that sweeps `ui_scale` 1.0–3.5 and asserts the floor does not move.
+
+**What the lower floor exposed: the bar's width is a staircase, and controls
+blinked.** Every control sizes from one `sz(HUD_ICON)`, so all thirteen round
+down together — crossing scale 0.75 takes ~16px off the row in a single 10px
+step of window width, while the room for it falls smoothly. Slack sawtooths,
+and a control sitting near zero is shed at 680, back at 670, shed again at 630.
+Measured on a 2px sweep of 511 widths, and present with the setting *off* too:
+it is a property of the measured fit, not of the new floor.
+
+`build_hud` snaps the shed decision to the bottom of the glyph step, which
+halves it (6 widths → 3). It cannot remove it — the clock and the "Ends at"
+label step on *font* metrics, whose period is different again — and removing
+the rest means measuring the row twice per repaint, the controls at the largest
+size in a width bucket against the room at the smallest. That is a full extra
+widget build per repaint to close a 2px window in a drag gesture, so it is
+**recorded as a bound** (`MAX_NON_MONOTONE = 3`) rather than paid for. Same
+class of bug and same conclusion as `music.py`'s `NP_TITLE_W`, which removed a
+title-width ladder for producing "three widths where controls popped in as you
+dragged the edge inwards".
+
+The snap has one trap worth keeping: **it is only valid where the glyph moves
+with the window.** Above 900px the glyph is pinned at full size and below the
+floor it has stopped shrinking; in both the row is constant while the room
+grows, so those are already monotone, and snapping there reported a 1920px
+window as having 885 and shed controls with half the bar empty. Caught by
+"nothing is given up that did not need to be" — the width sweep did not see it,
+because shedding the same wrong set at every wide width is perfectly monotone.
 
 **Refuted, and kept because it is the natural idea.** Three spellings were
 proposed for rescaling the breakpoints, and all three are wrong:

--- a/docs/ISSUES_2026-09.md
+++ b/docs/ISSUES_2026-09.md
@@ -1125,6 +1125,60 @@ measured what recording the bake-time extent actually costs on a full row.
 
 ---
 
+## The classic OSC fork, and why it mostly stopped being needed
+
+`trickplay-osc.lua` is a fork of mpv 0.38's `osc.lua` -- 3,000 lines carried
+in-tree. Its own header says why: *"Sadly there is no way to do this without
+forking the entire OSC script."* Its entire patch set is six thumbfast blocks
+and one compatibility fix, all marked `-- BEGIN patch`.
+
+**mpv 0.41 made that untrue.** The OSC Preview API (`DOCS/man/osc.rst`) has
+the OSC publish `user-data/osc/draw-preview` -- `{x, y, w, h, hover-sec,
+ass}` -- for any thumbnailer script to draw into, and nil to clear. That is
+precisely the hook the fork exists to work around.
+
+Measured before acting, against a real mpv:
+
+* the fork is **stale, not broken**: it loads clean on 0.41+/master, its
+  `input` section activates and deactivates correctly with OSC visibility,
+  and its play/pause button works. Upstream rewrote osc.lua substantially
+  for 0.41 (3,052 changed lines, a configurable per-button command system,
+  `select/` integration) and we have none of it;
+* `load-script @osc.lua` loads mpv's **builtin** OSC at runtime even when
+  constructed with `osc=no` -- `@osc.lua` is mpv's own internal name
+  (`player/scripting.c`);
+* hovering the stock OSC's seekbar sets `draw-preview` to
+  `{x:147, y:350, w:120, h:90, hover-sec:12.15, ass:'…'}`;
+* end to end, with `thumbfast.lua` observing that property: hovering emits
+  `shim-trickplay-need 12.15` and `shim-trickplay-need 46.33` -- the right
+  timestamps, through the handler the fork's client-message already used.
+
+**Verdict [iw]: Preview API where it exists, keep the fork below it** --
+"Debian & others still ship MPV v40 as a default". So the choice moved to
+`PlayerManager._load_classic_osc`, after construction, because it depends on
+the version of the mpv being built and **the libmpv client API cannot stand
+in: 0.40 and 0.41 both report 2.5**.
+
+Consequences worth knowing:
+
+* the fork is now dead code on any modern desktop, which means it is the
+  copy that will rot unseen. That is the argument for eventually dropping it
+  rather than keeping it indefinitely -- when 0.40 is no longer worth
+  supporting, `_load_classic_osc` loses a branch and 3,000 lines go with it;
+* `@osc.lua` is mpv's internal spelling, not documented API, so a refusal
+  falls back to the fork rather than leaving an OSC style with no OSC;
+* the `ass` border the Preview API offers is deliberately not drawn: it is
+  sized to the OSC's box and our frame has its own size, so drawing it would
+  put a rectangle around something the wrong size.
+
+**Still open:** whether to re-fork onto master's osc.lua for the 0.40 path,
+or leave that path on the 0.38 fork it has always used. Leaving it is the
+current state and costs nothing while it works; re-forking would give 0.40
+users upstream's newer OSC but is the larger and riskier change, and its
+value shrinks every time a distro moves to 0.41.
+
+---
+
 ## Not in scope, recorded so it is not re-derived
 
 - **`docs/do-not-fix.md` entries** to add once the above lands: #726's unbound

--- a/docs/ISSUES_2026-09.md
+++ b/docs/ISSUES_2026-09.md
@@ -1,0 +1,900 @@
+# Issues #717–#727 — triage and plan of record (2026-09)
+
+Eleven issues opened 2026-09-03 → 2026-09-05, ten of them from `Asinin3`
+smoke-testing 3.0.0pre14 on Windows 11 23H2 against Jellyfin 12.0.0 RC7.
+Investigated against the tree at `1f0aa4f4` (branch `release-review`).
+
+This file is the plan of record: the diagnosis, the verdict taken on each, and
+the shape of the fix. Decisions marked **[iw]** came from Izzie on review of
+the investigation; everything else is the investigation's own conclusion. A
+section that says "open" names a decision nobody has made yet — it is not a
+thing to guess at while implementing.
+
+The filename carries a `YYYY-MM` date, which is what keeps it out of
+`tests/test_doc_symbols.py` (`PLAN_DOCS`). That matters here: this document
+names config keys and functions that **do not exist yet**, which is exactly
+what a planning document is for.
+
+| # | Title | Kind | Verdict |
+|---|---|---|---|
+| [717](#717--the-hud-enter-key-cannot-be-remapped) | `kb menu ok` can't be remapped | bug (design gap) | new setting **[iw]** |
+| [718](#718--cli---minimized-must-not-become-a-saved-setting) | Launch minimized without the setting | closed → follow-up | fix persistence **[iw]** |
+| [719a](#719a--go-to-series-from-any-episode-tile) | Go to Series from a tile | enhancement | context menu **[iw]** |
+| [719b](#719b--clickable-caption-runs-on-a-tile) | Clickable series name on a tile | enhancement | **deferred, last** |
+| [720](#720--play-on-a-season-navigates-instead-of-playing) | Play on a season opens it | bug | match web **[iw]** |
+| [721](#721--three-hud-glyphs-ignore-ui_scale) | HUD icons don't scale | **regression** | fix `isz` scaling |
+| [722](#722--only-home-re-reads-user-data) | Watched status stale | bug | collapse two refreshers |
+| [723](#723--hud-scaling-with-window-size) | Scale HUD with window | enhancement | new setting **[iw]** |
+| [724](#724--the-mouse-in-classic-osc-modality) | Mouse play/pause broken | **regression** | neutralize **[iw]** |
+| [725](#725--keepaspect-window) | Keep window aspect ratio | enhancement | opt-in + matrix **[iw]** |
+| [726](#726--window-drag-with-left-click-pause-on) | Drag keybind not swapped | bug | **won't fix (JF UI)** [iw] |
+| [727](#727--window-buttons-and-the-title-bar) | Window buttons in title bar | bug + enhancement | two settings **[iw]** |
+
+Two repairs span several issues and are written once, at the bottom:
+[the classic-OSC mouse handover](#cross-cutting-a--one-suspended-state-for-classic-osc-modality)
+(#724, #726) and [CLI overrides must not persist](#cross-cutting-b--cli-overrides-must-not-reach-savedict)
+(#718).
+
+## Proposed work order
+
+Grouped by what they touch, not by issue number, so that two items in the same
+file are not written twice against each other. Ordering rationale, and the one
+place it matters: **#721 lands before #723**, because #723 changes how the HUD's
+scale is computed and #721 changes what that scale is applied to — doing them in
+the other order means writing #723's floor arithmetic against a glyph size that
+is about to start scaling.
+
+| Order | Item | Touches | Why here |
+|---|---|---|---|
+| 1 | [#721](#721--three-hud-glyphs-ignore-ui_scale) | `mpvtk/scaling.py`, `mpvtk/layout.py` | one table entry, no dependants, unblocks #723 |
+| 2 | [Cross-cutting B](#cross-cutting-b--cli-overrides-must-not-reach-savedict) (#718) | `mpv_shim.py`, `settings_base.py` | self-contained; every later setting inherits the rule |
+| 3 | [#720](#720--play-on-a-season-navigates-instead-of-playing) | `tiles.py`, `repository.py` | self-contained; touches the same file as 4 |
+| 4 | [#719a](#719a--go-to-series-from-any-episode-tile) | `tiles.py` | same file and same method family as 3 |
+| 5 | [#722](#722--only-home-re-reads-user-data) | `app.py`, `ui.py`, `pagination.py` | independent of everything above; collapses two refreshers into one, so size it as a refactor |
+| 6 | [Cross-cutting A](#cross-cutting-a--one-suspended-state-for-classic-osc-modality) (#724, #726) | `renderer.lua`, `app.py` | starts with a repro, so it can run while others land |
+| 7 | [#727](#727--window-buttons-and-the-title-bar) | `conf.py`, `player_window.py`, `mpv_options.py` | two settings; touches the window code #725 will |
+| 8 | [#717](#717--the-hud-enter-key-cannot-be-remapped) | `conf.py`, `renderer.lua`, `gateway/hud.py` | `renderer.lua` again — after 6 has settled it |
+| 9 | [#723](#723--hud-scaling-with-window-size) | `conf.py`, `hud.py` | needs #721's scaling to be correct first |
+| 10 | [#725](#725--keepaspect-window) | `player.py`, `player_window.py`, integration matrix | the test matrix is the bulk of it; after 7 |
+| 11 | [#719b](#719b--clickable-caption-runs-on-a-tile) | `strips.py`, `tile_renderer.py`, `metrics.py` | new capability, and 719a already makes the series reachable |
+
+Three items collide on a file and are deliberately separated in time:
+`renderer.lua` (6 then 8), `tiles.py` (3 then 4), and the window code (7 then
+10). Nothing else overlaps.
+
+---
+
+## #717 — the HUD ENTER key cannot be remapped
+
+**Symptom.** `kb_menu_ok` is set to something other than `enter`; ENTER keeps
+working and the new key does nothing.
+
+**Root cause — two different ENTERs, and the setting is attached to the wrong
+one.** `kb_menu_ok` reaches only the legacy OSD menu: `player.py:1221` binds it,
+and `_on_menu_ok` (`player.py:1425`) returns immediately unless
+`self.menu.is_menu_shown`. The ENTER the reporter is actually pressing belongs
+to the browser and the playback HUD, where `NAV_KEYS` in
+`jellyfin_mpv_shim/mpvtk/renderer.lua` **hardcodes** `'ENTER' → nav_activate`
+under `add_forced_key_binding`. Nothing reads a setting on that path.
+
+For completeness, the third ENTER: `hud_wake_key` (`conf.py:671`, labelled
+"Player Controls Activation Key") *is* remappable, and covers **summoning** a
+hidden HUD. It does not cover activating the focused control once the HUD or
+the browser is on screen.
+
+`claim_menu_keys._MENU_KEYS` (`player.py:1777`) carries left/right/up/down and
+not ok/esc, which is consistent with the reporter's "the other keys can be
+remapped properly".
+
+**Verdict [iw].** Add a setting for remapping the ENTER shortcut in the HUD.
+
+**Shape.** A new key setting — working name `kb_ui_select`, default `"ENTER"` —
+read by the same path that already carries `hud_wake_key` to the renderer
+(`mpvtk_browser/gateway/hud.py:37`, the `mpvtk-hud` opts blob), and applied to
+the `ENTER` entry of `NAV_KEYS`. Notes on doing it:
+
+- `NAV_KEYS` is a module-level table consumed by `bind_nav_keys` and by
+  `keyclaim.nav_names`. A configurable key means the table can no longer be
+  built once at load; the name has to be resolved when the bindings are
+  installed, and `keyclaim.nav_names` rebuilt with it. The comment above
+  `keyclaim.nav_names` is explicit that a claimed key outside that set needs
+  its own binding *and* its own removal — that invariant has to survive.
+- The opts blob only reaches the renderer on `mpvtk-hud` engage. Browse-mode
+  nav keys are installed by `mpvtk-active`, which carries no opts today. Either
+  push the key on both messages or move it to a `user-data` property the
+  renderer reads.
+- `_open_hud_menu`/`phud_summon_enter` special-case `ENTER` by literal string
+  in several places (`renderer.lua:2837`, `:5751`, `:5822`, `:5836`,
+  `:6234`). Those compare against `phud_wake_key()`, not against the select
+  key, but they are the places a second configurable ENTER will collide
+  with the first.
+
+**Open.** Whether the setting also governs the OSD menu's OK (i.e. whether
+`kb_menu_ok` is deprecated into it) or stays independent. Independent is the
+smaller change and keeps `kb_menu_ok` meaning what it has always meant.
+
+---
+
+## #718 — CLI `--minimized` must not become a saved setting
+
+Closed as answered (there is a settings option and a `--minimized` CLI option).
+Two follow-ups came out of that answer.
+
+**Follow-up 1 — the CLI flag persists.** `mpv_shim.py:139-140` assigns
+`settings.start_minimized = args.start_minimized`, and `Settings.save()`
+(`conf.py:891`) serialises `self.dict()`, which `settings_base.dict()` builds
+from **every** field. So one run with `--minimized` plus any later save writes
+`start_minimized: true` into `conf.json` permanently. Saves are not rare —
+`player_window.py:336` and `:368` (window geometry, i.e. `remember_window_size`
+is on by default), `player_audio.py:417`, `video_profile.py:90` and `:709`,
+`osc_bridge.py:434`, `conf.py:848` and `:884`, plus every settings-screen edit.
+
+This is one rule with four sites and **one of them already fixed in isolation**:
+`args.ui_scale` carries an explicit "in-memory only: `settings.save()` elsewhere
+would otherwise persist a scale the user asked for on ONE run" comment
+(`mpv_shim.py:143-147`). `enable_gui`, `start_minimized` and `mpv_loglevel` have
+the same shape and no such guard. See
+[cross-cutting B](#cross-cutting-b--cli-overrides-must-not-reach-savedict) for
+the repair — it is one mechanism, not four comments.
+
+**Follow-up 2 — a second launch must surface the window.** The handoff exists
+and looks right: `SingleInstance.acquire()` fails over to
+`_handoff_to_existing()`, the listener maps `SHOW` to `on_activate`
+(`single_instance.py:234`), and `mpv_shim.py:326` wires that to
+`mpvtk_browser/ui.py:activate()` → `maybe_relock()` → `enter_browse()` →
+`playerManager.raise_window()`.
+
+What is **not** covered by a test is the interaction with minimization.
+`MpvtkBrowser.minimize()` releases the window entirely (drops `force_window`);
+`enter_browse()` has to raise one from nothing. `tests/integration/
+test_single_instance_multiproc.py` and `test_startup_window.py` exist and are
+the right homes. What to pin:
+
+1. started with `start_minimized` in the config → second launch shows a window;
+2. started with `--minimized` and the config setting **off** → second launch
+   shows a window, and `conf.json` still says `start_minimized: false`
+   afterwards, *including after a save has been provoked* (resize the window,
+   or write any setting);
+3. started normally, minimized to tray by the user → second launch shows it;
+4. the PIN re-gate in `activate()` still fires on each of those.
+
+Item 2 is the regression test for follow-up 1 and must be written **from the
+issue's words before the fix exists**, then watched to fail.
+
+---
+
+## #719a — Go to Series from any episode tile
+
+**Symptom.** jellyfin-web's Next Up / Continue Watching card has three hit
+regions: the play chip plays, the image opens the item, the series title opens
+the series. Ours has the first two, so correcting a Next Up entry that is on the
+wrong episode costs extra clicks.
+
+**Current state.** An Episode tile routes to `kind="detail"`
+(`mpvtk_browser/app.py:1965`), and `Tiles._tile_menu_entries` offers no series
+entry. "Go to Series" already exists one click deeper, on the episode detail
+page (`mpvtk_browser/pages/detail.py:161-167`).
+
+**Verdict [iw].** If we are rendering the series name on the tile, clicking it
+should show the series. If not, just add a context-menu option. **Do the context
+menu first**, and carry the clickable caption as its own item at the end of the
+plan ([#719b](#719b--clickable-caption-runs-on-a-tile)).
+
+**Shape.** A "Go to Series" entry in `Tiles._tile_menu_entries` for any item
+carrying a `SeriesId`, navigating to the route `pages/detail.py:163-167` already
+builds:
+
+```python
+{"kind": "series", "server": server,
+ "item_id": item["SeriesId"], "title": item.get("SeriesName", "")}
+```
+
+Roughly ten lines plus the dispatch entry. Points to get right:
+
+- **Gate on `SeriesId`, not on `Type == "Episode"`.** A Season also carries one,
+  and "go up to the show" is just as wanted from a season tile. The detail page
+  gates on Episode because that is the only type that page renders; the tile menu
+  sees everything.
+- It belongs to no existing `MENU_*` set — those are keyed by type and this is
+  keyed by a field being present — so it is a separate `if` in
+  `_tile_menu_entries`, placed with the other navigation-ish entries rather than
+  among the destructive ones.
+- The verb must match the detail page's exactly (`_("Go to Series")`, icon
+  `"movie"`) or gettext gets a second key for the same string.
+
+**Why this is the better half of the two.** It applies to *every* episode and
+season tile everywhere — search results, a genre grid, a favourites row — not
+just the two home rows that have a caption with a series name in it.
+
+**Test.** A scene-level test that the entry appears for an item with `SeriesId`
+and is absent without one, plus an assertion that pressing it navigates. Per
+`CLAUDE.md`, a handler that changes state owes an `invalidate` assertion — but
+this one navigates, so the assertion is on the route, and a stray `build_scene`
+between the click and the check would hide nothing here.
+
+---
+
+## #720 — Play on a season navigates instead of playing
+
+**Symptom.** The hover play chip on a season tile opens the season.
+
+**Root cause.** `Tiles._resolve_play_ids` sends the **season** id to
+`get_series_queue` (`mpvtk_browser/tiles.py:615`), which calls
+`api.get_episodes(series_id, …)` → `Shows/{id}/Episodes`
+(`mpvtk_browser/repository.py:2485-2493`). A season id on that route is not a
+series, so the result is empty, and `_menu_play`'s `done([])` falls through to
+`self._open_item(item)` (`tiles.py:660`) — literally "navigate instead". Season
+is in `MENU_PLAYABLE` (`tiles.py:92-94`), so the chip is correctly offered; only
+the resolve is wrong.
+
+**Verdict [iw].** Match jellyfin-web semantics.
+
+**Web's exact semantics**, from
+`jellyfin-web/src/components/playback/playbackmanager.js:1986-2040`
+(`getSeriesOrSeasonPlaybackPromise`), for a season card (`items.length === 1`,
+so `seasonId` is set):
+
+- `SeriesId = firstItem.SeriesId`;
+- **the Next Up lookup is skipped** — it is guarded by `!seasonId`, so a season
+  play does *not* start from the series' next-up episode;
+- `getEpisodes(SeriesId, { SeasonId, IsVirtualUnaired: false, IsMissing: false,
+  UserId, Fields: ['Chapters','Trickplay'] })` — the whole season, no limit;
+- then it scans the returned items and sets `StartIndex` to the **first episode
+  with `!UserData.Played`**, falling back to 0.
+
+So: *queue the whole season in order, start at the first unplayed episode.* Not
+Next Up, and not a resume position.
+
+**Shape.**
+
+- `Repository.get_episodes(server_uuid, series_id, season_id)`
+  (`repository.py:2476`) already exists and is the right call. It goes through
+  `api.get_season`, which sends only `UserId` + `SeasonId`; web also sends
+  `IsVirtualUnaired=false` and `IsMissing=false`, and without those a season
+  with missing or unaired episodes queues placeholders. Switch it to
+  `api.get_episodes(series_id, season_id=…, fields=LIST_FIELDS)` and add the two
+  filters.
+- `_resolve_play_ids` currently returns ids only, and `_menu_play`'s `done`
+  hardcodes `self._play_list(ids, server, 0, …)`. The start index needs the
+  DTOs, so the Season path has to return `(ids, start_index, items)` — or gain a
+  season-specific sibling. `ItemActions.play_list(ids, server, start_index=0,
+  audio=False, items=None, …)` (`item_actions.py:171`) already takes both, and
+  its `items` argument is what supplies the resume offset for the entry actually
+  started, so passing the DTOs is wanted anyway.
+- Do **not** copy web's `StartIndex || seasonStartIndex || 0` chain — index 0 is
+  falsy there, so a season whose first episode is unplayed falls through the
+  `||` and lands on 0 by coincidence rather than by decision. Write the intent.
+- Verify `UserData` comes back on that route (it is a `UserId`-scoped route, so
+  it should) — the start index is unreachable without it, and a fake that omits
+  `UserData.Played` would make the whole feature untestable while reporting a
+  pass.
+
+**Also check the offline source.** `repository.py:3404` has a second
+`get_episodes` for the offline catalog with synthetic `p<ParentIndexNumber>`
+season ids. Whatever shape the Season path takes has to work there or decline
+cleanly.
+
+---
+
+## #721 — three HUD glyphs ignore `ui_scale`
+
+**Symptom (regression).** Chapters, Subtitles and Video Quality draw a
+fixed-size glyph in a hit box that grows with the interface scale. Favourites
+and the transport buttons scale correctly. Reported against pre14; present from
+pre12.
+
+**Root cause — measured, not inferred.** `Dropdown(trigger_icon=…,
+icon_size=…)` emits its glyph size as `node["isz"]`
+(`mpvtk/layout.py:889-893`), and **`isz` is in none of `scaling.py`'s tables**
+(`_PX_KEYS` at `mpvtk/scaling.py:74`, `_EXACT_KEYS` at `:81`), so `scale_scene`
+never converts it from logical to physical pixels. The trigger's box (`w`/`h`)
+*is* scaled. The renderer's fallback when `isz` is absent —
+`math.floor(node.size * 1.2)` (`renderer.lua:1429`) — reads `size`, which *is*
+scaled, which is why every other dropdown is fine.
+
+Measured on this tree (`ui_scale` set via `scaling.set_scale`, then
+`scale_scene`):
+
+| `ui_scale` | dropdown box `w` | dropdown glyph `isz` | `Button` icon `w` |
+|---|---|---|---|
+| 1.0 | 47 | 30 | 30 |
+| 2.0 | 94 | **30** | 60 |
+| 3.5 | 165 | **30** | 105 |
+
+The reporter's log says `mpvtk: UI scale: 2x`.
+
+Introduced by `6766a2f0` ("Say which tier a size is, not how many pixels"),
+which gave the pickers a real `icon_size` to fix a *type-scale* mismatch and in
+doing so moved them onto an unscaled key. The Audio Track picker has the same
+defect; the reporter simply had one audio track.
+
+**Why the test did not catch it.** `tests/test_hud_icon_sizes.py` exercises
+`tk.set_type_scale` and the user text multiplier and asserts `isz == 30` in both
+— which is correct and is the thing that file is named after — but it never
+touches `scaling.set_scale`, and it reads `layout()` output *before*
+`scale_scene` runs. It is a test that cannot fail for this.
+
+**Verdict.** Add `"isz"` to `_PX_KEYS`. This removes an exception rather than
+adding a guard: the key joins the table that already governs every other
+pixel-geometry field.
+
+**Tests.** Extend `test_hud_icon_sizes.py` with a `ui_scale` case that runs the
+scene through `scale_scene` and asserts the glyph tracks the box and the
+`Button` icon at 1.0 / 2.0 / 3.5 — the existing
+`test_it_matches_a_button_icon_at_every_setting` is the right assertion, one
+axis over. `tests/test_ui_scale.py` is where the `_PX_KEYS` table itself is
+pinned; the new key belongs in whatever enumeration lives there too.
+
+**While in there:** the `_PX_KEYS` comment says the tables were "audited against
+layout.py's emission and renderer.lua's reads". That audit missed `isz`, so it
+is worth re-running rather than trusting — every key `layout.py` emits that
+`renderer.lua` uses as a pixel length must be in exactly one of the tables. A
+lint over `node["…"] =` assignments against the three tables would make this
+enforceable instead of advisory.
+
+---
+
+## #722 — only Home re-reads user data
+
+**Symptom.** A series page shows "3 episodes remaining" for a season that is
+fully watched. Opening the season shows every episode ticked. Restarting the app
+fixes it, and it comes back.
+
+**Root cause.** `MpvtkBrowser.refresh_home()` returns immediately unless
+`self.route.get("kind") == "home"` (`mpvtk_browser/app.py:609`). Both callers
+that exist for this go through it: the `UserDataChanged` websocket event
+(`mpvtk_browser/ui.py:120-129`) and the return from playback (`enter_browse` →
+`refresh_home(now=True)`, `app.py:2273`). **No other route is ever re-read.**
+
+A series route therefore keeps the season DTOs it loaded, and the badge is read
+straight off them — `badge=int(ud.get("UnplayedItemCount") or 0)`
+(`tile_renderer.py:1215`), with `UnplayedItemCount` a server-computed field on
+the *parent*. It is stale by construction after playing an episode. The season
+screen issues a fresh episode query, which is why the ticks inside are right.
+
+This is #560's fix applied to one side. The mechanism is correct; it was wired
+to Home because Home was the screen in the report.
+
+**Verdict.** Widen the refresh to the routes that show container user data.
+
+**But there are already TWO copies of this mechanism, and the second one is the
+generalized form.** `refresh_live_tv` (`app.py:551-579`) does the same job for
+Live TV and gates on `route.get("kind") not in LIVE_KINDS` — a **set** of route
+kinds (`app.py:128`), not a single string. So "widen `refresh_home`'s gate"
+would produce a *third* near-copy of a rule that is already written twice and
+already differs between the two writings:
+
+| | `refresh_home` | `refresh_live_tv` |
+|---|---|---|
+| gate | `kind != "home"` | `kind not in LIVE_KINDS` |
+| also requires | `self._browsing` | `self.source`, `self.server` |
+| debounce | `USERDATA_DEBOUNCE` + daemon slot | none (has a poller instead) |
+| re-entrancy marker | none | `route["_refreshing"]`, cleared at `app.py:1376` |
+| `now=` fast path | yes | no |
+
+Two of those differences are load-bearing and one looks like drift.
+`refresh_live_tv`'s `self.server is None` check carries a comment saying
+`_load_route` would not dispatch and nothing would clear the marker — that is
+about the marker, which `refresh_home` does not set. And the `_refreshing`
+marker is read by `pagination.py:150`, so a route being refreshed does not page
+in against a list about to be replaced. **`refresh_home` has no such marker**,
+which means a Home refresh *can* race pagination today; on Home that is nearly
+harmless because its rows are strips rather than a paged grid — but the moment
+the same function serves `grid`, it stops being harmless.
+
+**Shape — collapse to one, do not widen one.** A single
+`refresh_route(kinds, debounce=…, slot=…)` with the union of the constraints,
+and `refresh_home` / `refresh_live_tv` becoming two calls into it. That is the
+repair that removes an authority; adding a third gate adds one. It is also the
+pattern this tree has been applying elsewhere (`cb6708b8`, "Collapse the sync
+manager's duplicated rules into one site each").
+
+Constraints that must survive the collapse — each has a reason written at its
+site, and the `_refreshing` marker must be adopted by the Home path rather than
+dropped from the Live TV one:
+
+- the `USERDATA_DEBOUNCE` burst window, and one thread per slot via
+  `_start_daemon` (`app.py:2406`);
+- **deferred, never forced,** while a menu or dialog is up;
+- skipped while `route["_loading"]` **or** `route["_refreshing"]`;
+- `route["_refreshing"] = True` on entry, cleared by `_route_async`
+  (`app.py:1376`) however the load ends — this is what `pagination.py:150`
+  reads;
+- a **load, not a reload** — no `_bump_epoch()` (see the note at `app.py:1306`),
+  so scroll position and in-flight artwork survive;
+- reached from the websocket thread, so it must be safe off the loop thread.
+
+**Which kinds.** `home` and `LIVE_KINDS` are the existing two sets. The ones
+this issue adds are `series` and `season`; `grid`, `favorites` and `detail` are
+candidates and each needs the pagination question answered before it is added,
+because that is where the missing marker starts to matter.
+
+**Do not** reach for a per-item optimistic patch of the parent's
+`UnplayedItemCount` on the client. `ItemActions.toggle_watched`
+(`item_actions.py:285-290`) already does that for a *deliberate* mark, and
+extending it to playback would make the client a second authority on a
+server-computed aggregate. Two authorities diverge; a re-read does not.
+
+**Server facts that bound what is possible** (`docs/jellyfin-api-notes.md`, and
+measured previously): progress reports announce nothing over the websocket, so
+the only events are a start, a stop, and manual marks. The stop is the one that
+matters here and it does arrive — so a route refresh is sufficient, and no
+polling is needed.
+
+**Tests.** The rule from `CLAUDE.md` applies directly: assert the property over
+several steps. Fire the event ≥3 times against a series route and assert the
+loader ran each time *and* the scroll offset did not walk — a one-step test
+cannot see the epoch/scroll interaction that `refresh_home`'s comments are
+about.
+
+---
+
+## #723 — HUD scaling with window size
+
+**Symptom.** Narrowing the window drops buttons out of the Jellyfin controls
+rather than shrinking them; the mpv OSC shrinks.
+
+**Current state — it already scales, but barely.** `mpvtk_browser/hud.py:765`:
+
+```python
+scale = min(1.0, max(0.72, w / 900.0))
+```
+
+so the floor is 72% and the ceiling is 100%, and below ~650px the width tiers
+(`hud.py:786-796`) start removing controls: `quality`, `favorite`, `ch_btns`,
+`chapters`, `volbar`, `ends_at`, `seek_btns`, `clock`.
+
+**Verdict [iw].** Add a checkbox to settings, default enabled, to implement HUD
+auto-scaling within reason.
+
+**Shape.** New `hud_auto_scale: bool = True` in `conf.py`, in the
+`Player Controls` group of `config.py:SECTIONS["playback"]` beside the other
+`hud_*` keys. It applies live (the HUD is rebuilt every repaint from
+`settings`), so it does **not** belong in `RESTART_REQUIRED` — see
+`docs/settings-curation.md`.
+
+**Off means today's behaviour [iw]** — the `max(0.72, …)` floor exactly as it
+stands. Not "fixed at 1.0": off is the compatibility setting, and anyone who
+turns it off is asking for what pre14 did, not for a third behaviour nobody has
+seen. That also makes the checkbox cheap to get right, because off is the
+existing code path unchanged.
+
+**On: the floor is an accessibility target size, in *physical* pixels, so it
+depends on the user's DPI [iw].** This is the part that makes the feature
+correct rather than just smaller. A fraction cannot be the floor, because the
+thing that must not get too small is the *hit target*, and how many real pixels
+a logical unit buys depends on `ui_scale`.
+
+The arithmetic, from the current sizes:
+
+- `HUD_ICON = 30` logical px (`hud.py:123`);
+- a picker's trigger box is `int(glyph / 1.2 * 1.9)` = **47** logical px
+  (`mpvtk/widgets.py:902-905`);
+- a transport button is the glyph plus `Button`'s default `pad=10` either side
+  = **50** logical px;
+- so the smallest interactive box on the bar is 47 logical px, and its physical
+  size is `47 × scale × ui_scale`.
+
+`ui_scale` is resolved once on ready (`mpvtk/app.py:528-546`, from
+`settings.ui_scale` or mpv's `display-hidpi-scale`) and is readable from
+`hud.py` as `scaling.scale()` — same process, no plumbing needed. So:
+
+```
+floor = MIN_TARGET_PX / (SMALLEST_BOX * scaling.scale())
+scale = min(1.0, max(floor, w / 900.0))       # clamped to <= 1.0
+```
+
+**The published metrics, and what each one produces at 47 logical px:**
+
+| Metric | Target | floor @ `ui_scale` 1.0 | floor @ 2.0 |
+|---|---|---|---|
+| WCAG 2.2 SC 2.5.8 (AA) | 24×24 CSS px | 0.51 | 0.26 |
+| WCAG 2.2 SC 2.5.5 (AAA) | 44×44 CSS px | 0.94 | 0.47 |
+| Apple HIG | 44×44 pt | 0.94 | 0.47 |
+| Material Design | 48×48 dp | 1.02 → no shrink at all | 0.51 |
+
+Read that table before picking: **at `ui_scale` 1.0 the 44/48 targets are
+effectively a refusal to scale** (floor ≈ 0.94–1.02, against today's 0.72), so
+adopting one of them makes the feature do nothing on exactly the 1x displays
+where the reporter hit the problem. WCAG AA's 24 px is the one that permits real
+shrinking at 1x while still being a published floor, and on a HiDPI display it
+lets the bar shrink much further, which is correct — the controls are physically
+larger there to begin with.
+
+That is the recommendation: **`MIN_TARGET_PX = 24`, with a hard fraction floor
+under it** (0.5 or so) so that a very large `ui_scale` cannot shrink the bar into
+illegibility for reasons that have nothing to do with hit targets — a target big
+enough to click is not the same claim as a glyph big enough to read, and only the
+first is what the metric governs.
+
+**Open — the tiers.** `tiers` (`hud.py:786-796`) is a set of absolute pixel
+breakpoints (`w >= 500`, `w >= 560`, `w >= 700`, `w >= 760`, `w >= 1000`) tuned
+against the current 0.72 floor. With a lower floor the controls fit in less
+width, so the breakpoints should fall with the scale rather than firing at the
+same window width regardless — otherwise the bar shrinks and *still* drops the
+quality picker at 560px. Whether that means dividing each breakpoint by the
+scale, or re-tuning them, is the decision. This is the part that will bite: the
+tiers and the scale currently answer to the same `w` and are tuned against each
+other.
+
+---
+
+## #724 — the mouse in classic-OSC modality
+
+**Issue 2** (jellyfin controls; pause stops responding after the controls
+auto-hide until the pointer moves) is the #700 hover strand, fixed by
+`2035d720`, which landed **after** pre14 was cut. The reporter confirms it is
+fixed on dev. Nothing to do; it ships in pre15.
+
+**Issue 1** (mpv built-in controls; neither button pauses) — mechanism
+confirmed against mpv's source, trigger not reproduced here.
+
+**Mechanism.** The `mpvtk_mouse` forced section claims `mbtn_left`,
+`mbtn_left_dbl` and `mbtn_right` (`renderer.lua:4808-4818`). It sets **no**
+mouse area, and mpv's `get_bind_section` gives an unset section
+`{INT_MIN…INT_MAX}` with `mouse_area_set = true` (mpv `input/input.c:414-416`)
+— the whole screen. In `get_cmd_from_keys` (`input/input.c:484-497`) mpv walks
+the active sections newest-first and takes the first binding whose section's
+mouse area contains the pointer, preferring non-builtin over builtin. So while
+that section is enabled it beats the builtin `MBTN_RIGHT cycle pause` in
+`default`, everywhere in the window. (`mouse_hover` plays no part in button
+dispatch — it only ever gates section *selection* on move and VO dragging — so
+this shares no cause with issue 2.)
+
+And in classic-OSC modality both of the renderer's bare-video fall-throughs are
+gated on `state.phud.mode`, which is never true there:
+`on_mouse_down`'s bare-video branch (`renderer.lua:3517`) and `on_rclick`
+(`renderer.lua:3980`). So the claimed buttons do nothing at all.
+
+**The OSC is not the cause.** `trickplay-osc.lua` is a near-verbatim fork of
+mpv 0.38's `osc.lua` — 637 diff lines against `src/v0.38/player/lua/osc.lua`,
+and the only mouse-binding difference is a *removal*, the
+`window-controls-title` drag section. Its `input` section handling is stock, so
+right-click pauses there exactly as in plain mpv.
+
+**What is not established** is what leaves `mpvtk_mouse` enabled during
+classic-OSC playback. On paper the suspend path is correct:
+`LoadFeedback.clear()` → `_hand_off` → `MpvtkBrowser._yield()` →
+`hud.available()` is False → `_set_renderer_active(False)` → `mpvtk-active no`
+→ `ui_suspend()`. Worth noting while looking: `app.py:2371`'s
+`if self._browsing: self._yield()` is **dead for video**, because `_start`
+(`app.py:2156-2157`) already cleared `_browsing` to draw the spinner. The real
+handoff is `load.clear()`, so anything that skips `clear()` skips the suspend
+— and `clear()` returns early when `self.starting is None`.
+
+**Verdict [iw].** Neutralize all mouse bindings when using a third-party or
+classic OSC, except when the `c` menu is open. For the Jellyfin UI, make sure
+mouse behaviour matches expectations based on the settings — there is no
+intention of allowing mouse remapping in the JF UI beyond what is already
+offered.
+
+The `c`-menu exception **already works and needs nothing**: `mouse.lua` installs
+`MOUSE_BTN0` / `MOUSE_MOVE` / `MBTN_BACK` only on `shim-menu-enable True` and
+removes them on False, and it says so at the bottom of the file. It uses
+`add_key_binding` (non-forced), which is one more reason the neutralization
+matters — a live `mpvtk_mouse` currently outranks it.
+
+See [cross-cutting A](#cross-cutting-a--one-suspended-state-for-classic-osc-modality)
+for the repair.
+
+---
+
+## #725 — `keepaspect-window`
+
+**Request.** mpv's default `keepaspect-window=yes` snaps a window resize to the
+video's aspect; the shim turns it off, so resizing a *player* window leaves
+black bars unless you are pixel-perfect.
+
+**Current state.** `player.py:1139-1151` sets **both** `keepaspect_window` and
+`auto_window_resize` to `False`, once, at init, whenever `enable_gui` — with
+the reason written there: one window is shared by the browser and playback, the
+user sizes it to suit, and mpv must not resize it on their behalf. Neither is
+ever restored for playback. `mpvtk/app.py:37` sets the same in `_SPAWN_OPTS`
+for the standalone toolkit harness.
+
+Note this is a *different* property from `keepaspect`, which `player_window.py`
+already flips per mode (`set_browse_window` off, `browse_yield` on) and which
+`CLAUDE.md` warns about at length — the comic reader borrows it, and
+`reset_picture_view` putting it back mid-playback is what made every film play
+stretched.
+
+**Verdict [iw].** `keepaspect-window` causes a lot of misery and
+platform-specific behaviour. This one deserves a full integration test matrix
+and Windows tests. Default should be to suppress it; if the user wants it, they
+can enable it.
+
+**Shape.** New `keepaspect_window: bool = False` in `conf.py`. When on, the
+property follows the mode the way `keepaspect` does — off while the browser owns
+the window (there is no video, so there is no aspect to keep), on while a video
+is playing. `player_window.py` is where that handover lives.
+
+**Why this one is not a small change.** The property is honoured by the VO and
+the window manager together, so the failure modes are per-platform and are
+exactly the class this repo has been bitten by before:
+
+- the browse → video → browse handover runs through `run_action`, which defers
+  whenever the player lock is busy — and it is busy for the whole of a playback
+  start. That is the ordering that produced the stretched-film bug;
+  `tests/test_window_geometry.py:PictureViewHandoffTest` asserts both
+  interleavings for `keepaspect` and is the model for this;
+- a still / comic page / photo has an aspect of its own, and the reader borrows
+  the window;
+- fullscreen and maximize transitions;
+- Wayland CSD versus X11 versus Windows.
+
+**Test plan** (this is the deliverable, not an afterthought):
+
+- `tests/integration/` — a leg covering browse → video → browse and
+  video → reader → video on **both** backends, with the setting on and off, and
+  the two `run_action` interleavings. `test_window_decorations.py` and
+  `test_startup_window.py` are the neighbours; the legs are serial on purpose
+  (`docs/testing.md` §9) — do not parallelize them.
+- Windows VM run (`ssh ian@192.168.122.80`, console session 1 — DXGI refuses a
+  swapchain over ssh; see the memory note). Windows is where the aspect snap is
+  most visible and where the reporter is.
+- The mpv matrix (`~/Desktop/mpv-matrix`) for at least 0.38 / 0.40 / 0.41, since
+  window-geometry behaviour has moved between them.
+
+Do not land the setting without the matrix. The reason it is off today is that
+somebody already paid for it once.
+
+---
+
+## #726 — window drag with left-click-pause on
+
+**Symptom.** With "Left Click Pauses Playback" on, the window can only be
+dragged by its title bar; mpv's convention is that the button that does *not*
+pause is the one that drags.
+
+**Root cause.** The asymmetry is explicit in the code and there is no
+right-hand branch. `renderer.lua:3517-3533`: `click_pauses` → `pause_now()`,
+else → `begin-vo-dragging`. `on_rclick` (`renderer.lua:3971-3983`) only pauses
+in the *not* `click_pauses` case. So with the setting on, the right button means
+nothing, and `ui_resume` has already set `input-builtin-dragging=false`
+(`renderer.lua:5549-5551`), so mpv will not drag either. (mpv's built-in
+dragging is left-button only; there is no right-button drag to inherit.)
+
+Feasible, if it were wanted: pre14 gave `mbtn_right` a **down** callback
+(`renderer.lua:4816`), and `begin-vo-dragging` has to start on the press — so
+the branch has somewhere to live.
+
+**Verdict [iw]. Won't fix.** For the Jellyfin UI the decision is deliberate and
+stays as-is; there is no intention of allowing mouse remapping in the JF UI
+beyond what is already offered.
+
+**Action:** none in the JF UI. In classic-OSC modality the user gets mpv's own
+modality back in full, which is
+[cross-cutting A](#cross-cutting-a--one-suspended-state-for-classic-osc-modality).
+This belongs in `docs/do-not-fix.md` once that lands, so the next reviewer does
+not re-open it: *the right button is deliberately unbound while
+`mouse_click_pauses` is on.*
+
+---
+
+## #727 — window buttons and the title bar
+
+Three separate things in one report.
+
+**1. "Only when window has no title bar" shows nothing in fullscreen.**
+Working as designed: `WindowMixin.window_controls_wanted`
+(`player_window.py:763-779`) returns False on fullscreen *before* consulting
+the mode, with the reasoning written there — a fullscreen window has no title
+bar anywhere and nothing to minimize, maximize or drag. The label is what
+misleads.
+
+**2. mpv controls never show the window buttons, even on "always".** Two
+independent causes, either of which is sufficient:
+
+- the buttons are drawn by `window_chrome.window_controls()` inside the
+  **mpvtk** browser chrome (`window_chrome.py:334`) and the mpvtk HUD's top bar
+  (`hud.py:1000`). In classic-OSC modality neither is on screen during playback;
+- `trickplay-osc.lua` has its own, independent `windowcontrols` option
+  (`trickplay-osc.lua:90`), and `window_controls_enabled()` (`:474-478`) returns
+  `not state.border` under `auto` — so on a normal bordered Windows window the
+  OSC correctly suppresses its own. The shim's `window_controls` setting is
+  never pushed to it. The fork also *dropped* the stock OSC's
+  `window-controls-title` drag section.
+
+**3. No way to hide the system title bar.** Correct — there is no `border`
+config key anywhere; `conf.py:228-243` mentions `--border=no` only in prose,
+as something a user might have set themselves. Today the workaround is
+`border=no` in the user's own `mpv.conf`.
+
+**Verdict [iw].** Two things:
+
+- add a settings checkbox to hide the title bar from the system, default **off**;
+- add a checkbox to show window controls while fullscreen, default **off**;
+- push the window-controls option to other OSCs where possible.
+
+**Shape.**
+
+`hide_title_bar: bool = False` → mpv's `border`. It is a plain option, so it can
+be set at construction in `mpv_options.build_mpv_options` and also written live.
+Two consequences to handle deliberately:
+
+- it interacts with `window_controls: "auto"`, which asks mpv's `border`
+  property (`_read_decorations()`); turning the title bar off makes "auto"
+  start answering True, which is coherent and is the point;
+- `_on_border_change` (`player_window.py:800`) already observes the property, so
+  the browser's own chrome will follow — check it does rather than assuming.
+
+`window_controls_fullscreen: bool = False` → the early return in
+`window_controls_wanted`. Note the same function is the single source for both
+the browser chrome and the HUD top bar (`hud.py:998` says "nothing extra is
+needed for fullscreen — `window_controls_wanted()` …"), so this is one site.
+
+**And the refresh already fires on fullscreen**, which is the first thing worth
+checking before writing it: `player.py:1291` observes `fullscreen` (alongside
+`border` at `:1284` and `window-maximized` at `:1290`), all three routed through
+`_on_border_change` (`player_window.py:800`) → `on_decorations_changed` →
+`MpvtkBrowser.refresh_window_controls` (`app.py:2984`, wired at `ui.py:310`).
+So the snapshot is re-taken on the transition and no new trigger is needed —
+only the predicate changes.
+
+Pushing to other OSCs: `trickplay-osc.lua:101` reads its options with
+`opt.read_options(user_opts, "osc", …)` and has an `update_options` callback, so
+the lever is the `script-opts` property, key `osc-windowcontrols`
+(`yes`/`no`/`auto`). **Use `change-list script-opts append`, not a whole-property
+write** — `script-opts` is shared, and clobbering it would take the user's own
+script options with it, which is the same class of mistake as writing over their
+`mpv.conf`. This reaches the shim's fork and any other stock-osc-derived script;
+scripts with their own option namespace (uosc and friends) are out of scope, and
+"where possible" is doing real work in the verdict.
+
+**Docs.** Both new keys need entries in `docs/configuration.md` —
+`tests/test_docs_coverage.py` fails a setting without one — and a placement
+decision in `docs/settings-curation.md`. Neither is `RESTART_REQUIRED` if both
+are applied live, which is the target; if `border` turns out to need a restart
+on some platform, it goes in the set and the row gets the marker.
+
+---
+
+## Cross-cutting A — one suspended state for classic-OSC modality
+
+Covers #724 issue 1 and the classic-OSC half of #726.
+
+The renderer already has exactly one correct state for "a classic OSC owns the
+window": suspended. `ui_suspend()` (`renderer.lua:5572-5613`) drops
+`mpvtk_mouse`, `mpvtk_thumb` and the wheel section, gives
+`input-builtin-dragging` back, unbinds the nav keys and clears the scene. That
+is precisely the neutralization the verdict asks for, and it is already written.
+
+So the repair is **to make that state reliably reached, not to add a second
+neutralize path.** Removing the ways it can be missed is the fix that has no
+heat-affected zone; a new "if classic OSC then unbind" branch would be a second
+authority on section ownership, and the two would diverge.
+
+Three things to establish, in this order:
+
+1. **Reproduce.** Set `osc_style` to `"mpv"`, play a video, and read the live
+   `input-bindings` / section state. `tools/probe_hover_strand.py` is the model
+   for driving a real mpv from outside; `docs/testing.md` has the note on
+   driving real mouse input in an integration test (added by `69220bed`). The
+   question to answer is narrow: *after playback starts in classic-OSC modality,
+   is `mpvtk_mouse` enabled?*
+2. **If it is enabled**, find which transition skipped `ui_suspend`. The two
+   candidates already visible from reading: `mpvtk-active`'s
+   `if want == state.active then return end` early return, and
+   `LoadFeedback.clear()` returning early when `starting is None`. Both are
+   real early returns on the only path that suspends.
+3. **If it is not enabled**, the mechanism above is not the trigger and the
+   investigation restarts from the log — ask the reporter for a log from an
+   actual classic-OSC run. The one attached to #724 is from an `mpvtk=1` run
+   (`window: browse=on (… mpvtk=1 …)`) and does not cover this case.
+
+**Then pin it.** An integration leg that asserts, in classic-OSC modality with a
+video playing: `mpvtk_mouse` / `mpvtk_thumb` / `mpvtk_wheel` are all disabled,
+`input-builtin-dragging` is back to what the user had, and a synthesized
+`MBTN_RIGHT` toggles pause. `tests/integration/test_keyboard_controls.py` and
+`test_mpvtk_hud.py` are the neighbours. Derive the failing case from the issue's
+words and watch it fail **before** writing the fix — an assertion written after
+the fix is structurally unable to fail.
+
+**While there, delete the dead branch:** `app.py:2371`'s
+`if self._browsing: self._yield()` cannot fire for video, because `_start`
+cleared `_browsing` first. Leaving it in place makes the suspend look like it
+has two guards when it has one, which is how this stayed invisible.
+
+---
+
+## Cross-cutting B — CLI overrides must not reach `save()`/`dict()`
+
+Covers #718 follow-up 1.
+
+**The rule.** A value the user passed on the command line applies to *this run*.
+`Settings.save()` serialises `self.dict()`, and `settings_base.dict()`
+(`settings_base.py:67-77`) walks every field — so any CLI value assigned into
+`settings` is written to `conf.json` by the next save from anywhere.
+
+**Four sites, one already patched in isolation** (`mpv_shim.py:137-148`):
+
+| flag | field | guarded today |
+|---|---|---|
+| `--gui` / `--no-gui` | `enable_gui` | no |
+| `--minimized` | `start_minimized` | no |
+| `--mpv-loglevel` | `mpv_log_level` | no |
+| `--ui-scale` | `ui_scale` | comment only |
+
+Per `CLAUDE.md`'s applying-review-findings rule: count the sites before the
+first patch, and prefer the repair that removes an authority. Three more
+comments is the shape that does not hold.
+
+**Shape.** One `apply_cli_overrides(args)` in `mpv_shim.py` that records the
+overridden field names alongside the value loaded from disk, and a `dict()` that
+writes the **loaded** value for those fields. Where the record lives is the
+design choice — a set on the settings object that `dict()` consults is the
+smallest thing that works, and it puts the rule at the one place that
+serialises rather than at each of the four places that assign.
+
+`ui_scale`'s existing comment then describes the mechanism instead of standing
+in for it, and a fifth CLI override added later is covered by construction
+rather than by remembering.
+
+**Test.** Assert `dict()` — not just `save()` — returns the on-disk value for
+every overridden field, for all four flags, with the override in place. Then the
+integration case from #718 follow-up 2 item 2: launch with `--minimized`,
+provoke a save, and read `conf.json` back.
+
+---
+
+## #719b — clickable caption runs on a tile
+
+**Last in the plan, and separable from [#719a](#719a--go-to-series-from-any-episode-tile)
+on purpose:** once the context-menu entry ships, the series is reachable from
+every tile. This item is the *parity* half — jellyfin-web's third hit region —
+and it is a new capability rather than a wiring change, so it should not hold up
+anything above it.
+
+**The condition in the verdict is met.** `components/labels.py:53-61` builds an
+episode's subtitle as `"SeriesName · S1E2"`, precisely so a Next Up tile says
+which show it belongs to. We are rendering the series name.
+
+**But a tile's caption is not a widget.** `TileRenderer` returns a
+`Tile(title=…, subtitle=…, subtitle2=…)` (`tile_renderer.py:1206-1226`) and the
+strip compositor **bakes** all three lines into one bitmap per row. There is no
+node for the subtitle line, let alone for the `SeriesName` run inside it. A tile
+is one rect to the hit test.
+
+So this needs two things that do not exist:
+
+1. **The x-extent of the series-name run within the baked caption.**
+   `mpvtk.metrics` already measures the text that is drawn, so the measurement
+   is available — but it has to be taken at bake time, cached with the tile, and
+   invalidated with it. It moves with ellipsization, with the type scale, and
+   with `ui_scale`, and the caption is baked at one tile size for the whole row
+   (`caption_geom`, `tile_renderer.py:486`), so the extent is per-tile while the
+   geometry is per-row.
+2. **A sub-rect hit region on a tile node.** The strip hit test resolves a
+   pointer to a tile; there is no notion of "and which part of it". Adding one
+   is a change to the shape of what a strip reports, which is shared by every
+   screen that draws tiles.
+
+**Risks worth naming before anyone starts.** A caption sub-rect is a *second*
+place that decides what a click on a tile means, and the first one (the tile
+itself) is on every screen. Two authorities on one gesture is the shape this
+repo has been bitten by; if it is built, the tile's own handler and the caption's
+should come from one dispatch rather than two independent hit tests. Keyboard
+and remote users also get nothing from a hit region — the context-menu entry is
+the only affordance they can reach, which is a second reason 719a is the load-
+bearing half.
+
+**Open [iw]:** whether this is worth the two new mechanisms, given 719a makes
+the destination reachable. Recommendation is to leave it until somebody has
+measured what recording the bake-time extent actually costs on a full row.
+
+---
+
+## Not in scope, recorded so it is not re-derived
+
+- **`docs/do-not-fix.md` entries** to add once the above lands: #726's unbound
+  right button (deliberate), and #727 item 1 (no window controls in fullscreen
+  is deliberate — with the caveat that the new
+  `window_controls_fullscreen` setting is the escape hatch, so the entry has to
+  be written *after* that setting exists or it will be wrong).
+- **`test_hud_icon_sizes.py` is a green-but-blind test** for #721. The general
+  shape — a test that pins a value on the near side of a transform the bug lives
+  in — is worth a line in `docs/testing.md`'s catalogue of tests that cannot
+  fail.
+- **The `_PX_KEYS` audit** (#721) is the only item here that could plausibly be
+  hiding siblings. Nothing else in this batch shares a rule with another item
+  beyond the two cross-cutting sections.

--- a/docs/ISSUES_2026-09.md
+++ b/docs/ISSUES_2026-09.md
@@ -34,11 +34,11 @@ what a planning document is for.
 | [719a](#719a--go-to-series-from-any-episode-tile) | Go to Series from a tile | enhancement | context menu **[iw]** |
 | [719b](#719b--clickable-caption-runs-on-a-tile) | Clickable series name on a tile | enhancement | **deferred, last** |
 | [720](#720--play-on-a-season-navigates-instead-of-playing) | Play on a season opens it | bug | match web **[iw]** |
-| [721](#721--three-hud-glyphs-ignore-ui_scale) | HUD icons don't scale | **regression** | fix `isz` scaling |
+| [721](#721--three-hud-glyphs-ignore-ui_scale) | HUD icons don't scale, then overlap | **regression** + latent bug | scale `isz`; floor the trigger; measured fit |
 | [722](#722--only-home-re-reads-user-data) | Watched status stale | bug | collapse two refreshers |
 | [723](#723--hud-scaling-with-window-size) | Scale HUD with window | enhancement | new setting **[iw]** |
 | [724](#724--the-mouse-in-classic-osc-modality) | Mouse play/pause broken | **regression** | neutralize **[iw]** |
-| [725](#725--keepaspect-window) | Keep window aspect ratio | enhancement | opt-in + matrix **[iw]** |
+| [725](#725--keepaspect-window) | Keep window aspect ratio | enhancement | **won't fix** **[iw]** |
 | [726](#726--window-drag-with-left-click-pause-on) | Drag keybind not swapped | bug | **won't fix (JF UI)** [iw] |
 | [727](#727--window-buttons-and-the-title-bar) | Window buttons in title bar | bug + enhancement | two settings **[iw]** |
 
@@ -84,8 +84,8 @@ Status is kept current; a done row names the commit.
 | 7 | [Cross-cutting A](#cross-cutting-a--one-suspended-state-for-classic-osc-modality) (#724, #726) | tests + `tools/probe_classic_osc_mouse.py` | **done** `a7324740` — the repro DID exonerate our code; no production change |
 | 8 | [#727](#727--window-buttons-and-the-title-bar) | S ×2, `player_window.py`, `mpv_options.py`, `player.py` | **done** `73d1236d` |
 | 9 | [#717](#717--the-hud-enter-key-cannot-be-remapped) | S, `renderer.lua`, `gateway/hud.py`, `gamepad.py`, `player.py` | `renderer.lua` again — after 7 has settled it; and it is three input sources, not one |
-| 10 | [#723](#723--hud-scaling-with-window-size) | S, `hud.py` | independent; grouped with the other settings work |
-| 11 | [#725](#725--keepaspect-window) | S, `player.py`, `player_window.py`, integration matrix | the test matrix is the bulk of it; after 8 |
+| 10 | [#723](#723--hud-scaling-with-window-size) | S, `hud.py` | the *fit* half landed with #721; what is left is the accessibility floor |
+| 11 | ~~[#725](#725--keepaspect-window)~~ | — | **dropped [iw]**; see the section |
 | 12 | [#719b](#719b--clickable-caption-runs-on-a-tile) | `strips.py`, `tile_renderer.py`, `metrics.py` | new capability, and 3 already makes the series reachable |
 
 **Where items genuinely collide.** `renderer.lua` (7 then 9), `tiles.py`
@@ -147,8 +147,32 @@ read by the same path that already carries `hud_wake_key` to the renderer
 (`mpvtk_browser/gateway/hud.py:37`, the `mpvtk-hud` opts blob), and applied to
 the `ENTER` entry of `NAV_KEYS`.
 
-**The trap, and it is the whole difficulty: ENTER is not only a keyboard key
-here — it is the wire format two other input sources use to mean "Select".**
+**Settled [iw]: this remaps the KEYBOARD, and yields ENTER back.** *"Let's
+just let them change what the keyboard ENTER key actually maps to, so if they
+have some kind of attachment to ENTER being used for something else, we can
+yield that key back to them while in the video player and they can remap our
+ENTER to some other key. Maybe like 0.1% of users will use it."*
+
+So it is a replacement, not an alias — ENTER must stop being force-bound when
+the setting names another key, or nothing has been yielded. That settles the
+question the rest of this section was written around, and it settles it toward
+the cheaper of the two shapes: all three producers **read the setting**, rather
+than the two synthetic ones being rebuilt to send a semantic Select. Two Python
+literals become a settings read, and the three cannot disagree because they are
+reading one value.
+
+An additive spelling was considered and rejected on the words above: it would
+fix the reporter's complaint (their key does nothing) while leaving ENTER bound,
+which is precisely what the request asks to stop.
+
+**One consequence to accept going in, not to fix:** gamepad Confirm reaches the
+*legacy OSD menu* today only by virtue of being literal ENTER, which is what
+`kb_menu_ok` binds. Anyone who remaps `kb_ui_select` will want to move
+`kb_menu_ok` with it. Documented on both settings rather than coupled, because
+coupling them would make one setting silently rewrite another.
+
+**The trap this all comes from: ENTER is not only a keyboard key here — it is
+the wire format two other input sources use to mean "Select".**
 Remapping the `NAV_KEYS` entry alone silently kills both of them:
 
 - the **game controller**. `gamepad.py:74` maps Confirm to the literal
@@ -188,9 +212,10 @@ Other notes on doing it:
   key, but they are the places a second configurable ENTER will collide
   with the first.
 
-**Open.** Whether the setting also governs the OSD menu's OK (i.e. whether
-`kb_menu_ok` is deprecated into it) or stays independent. Independent is the
-smaller change and keeps `kb_menu_ok` meaning what it has always meant.
+**Settled.** `kb_menu_ok` stays independent — the smaller change, and it keeps
+that setting meaning what it has always meant. Its `docs/configuration.md` entry
+gains the words *legacy OSD menu only*, which is the whole of the original bug
+report: the name promised the HUD.
 
 ---
 
@@ -433,6 +458,44 @@ nowhere to live.
 
 ---
 
+### Part 2 — the same three glyphs then OVERLAPPED
+
+Reported by [iw] after the scaling fix landed: *"The current settings look fine
+from a legibility standpoint, but the math is bugged and I am seeing overlapping
+icons."*
+
+**Not a regression of the fix — a latent bug the fix made visible.** The glyph
+used to stay small while its box collapsed, so the collapse read as "the icon is
+too small", which is how it arrived as part 1.
+
+`layout.py`'s flex-shrink pass decides who absorbs a row's overflow:
+
+```python
+if lo is None and isinstance(c, Box) and (c.on_click or c.on_dbl):
+    lo = s      # "buttons floor at natural"
+```
+
+`Button` is a `Box`. **`Dropdown` is an `Element`.** So the four track pickers —
+buttons in every way a user can perceive — had no floor and absorbed the *whole*
+overflow, down to and including **zero width**, while `draw_dropdown` went on
+centring a full-size `isz` glyph in them. Measured on the real HUD: `34x47` at
+900px, `26x34` at 640, and at `ui_scale` 2 a **`0x68` trigger whose glyph
+overlapped its neighbour by 36px**. Those three pickers also had no hit area
+left, so they were unclickable.
+
+Site count before the first patch: **1**. `Checkbox` is a `Row(Box)` with
+`on_click` and already floors; `Slider` and `TextBox` degrade gracefully (a
+shorter bar is still a bar, text ellipsizes). A glyph is a path — it has no
+smaller reading — so the icon trigger is the only control that must floor and
+did not. Repaired in `widgets.Dropdown`, beside the line that computes the box,
+so one place decides the size and the floor.
+
+**The floor alone would only have moved the damage**, and that is the part worth
+remembering: with the pickers refusing to shrink, the overflow went off the
+right edge instead and took the gear and fullscreen buttons out of the window
+between 500 and 900px. Measuring the bar showed why — see
+[#723](#723--hud-scaling-with-window-size), whose fit half landed with this.
+
 ## #722 — only Home re-reads user data
 
 **Symptom.** A series page shows "3 episodes remaining" for a season that is
@@ -623,28 +686,78 @@ illegibility for reasons that have nothing to do with hit targets — a target b
 enough to click is not the same claim as a glyph big enough to read, and only the
 first is what the metric governs.
 
-**Open — the tiers.** `tiers` (`hud.py:786-796`) is a set of absolute pixel
-breakpoints (`w >= 500`, `w >= 560`, `w >= 700`, `w >= 760`, `w >= 1000`) tuned
-against the current 0.72 floor. With a lower floor the controls fit in less
-width, so a breakpoint should fall as the controls shrink — otherwise the bar
-shrinks and *still* drops the quality picker at 560px.
+### DONE: the tiers are gone, replaced by a measured fit
 
-**Do not "divide the breakpoint by the scale".** An earlier draft suggested
-that and it is backwards: `560 / 0.5 = 1120` moves the threshold *up*, dropping
-controls twice as early, which is the opposite of the goal. The scale is ≤ 1, so
-dividing by it can only ever raise a threshold.
+**The advice this section first gave — "lower the floor, leave the breakpoints
+alone, they only become conservative" — was wrong, and measurement is what
+refuted it.** That argument holds only if the bar fits at the current floor. It
+did not: swept across 400–1400px, the transport row overflowed its own window at
+**every width between ~700 and ~1000, by up to 113px**. Controls had been added
+to the bar over the years and the five numbers never moved. Nothing showed it
+because the overflow was being absorbed by the four floorless track pickers —
+[#721 part 2](#part-2--the-same-three-glyphs-then-overlapped) — so the symptom
+surfaced as overlapping icons rather than as a bar that does not fit.
 
-The two candidate spellings, both of which move it the right way:
+**Verdict [iw].** *"Agreed, the existing breakpoints encoded which icons I
+wanted to have certain priority, so we can first scale the icons down then start
+sacrificing them as the screen gets narrower. Note that some icons only make
+sense to get rid of in pairs."*
 
-- **compare against a scaled width** — `w / scale >= 560`, i.e. ask "how much
-  room would this be at full size", which keeps the tuned numbers meaningful;
-- **multiply the breakpoint** — `w >= 560 * scale`, arithmetically the same
-  thing rearranged, and easier to read wrong later.
+So `hud.SHED_ORDER` + `hud._shed` replace the table: build every optional
+control, measure the row, and give up the shortest prefix of the order that
+makes it fit. Three properties, each with a test:
 
-The first is the honest spelling; either way the decision is which, plus whether
-the numbers still want re-tuning once the floor moves. This is the part that
-will bite: the tiers and the scale currently answer to the same `w` and are
-tuned against each other.
+- **Shrink first, sacrifice second.** `scale` is unchanged and still runs first;
+  shedding only happens once everything is as small as it is allowed to get.
+- **The order is the one the breakpoints encoded.** `ends_at` (was 1000),
+  `volbar` (760), `ch_btns` and `chapters` (700), `favorite` and `quality`
+  (560), `clock` and `seek_btns` (500). Where two shared a breakpoint they are
+  separated in favour of the more capable control — the chapter *dropdown*
+  reaches any chapter and outlives its two step buttons, quality outlives
+  favourite, and the seek buttons outlive a clock the seek bar already reads
+  approximately. Those three splits are the only judgement in the table and are
+  a one-line edit each.
+- **A key is a group, not an icon [iw].** `seek_btns` tags *both* step buttons
+  and `ch_btns` tags *both* chapter buttons, so a symmetric pair can only leave
+  together. Tagging is what makes that structural instead of remembered.
+
+Two things the rewrite turned up that the breakpoints had hidden:
+
+- **`QUALITY_BTN_W` is deleted.** The gear menu offered "Change Video Quality"
+  only below that breakpoint, i.e. it asked the window width whether the bar had
+  the button. Width was always the weaker question — at 600px it answered "on
+  screen" while the bar overflowed by 36 — and there is no breakpoint left to
+  ask. `_menu_rows` now reads `b.hud.shed`, recorded by the build that decided
+  it, and still fails open (`None` → keep the row).
+- **The clock had to be sized for its widest reading.** It is the one control
+  whose width changes *during* an item: `"59:59 / 2:00:00"` gains two characters
+  at the hour mark. Measured like everything else, that flipped a shed — the
+  favourite button vanished at 1:00:00 with nothing on screen to explain it.
+  Caught by a test written for the possibility before the behaviour was known,
+  and fixed by giving the box the width of `_clock(dur) / -_clock(dur)`, which
+  also stops the bar shifting once a second.
+
+**Still open — the accessibility floor**, which is the `hud_auto_scale` checkbox
+above and the only part of #723 not yet built. The fit composes with it: a lower
+floor means the controls shrink further before anything is shed, and `_shed`
+needs no change to benefit.
+
+**Refuted, and kept because it is the natural idea.** Three spellings were
+proposed for rescaling the breakpoints, and all three are wrong:
+
+- *divide the breakpoint* — `560 / 0.5 = 1120` moves the threshold **up**,
+  dropping controls twice as early. The scale is ≤ 1, so dividing can only raise
+  a threshold.
+- *compare against a scaled width* (`w / scale >= 560`) and *multiply the
+  breakpoint* (`w >= 560 * scale`) — arithmetically the same thing, and both
+  **degenerate**. Where the floor is not binding, `scale == w / 900` exactly, so
+  `w / scale` is the constant 900, greater than every breakpoint. With a 0.51
+  floor that region is w ∈ (459, 900) — which contains 560, 700 and 760. Three
+  of the five breakpoints simply stop existing, and the bar shrinks to half size
+  while still carrying the quality picker, the chapter list and the volume
+  slider at 470px.
+
+The answer was none of them: measure the row instead.
 
 ---
 
@@ -792,10 +905,18 @@ already flips per mode (`set_browse_window` off, `browse_yield` on) and which
 `reset_picture_view` putting it back mid-playback is what made every film play
 stretched.
 
-**Verdict [iw].** `keepaspect-window` causes a lot of misery and
-platform-specific behaviour. This one deserves a full integration test matrix
-and Windows tests. Default should be to suppress it; if the user wants it, they
-can enable it.
+**Verdict [iw] — won't fix.** *"Honestly this one is probably not worth
+touching, it is very much in the 'no other video player with an actual browser
+UI does this'. If we did we'd just enable it in the video player UI and leave
+everything else alone."*
+
+An earlier verdict asked for the opt-in setting plus a full matrix, and the
+sizing below is why that was reconsidered: the deliverable was a test matrix on
+three platforms and three mpv versions, for a behaviour no comparable client
+ships. What is written below is kept because it is the *cost* estimate that
+justified dropping it, and because "just turn it back on" is the obvious idea
+somebody will have again — the shape it would have to take, if it ever
+returns, is video-playback only, with the browser and both readers untouched.
 
 **Shape.** New `keepaspect_window: bool = False` in `conf.py`. When on, the
 property follows the mode the way `keepaspect` does — off while the browser owns
@@ -1096,19 +1217,40 @@ strip compositor **bakes** all three lines into one bitmap per row. There is no
 node for the subtitle line, let alone for the `SeriesName` run inside it. A tile
 is one rect to the hit test.
 
-So this needs two things that do not exist:
+**Both "missing mechanisms" turned out to exist — this section overestimated
+the cost and the estimate is corrected here rather than deleted, because the
+reasoning that produced it was the plausible one.**
 
-1. **The x-extent of the series-name run within the baked caption.**
-   `mpvtk.metrics` already measures the text that is drawn, so the measurement
-   is available — but it has to be taken at bake time, cached with the tile, and
-   invalidated with it. It moves with ellipsization, with the type scale, and
-   with `ui_scale`, and the caption is baked at one tile size for the whole row
-   (`caption_geom`, `tile_renderer.py:486`), so the extent is per-tile while the
-   geometry is per-row.
-2. **A sub-rect hit region on a tile node.** The strip hit test resolves a
-   pointer to a tile; there is no notion of "and which part of it". Adding one
-   is a change to the shape of what a strip reports, which is shared by every
-   screen that draws tiles.
+1. **The x-extent of the series-name run.** There is one chokepoint, and it is
+   the right one: `strips._paint_caption`'s `if t.subtitle:` block is the single
+   place the subtitle becomes pixels, and it already holds the tile origin, the
+   resolved face and the *ellipsized* string. Measuring the prefix there is one
+   `pilfont` call at the exact point of truth, so ellipsization, type scale and
+   `ui_scale` are all already applied — none of them has to be reasoned about.
+2. **A sub-rect hit region.** `ImageMap` has taken arbitrary sub-regions since
+   it was written — `regions` is a list of rects with `on_click`/`on_context` in
+   image-local coordinates — and it has the exact flag this wants:
+   `"zone": True`, "a *place on the bitmap* rather than a thing in it", no hover
+   ring and out of the spatial-nav order. That is right for a caption run:
+   keyboard and remote users should reach the series through
+   [719a](#719a--go-to-series-from-any-episode-tile)'s menu entry, not by having
+   a second stop appear in the focus ring on every tile.
+
+   Better still, `_paint_caption` and the region builder are **the same loop**
+   over the same `Tile` at the same `lx` (`strips.py:718-731`), so the extent
+   never has to be stored, cached or invalidated: it is produced and consumed
+   in one pass.
+
+**The one real design question, which the earlier estimate missed entirely:**
+the painter sees a *string*, not a structure. Splitting "SeriesName · S1E2" on
+the separator is string-sniffing, and it breaks on the first series whose name
+contains a `·`. So `components.tile_lines` has to hand the prefix length over
+with the subtitle, and `Tile` gains one optional field to carry it. That is the
+part to get right; it is also what keeps the hit region honest when the caption
+is truncated mid-name.
+
+**Revised estimate: ~30-40 lines plus tests**, not a new capability. The
+recommendation to defer stands only on priority now, not on cost.
 
 **Risks worth naming before anyone starts.** A caption sub-rect is a *second*
 place that decides what a click on a tile means, and the first one (the tile
@@ -1119,9 +1261,16 @@ and remote users also get nothing from a hit region — the context-menu entry i
 the only affordance they can reach, which is a second reason 719a is the load-
 bearing half.
 
-**Open [iw]:** whether this is worth the two new mechanisms, given 719a makes
-the destination reachable. Recommendation is to leave it until somebody has
-measured what recording the bake-time extent actually costs on a full row.
+**Verdict [iw].** *"This depends a lot on complexity — if we can make it so
+clicking exactly in the zone where we render the text for the series name on
+keep watching / next up, that would be nice, but if there is no easy chokepoint
+to do it, I would say leave it at the context menu."*
+
+The chokepoint exists and is a good one (above), so the condition is met. The
+"two authorities on one gesture" risk in the paragraph below is still the thing
+to design against: the caption region and the tile region are appended in the
+same loop, so they can and should be built together rather than by two
+independent hit tests.
 
 ---
 

--- a/docs/ISSUES_2026-09.md
+++ b/docs/ISSUES_2026-09.md
@@ -29,7 +29,7 @@ what a planning document is for.
 
 | # | Title | Kind | Verdict |
 |---|---|---|---|
-| [717](#717--the-hud-enter-key-cannot-be-remapped) | `kb menu ok` can't be remapped | bug (design gap) | new setting **[iw]** |
+| [717](#717--the-hud-enter-key-cannot-be-remapped) | `kb menu ok` can't be remapped | bug (design gap) | `ui_select_key` **[iw]** — renderer half open |
 | [718](#718--cli---minimized-must-not-become-a-saved-setting) | Launch minimized without the setting | closed → follow-up | fix persistence **[iw]** |
 | [719a](#719a--go-to-series-from-any-episode-tile) | Go to Series from a tile | enhancement | context menu **[iw]** |
 | [719b](#719b--clickable-caption-runs-on-a-tile) | Clickable series name on a tile | enhancement | **deferred, last** |
@@ -83,7 +83,7 @@ Status is kept current; a done row names the commit.
 | 6 | [#722](#722--only-home-re-reads-user-data) | `app.py`, `ui.py` | **done** `da499b96` |
 | 7 | [Cross-cutting A](#cross-cutting-a--one-suspended-state-for-classic-osc-modality) (#724, #726) | tests + `tools/probe_classic_osc_mouse.py` | **done** `a7324740` — the repro DID exonerate our code; no production change |
 | 8 | [#727](#727--window-buttons-and-the-title-bar) | S ×2, `player_window.py`, `mpv_options.py`, `player.py` | **done** `73d1236d` |
-| 9 | [#717](#717--the-hud-enter-key-cannot-be-remapped) | S, `renderer.lua`, `gateway/hud.py`, `gamepad.py`, `player.py` | `renderer.lua` again — after 7 has settled it; and it is three input sources, not one |
+| 9 | [#717](#717--the-hud-enter-key-cannot-be-remapped) | S, `renderer.lua`, `gamepad.py`, `player.py` | **Python half done**; `renderer.lua` handed off |
 | 10 | [#723](#723--hud-scaling-with-window-size) | S, `hud.py` | **done** — fit with #721, floor after it |
 | 11 | ~~[#725](#725--keepaspect-window)~~ | — | **dropped [iw]**; see the section |
 | 12 | [#719b](#719b--clickable-caption-runs-on-a-tile) | `strips.py`, `tile_renderer.py`, `metrics.py` | new capability, and 3 already makes the series reachable |
@@ -190,9 +190,62 @@ synthetic sources stop spelling their intent as a keystroke and send a Select
 message the renderer answers directly, leaving `kb_ui_select` to govern only the
 physical keyboard.
 
-Exit predicate for this item: with `kb_ui_select` set to a non-ENTER key,
-keyboard, gamepad Confirm and remote Select all still activate the same focused
-control. A test that only presses the keyboard cannot fail for this.
+Exit predicate for this item: with the setting on a non-ENTER key, keyboard,
+gamepad Confirm and remote Select all still activate the same focused control.
+A test that only presses the keyboard cannot fail for this.
+
+### DONE: the Python half. HANDOFF: the renderer half
+
+The setting shipped as **`ui_select_key`**, not `kb_ui_select`: the `kb_*`
+family is the legacy OSD menu's, spelled in lowercase mpv names and bound by
+`_bind_key`, and putting this there would have implied it was one of them —
+which is the confusion the issue is about. It sits with `hud_wake_key` instead,
+uppercase, bound by the renderer.
+
+**Landed, and safe on its own:**
+
+- `conf.select_key()` — one reader for the three producers, holding the
+  fallback. Two spellings of a default is how they come to differ.
+- `gamepad.bindings(swap_confirm, select_key)` takes it as a **parameter**.
+  That module's header promises "no settings import", and a parameter is also
+  the repair that cannot be forgotten: `DEFAULT_BINDS` now carries a `SELECT`
+  sentinel where the literal was, so a caller has to supply the key.
+- `player.py`'s remote path resolves it **per press**. `_NAV_KEYPRESS` lost its
+  `"ok"` entry — that dict is a class attribute built at import, so a value
+  read there would be whatever the setting said when `player` was imported.
+- `docs/configuration.md`: `kb_menu_ok` now says **"legacy OSD menu only"**,
+  which is the whole of the original report. That fix stands alone.
+
+**Not landed, and deliberately unreachable:** the setting is *not* in
+`SECTIONS`, so it is not on the settings screen, and its docs entry says
+changing it by hand does nothing useful yet. It is a replacement, not an alias
+[iw] — ENTER has to stop being force-bound — and until the renderer does that,
+moving the value would put the gamepad and the remote on a key nothing listens
+for while the keyboard kept ENTER. That is worse than the bug.
+
+**What the renderer half has to do**, all in `jellyfin_mpv_shim/mpvtk/renderer.lua`:
+
+1. `NAV_KEYS`' activation entry binds the configured name instead of `'ENTER'`.
+   The table is module-level and consumed by `bind_nav_keys` *and*
+   `keyclaim.nav_names`, so the name has to be resolved when the bindings are
+   installed rather than at load, and `keyclaim.nav_names` rebuilt with it. The
+   comment above that table is explicit that a claimed key **outside** the set
+   needs its own binding *and* its own removal (SPACE is mpv's pause; leaving
+   it bound after a reader closes swallows it for the session).
+2. Get the value in. The `mpvtk-hud` opts blob only arrives on HUD engage, but
+   browse-mode nav is installed by `mpvtk-active`, which carries no opts —
+   push it on both, or use a `user-data` property the renderer reads.
+   `user-data/mpvtk/active` is the precedent.
+3. `_open_hud_menu` / `phud_summon_enter` compare against `phud_wake_key()` by
+   literal `'ENTER'` in several places. Those are the *wake* key, not this one,
+   but they are where a second configurable ENTER will collide with the first.
+
+`tests/test_ui_select_key.py` is the executable spec, written before the work:
+`AgreementTest` pins that the three name one key and that the two synthetic
+producers move together, and `NotYetOfferedTest` is a pair of **tripwires that
+are meant to fail** when the renderer stops hardcoding ENTER — at which point
+the setting can be added to the `Input` group (not `HUD_ONLY`: it governs the
+library too, which exists under every OSC style) and those cases deleted.
 
 Other notes on doing it:
 

--- a/docs/ISSUES_2026-09.md
+++ b/docs/ISSUES_2026-09.md
@@ -29,7 +29,7 @@ what a planning document is for.
 
 | # | Title | Kind | Verdict |
 |---|---|---|---|
-| [717](#717--the-hud-enter-key-cannot-be-remapped) | `kb menu ok` can't be remapped | bug (design gap) | `ui_select_key` **[iw]** — renderer half open |
+| [717](#717--the-hud-enter-key-cannot-be-remapped) | `kb menu ok` can't be remapped | bug (design gap) | `ui_select_key` **[iw]** — **done** |
 | [718](#718--cli---minimized-must-not-become-a-saved-setting) | Launch minimized without the setting | closed → follow-up | fix persistence **[iw]** |
 | [719a](#719a--go-to-series-from-any-episode-tile) | Go to Series from a tile | enhancement | context menu **[iw]** |
 | [719b](#719b--clickable-caption-runs-on-a-tile) | Clickable series name on a tile | enhancement | **deferred, last** |
@@ -83,7 +83,7 @@ Status is kept current; a done row names the commit.
 | 6 | [#722](#722--only-home-re-reads-user-data) | `app.py`, `ui.py` | **done** `da499b96` |
 | 7 | [Cross-cutting A](#cross-cutting-a--one-suspended-state-for-classic-osc-modality) (#724, #726) | tests + `tools/probe_classic_osc_mouse.py` | **done** `a7324740` — the repro DID exonerate our code; no production change |
 | 8 | [#727](#727--window-buttons-and-the-title-bar) | S ×2, `player_window.py`, `mpv_options.py`, `player.py` | **done** `73d1236d` |
-| 9 | [#717](#717--the-hud-enter-key-cannot-be-remapped) | S, `renderer.lua`, `gamepad.py`, `player.py` | **Python half done**; `renderer.lua` handed off |
+| 9 | [#717](#717--the-hud-enter-key-cannot-be-remapped) | S, `renderer.lua`, `gamepad.py`, `player.py` | **done** — Python `7ed35b67`, renderer half below |
 | 10 | [#723](#723--hud-scaling-with-window-size) | S, `hud.py` | **done** — fit with #721, floor after it |
 | 11 | ~~[#725](#725--keepaspect-window)~~ | — | **dropped [iw]**; see the section |
 | 12 | [#719b](#719b--clickable-caption-runs-on-a-tile) | `strips.py`, `tile_renderer.py`, `metrics.py` | new capability, and 3 already makes the series reachable |
@@ -165,12 +165,6 @@ An additive spelling was considered and rejected on the words above: it would
 fix the reporter's complaint (their key does nothing) while leaving ENTER bound,
 which is precisely what the request asks to stop.
 
-**One consequence to accept going in, not to fix:** gamepad Confirm reaches the
-*legacy OSD menu* today only by virtue of being literal ENTER, which is what
-`kb_menu_ok` binds. Anyone who remaps `kb_ui_select` will want to move
-`kb_menu_ok` with it. Documented on both settings rather than coupled, because
-coupling them would make one setting silently rewrite another.
-
 **The trap this all comes from: ENTER is not only a keyboard key here — it is
 the wire format two other input sources use to mean "Select".**
 Remapping the `NAV_KEYS` entry alone silently kills both of them:
@@ -194,7 +188,7 @@ Exit predicate for this item: with the setting on a non-ENTER key, keyboard,
 gamepad Confirm and remote Select all still activate the same focused control.
 A test that only presses the keyboard cannot fail for this.
 
-### DONE: the Python half. HANDOFF: the renderer half
+### DONE: both halves
 
 The setting shipped as **`ui_select_key`**, not `kb_ui_select`: the `kb_*`
 family is the legacy OSD menu's, spelled in lowercase mpv names and bound by
@@ -202,68 +196,83 @@ family is the legacy OSD menu's, spelled in lowercase mpv names and bound by
 which is the confusion the issue is about. It sits with `hud_wake_key` instead,
 uppercase, bound by the renderer.
 
-**Landed, and safe on its own:**
+**The Python half** (`7ed35b67`) gave the three producers one reader:
 
-- `conf.select_key()` — one reader for the three producers, holding the
-  fallback. Two spellings of a default is how they come to differ.
+- `conf.select_key()` holds the value and the fallback. Two spellings of a
+  default is how they come to differ.
 - `gamepad.bindings(swap_confirm, select_key)` takes it as a **parameter**.
   That module's header promises "no settings import", and a parameter is also
-  the repair that cannot be forgotten: `DEFAULT_BINDS` now carries a `SELECT`
+  the repair that cannot be forgotten: `DEFAULT_BINDS` carries a `SELECT`
   sentinel where the literal was, so a caller has to supply the key.
 - `player.py`'s remote path resolves it **per press**. `_NAV_KEYPRESS` lost its
   `"ok"` entry — that dict is a class attribute built at import, so a value
   read there would be whatever the setting said when `player` was imported.
 - `docs/configuration.md`: `kb_menu_ok` now says **"legacy OSD menu only"**,
-  which is the whole of the original report. That fix stands alone.
+  which is the whole of the original report.
 
-**Not landed, and deliberately unreachable:** the setting is *not* in
-`SECTIONS`, so it is not on the settings screen, and its docs entry says
-changing it by hand does nothing useful yet. It is a replacement, not an alias
-[iw] — ENTER has to stop being force-bound — and until the renderer does that,
-moving the value would put the gamepad and the remote on a key nothing listens
-for while the keyboard kept ENTER. That is worse than the bug.
+**The renderer half** made it a replacement rather than an alias [iw], which
+is what the setting was withheld for:
 
-**What the renderer half has to do**, all in `jellyfin_mpv_shim/mpvtk/renderer.lua`:
+- `NAV_KEYS`' activation row carries a third field marking it as following
+  `state.select_key`; its `'ENTER'` is now that row's *default*. `bind_nav_keys`
+  and `unbind_nav_keys` resolve through `keyclaim.nav_key`, so ENTER is not
+  bound at all once the key moves.
+- `keyclaim.nav_names` is **derived** (`keyclaim.rebuild_nav`) rather than
+  written down, because the invariant its comment carries moves in both
+  directions: the old key leaves the set and needs a binding of its own the
+  moment a page claims it, and the new key joins the set and must stop getting
+  a second one on top of the nav binding.
+- A claim held **across** the move is re-laid through `keyclaim.set` rather
+  than repaired in place — that call is the authority on which keys carry a
+  binding of their own, and both of the above are its answer changing.
+- **The channel is `mpvtk-select-key`**, its own message
+  (`MpvtkApp.push_select_key`, on ready and on every edit), not a field on the
+  `mpvtk-hud` opts blob: that blob arrives only on HUD engage, while the same
+  bindings come up for browsing under `mpvtk-active`, which carries no opts.
+  Editing the setting re-pushes the **gamepad table too** — a pad's Confirm
+  carries the key as a literal, so one push without the other re-creates the
+  disagreement this issue is about.
+- The renderer's own "is this Select?" test (the gamepad's wake path) asks
+  `state.select_key`, not `'ENTER'`. Left as a literal, a remapped pad's
+  Confirm fell through to `keypress`, where over a hidden HUD nothing is
+  listening — which is the exit predicate failing on the one producer a
+  keyboard test cannot see.
 
-1. `NAV_KEYS`' activation entry binds the configured name instead of `'ENTER'`.
-   The table is module-level and consumed by `bind_nav_keys` *and*
-   `keyclaim.nav_names`, so the name has to be resolved when the bindings are
-   installed rather than at load, and `keyclaim.nav_names` rebuilt with it. The
-   comment above that table is explicit that a claimed key **outside** the set
-   needs its own binding *and* its own removal (SPACE is mpv's pause; leaving
-   it bound after a reader closes swallows it for the session).
-2. Get the value in. The `mpvtk-hud` opts blob only arrives on HUD engage, but
-   browse-mode nav is installed by `mpvtk-active`, which carries no opts —
-   push it on both, or use a `user-data` property the renderer reads.
-   `user-data/mpvtk/active` is the precedent.
-3. `_open_hud_menu` / `phud_summon_enter` compare against `phud_wake_key()` by
-   literal `'ENTER'` in several places. Those are the *wake* key, not this one,
-   but they are where a second configurable ENTER will collide with the first.
+`tests/lua/test_renderer.lua` drives all of that through the real
+script-message boundary; `tests/test_ui_select_key.py` keeps the three
+producers agreeing and pins that the setting is offered. Five mutations of the
+renderer change were each caught by a distinct case.
 
-`tests/test_ui_select_key.py` is the executable spec, written before the work:
-`AgreementTest` pins that the three name one key and that the two synthetic
-producers move together, and `NotYetOfferedTest` is a pair of **tripwires that
-are meant to fail** when the renderer stops hardcoding ENTER — at which point
-the setting can be added to the `Input` group (not `HUD_ONLY`: it governs the
-library too, which exists under every OSC style) and those cases deleted.
+**Left alone, deliberately.** `phud_bind_wake`, `phud_bind_summon` and
+`phud_skip_bind` still compare against `'ENTER'` by literal. Those are the
+**wake** key's (`hud_wake_key`), not this one: they govern summoning a hidden
+HUD, where nothing is focused for a select key to activate. Two consequences
+worth knowing before touching them:
 
-Other notes on doing it:
+- **ENTER is not fully yielded while `hud_wake_key` is still ENTER.** Moving
+  `ui_select_key` yields it in the library and over a summoned HUD; over a
+  *hidden* HUD the wake key is still bound, and that is its own setting to
+  move.
+- `phud_skip_bind` binds literal ENTER for the Skip button regardless of what
+  `hud_wake_key` says, so with a moved wake key ENTER unexpectedly accepts a
+  skip. That is a latent `hud_wake_key` bug, not a `ui_select_key` one, and it
+  is **not fixed here** — it wants its own decision about whether the skip
+  offer follows the wake key or the select key. Recorded as F35 in
+  `docs/do-not-fix.md`.
 
-- `NAV_KEYS` is a module-level table consumed by `bind_nav_keys` and by
-  `keyclaim.nav_names`. A configurable key means the table can no longer be
-  built once at load; the name has to be resolved when the bindings are
-  installed, and `keyclaim.nav_names` rebuilt with it. The comment above
-  `keyclaim.nav_names` is explicit that a claimed key outside that set needs
-  its own binding *and* its own removal — that invariant has to survive.
-- The opts blob only reaches the renderer on `mpvtk-hud` engage. Browse-mode
-  nav keys are installed by `mpvtk-active`, which carries no opts today. Either
-  push the key on both messages or move it to a `user-data` property the
-  renderer reads.
-- `_open_hud_menu`/`phud_summon_enter` special-case `ENTER` by literal string
-  in several places (`renderer.lua:2837`, `:5751`, `:5822`, `:5836`,
-  `:6234`). Those compare against `phud_wake_key()`, not against the select
-  key, but they are the places a second configurable ENTER will collide
-  with the first.
+A **focused textbox** keeps ENTER too (`bind_text_keys`' `ops` table), and that
+one is correct: it is an editing binding beside BS, DEL and ESC, and it cannot
+collide, because mpv resolves `any_unicode` before the exact key
+(`input/input.c`, `get_cmd_from_keys`). So a printable select key types
+into a search box rather than activating, and the nav binding answers only
+once the field is blurred — checked in mpv's source rather than assumed, since
+the opposite ordering would have made a letter key unusable.
+
+**One consequence to accept, not to fix:** gamepad Confirm reaches the *legacy
+OSD menu* only by virtue of being literal ENTER, which is what `kb_menu_ok`
+binds. Anyone who remaps `ui_select_key` will want to move `kb_menu_ok` with
+it. Documented on both settings rather than coupled, because coupling them
+would make one setting silently rewrite another.
 
 **Settled.** `kb_menu_ok` stays independent — the smaller change, and it keeps
 that setting meaning what it has always meant. Its `docs/configuration.md` entry

--- a/docs/ISSUES_2026-09.md
+++ b/docs/ISSUES_2026-09.md
@@ -1171,7 +1171,12 @@ Consequences worth knowing:
   sized to the OSC's box and our frame has its own size, so drawing it would
   put a rectangle around something the wrong size.
 
-### Proposed: collapse "MPV UI with thumbnails" and "MPV built-in default"
+### DONE: collapsed "MPV UI with thumbnails" and "MPV built-in default"
+
+Landed at CONFIG_VERSION 5. The two questions below were settled by [iw]
+and the answers are recorded in `docs/do-not-fix.md` §3, because both look
+like defects from the outside: `default` no longer being offered, and a
+2.9.0 `enable_osc: false` being ignored rather than migrated.
 
 **[iw], from hand-testing the above:** now that the shim loads mpv's own OSC
 and feeds it through the Preview API, those two styles are nearly the same

--- a/docs/ISSUES_2026-09.md
+++ b/docs/ISSUES_2026-09.md
@@ -71,13 +71,14 @@ makes that five files, not one: `conf.py` (the typed default),
 any new user-facing string.
 
 `S` in the Touches column = the five-file settings surface above.
+Status is kept current; a done row names the commit.
 
 | Order | Item | Touches | Why here |
 |---|---|---|---|
-| 1 | [#721](#721--three-hud-glyphs-ignore-ui_scale) | `mpvtk/scaling.py`, `mpvtk/layout.py`, `tests/test_ui_scale.py` | smallest; one table entry and one fixture field |
-| 2 | [#720](#720--play-on-a-season-navigates-instead-of-playing) | `tiles.py`, `repository.py` | self-contained; same file as 3 |
-| 3 | [#719a](#719a--go-to-series-from-any-episode-tile) | `tiles.py`, `base.pot` | same file and same method family as 2 |
-| 4 | [Cross-cutting B](#cross-cutting-b--cli-overrides-must-not-reach-savedict) (#718 persistence) | `mpv_shim.py`, `settings_base.py`, `mpvtk_browser/config.py` | every later setting inherits the rule, so before 6-10 |
+| 1 | [#721](#721--three-hud-glyphs-ignore-ui_scale) | `mpvtk/scaling.py`, `mpvtk/layout.py`, `tests/test_ui_scale.py` | **done** `daa4f8da` |
+| 2 | [#720](#720--play-on-a-season-navigates-instead-of-playing) | `tiles.py`, `repository.py` | **done** `d8b655f9` |
+| 3 | [#719a](#719a--go-to-series-from-any-episode-tile) | `tiles.py`, `base.pot` | **done** `f05ffe64` |
+| 4 | [Cross-cutting B](#cross-cutting-b--cli-overrides-must-not-reach-savedict) (#718 persistence) | `args.py`, `mpv_shim.py`, `settings_base.py`, `restart.py` | **done** `5f39561e` |
 | 5 | [#718 activation](#718--cli---minimized-must-not-become-a-saved-setting) (follow-up 2) | `tests/integration/` only | pure test work; independent of 4 despite sharing the issue |
 | 6 | [#722](#722--only-home-re-reads-user-data) | `app.py`, `ui.py`, `pagination.py` | collapses two refreshers into one — size it as a refactor, not a gate change |
 | 7 | [Cross-cutting A](#cross-cutting-a--one-suspended-state-for-classic-osc-modality) (#724, #726) | `renderer.lua`, `app.py`, an mpv-version bisect | starts with a repro that may exonerate our code entirely |
@@ -98,6 +99,13 @@ the end of the group rather than four times.
 Item 5 is separated from 4 deliberately: they share issue #718 but nothing else.
 4 is a change to how settings serialize; 5 is regression coverage for
 second-launch activation and touches no production code at all.
+
+**What landing 1-4 changed about the plan.** Item 4 found a THIRD site for
+the flag/setting pairing that this document did not know about:
+`restart._durable_flags` already dropped an override when the setting it
+shadows was what the restart was for, with the four pairings written out by
+hand a second time. The pairing now lives once, in `args.CLI_OVERRIDES`, read
+by all three. Nothing else in 1-4 diverged from what is written below.
 
 ---
 

--- a/docs/ISSUES_2026-09.md
+++ b/docs/ISSUES_2026-09.md
@@ -1171,6 +1171,45 @@ Consequences worth knowing:
   sized to the OSC's box and our frame has its own size, so drawing it would
   put a rectangle around something the wrong size.
 
+### Proposed: collapse "MPV UI with thumbnails" and "MPV built-in default"
+
+**[iw], from hand-testing the above:** now that the shim loads mpv's own OSC
+and feeds it through the Preview API, those two styles are nearly the same
+thing. Merge them into one "MPV UI", make thumbnail support a checkbox, and
+let the fallback fork become a hidden implementation detail. Needs a settings
+migration.
+
+The checkbox already exists: `thumbnail_enable` (`conf.py`) is the trickplay
+master switch, and `mpv_scripts` already declines to load `thumbfast.lua`
+when the worker never started. So the work is the enum and the migration,
+not a new key.
+
+What the two values do today, which is what a migration has to preserve or
+deliberately drop:
+
+| value | `osc` at construction | who loads an OSC |
+|---|---|---|
+| `mpv` | `False` (in `REPLACES_OSC`) | us: stock on 0.41+, the fork below |
+| `default` | `True` | mpv itself, per the user's own config |
+
+**`default` is the only value that leaves mpv's OSC loading alone**, and
+that is the open question: merging it into `mpv` means a former-`default`
+user gets an OSC the shim loaded rather than the one their `mpv.conf` would
+have. For almost everyone that is the same OSC. For someone with `osc=no` in
+`mpv.conf`, it is an OSC where they had none -- though "No player controls"
+says that better, and `custom` already covers "I have my own".
+
+Also to settle before writing it: `resolve_osc_style` demotes `mpvtk` to
+`default` for the legacy `thumbnail_osc_builtin=False` opt-out ("don't
+replace my OSC"). With `default` gone that demotion needs a new target, and
+`custom` is the closer match -- but `custom` is in `REPLACES_OSC`, so it
+sets `osc=False` and gives those users *no* OSC rather than mpv's own. That
+is a behaviour change for an opt-out whose whole point was not changing
+their setup, so it probably wants `REPLACES_OSC` revisited at the same time.
+
+Sequencing note: this is the five-file settings surface plus a `_migrate`
+entry, and it lands on top of the Preview API work rather than beside it.
+
 **Still open:** whether to re-fork onto master's osc.lua for the 0.40 path,
 or leave that path on the 0.38 fork it has always used. Leaving it is the
 current state and costs nothing while it works; re-forking would give 0.40

--- a/docs/ISSUES_2026-09.md
+++ b/docs/ISSUES_2026-09.md
@@ -79,8 +79,8 @@ Status is kept current; a done row names the commit.
 | 2 | [#720](#720--play-on-a-season-navigates-instead-of-playing) | `tiles.py`, `repository.py` | **done** `d8b655f9` |
 | 3 | [#719a](#719a--go-to-series-from-any-episode-tile) | `tiles.py`, `base.pot` | **done** `f05ffe64` |
 | 4 | [Cross-cutting B](#cross-cutting-b--cli-overrides-must-not-reach-savedict) (#718 persistence) | `args.py`, `mpv_shim.py`, `settings_base.py`, `restart.py` | **done** `5f39561e` |
-| 5 | [#718 activation](#718--cli---minimized-must-not-become-a-saved-setting) (follow-up 2) | `tests/integration/` only | pure test work; independent of 4 despite sharing the issue |
-| 6 | [#722](#722--only-home-re-reads-user-data) | `app.py`, `ui.py`, `pagination.py` | collapses two refreshers into one — size it as a refactor, not a gate change |
+| 5 | [#718 activation](#718--cli---minimized-must-not-become-a-saved-setting) (follow-up 2) | `tests/integration/`, `single_instance.py` | **done** `6a5b3eca` — not pure test work after all; see below |
+| 6 | [#722](#722--only-home-re-reads-user-data) | `app.py`, `ui.py` | **done** `da499b96` |
 | 7 | [Cross-cutting A](#cross-cutting-a--one-suspended-state-for-classic-osc-modality) (#724, #726) | `renderer.lua`, `app.py`, an mpv-version bisect | starts with a repro that may exonerate our code entirely |
 | 8 | [#727](#727--window-buttons-and-the-title-bar) | S ×2, `player_window.py`, `mpv_options.py` | two settings; touches the window code 10 will |
 | 9 | [#717](#717--the-hud-enter-key-cannot-be-remapped) | S, `renderer.lua`, `gateway/hud.py`, `gamepad.py`, `player.py` | `renderer.lua` again — after 7 has settled it; and it is three input sources, not one |
@@ -99,6 +99,15 @@ the end of the group rather than four times.
 Item 5 is separated from 4 deliberately: they share issue #718 but nothing else.
 4 is a change to how settings serialize; 5 is regression coverage for
 second-launch activation and touches no production code at all.
+
+**What landing 5 changed about the plan.** It was filed as "pure test work;
+touches no production code at all". Writing the tests found two defects instead:
+`SI_WEDGE` never wedged anything (a plain `close()` does not interrupt a thread
+already blocked in `accept()`, measured -- so the existing wedge test passed on
+the election alone), and `SingleInstance.release()` deleted an endpoint file it
+did not own, which would make every launch after the first silently fail to
+surface the window. Neither is reachable from shipped code today; both are now
+guarded. A test-only item is a prediction, not a fact.
 
 **What landing 1-4 changed about the plan.** Item 4 found a THIRD site for
 the flag/setting pairing that this document did not know about:

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -476,8 +476,15 @@ stick **wakes a hidden playback HUD** rather than falling through to mpv's arrow
 way the keyboard does under the default `hud_grab_keys`: a keyboard has one set of
 arrows and has to share them, and a controller does not.
 
-Confirm is ENTER (what the browser's nav activates on and what the hidden HUD wakes
-on) and back is ESC (it already steps out exactly one layer — page, dialog, menu,
+Confirm is `conf.select_key()` — whatever the browser's nav activates on, ENTER
+until `ui_select_key` says otherwise. That is a **parameter** to `bindings()` and a
+`SELECT` sentinel in `DEFAULT_BINDS`, not a literal: this module imports no settings,
+and a caller who cannot supply the key cannot silently ship the old one. Three things
+send that key (this, a Jellyfin remote's Select, the keyboard) and one reader holds
+it, because a remap that moves one leaves the others pressing a key nothing listens
+for — #717 and `tests/test_ui_select_key.py`.
+
+Back is ESC (it already steps out exactly one layer — page, dialog, menu,
 playback — and a second implementation of that ladder would drift from it; the
 mouse's back button is routed the same way for the same reason). Play/pause is SPACE
 rather than `cycle pause`, so it lands on the shim's claim of that key: in a SyncPlay

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -638,8 +638,11 @@ You can use the config file to enable and disable features.
     two of them on a key nothing listens for.
   - A **replacement**, not an alias: point it somewhere else and `ENTER`
     stops being taken in the library and on the player controls, which is
-    the reason to change it. Applies without a restart. Also in Settings →
-    General → Input.
+    the reason to change it. Applies without a restart.
+  - In Settings under **General → Advanced**, or search the settings screen
+    for "enter" or "remap". Deliberately not promoted into a normal group:
+    remapping keys is an answer for somebody who wants it rather than a
+    control everyone has to read past.
   - Two keys it does *not* move with it. While the controls are hidden,
     `hud_wake_key` still holds its own key — move that one too if you want
     `ENTER` free during playback. And `kb_menu_ok` stays where it is, so a

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -453,8 +453,9 @@ You can use the config file to enable and disable features.
   - It pairs with `window_controls`: on `auto`, the buttons appear as soon as this is on, because `auto` reads the same `border` property.
   - Set only when it is on. Leaving it alone otherwise is what lets someone who put `border=no` in their own `mpv.conf` keep the buttons — writing `border=yes` for them would take the title bar back *and* the replacement with it.
   - Leave both off unless you want them: a window with neither a title bar nor the top-bar buttons can be awkward to move on some desktops.
-- `display_mirror_summon` - Let casting *open* the window when it is closed to the tray. Default: `false`
-  - Mirroring itself is always on; this only controls whether idly browsing on a phone can pop the window open.
+- `display_mirror_summon` - Let casting take the screen: open the window when it is closed to the tray, and bring it forward when it is already open. Default: `false`
+  - Mirroring itself is always on; this only controls whether idly browsing on a phone can pop the window open or in front of what you are doing.
+  - With it off, casting a page to an already-open library still navigates it — silently, without taking focus back from the web client you are casting *from*.
 - `library_image_cache_mb` - Memory budget for **decoded** library artwork. Default: `96`
   - Requires restart. The budget is baked into the artwork cache when the browser starts.
   - Decoded is the expensive form — a 4K backdrop is 33 MB decoded against ~400 KB on the wire — and this is a working set rather than a library: decoded images exist to composite tile strips, and the strips are cached in their own right, so scrolling back over a cached row never asks for one. Raise it if you browse enormous libraries on a machine with RAM to spare.

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -453,6 +453,7 @@ You can use the config file to enable and disable features.
   - It pairs with `window_controls`: on `auto`, the buttons appear as soon as this is on, because `auto` reads the same `border` property.
   - Set only when it is on. Leaving it alone otherwise is what lets someone who put `border=no` in their own `mpv.conf` keep the buttons — writing `border=yes` for them would take the title bar back *and* the replacement with it.
   - Leave both off unless you want them: a window with neither a title bar nor the top-bar buttons can be awkward to move on some desktops.
+  - During video playback under an `osc_style` other than the in-window one, the OSC on screen draws its own window buttons — the stock MPV OSC, this client's classic OSC and most custom ones all do, and they turn them on for exactly this case (no border). The in-window UI's buttons are only suppressed there, so you are not offered two sets.
 - `display_mirror_summon` - Let casting take the screen: open the window when it is closed to the tray, and bring it forward when it is already open. Default: `false`
   - Mirroring itself is always on; this only controls whether idly browsing on a phone can pop the window open or in front of what you are doing.
   - With it off, casting a page to an already-open library still navigates it — silently, without taking focus back from the web client you are casting *from*.

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -649,6 +649,19 @@ You can use the config file to enable and disable features.
     mode — a zero delay means nothing without a pointer test, since mouse
     motion is also what summons them. The timer never runs shorter than
     0.5s, so the controls cannot blink out in the same frame they appear.
+- `hud_auto_scale` - Let the player controls shrink further on a narrow
+  window before any of them are dropped. Default: `true`
+  - On, the controls shrink until the smallest button reaches **24x24**
+    logical pixels — WCAG 2.2 SC 2.5.8 (AA), the published minimum for a
+    pointer target — and only then are the less important ones given up,
+    in the order under **Player Controls** below.
+  - Off restores the older floor of 72%, where the controls stop shrinking
+    sooner and buttons start disappearing instead. It is the compatibility
+    setting, not a third behaviour.
+  - The floor is in *logical* pixels, so it does not fight `ui_scale`:
+    raising that makes the controls bigger, never smaller. A forced
+    `ui_scale` for a TV across the room keeps every button above the
+    minimum by a wide margin.
 - `media_key_seek` - Use the media next/prev keys to seek instead of skip episodes. Default: `false`
 - `mouse_chapter_nav` - The mouse's back/forward buttons jump a chapter
   during playback. Off by default: they are easy to hit by accident on

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -636,11 +636,15 @@ You can use the config file to enable and disable features.
   - The gamepad's Confirm button and a Jellyfin remote's Select both send
     this key, so remapping it moves all three together rather than leaving
     two of them on a key nothing listens for.
-  - **Not yet offered in the settings screen, and changing it by hand does
-    nothing useful yet.** Yielding `ENTER` back needs the in-window
-    renderer to stop binding it, which has not landed; until then the value
-    is read by the gamepad and the remote but not by the keyboard. See
-    `docs/ISSUES_2026-09.md` (#717).
+  - A **replacement**, not an alias: point it somewhere else and `ENTER`
+    stops being taken in the library and on the player controls, which is
+    the reason to change it. Applies without a restart. Also in Settings →
+    General → Input.
+  - Two keys it does *not* move with it. While the controls are hidden,
+    `hud_wake_key` still holds its own key — move that one too if you want
+    `ENTER` free during playback. And `kb_menu_ok` stays where it is, so a
+    game controller's Confirm stops reaching the legacy OSD menu once these
+    two disagree.
 - `hud_scrim` - How the picture is shaded behind the player controls, so they
   stay legible over any frame. One of `default`, `panel`, `none`.
   Default: `default`

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -1057,9 +1057,10 @@ between themes already on disk repaints immediately.
 
 ## Trickplay Thumbnails
 
-MPV will automatically display thumbnail previews. By default it uses the Trickplay images and falls back to chapter images. It also requires
-overriding the default MPV OSC, which may conflict with some custom user script. Trickplay is compatible
-with any OSC that uses [thumbfast](https://github.com/po5/thumbfast), as I have added a [compatibility layer](https://github.com/jellyfin/jellyfin-mpv-shim/blob/master/jellyfin_mpv_shim/thumbfast.lua).
+MPV will automatically display thumbnail previews. By default it uses the Trickplay images and falls back to chapter images. Trickplay is compatible
+with any OSC that uses [thumbfast](https://github.com/po5/thumbfast), as I have added a [compatibility layer](https://github.com/jellyfin/jellyfin-mpv-shim/blob/master/jellyfin_mpv_shim/thumbfast.lua)
+— so previews reach the Jellyfin UI, MPV's own controls and your own OSC
+script alike, whatever `osc_style` you have chosen.
 
 Previews are downloaded as JPEG mosaics and uncompressed to raw bitmaps, which
 is where the size is: a two-hour film is about 130 MB of them at the default
@@ -1073,10 +1074,15 @@ short enough to fit under the limit are loaded whole and never wait at all.
 older versions did — every preview is then instant, at the cost of the full
 download and the full memory.
 
-- `thumbnail_enable` - Enable thumbnail feature. (Default: `true`)
-- `thumbnail_osc_builtin` - Legacy alias: disabling this behaves like `osc_style: custom` (use your own OSC but leave trickplay enabled). Prefer `osc_style`. (Default: `true`)
+- `thumbnail_enable` - Enable trickplay thumbnails: the preview frame shown while you drag the seek bar. Applies to every `osc_style`. Read when MPV is built, so changing it needs a restart. Turning it off also stops the images being downloaded, which is the reason to. (Default: `true`)
 - `thumbnail_preferred_size` - The ideal size for thumbnails. (Default: `320`)
 - `trickplay_fast_mode` - Load every preview frame at once instead of a window around the seek position. Previews never wait, but a long video costs hundreds of megabytes of memory. Turning it *on* applies to the video you are watching, the next time you scrub outside the part already loaded; turning it *off* applies to the next video. (Default: `false`)
+
+`thumbnail_osc_builtin` was removed. It meant "use your own custom OSC but
+leave trickplay enabled", which is `osc_style: custom` — thumbfast is loaded
+whatever the style, so your OSC still gets the previews. A `false` left in
+`conf.json` is ignored (the log says so) and dropped on the next save; if you
+run your own OSC, set `osc_style` to `custom`.
 
 ## SVP Integration
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -444,6 +444,15 @@ You can use the config file to enable and disable features.
   - The playback HUD grows the same three buttons and the same corner, so a windowed video is not a window you can only get out of by pressing ESC first.
   - `always` and `never` override the detection. `never` is the escape hatch if your compositor decorates windows in a way MPV does not report.
   - **Dragging needs MPV 0.39.** MPV refuses to drag its window while the pointer is inside a script's input section, and the only way to say "except for this one" also re-arms MPV's own drag-from-anywhere — which over a UI moves the window instead of dragging a scrollbar. Turning that off is `--input-builtin-dragging`, added in 0.39, so on 0.38 the buttons and the resize grip work but the bar does not drag. Resizing and the buttons need nothing special.
+- `window_controls_fullscreen` - Keep those buttons on screen in full screen. Default: `false`
+  - Off, because full screen has no title bar anywhere and nothing to move, maximize or drag — so the buttons are furniture over the picture.
+  - On is for anyone who wants a way out of full screen that is not a keyboard shortcut, which matters most with `hide_title_bar` also on.
+  - In-window UI only. A classic OSC decides its own window buttons from `border` and never asks about full screen, so this cannot be passed on to it.
+- `hide_title_bar` - Ask the desktop for no title bar on the player window, so the browser's own top bar is the only one. Default: `false`
+  - This is MPV's `border` option, set at startup, so changing it needs a restart.
+  - It pairs with `window_controls`: on `auto`, the buttons appear as soon as this is on, because `auto` reads the same `border` property.
+  - Set only when it is on. Leaving it alone otherwise is what lets someone who put `border=no` in their own `mpv.conf` keep the buttons — writing `border=yes` for them would take the title bar back *and* the replacement with it.
+  - Leave both off unless you want them: a window with neither a title bar nor the top-bar buttons can be awkward to move on some desktops.
 - `display_mirror_summon` - Let casting *open* the window when it is closed to the tray. Default: `false`
   - Mirroring itself is always on; this only controls whether idly browsing on a phone can pop the window open.
 - `library_image_cache_mb` - Memory budget for **decoded** library artwork. Default: `96`

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -627,6 +627,20 @@ You can use the config file to enable and disable features.
   driving while they are hidden, and that takes keyboard control of controls
   already showing (mpv key name syntax). ENTER also toggles pause/play when
   it wakes them. Default: `ENTER`
+- `ui_select_key` - The key that **activates** whatever the in-window
+  interface has focused — a tile in the library, a button on the player
+  controls (mpv key name syntax). Default: `ENTER`
+  - Not the same as `hud_wake_key`, which *summons* hidden controls, nor as
+    `kb_menu_ok`, which is the legacy OSD menu's OK and reaches neither the
+    library nor the player controls.
+  - The gamepad's Confirm button and a Jellyfin remote's Select both send
+    this key, so remapping it moves all three together rather than leaving
+    two of them on a key nothing listens for.
+  - **Not yet offered in the settings screen, and changing it by hand does
+    nothing useful yet.** Yielding `ENTER` back needs the in-window
+    renderer to stop binding it, which has not landed; until then the value
+    is read by the gamepad and the remote but not by the keyboard. See
+    `docs/ISSUES_2026-09.md` (#717).
 - `hud_scrim` - How the picture is shaded behind the player controls, so they
   stay legible over any frame. One of `default`, `panel`, `none`.
   Default: `default`
@@ -816,7 +830,8 @@ You can reconfigure the custom keyboard shortcuts. You can also set them to `nul
 - `kb_unwatched` - Mark the video as unwatched and quit. (Default: `u`)
 - `kb_menu` - Open the configuration menu. (Default: `c`)
 - `kb_menu_esc` - Leave the menu. Exits fullscreen otherwise. (Default: `esc`)
-- `kb_menu_ok` - "ok" for menu. (Default: `enter`)
+- `kb_menu_ok` - "ok" for the **legacy OSD menu only** — not the library and
+  not the player controls, which use `ui_select_key`. (Default: `enter`)
 - `kb_menu_left` - "left" for menu. Seeks otherwise. (Default: `left`)
 - `kb_menu_right` - "right" for menu. Seeks otherwise. (Default: `right`)
 - `kb_menu_up` - "up" for menu. Seeks otherwise. (Default: `up`)

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -456,6 +456,11 @@ You can use the config file to enable and disable features.
 - `display_mirror_summon` - Let casting take the screen: open the window when it is closed to the tray, and bring it forward when it is already open. Default: `false`
   - Mirroring itself is always on; this only controls whether idly browsing on a phone can pop the window open or in front of what you are doing.
   - With it off, casting a page to an already-open library still navigates it — silently, without taking focus back from the web client you are casting *from*.
+- `browse_block_keys` - Swallow MPV's own keyboard shortcuts while the library browser is on screen. Default: `true`
+  - MPV is started with its default bindings on for the whole session, so in the library every key the client has not taken is still MPV's — `1`-`8` move contrast, brightness, gamma and saturation, `d` cycles deinterlacing, `s` writes a screenshot. There is no video for them to act on, they persist into the *next* thing you play, and the only feedback is MPV's own OSD, which draws underneath the library.
+  - Only unmodified printable keys are blocked. The arrows, Page Up/Down, Home/End and the scroll wheel are the browser's own either way, and modified keys (`ctrl+`, `alt+`) are left alone.
+  - While music is playing, `9`, `0` and `m` are re-claimed by the browser itself, so they still change the volume — and unlike MPV's own bindings they move the now-playing bar's slider with them.
+  - Turn it off to use your own `input.conf` bindings in the library. That also gives MPV's `9`/`0`/`m` back in place of the browser's.
 - `library_image_cache_mb` - Memory budget for **decoded** library artwork. Default: `96`
   - Requires restart. The budget is baked into the artwork cache when the browser starts.
   - Decoded is the expensive form — a 4K backdrop is 33 MB decoded against ~400 KB on the wire — and this is a working set rather than a library: decoded images exist to composite tile strips, and the strips are cached in their own right, so scrolling back over a cached row never asks for one. Raise it if you browse enormous libraries on a machine with RAM to spare.

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -423,7 +423,7 @@ You can use the config file to enable and disable features.
   - The library browser and the player share one window, so playback no longer takes over the screen unless you ask it to.
 - `enable_gui` - Enable the system tray icon and GUI features. Default: `true`
   - Turning this off puts the app in command-line mode: no window, no system tray and no settings screen, so on Windows the only way back is editing `conf.json` by hand. It is listed under "Advanced" in the settings form for that reason.
-  - It is *not* how you get MPV's own on-screen controls back — set `osc_style` to `mpv` (or `default`) and leave this on.
+  - It is *not* how you get MPV's own on-screen controls back — set `osc_style` to `mpv` and leave this on.
   - For the classic "sit in the background and play what is cast to me" setup, enable `close_to_tray` (or `allow_background` where there is no tray), `start_minimized` and `fullscreen`; closing the video with `q` or the back button returns to waiting.
 - `browser_fullscreen` - Run the in-window library browser fullscreen. Default: `false`
   - Browsing is a desktop activity, so it opens windowed even when `fullscreen` is set. `fullscreen` still applies when playback starts.
@@ -548,14 +548,21 @@ You can use the config file to enable and disable features.
     navigable with a keyboard or a Jellyfin remote. Needs `enable_gui`
     (falls back to `mpv` otherwise). `jellyfin` is accepted as a legacy
     alias.
-  - `mpv` - The stock mpv controls, patched with trickplay preview support.
-  - `default` - Whatever OSC is built into your mpv, or your own OSC scripts.
-    Thumbnail data is still published for thumbfast-aware OSCs like uosc.
-    - **Running your own OSC:** drop the script in the `scripts/` folder beside
-      `conf.json` (see the paths at the top of this file) and any font it needs
-      in `fonts/`, then put `osc=no` in `mpv.conf` there so mpv's built-in one
-      does not draw underneath it. That line is honoured — `default` is the one
-      style where the shim never overrides the option.
+  - `mpv` - MPV's own on-screen controls, with seek previews where your mpv
+    can show them. Turn previews on or off with `thumbnail_enable`.
+    - On **mpv 0.41 and newer** this is mpv's stock OSC, driven through its
+      OSC Preview API (`user-data/osc/draw-preview`) — you get upstream's
+      controls, upstream's fixes, and our trickplay images in them.
+    - On **older mpv** the shim loads a bundled fork of mpv 0.38's OSC
+      instead, because the Preview API does not exist there and that fork is
+      the only way to get previews. Which one you get is an implementation
+      detail; the controls look and behave the same either way.
+    - `default` is accepted as a legacy alias. It used to be a separate
+      choice — "whatever OSC is built into your mpv" — and folded into `mpv`
+      once the shim started using mpv's own OSC for both. It is migrated
+      automatically.
+    - Thumbnail data is still published for thumbfast-aware OSCs like uosc;
+      to run one of those, use `custom`.
     - The shim asks the OSC to get out of the way when the library browser
       opens, and when you choose `none`, with the `osc-visibility` and
       `osc-idlescreen` script-messages. Mpv's own OSC and the scripts forked
@@ -571,8 +578,12 @@ You can use the config file to enable and disable features.
       paints itself can.
     - This style also lets the library draw above the OSC's own layer, which
       uosc in particular needs. That is why it is a separate choice rather
-      than something `default` does for everyone: the same layer is used by
+      than something `mpv` does for everyone: the same layer is used by
       MPV's console when it is showing a menu.
+    - **Running your own OSC:** drop the script in the `scripts/` folder beside
+      `conf.json` (see the paths at the top of this file) and any font it needs
+      in `fonts/`, then put `osc=no` in `mpv.conf` there. This style already
+      turns MPV's built-in controls off, so nothing draws underneath yours.
     - **Two things a third-party OSC cannot do, and will not.** Both apply to
       `default` as well; trickplay previews are the part that does work.
       - **Tracks.** Its subtitle and audio pickers see only what MPV has, and
@@ -1012,7 +1023,7 @@ older versions did — every preview is then instant, at the cost of the full
 download and the full memory.
 
 - `thumbnail_enable` - Enable thumbnail feature. (Default: `true`)
-- `thumbnail_osc_builtin` - Legacy alias: disabling this behaves like `osc_style: default` (use your own OSC but leave trickplay enabled). Prefer `osc_style`. (Default: `true`)
+- `thumbnail_osc_builtin` - Legacy alias: disabling this behaves like `osc_style: custom` (use your own OSC but leave trickplay enabled). Prefer `osc_style`. (Default: `true`)
 - `thumbnail_preferred_size` - The ideal size for thumbnails. (Default: `320`)
 - `trickplay_fast_mode` - Load every preview frame at once instead of a window around the seek position. Previews never wait, but a long video costs hundreds of megabytes of memory. Turning it *on* applies to the video you are watching, the next time you scrub outside the part already loaded; turning it *off* applies to the next video. (Default: `false`)
 

--- a/docs/do-not-fix.md
+++ b/docs/do-not-fix.md
@@ -76,11 +76,29 @@ produce a finding a third time:
   It folded into "MPV UI" at CONFIG_VERSION 5 — the two only differed in who
   loaded the OSC, and once the shim used mpv's own for both, `default` was
   just the one that forgot to suppress the idle logo. `custom` covers "I run
-  my own OSC" and `none` covers "no controls". The value survives as an
-  internal resolution for the legacy `thumbnail_osc_builtin` opt-out, which
-  is the only path that still needs "let mpv decide"; see
-  `mpv_options.resolve_osc_style` and the property test that no fallback may
-  land on a style drawing no controls.
+  my own OSC" and `none` covers "no controls". It is now an inbound legacy
+  value only: `resolve_osc_style` accepts it and returns "mpv", and nothing
+  resolves *to* it. `build_mpv_options` still maps it, because that function
+  is a pure style → options mapping and "let mpv decide" is still what the
+  value means — not because a caller can produce it.
+- **`thumbnail_osc_builtin` is deleted with no migration, like `enable_osc`
+  above, and a `false` in an old config is ignored on purpose.** Its one
+  documented meaning was "use your own custom osc but leave trickplay
+  enabled" (`acbc3e9d`'s README), which is exactly `osc_style: custom` — and
+  `mpv_scripts` loads thumbfast under every style, so `custom` keeps the
+  previews that sentence promises. Nothing it could express was lost, so
+  there is nothing to carry across.
+
+  It is not migrated to `custom` automatically because the flag is a
+  default-*on* switch somebody turned off, not proof that a replacement OSC
+  exists, and `custom` sets `osc=False` and loads nothing — the one outcome
+  a silent upgrade must never produce is a user with no controls at all.
+  [iw]. Someone who really is running uosc sets `osc_style: custom` once and
+  can see that they have.
+
+  Do not re-add the key as a compatibility shim. The `resolve_osc_style`
+  branch it had was the last thing that could resolve to `"default"`, which
+  is why that value's status changed in the entry above.
 - **The startup PIN is parental control, not a security boundary.** It stops a
   kid on an HTPC opening R-rated films. So the work is enumerating the doors and
   a catch-all test — *not* deferring connection until unlock.

--- a/docs/do-not-fix.md
+++ b/docs/do-not-fix.md
@@ -56,6 +56,31 @@ produce a finding a third time:
 
 ## 3. Settled design decisions
 
+- **`enable_osc` from a 2.9.0 config is ignored on purpose, and must not be
+  migrated to `osc_style: none`.** It is gone from the schema, so an upgrader
+  who had it off gets `Config item enable_osc was ignored` in the log and
+  lands on the `mpvtk` default. That reads exactly like a missing migration
+  and is the intended destination.
+
+  In 2.9.0 mpv's OSC was the only OSC, so turning it off meant "this OSC is
+  not good enough". The Jellyfin UI is new in v3 and is markedly better than
+  every other option because the shim integrates with it at the player level
+  — so the upgrade *answers* that complaint rather than contradicting it.
+  Mapping the old flag to "no controls at all" would take the new one away
+  from precisely the users it was built for. [iw].
+
+  `resolve_osc_style`'s comment that "none is where the old enable_osc
+  setting went" is about where the *switch* went as a user-facing choice, not
+  about migrating anyone onto it.
+- **`osc_style: "default"` no longer being offered is not a lost feature.**
+  It folded into "MPV UI" at CONFIG_VERSION 5 — the two only differed in who
+  loaded the OSC, and once the shim used mpv's own for both, `default` was
+  just the one that forgot to suppress the idle logo. `custom` covers "I run
+  my own OSC" and `none` covers "no controls". The value survives as an
+  internal resolution for the legacy `thumbnail_osc_builtin` opt-out, which
+  is the only path that still needs "let mpv decide"; see
+  `mpv_options.resolve_osc_style` and the property test that no fallback may
+  land on a style drawing no controls.
 - **The startup PIN is parental control, not a security boundary.** It stops a
   kid on an HTPC opening R-rated films. So the work is enumerating the doors and
   a catch-all test — *not* deferring connection until unlock.

--- a/docs/do-not-fix.md
+++ b/docs/do-not-fix.md
@@ -131,6 +131,7 @@ then dropped in the same commit).
 | F25 | `sync/manager.py`, `sync/auto.py` | A live `work_offline` toggle leaves the download worker streaming on a metered link. Low priority per section 3; "won't fix" and removing the setting are both on the table. |
 | F26 | `cast.py` | Cast parks the last composite. |
 | F29 | `player.py` load gate / `_on_cache_pause` | Field report, below. |
+| F35 | `renderer.lua` `phud_skip_bind` | Binds literal `'ENTER'` for the Skip button whatever `hud_wake_key` says, so a moved wake key leaves ENTER accepting a skip. Found while doing #717 and deliberately left: it is a `hud_wake_key` bug, and it wants a decision about whether the idle Skip offer follows the wake key or `ui_select_key`. |
 
 ### F29 — sleeping NAS, not reproduced
 

--- a/docs/mpv-backends.md
+++ b/docs/mpv-backends.md
@@ -307,6 +307,26 @@ The governing rule is *stop intercepting keys whose meaning we did not change*.
   `seeking` property and applies it to *any* forward seek, mpv's own bindings
   included. Claiming a key would double-handle, since the claim's own `seek()`
   raises that same observer.
+- **The library is the exception, and it is a different rule (#730).** Everything
+  above is about *playback*, where mpv's meaning is the right meaning and taking a
+  key is only justified by having changed it. In the library there is no video, so
+  the commands are not differently-interpreted but inapplicable: `1`-`8` move a
+  picture that is not there, the change survives into the next thing played, and
+  the OSD reporting it is ASS and therefore draws *under* the overlay bitmaps the
+  UI is made of. `browse_block_keys` (default on) swallows them with **one forced
+  `any_unicode` binding**, which outranks every exact-key default across the
+  printable range — measured, and pinned by
+  `tests/integration/test_mpvtk_browser.py:BrowseKeyBlockTest`. It covers nothing
+  else and does not need to: the arrows, PGUP/PGDWN, HOME/END and the wheel are
+  the renderer's own, and modified keys are left alone. `keyclaim.block_*` in
+  `renderer.lua`; browse only, never a summoned playback HUD.
+  - A focused text box binds its **own** `any_unicode`, and between two forced
+    bindings of one key the last bound wins — so typing is unaffected. The block's
+    handler routes to the text box anyway, which is what makes the order stop
+    mattering when the setting is changed live.
+  - `9`/`0`/`m` are claimed back by the browser while music plays, so they still
+    work and now move the now-playing bar's slider with them. Turning the setting
+    off gives those back to mpv along with everything else.
 - ENTER confirms the OSD menu and does nothing else. It is swallowed rather than
   left to mpv, which binds it to `playlist-next`; the shim's mpv playlist holds
   one file, so what that does depends on `keep-open` and is not a behaviour to

--- a/docs/settings-curation.md
+++ b/docs/settings-curation.md
@@ -89,6 +89,7 @@ picked was the wrong one or whether the control does nothing.
 | `scroll_wheel_pixels`, `scroll_mode` | `app.push_scroll_config()` — the renderer re-derives |
 | `gamepad_swap_confirm` | `app.push_gamepad()` — the renderer rebinds |
 | `ui_select_key` | `app.push_select_key()` **and** `app.push_gamepad()` — one key, two pushes: the pad's binding table spells it out as a literal, so re-pushing the keyboard alone leaves the controller on the old key (#717) |
+| `browser_fullscreen` | `controller.apply_browser_fullscreen()` -> `WindowMixin._apply_browse_fullscreen`, the same decision `set_browse_window` makes (#729) |
 | `poster_scale` (Cover Size) | `apply_cover_size()` |
 | `ui_text_scale`, `ui_text_min` | toolkit type scale **and** `apply_cover_size()` |
 | `logo_legibility_*` | `apply_logo_legibility()` → `StripStore.retag()` |

--- a/docs/settings-curation.md
+++ b/docs/settings-curation.md
@@ -89,6 +89,7 @@ picked was the wrong one or whether the control does nothing.
 | `scroll_wheel_pixels`, `scroll_mode` | `app.push_scroll_config()` — the renderer re-derives |
 | `gamepad_swap_confirm` | `app.push_gamepad()` — the renderer rebinds |
 | `ui_select_key` | `app.push_select_key()` **and** `app.push_gamepad()` — one key, two pushes: the pad's binding table spells it out as a literal, so re-pushing the keyboard alone leaves the controller on the old key (#717) |
+| `browse_block_keys` | `app.push_browse_keys()` — the renderer binds or removes one key binding; the shell's volume claim reads the same setting, so the write also asks for a frame (#730) |
 | `browser_fullscreen` | `controller.apply_browser_fullscreen()` -> `WindowMixin._apply_browse_fullscreen`, the same decision `set_browse_window` makes (#729) |
 | `poster_scale` (Cover Size) | `apply_cover_size()` |
 | `ui_text_scale`, `ui_text_min` | toolkit type scale **and** `apply_cover_size()` |

--- a/docs/settings-curation.md
+++ b/docs/settings-curation.md
@@ -38,6 +38,17 @@ Two conventions:
   and turning the parent off *says so* if it also had to clear a dependant
   (`TRAY_DEPENDENT` → `start_minimized`). Leaving a hidden setting acting at
   every startup with no way to see or undo it is the failure being avoided.
+  The sets are `TRAY_DEPENDENT`, `BACKGROUND_DEPENDENT`, `AUDIO_MODE_ONLY`,
+  `HUD_ONLY` and `TRICKPLAY_DEPENDENT`; each is seeded into `sections()`'s
+  `curated` set, and **that seeding is the part to get wrong**. `hidden` is
+  computed as `curated - shown`, so a key nobody seeded is never in `hidden`
+  and the filter never reaches it: the row goes on being drawn and nothing
+  says why. Silently, and with a form that still looks complete — which is
+  why the test for a new dependent asserts it is *absent from every group*
+  when its parent is off, not merely that it is absent from Advanced. That
+  second assertion cannot fail (`hidden` is a subset of `curated` by
+  construction); `c06e0351` deleted one written that way, and
+  `tests/test_trickplay_setting.py` says so where the next one would go.
 - **A control that is not offered beats a control that is disabled** where the
   reason is a permission or a missing capability, because a disabled control
   invites the user to go looking for the switch that enables it.
@@ -173,6 +184,7 @@ type.
 |---|---|
 | `ui_scale` | the whole interface geometry is derived once |
 | `osc_style` | picks which OSC mpv is *constructed* with |
+| `thumbnail_enable` | `_init_mpv` starts the TrickPlay worker, and `mpv_scripts` loads thumbfast only if it did — and mpv is not re-created between queue items |
 | `input_gamepad` | mpv reads it once, at startup |
 | `theme` — the **size** half | `poster_scale`/`tile_landscape` feed sizes a live rebuild would have to rediscover through every cached row; see `docs/browser-shell.md` §9 |
 | shader pack directory | read once at startup |

--- a/docs/settings-curation.md
+++ b/docs/settings-curation.md
@@ -88,6 +88,7 @@ picked was the wrong one or whether the control does nothing.
 | `audio_*` | `_apply_audio_settings` |
 | `scroll_wheel_pixels`, `scroll_mode` | `app.push_scroll_config()` — the renderer re-derives |
 | `gamepad_swap_confirm` | `app.push_gamepad()` — the renderer rebinds |
+| `ui_select_key` | `app.push_select_key()` **and** `app.push_gamepad()` — one key, two pushes: the pad's binding table spells it out as a literal, so re-pushing the keyboard alone leaves the controller on the old key (#717) |
 | `poster_scale` (Cover Size) | `apply_cover_size()` |
 | `ui_text_scale`, `ui_text_min` | toolkit type scale **and** `apply_cover_size()` |
 | `logo_legibility_*` | `apply_logo_legibility()` → `StripStore.retag()` |

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -223,9 +223,15 @@ process per module:
 xvfb-run -a python3 tools/run_tests_parallel.py
 ```
 
-**~64s against ~7 minutes**, same 4,905 tests. It is stdlib-only, like the
-suite, and it exists because the suite got slow enough that re-running it to
-see a failure you did not keep costs more than the failure did.
+**~30s against ~2m15s**, same ~5,500 tests (measured 2026-09-05 on a 16-core
+box). It is stdlib-only, like the suite, and it exists because the suite got
+slow enough that re-running it to see a failure you did not keep costs more
+than the failure did.
+
+Both figures had rotted -- they were written as 64s against 7 minutes, and the
+serial suite has since roughly halved while the test count grew by 600. Quote
+them as the shape of the wait rather than as a benchmark, and re-measure
+before using either as evidence about a change.
 
 `xvfb-run` goes in front of *this script*, not around the workers: `-a` picks
 a display by probing for a free one, and sixteen of those probing at once race

--- a/jellyfin_mpv_shim/args.py
+++ b/jellyfin_mpv_shim/args.py
@@ -5,6 +5,7 @@ directly. Adding a new flag means editing this file and nothing else.
 """
 
 import argparse
+from typing import NamedTuple, Optional
 
 from .constants import APP_NAME, CLIENT_VERSION
 
@@ -13,6 +14,45 @@ _args = None
 #: Accepted values for the positional command. Not passed to argparse as
 #: choices= — see _build_parser.
 COMMANDS = ("add", "clear", "stop")
+
+
+class CliOverride(NamedTuple):
+    """A flag that shadows a `conf.Settings` field for one run."""
+
+    #: Attribute on the parsed args.
+    dest: str
+    #: The settings field it shadows.
+    key: str
+    #: How to spell it back on a command line.
+    flag: str
+    #: The negative spelling, for a `BooleanOptionalAction` flag.
+    off: Optional[str] = None
+
+    def spell(self, value):
+        """This override, as command-line arguments."""
+        if self.off is not None:
+            return [self.flag if value else self.off]
+        return [self.flag, str(value)]
+
+
+#: The flags that OVERRIDE a config key, and the key each one shadows.
+#:
+#: One table because three places need the same pairing and they must not
+#: drift: `mpv_shim.main` applies them after the config loads,
+#: `settings_base` keeps them out of the file they would otherwise be
+#: written to (#718), and `restart._durable_flags` re-passes them across a
+#: self-restart -- except for the setting the restart is FOR, since
+#: re-passing that one would overwrite what the user just saved.
+#:
+#: A flag added here is covered by all three by construction. A flag added
+#: to only one of them was the bug.
+CLI_OVERRIDES = (
+    CliOverride("enable_gui", "enable_gui", "--gui", "--no-gui"),
+    CliOverride("start_minimized", "start_minimized",
+                "--minimized", "--no-minimized"),
+    CliOverride("mpv_loglevel", "mpv_log_level", "--mpv-loglevel"),
+    CliOverride("ui_scale", "ui_scale", "--scale"),
+)
 
 
 def _build_parser() -> argparse.ArgumentParser:

--- a/jellyfin_mpv_shim/conf.py
+++ b/jellyfin_mpv_shim/conf.py
@@ -579,15 +579,21 @@ class Settings(SettingsBase):
     # segment. Applies to keyboard/remote seeks; seeks made from the
     # jellyfin OSC's seekbar never trigger it (it has its own button).
     skip_intro_on_seek: bool = False
+    # The trickplay feature as a whole: the worker that fetches the images
+    # and the thumbfast script that draws them. Every OSC style consumes it
+    # — the HUD's own bubble, both classic OSCs, and a thumbfast-aware
+    # script of the user's — so it is not an OSC question and does not
+    # live with them.
     thumbnail_enable: bool = True
-    thumbnail_osc_builtin: bool = True
     # In-player UI: "mpvtk" (the in-window playback HUD rendered by the
     # library browser — jellyfin-web styled, remote navigable; needs
-    # enable_gui, falls back to "mpv" otherwise), "mpv" (stock
-    # mpv OSC patched with trickplay previews), or "default" (whatever
-    # OSC is built into the mpv binary / the user's own scripts).
-    # "jellyfin" is a legacy alias for "mpvtk" (the lua OSC it used to
-    # name was retired once the HUD reached parity).
+    # enable_gui, falls back to "mpv" otherwise), "mpv" (mpv's own OSC,
+    # loaded by us so it can draw trickplay previews), "custom" (the
+    # user's own OSC script; ours stays out of the way) or "none".
+    # Two legacy aliases, both accepted on the way in and neither
+    # produced: "jellyfin" for "mpvtk" (the lua OSC it used to name was
+    # retired once the HUD reached parity) and "default" for "mpv"
+    # (CONFIG_VERSION 5).
     osc_style: str = "mpvtk"
     # Playback HUD looks and lifecycle (osc_style "mpvtk"). The scrim
     # is what makes the controls legible over any frame; "none" pays

--- a/jellyfin_mpv_shim/conf.py
+++ b/jellyfin_mpv_shim/conf.py
@@ -724,6 +724,15 @@ class Settings(SettingsBase):
     # ENTER when this moves, which is the point -- the request was to get
     # ENTER back for mpv's own use.
     ui_select_key: str = "ENTER"
+    #: Swallow mpv's own keyboard shortcuts while the library is on screen
+    #: (#730). What it covers and how: docs/mpv-backends.md section 5.
+    #:
+    #: On by default, which is the half worth writing down here: browsing a
+    #: library is not a context where anybody means "adjust the picture",
+    #: and the change would outlive the browse session. It is a setting at
+    #: all because turning it off is the only way to reach your own
+    #: input.conf bindings there.
+    browse_block_keys: bool = True
     thumbnail_preferred_size: int = 320
     #: Load every trickplay preview frame at once instead of a window
     #: around where you are seeking.

--- a/jellyfin_mpv_shim/conf.py
+++ b/jellyfin_mpv_shim/conf.py
@@ -28,7 +28,9 @@ config_path = None
 #      "None" and been saved back verbatim; those become real nulls.
 #   4: the seek_* settings leave conf.json -- the keys the user CHANGED
 #      become real bindings in their input.conf (see input_conf.py).
-CONFIG_VERSION = 4
+#   5: osc_style "default" folds into "mpv" -- one "MPV UI" instead of two
+#      that only differed in who loaded the OSC.
+CONFIG_VERSION = 5
 
 # Media segment types the server publishes, and the setting that decides what
 # each one does. Jellyfin's enum also has "Unknown", which has no meaning to
@@ -766,6 +768,28 @@ class Settings(SettingsBase):
                     "(mpv now supports Dolby Vision natively)."
                 )
                 self.transcode_dolby_vision = False
+        if self.config_version < 5:
+            # "MPV built-in default" and "MPV UI with thumbnails" collapse
+            # into one "MPV UI". They only ever differed in who loaded the
+            # OSC -- mpv itself, or us -- and once the shim started using
+            # mpv's OWN OSC for both (the 0.41 Preview API, see
+            # `player._load_classic_osc`) the difference stopped being
+            # visible except as a bug: under "default" nothing suppressed
+            # mpv's "Drop files or URLs to play" logo, so it sat behind the
+            # library.
+            #
+            # [iw]: "we already have a custom and no osc option for people
+            # who want that" -- `custom` leaves the user's own OSC to run
+            # and `none` turns controls off, so nothing is lost by the shim
+            # owning this one.
+            #
+            # A RENAME-shaped step: it carries a real choice across rather
+            # than overriding one.
+            if self.osc_style == "default":
+                log.info("Config migration: osc_style \"default\" -> "
+                         "\"mpv\" (one MPV UI; see CONFIG_VERSION 5).")
+                self.osc_style = "mpv"
+                changed = True
         if self.config_version < 4:
             # #16: the keys the user CHANGED become real mpv bindings, and
             # the settings are cleared so nothing binds them twice. The

--- a/jellyfin_mpv_shim/conf.py
+++ b/jellyfin_mpv_shim/conf.py
@@ -84,6 +84,25 @@ SCROLL_MODES = ("continuous", "aligned", "row")
 _save_lock = threading.Lock()
 
 
+def select_key():
+    """The key that activates whatever the in-window UI has focused.
+
+    **One reader for three producers.** The gamepad's Confirm button, a
+    Jellyfin remote's "ok" and the renderer's own binding all have to name
+    this same key: each of the first two synthesizes a KEYPRESS, so a
+    remap that moves one and not the others leaves that one pressing a key
+    nothing listens for. `gamepad.bindings` takes it as a parameter (that
+    module is pure), the player reads it per press, and the fallback lives
+    here rather than at each call site -- two spellings of a default is
+    how they come to differ.
+
+    Falls back when cleared: a config with no select key is an interface
+    that cannot be operated by anything but the mouse, and the settings
+    screen that would fix it is inside that interface.
+    """
+    return getattr(settings, "ui_select_key", None) or "ENTER"
+
+
 def get_default_sdir():
     if sys.platform.startswith("win32"):
         if os.environ.get("USERPROFILE"):
@@ -692,6 +711,21 @@ class Settings(SettingsBase):
     # The key that summons the HUD for keyboard driving while it is
     # hidden (mpv key name syntax). ENTER also toggles pause on wake.
     hud_wake_key: str = "ENTER"
+    # The key that ACTIVATES whatever the in-window UI has focused -- the
+    # library's tiles and the player controls both. An mpv key name, and
+    # uppercase like hud_wake_key beside it rather than lowercase like the
+    # kb_* family, because it is bound by the renderer and not by
+    # _bind_key.
+    #
+    # Distinct from kb_menu_ok, which is the LEGACY OSD menu's OK and
+    # reaches nothing else -- the confusion behind #717.
+    #
+    # **Not yet reachable from the settings screen, on purpose.** It is a
+    # replacement and not an alias: the renderer has to stop force-binding
+    # ENTER for the old key to be yielded, and until it does, changing
+    # this would move the gamepad and the remote onto a key nothing
+    # listens for. See docs/ISSUES_2026-09.md #717.
+    ui_select_key: str = "ENTER"
     thumbnail_preferred_size: int = 320
     #: Load every trickplay preview frame at once instead of a window
     #: around where you are seeking.

--- a/jellyfin_mpv_shim/conf.py
+++ b/jellyfin_mpv_shim/conf.py
@@ -720,11 +720,9 @@ class Settings(SettingsBase):
     # Distinct from kb_menu_ok, which is the LEGACY OSD menu's OK and
     # reaches nothing else -- the confusion behind #717.
     #
-    # **Not yet reachable from the settings screen, on purpose.** It is a
-    # replacement and not an alias: the renderer has to stop force-binding
-    # ENTER for the old key to be yielded, and until it does, changing
-    # this would move the gamepad and the remote onto a key nothing
-    # listens for. See docs/ISSUES_2026-09.md #717.
+    # A replacement and not an alias [iw]: the renderer stops force-binding
+    # ENTER when this moves, which is the point -- the request was to get
+    # ENTER back for mpv's own use.
     ui_select_key: str = "ENTER"
     thumbnail_preferred_size: int = 320
     #: Load every trickplay preview frame at once instead of a window

--- a/jellyfin_mpv_shim/conf.py
+++ b/jellyfin_mpv_shim/conf.py
@@ -581,6 +581,11 @@ class Settings(SettingsBase):
     # Seconds of no input before they hide. 0 means "as soon as the
     # pointer is not on them", and forces the hover mode.
     hud_hide_secs: float = 4.0
+    # Let the controls shrink further on a narrow window before any of
+    # them are dropped. Off is the older behaviour: they stop at 72% and
+    # buttons start disappearing instead. On, they shrink until the
+    # smallest hit target reaches the accessibility minimum.
+    hud_auto_scale: bool = True
     # Scale factor for the whole in-player UI (tiles, text, chrome).
     # null follows the display: mpv's display-hidpi-scale, which is 1.0
     # on X11 and the compositor's factor on Wayland/macOS. Set a number

--- a/jellyfin_mpv_shim/conf.py
+++ b/jellyfin_mpv_shim/conf.py
@@ -243,6 +243,22 @@ class Settings(SettingsBase):
     #
     # "always" / "never" override it.
     window_controls: str = "auto"
+    #: Ask the desktop for no title bar at all (mpv's `border`), so the
+    #: browser's own top bar is the only one.
+    #:
+    #: Off by default because it is a one-way door on some desktops: with no
+    #: title bar and no window controls drawn, a window can be hard to move
+    #: or close. It pairs with `window_controls` -- "auto" starts answering
+    #: yes the moment this is on, because it asks mpv the same `border`
+    #: question this sets.
+    hide_title_bar: bool = False
+    #: Keep the browser's own window buttons on screen in fullscreen.
+    #:
+    #: Off, because a fullscreen window has no title bar anywhere and nothing
+    #: to minimize, maximize or drag -- so the buttons are furniture over the
+    #: top of a video. On for anyone who wants a way out of fullscreen that
+    #: is not a keyboard shortcut. See `window_controls_wanted`.
+    window_controls_fullscreen: bool = False
     # Persist the window size across launches. Off means window_width/height
     # are a fixed preference the app always opens at, which is what you want
     # if you deliberately pinned a size.

--- a/jellyfin_mpv_shim/gamepad.py
+++ b/jellyfin_mpv_shim/gamepad.py
@@ -26,6 +26,13 @@ Pure data plus one function: no mpv, no settings import, no I/O.
 #: to it answer.
 KEY = "key"
 
+#: Stands in for "the key that activates the focused control" in
+#: :data:`DEFAULT_BINDS`, replaced by :func:`bindings`. A placeholder rather
+#: than a settings read, because this module is pure (see the header) -- and
+#: because a caller that has to pass the key cannot forget that Confirm and
+#: the keyboard have to name the same one.
+SELECT = object()
+
 #: Seek the way that arrow key seeks. The third field is a ``kb_seek``
 #: direction ("up" / "down" / "left" / "right").
 SEEK = "seek"
@@ -71,12 +78,15 @@ DEFAULT_BINDS = (
     ("GAMEPAD_LEFT_STICK_LEFT", KEY, "LEFT", DIRECTION_REPEAT),
     ("GAMEPAD_LEFT_STICK_RIGHT", KEY, "RIGHT", DIRECTION_REPEAT),
 
-    # Confirm and back. ENTER because that is what the browser's nav
-    # activates on and what the hidden HUD wakes on; ESC because it already
-    # steps out exactly one layer -- page, dialog, menu, playback -- and a
-    # second implementation of that ladder would drift from it. The mouse's
-    # back button is routed the same way for the same reason.
-    (CONFIRM_BUTTON, KEY, "ENTER", NO_REPEAT),
+    # Confirm and back. Confirm's key is a PLACEHOLDER here and is
+    # substituted by `bindings()` -- it is whatever activates the focused
+    # control, which the user may remap (`ui_select_key`), and the three
+    # things that synthesize it have to agree or two of them stop working.
+    # ESC is a literal because it already steps out exactly one layer --
+    # page, dialog, menu, playback -- and a second implementation of that
+    # ladder would drift from it. The mouse's back button is routed the
+    # same way for the same reason.
+    (CONFIRM_BUTTON, KEY, SELECT, NO_REPEAT),
     (BACK_BUTTON, KEY, "ESC", NO_REPEAT),
 
     # Play/pause. SPACE rather than `cycle pause`, so it lands on the shim's
@@ -103,8 +113,15 @@ DEFAULT_BINDS = (
 )
 
 
-def bindings(swap_confirm=False):
+def bindings(swap_confirm=False, select_key="ENTER"):
     """The binding table as a list of ``[key, kind, argument, repeat]``.
+
+    ``select_key`` is what Confirm sends: the key that activates the focused
+    control, which the user may remap. It is a PARAMETER and not a settings
+    read, so this module stays pure (see the header) and so a caller cannot
+    quietly leave the pad naming a different key from the keyboard -- the
+    failure mode #717's repair is most likely to produce, since a test that
+    only presses the keyboard cannot see it.
 
     Lists rather than tuples because this is JSON on the way to the renderer,
     and a tuple would come back as a list anyway -- pinning the shape here
@@ -116,5 +133,6 @@ def bindings(swap_confirm=False):
         swapped = {CONFIRM_BUTTON: BACK_BUTTON, BACK_BUTTON: CONFIRM_BUTTON}
     out = []
     for key, kind, arg, rate in DEFAULT_BINDS:
-        out.append([swapped.get(key, key), kind, arg, rate])
+        out.append([swapped.get(key, key), kind,
+                    select_key if arg is SELECT else arg, rate])
     return out

--- a/jellyfin_mpv_shim/messages/base.pot
+++ b/jellyfin_mpv_shim/messages/base.pot
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: jellyfin-mpv-shim\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2026-09-05 14:45-0400\n"
+"POT-Creation-Date: 2026-09-05 17:24-0400\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -1764,6 +1764,10 @@ msgid "Hide the Player Controls After (seconds)"
 msgstr ""
 
 #: jellyfin_mpv_shim/mpvtk_browser/config.py
+msgid "Shrink the Player Controls on a Narrow Window"
+msgstr ""
+
+#: jellyfin_mpv_shim/mpvtk_browser/config.py
 msgid "Mouse Back/Forward Buttons Skip Chapters"
 msgstr ""
 
@@ -2091,6 +2095,13 @@ msgstr ""
 msgid ""
 "0 hides them as soon as the pointer is not on them, and forces \"Hide unless "
 "hovered\"."
+msgstr ""
+
+#: jellyfin_mpv_shim/mpvtk_browser/config.py
+msgid ""
+"Narrowing the window shrinks the controls until the smallest button reaches "
+"the accessibility minimum, instead of dropping buttons sooner. Off keeps the "
+"older, larger floor."
 msgstr ""
 
 #: jellyfin_mpv_shim/mpvtk_browser/config.py

--- a/jellyfin_mpv_shim/messages/base.pot
+++ b/jellyfin_mpv_shim/messages/base.pot
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: jellyfin-mpv-shim\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2026-09-05 19:49-0400\n"
+"POT-Creation-Date: 2026-09-06 13:05-0400\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -1744,6 +1744,10 @@ msgid "Fullscreen Library Browser"
 msgstr ""
 
 #: jellyfin_mpv_shim/mpvtk_browser/config.py
+msgid "Block Player Keybinds While Browsing"
+msgstr ""
+
+#: jellyfin_mpv_shim/mpvtk_browser/config.py
 msgid "Always Bind Arrow Keys to Player Controls"
 msgstr ""
 
@@ -1847,6 +1851,14 @@ msgstr ""
 msgid ""
 "Turn this on for a controller whose A button is on the right rather than at "
 "the bottom (Switch Pro, most 8BitDo pads)."
+msgstr ""
+
+#: jellyfin_mpv_shim/mpvtk_browser/config.py
+msgid ""
+"Stops MPV's own shortcuts -- picture adjustment, screenshots, subtitle and "
+"audio switching -- from acting while you are in the library, where there is "
+"no video for them to act on. Turn it off to use your own MPV key bindings "
+"there."
 msgstr ""
 
 #: jellyfin_mpv_shim/mpvtk_browser/config.py

--- a/jellyfin_mpv_shim/messages/base.pot
+++ b/jellyfin_mpv_shim/messages/base.pot
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: jellyfin-mpv-shim\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2026-09-02 16:20-0400\n"
+"POT-Creation-Date: 2026-09-05 10:25-0400\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -3396,6 +3396,7 @@ msgid "More Like This"
 msgstr ""
 
 #: jellyfin_mpv_shim/mpvtk_browser/pages/detail.py
+#: jellyfin_mpv_shim/mpvtk_browser/tiles.py
 msgid "Go to Series"
 msgstr ""
 
@@ -4562,7 +4563,22 @@ msgid ""
 msgstr ""
 
 #: jellyfin_mpv_shim/sync/manager.py
+msgid ""
+"That folder is inside the current download folder. Choose one outside it."
+msgstr ""
+
+#: jellyfin_mpv_shim/sync/manager.py
+msgid "Can't read that folder. Check the path and its permissions."
+msgstr ""
+
+#: jellyfin_mpv_shim/sync/manager.py
 msgid "That folder already contains downloads. Choose an empty folder."
+msgstr ""
+
+#: jellyfin_mpv_shim/sync/manager.py
+msgid ""
+"That folder isn't empty. Choose an empty folder — the download folder is "
+"managed by this app and anything else in it can be moved or removed."
 msgstr ""
 
 #: jellyfin_mpv_shim/sync/manager.py

--- a/jellyfin_mpv_shim/messages/base.pot
+++ b/jellyfin_mpv_shim/messages/base.pot
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: jellyfin-mpv-shim\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2026-09-05 17:24-0400\n"
+"POT-Creation-Date: 2026-09-05 19:49-0400\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -1752,6 +1752,10 @@ msgid "Player Controls Activation Key"
 msgstr ""
 
 #: jellyfin_mpv_shim/mpvtk_browser/config.py
+msgid "Select Key"
+msgstr ""
+
+#: jellyfin_mpv_shim/mpvtk_browser/config.py
 msgid "Shading Behind the Player Controls"
 msgstr ""
 
@@ -1843,6 +1847,13 @@ msgstr ""
 msgid ""
 "Turn this on for a controller whose A button is on the right rather than at "
 "the bottom (Switch Pro, most 8BitDo pads)."
+msgstr ""
+
+#: jellyfin_mpv_shim/mpvtk_browser/config.py
+msgid ""
+"Activates whatever is highlighted, in the library and on the player "
+"controls. An mpv key name; changing it hands Enter back to MPV. The game "
+"controller's Confirm button and a phone's Select follow it."
 msgstr ""
 
 #: jellyfin_mpv_shim/mpvtk_browser/config.py

--- a/jellyfin_mpv_shim/messages/base.pot
+++ b/jellyfin_mpv_shim/messages/base.pot
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: jellyfin-mpv-shim\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2026-09-05 14:16-0400\n"
+"POT-Creation-Date: 2026-09-05 14:45-0400\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -1659,6 +1659,14 @@ msgid "Window Buttons in the Top Bar"
 msgstr ""
 
 #: jellyfin_mpv_shim/mpvtk_browser/config.py
+msgid "Keep Window Buttons in Full Screen"
+msgstr ""
+
+#: jellyfin_mpv_shim/mpvtk_browser/config.py
+msgid "Hide the Desktop Title Bar"
+msgstr ""
+
+#: jellyfin_mpv_shim/mpvtk_browser/config.py
 msgid "Player Controls Style"
 msgstr ""
 
@@ -1939,6 +1947,22 @@ msgid ""
 "maximize and close in the top bar instead, and lets you drag the window by "
 "it. On \"Only when the window has no title bar\", MPV is asked whether this "
 "window got one, so desktops that draw a title bar are left alone."
+msgstr ""
+
+#: jellyfin_mpv_shim/mpvtk_browser/config.py
+msgid ""
+"Full screen has no title bar anywhere and nothing to move or maximize, so "
+"the buttons are normally hidden there. Turn this on to keep a way out of "
+"full screen that is not a keyboard shortcut."
+msgstr ""
+
+#: jellyfin_mpv_shim/mpvtk_browser/config.py
+msgid ""
+"Asks the desktop for no title bar on the player window, so the top bar above "
+"is the only one. Pairs with the setting above: on \"Only when the window has "
+"no title bar\" the buttons appear as soon as this is on. Leave both off "
+"unless you want them, since a window with neither can be awkward to move on "
+"some desktops."
 msgstr ""
 
 #: jellyfin_mpv_shim/mpvtk_browser/config.py

--- a/jellyfin_mpv_shim/messages/base.pot
+++ b/jellyfin_mpv_shim/messages/base.pot
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: jellyfin-mpv-shim\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2026-09-05 13:27-0400\n"
+"POT-Creation-Date: 2026-09-05 14:16-0400\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -1326,11 +1326,7 @@ msgid "Jellyfin UI"
 msgstr ""
 
 #: jellyfin_mpv_shim/mpvtk_browser/config.py
-msgid "MPV UI with thumbnails"
-msgstr ""
-
-#: jellyfin_mpv_shim/mpvtk_browser/config.py
-msgid "MPV built-in default"
+msgid "MPV UI"
 msgstr ""
 
 #: jellyfin_mpv_shim/mpvtk_browser/config.py

--- a/jellyfin_mpv_shim/messages/base.pot
+++ b/jellyfin_mpv_shim/messages/base.pot
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: jellyfin-mpv-shim\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2026-09-06 13:05-0400\n"
+"POT-Creation-Date: 2026-09-06 16:28-0400\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -1671,6 +1671,10 @@ msgid "Player Controls Style"
 msgstr ""
 
 #: jellyfin_mpv_shim/mpvtk_browser/config.py
+msgid "Enable Trickplay Thumbnails"
+msgstr ""
+
+#: jellyfin_mpv_shim/mpvtk_browser/config.py
 msgid "Load All Seek Previews at Once"
 msgstr ""
 
@@ -1990,6 +1994,14 @@ msgid ""
 "no title bar\" the buttons appear as soon as this is on. Leave both off "
 "unless you want them, since a window with neither can be awkward to move on "
 "some desktops."
+msgstr ""
+
+#: jellyfin_mpv_shim/mpvtk_browser/config.py
+msgid ""
+"Shows a preview frame while you drag the seek bar. Works with every player "
+"control style, including your own OSC script if it supports thumbfast. The "
+"images are fetched from the server per video, which costs disk space and "
+"memory -- tens of MB for an episode, a few hundred for a long film."
 msgstr ""
 
 #: jellyfin_mpv_shim/mpvtk_browser/config.py

--- a/jellyfin_mpv_shim/messages/base.pot
+++ b/jellyfin_mpv_shim/messages/base.pot
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: jellyfin-mpv-shim\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2026-09-05 10:25-0400\n"
+"POT-Creation-Date: 2026-09-05 13:27-0400\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -1852,7 +1852,8 @@ msgstr ""
 #: jellyfin_mpv_shim/mpvtk_browser/config.py
 msgid ""
 "Off gives MPV's own mouse behaviour instead: drag the video to move the "
-"window, and right click to pause. Double click is full screen either way."
+"window, and the right button does whatever your MPV config gives it. Double "
+"click is full screen either way."
 msgstr ""
 
 #: jellyfin_mpv_shim/mpvtk_browser/config.py

--- a/jellyfin_mpv_shim/mpv_options.py
+++ b/jellyfin_mpv_shim/mpv_options.py
@@ -220,6 +220,39 @@ def resolve_osc_style():
     return osc_style
 
 
+def osc_script_opts(osc_style):
+    """The ``osc-*`` entries appended to ``script-opts`` at construction.
+
+    Every osc.lua and every fork of it reads ``script-opts`` under the
+    ``osc`` prefix at startup, so these are read by construction rather than
+    in time. They are appended, never written over the whole property, which
+    is shared with the user's own scripts.
+
+    ``osc-idlescreen`` is unconditional: it has to cover the styles where
+    mpv loads the OSC itself as well as the one we load by hand, and it is
+    inert for a style with no OSC and for a third-party one reading another
+    prefix.
+
+    ``osc-windowcontrols`` is **not**, and the difference is who is drawing
+    window buttons over PLAYBACK. Only ``mpvtk`` does -- its HUD asks
+    ``window_chrome.window_controls`` for a set -- so only there does a
+    second set from the OSC mean two. Under every other style the OSC on
+    screen is the only thing that could offer any: the stock OSC, our
+    ``trickplay-osc.lua`` fork under ``mpv``, and whatever ``custom``
+    loaded. Their default is "auto", i.e. "whenever the window has no
+    border" -- which is precisely the ``hide_title_bar`` case, where saying
+    no left a windowed video with no title bar and no buttons anywhere and
+    nothing but an undocumented key to close it (#727 follow-up).
+
+    The library's own top bar is not the answer to that: it is not on screen
+    while a video is playing.
+    """
+    opts = ["osc-idlescreen=no"]
+    if osc_style == "mpvtk":
+        opts.append("osc-windowcontrols=no")
+    return opts
+
+
 def mpv_scripts(osc_style, trickplay):
     """Lua scripts to load at construction, in load order.
 

--- a/jellyfin_mpv_shim/mpv_options.py
+++ b/jellyfin_mpv_shim/mpv_options.py
@@ -583,6 +583,16 @@ def build_mpv_options(osc_style, scripts, ext_mpv, browser_wants_window):
     # the title follows playback without us pushing updates.
     mpv_options["title"] = "${?media-title:${media-title} - }%s" % USER_APP_NAME
 
+    # No desktop title bar, so the browser's own top bar is the only one
+    # (#727). A construction option rather than a runtime write, and only
+    # when it is ON: `border` is one of the properties `window_controls`
+    # "auto" reads to decide whether to draw its own buttons, so writing
+    # `border=True` unconditionally would override a user who set
+    # `border=no` in their mpv.conf and take those buttons away from
+    # exactly the person who wants them. Off means "say nothing".
+    if settings.hide_title_bar:
+        mpv_options["border"] = False
+
     # Window size. mpv defaults to a fixed 960x540 whatever the display
     # size, which is cramped for a browsable UI. Restored from the last
     # session when remember_window_size is on (see _save_window_geometry).

--- a/jellyfin_mpv_shim/mpv_options.py
+++ b/jellyfin_mpv_shim/mpv_options.py
@@ -188,11 +188,19 @@ def resolve_osc_style():
 
 
 def mpv_scripts(osc_style, trickplay):
-    """Lua scripts to load, in load order.
+    """Lua scripts to load at construction, in load order.
 
     ``trickplay`` is whether the TrickPlay worker actually started -- not
     whether it was asked to. thumbfast is the script side of that feature, so
     a worker that failed to come up must not advertise it to mpv.
+
+    **The classic OSC is deliberately not here.** Which one to load depends
+    on the mpv that is about to be built -- the stock OSC where it can drive
+    our previews (0.41+, the OSC Preview API), our fork where it cannot --
+    and the version is not knowable until the player exists. The libmpv
+    client API cannot stand in for it either: 0.40 and 0.41 both report 2.5.
+    So `PlayerManager._load_classic_osc` picks one and `load-script`s it
+    right after construction, while nothing is on screen yet.
     """
     scripts = []
     if settings.menu_mouse:
@@ -202,8 +210,6 @@ def mpv_scripts(osc_style, trickplay):
         # it, and thumbfast-aware user OSCs (e.g. uosc) benefit
         # under "default" too.
         scripts.append(get_resource("thumbfast.lua"))
-    if osc_style == "mpv":
-        scripts.append(get_resource("trickplay-osc.lua"))
     return scripts
 
 

--- a/jellyfin_mpv_shim/mpv_options.py
+++ b/jellyfin_mpv_shim/mpv_options.py
@@ -160,10 +160,18 @@ def resolve_osc_style():
     """Which in-player UI to load, after the aliases and fallbacks.
 
     ``settings.osc_style`` is not the answer on its own: it may hold a legacy
-    alias, and two settings can force a fallback. The result is stored on the
+    alias, and `enable_gui` can force a fallback. The result is stored on the
     player as ``_osc_style_resolved`` because the c-menu routing, enable_osc
     and the skip-button path all key off the resolved value rather than the
     configured one.
+
+    **Nothing resolves TO "default" any more.** It is an inbound legacy value
+    only -- a pre-CONFIG_VERSION-5 conf.json, or one hand-edited -- and the
+    alias below turns it into "mpv". It survived as an internal resolution
+    for exactly one caller, the `thumbnail_osc_builtin` opt-out, and went
+    with it; `build_mpv_options` still maps the value because it is a pure
+    style -> options function and that mapping is still what "default"
+    means.
     """
     # Which in-player UI to load: the in-window mpvtk playback HUD
     # ("mpvtk"; no lua script — the browser renders it, see
@@ -172,7 +180,9 @@ def resolve_osc_style():
     # ("none"). Two legacy aliases: "jellyfin" for the HUD — the
     # jellyfin-styled lua OSC it named was retired once the HUD reached
     # parity — and "default", which folded into "mpv" at
-    # CONFIG_VERSION 5.
+    # CONFIG_VERSION 5. `thumbnail_osc_builtin` was a third way in and is
+    # gone: "use your own OSC but keep trickplay" is `custom`, and
+    # "no controls" is `none`, so it named nothing this cannot say.
     #
     # "none" is where the old enable_osc setting went. That was a
     # separate switch that only ever reached mpv's OWN controls, so
@@ -197,26 +207,6 @@ def resolve_osc_style():
         # GUI disabled there is nothing to render it, so the patched
         # stock OSC is the closest thing.
         osc_style = "mpv"
-    if osc_style == "mpvtk" and not settings.thumbnail_osc_builtin:
-        # Legacy opt-out: thumbnail_osc_builtin=False used to mean
-        # "don't replace my OSC" (e.g. users running uosc).
-        #
-        # **"default" survives here as an internal resolution, and only
-        # here.** It is gone from the settings screen and migrated out of
-        # conf.json (CONFIG_VERSION 5), but it is the only value that leaves
-        # mpv's own OSC to load itself -- everything else is in
-        # `REPLACES_OSC` and turns it off.
-        #
-        # That matters because of who reaches this line. `custom` was tried
-        # and is wrong: it sets `osc=False` and loads nothing, which is
-        # right for someone who really is running uosc and leaves anyone
-        # else **with no OSC at all**. The flag is a legacy default-off
-        # switch, not proof that a replacement exists, so the safe reading
-        # is "let mpv decide", which is what it has always done.
-        #
-        # Note the ordering: the "default" -> "mpv" alias above has already
-        # run, so this assignment is not folded back into "mpv".
-        osc_style = "default"
     return osc_style
 
 

--- a/jellyfin_mpv_shim/mpv_options.py
+++ b/jellyfin_mpv_shim/mpv_options.py
@@ -26,12 +26,18 @@ from .utils import get_resource
 
 log = logging.getLogger("mpv_options")
 
-#: Styles that must not leave mpv's built-in OSC on: two that replace it
-#: with something of ours, one that replaces it with nothing, and one where
-#: the replacement is a script of the user's that we never see.
+#: Styles that must not leave mpv's built-in OSC to load itself.
 #:
-#: "default" is deliberately absent -- there mpv's own OSC is the answer, and
-#: whether to have it is the user's to say in their mpv.conf (section 12 of
+#: Since CONFIG_VERSION 5 that is every style there is, and for three
+#: different reasons: "mpvtk" replaces it with the in-window HUD, "none" with
+#: nothing, "custom" with a script of the user's that we never see, and "mpv"
+#: loads mpv's OWN OSC -- but by hand, after construction, so the version can
+#: be checked and the idle logo suppressed first
+#: (`player._load_classic_osc`).
+#:
+#: The `elif` below is therefore no longer reachable from a configured value.
+#: It stays for a hand-edited `osc_style` nobody recognises, where behaving
+#: like mpv normally would is the right answer (section 12 of
 #: docs/mpv-backends.md).
 REPLACES_OSC = ("mpv", "mpvtk", "none", "custom")
 
@@ -161,11 +167,12 @@ def resolve_osc_style():
     """
     # Which in-player UI to load: the in-window mpvtk playback HUD
     # ("mpvtk"; no lua script — the browser renders it, see
-    # mpvtk_browser/hud.py), the stock mpv OSC patched with
-    # trickplay previews ("mpv"), whatever the mpv binary ships and
-    # the user's own scripts ("default"), or nothing at all ("none").
-    # "jellyfin" is a legacy alias for the HUD — the jellyfin-styled
-    # lua OSC it used to name was retired once the HUD reached parity.
+    # mpvtk_browser/hud.py), mpv's own OSC ("mpv"), a script of the
+    # user's that we leave alone ("custom"), or nothing at all
+    # ("none"). Two legacy aliases: "jellyfin" for the HUD — the
+    # jellyfin-styled lua OSC it named was retired once the HUD reached
+    # parity — and "default", which folded into "mpv" at
+    # CONFIG_VERSION 5.
     #
     # "none" is where the old enable_osc setting went. That was a
     # separate switch that only ever reached mpv's OWN controls, so
@@ -175,6 +182,16 @@ def resolve_osc_style():
     osc_style = settings.osc_style
     if osc_style == "jellyfin":
         osc_style = "mpvtk"
+    if osc_style == "default":
+        # Legacy alias since CONFIG_VERSION 5. "MPV built-in default" and
+        # "MPV UI with thumbnails" collapsed into one "MPV UI": they only
+        # differed in who loaded the OSC, and once the shim started loading
+        # mpv's own (`player._load_classic_osc`) the difference showed up
+        # only as a bug -- nothing suppressed the idle logo under "default",
+        # so it sat behind the library. `_migrate` rewrites the stored
+        # value; this covers a hand-edited conf.json and a config from the
+        # future that was never migrated.
+        osc_style = "mpv"
     if osc_style == "mpvtk" and not settings.enable_gui:
         # The playback HUD is rendered by the library browser; with the
         # GUI disabled there is nothing to render it, so the patched
@@ -183,6 +200,22 @@ def resolve_osc_style():
     if osc_style == "mpvtk" and not settings.thumbnail_osc_builtin:
         # Legacy opt-out: thumbnail_osc_builtin=False used to mean
         # "don't replace my OSC" (e.g. users running uosc).
+        #
+        # **"default" survives here as an internal resolution, and only
+        # here.** It is gone from the settings screen and migrated out of
+        # conf.json (CONFIG_VERSION 5), but it is the only value that leaves
+        # mpv's own OSC to load itself -- everything else is in
+        # `REPLACES_OSC` and turns it off.
+        #
+        # That matters because of who reaches this line. `custom` was tried
+        # and is wrong: it sets `osc=False` and loads nothing, which is
+        # right for someone who really is running uosc and leaves anyone
+        # else **with no OSC at all**. The flag is a legacy default-off
+        # switch, not proof that a replacement exists, so the safe reading
+        # is "let mpv decide", which is what it has always done.
+        #
+        # Note the ordering: the "default" -> "mpv" alias above has already
+        # run, so this assignment is not folded back into "mpv".
         osc_style = "default"
     return osc_style
 

--- a/jellyfin_mpv_shim/mpv_shim.py
+++ b/jellyfin_mpv_shim/mpv_shim.py
@@ -11,7 +11,7 @@ from threading import Event
 
 from . import conffile
 from . import i18n
-from .args import get_args
+from .args import CLI_OVERRIDES, get_args
 from .conf import settings
 from .constants import APP_NAME
 from .log_utils import (
@@ -133,18 +133,15 @@ def main():
     load_success = settings.load(conf_file)
     i18n.configure()
 
-    # CLI overrides applied after config load so they win.
-    if args.enable_gui is not None:
-        settings.enable_gui = args.enable_gui
-    if args.start_minimized is not None:
-        settings.start_minimized = args.start_minimized
-    if args.mpv_loglevel is not None:
-        settings.mpv_log_level = args.mpv_loglevel
-    if args.ui_scale is not None:
-        # In-memory only: settings.save() elsewhere would otherwise persist
-        # a scale the user asked for on ONE run. Resolved on the mpvtk
-        # ready event (app._resolve_scale), which reads settings.ui_scale.
-        settings.ui_scale = args.ui_scale
+    # CLI overrides applied after config load so they win -- and through
+    # `apply_cli_override`, not assignment, so they win for THIS RUN only.
+    # `save()` writes every field, so a flag assigned onto `settings` is
+    # persisted by the next save from anywhere (see settings_base). Only
+    # `--scale` used to dodge that, and only by asking in a comment.
+    for override in CLI_OVERRIDES:
+        value = getattr(args, override.dest, None)
+        if value is not None:
+            settings.apply_cli_override(override.key, value)
 
     if settings.sanitize_output:
         enable_sanitization()

--- a/jellyfin_mpv_shim/mpvtk/GUIDE.md
+++ b/jellyfin_mpv_shim/mpvtk/GUIDE.md
@@ -141,7 +141,15 @@ flex-shrink on overflow: fixed/natural children squeeze proportionally
 down to their min (bitmaps/icons AND clickable Boxes — buttons — floor
 at natural; a squeezed "E…" button is garbage, so plain Text absorbs
 the shrink and re-ellipsizes); columns still overflow on purpose
-(vertical overflow is pre-scroll content, not an error). `layout.natural_size(tree)` is
+(vertical overflow is pre-scroll content, not an error).
+**The floor is by class, and the class list has been wrong once**: it is
+`isinstance`-based, so an interactive control that is not a `Box` gets
+none. An icon-trigger `Dropdown` is a `Button` in everything but its base
+class, and it sets its own `min_w` for that reason — without it the four
+playback-HUD track pickers were the only floorless children of a row that
+overflows, collapsed to zero width, and had their full-size glyphs drawn
+across each other (#721). **A new control whose content cannot degrade —
+a glyph, a bitmap — must say so; only text may absorb a shrink.** `layout.natural_size(tree)` is
 the build-time fit probe: measure a candidate (e.g. the labelled
 chrome bar) against the window and pick a layout — no hardcoded
 breakpoints.

--- a/jellyfin_mpv_shim/mpvtk/GUIDE.md
+++ b/jellyfin_mpv_shim/mpvtk/GUIDE.md
@@ -186,6 +186,27 @@ state is mirrored to `user-data/mpvtk/active` so the player can route
 Jellyfin remote commands (MoveUp/Select/…) into these keys only while
 the UI owns them.
 
+**The activation key is configurable and the arrows are not.**
+`mpvtk-select-key <name>` (`MpvtkApp.push_select_key`, on ready and on
+every edit of `ui_select_key`) moves it, and it is a *replacement* —
+ENTER stops being force-bound, which is the point of the setting. Its
+own message rather than a field on the `mpvtk-hud` opts blob because
+that blob only arrives on HUD engage while the same bindings come up
+for browsing under `mpvtk-active`, which carries no opts. Two things
+move with it: `keyclaim.nav_names` is rebuilt, so the *old* key becomes
+claimable and the new one stops being claimed twice, and the pushed
+gamepad table has to be re-sent, because a pad's Confirm carries the
+key as a literal (`conf.select_key` is the one reader all three go
+through). #717.
+
+**A printable select key still types into a focused textbox**, and needs
+no guard for it: mpv resolves `any_unicode` *before* the exact key
+(`input/input.c`, `get_cmd_from_keys`), so the text bindings win for
+as long as they are installed and `mpvtk_nav_<key>` answers only once the
+field is blurred. That ordering is the reason `ENTER` may stay bound as
+the textbox's submit key while the select key lives elsewhere: the two
+are never live at the same time.
+
 **MENU opens the focused node's context menu** — the keyboard's
 right-click, and the only way a tile's actions (Play, Queue, Watched,
 Favorite, Download) are reachable from ten feet away. A remote's

--- a/jellyfin_mpv_shim/mpvtk/app.py
+++ b/jellyfin_mpv_shim/mpvtk/app.py
@@ -478,13 +478,14 @@ class MpvtkApp:
         bindings are inert without it, and a user turning the setting on has
         to restart anyway, so a gate could make nothing correct.
         """
-        from ..conf import settings
+        from ..conf import select_key, settings
         from ..gamepad import bindings
 
         self.backend.command(
             "script-message", "mpvtk-gamepad",
             json.dumps(bindings(
-                bool(getattr(settings, "gamepad_swap_confirm", False))))
+                bool(getattr(settings, "gamepad_swap_confirm", False)),
+                select_key()))
         )
 
     def push_scroll_config(self):

--- a/jellyfin_mpv_shim/mpvtk/app.py
+++ b/jellyfin_mpv_shim/mpvtk/app.py
@@ -488,6 +488,27 @@ class MpvtkApp:
                 select_key()))
         )
 
+    def push_select_key(self):
+        """Forward the key that activates whatever the UI has focused.
+
+        The third producer of ``conf.select_key`` -- the keyboard. The
+        gamepad's Confirm and a Jellyfin remote's Select synthesize a
+        keypress of the same name, so this has to be pushed *with*
+        :meth:`push_gamepad`, never instead of it: the pad's binding
+        table carries the key as a literal.
+
+        Its own message rather than a field on the ``mpvtk-hud`` opts
+        blob, which is where the HUD's own keyboard policy travels: that
+        blob only arrives on HUD engage, while the same bindings are
+        installed for browsing by ``mpvtk-active``, which carries no opts
+        at all. See docs/ISSUES_2026-09.md (#717).
+        """
+        from ..conf import select_key
+
+        self.backend.command(
+            "script-message", "mpvtk-select-key", select_key()
+        )
+
     def push_scroll_config(self):
         """Forward the wheel step (px per notch) and what ``scroll_mode``
         means to the renderer. All are safe to re-push live: the renderer
@@ -673,6 +694,7 @@ class MpvtkApp:
                 self.push_scale()
                 self.push_scroll_config()
                 self.push_gamepad()
+                self.push_select_key()
                 self.push_overlay_z()
                 self.ready.set()
             return

--- a/jellyfin_mpv_shim/mpvtk/app.py
+++ b/jellyfin_mpv_shim/mpvtk/app.py
@@ -509,6 +509,26 @@ class MpvtkApp:
             "script-message", "mpvtk-select-key", select_key()
         )
 
+    def push_browse_keys(self):
+        """Tell the renderer whether to swallow mpv's own keyboard
+        shortcuts while the library is on screen (``browse_block_keys``,
+        #730).
+
+        Its own message rather than a field on the ``mpvtk-hud`` opts blob,
+        for the reason :meth:`push_select_key` gives: that blob only arrives
+        on HUD engage, and this governs BROWSE, whose input is installed by
+        ``mpvtk-active``, which carries no opts at all.
+
+        Safe to re-push live in either direction -- the renderer binds or
+        removes one key binding and holds no derived state.
+        """
+        from ..conf import settings
+
+        self.backend.command(
+            "script-message", "mpvtk-browse-keys",
+            "yes" if settings.browse_block_keys else "no"
+        )
+
     def push_scroll_config(self):
         """Forward the wheel step (px per notch) and what ``scroll_mode``
         means to the renderer. All are safe to re-push live: the renderer
@@ -695,6 +715,7 @@ class MpvtkApp:
                 self.push_scroll_config()
                 self.push_gamepad()
                 self.push_select_key()
+                self.push_browse_keys()
                 self.push_overlay_z()
                 self.ready.set()
             return

--- a/jellyfin_mpv_shim/mpvtk/renderer.lua
+++ b/jellyfin_mpv_shim/mpvtk/renderer.lua
@@ -4833,10 +4833,28 @@ function keyclaim.block_take(e)
     -- stop mattering: re-installing this block while a box already has
     -- focus (a live settings change) would otherwise eat every keystroke.
     if state.focus then return tb_key_text(e) end
-    -- A claim still gets its key. `keyclaim.take` owns the precedence --
-    -- dropdown, menu, modal, focus ring -- and answers false when something
-    -- on screen outranks it, which for a blocked key means "swallow".
-    if state.keys[t] then keyclaim.take(t) end
+    -- A claim still gets its key. Looked up by mpv's key NAME and never by
+    -- the text: they are the same character for nearly every printable key
+    -- and NOT for SPACE, whose name is "SPACE" and whose text is " " --
+    -- which both readers claim, and which is also the shim's pause key. A
+    -- text lookup matched nothing there and swallowed it, and a forced
+    -- binding that returns does not hand the key back to the binding
+    -- underneath, so "swallowed" meant gone.
+    --
+    -- `keyclaim.take` owns the rest of the precedence -- dropdown, menu,
+    -- modal, focus ring -- and answers false when something on screen
+    -- outranks it, which for a blocked key means swallow after all.
+    local name = e.key_name or t
+    -- The select key, which is configurable and may be printable (#717).
+    -- Bind order already keeps it ahead of this block everywhere the UI
+    -- installs it -- but a LIVE re-install (the setting toggled from the
+    -- settings screen) puts this binding last again, so route it rather
+    -- than rely on the order holding. Same fallback the nav row uses.
+    if name == state.select_key then
+        if not keyclaim.take(name) then nav_activate() end
+        return
+    end
+    if state.keys[name] then keyclaim.take(name) end
 end
 
 function keyclaim.block_bind()
@@ -5686,10 +5704,18 @@ local function ui_resume(no_nav)
     -- no_nav: the playback HUD came up under the pointer with
     -- hud_grab_keys off — the mouse drives it and the arrows stay
     -- mpv's seek keys. Browse always takes the arrows.
-    if not no_nav then bind_nav_keys() end
+    -- **First, before every exact binding below.** The block is
+    -- `any_unicode`, which outranks an exact key, and between two forced
+    -- bindings of one key the LATER one wins -- so installing it last made
+    -- it outrank the UI's own keys. A printable `ui_select_key` (#717 made
+    -- it configurable) was then swallowed instead of activating what was
+    -- focused. Bound first, everything installed afterwards outranks it by
+    -- construction, and the block only ever catches what nothing took.
+    --
     -- Browse only (#730). Over a real video mpv's keys have their real
     -- meaning, and taking them there is the interception #16 removed.
     if not state.phud.mode then keyclaim.block_bind() end
+    if not no_nav then bind_nav_keys() end
     mp.add_forced_key_binding('F12', 'mpvtk_hud', function()
         state.hud = not state.hud
         request_render()
@@ -5777,17 +5803,18 @@ mp.register_script_message('mpvtk-active', function(on)
         -- ...and the wheel, which a summoned HUD declines for the same
         -- reason and which browse cannot do without.
         state.wheel_sync()
+        -- The key block (#730) is a third thing that fails this way, and it
+        -- fails LOUDER than the two above: it is the whole of the feature,
+        -- and the states that skip ui_resume include startup. It records its
+        -- own console-loan intent, so it is called flat -- and it goes
+        -- FIRST, for the ordering reason ui_resume spells out.
+        keyclaim.block_bind()
         if state.kb_saved then
             -- mpv's console has them on loan; let it give them back.
             state.kb_saved.nav = true
         else
             bind_nav_keys()
         end
-        -- The key block (#730) is a third thing that fails this way, and it
-        -- fails LOUDER than the two above: it is the whole of the feature,
-        -- and the states that skip ui_resume include startup. It records its
-        -- own console-loan intent, so it is called flat.
-        keyclaim.block_bind()
     end
     if want == state.active then return end
     state.active = want
@@ -6823,12 +6850,13 @@ mp.observe_property('user-data/mpv/console/open', 'bool', function(_, open)
         -- and the arrows, ENTER and TAB would be taken as forced bindings
         -- over a video nobody could seek any more. This is the predicate the
         -- binders themselves use.
+        -- Before the nav keys, for the ordering reason ui_resume gives.
+        if was.block and state.active and not state.phud.mode then
+            keyclaim.block_bind()
+        end
         if was.nav and ((state.active and not state.phud.mode)
                         or (state.phud.mode and state.phud.kbd)) then
             bind_nav_keys()
-        end
-        if was.block and state.active and not state.phud.mode then
-            keyclaim.block_bind()
         end
         if was.summon and state.phud.mode and not state.phud.shown then
             phud_bind_summon()

--- a/jellyfin_mpv_shim/mpvtk/renderer.lua
+++ b/jellyfin_mpv_shim/mpvtk/renderer.lua
@@ -4807,6 +4807,70 @@ function keyclaim.set(list)
     state.wheel_sync()
 end
 
+-- ------------------------------------------------- browse key block (#730)
+-- mpv is constructed with `input_default_bindings=yes` for the life of the
+-- process, so in the library every key the shim has not taken is still
+-- mpv's: `1`-`8` move contrast/brightness/gamma/saturation, `d` cycles
+-- deinterlace, `s` writes a screenshot. They act on a video that is not
+-- there, they OUTLIVE the browse session (mpv options survive a queue
+-- item), and their only feedback is mpv's own OSD -- which is ASS, so it
+-- draws UNDERNEATH the overlay bitmaps this UI is made of.
+--
+-- One forced `any_unicode` binding is the whole block: it outranks every
+-- exact-key default, measured across the printable range. Modified keys
+-- (`ctrl+`, `alt+`) and named keys are NOT covered and do not need to be --
+-- the arrows, PGUP/PGDWN, HOME/END and the wheel are already ours.
+--
+-- These hang off `keyclaim` rather than being file-scope functions because
+-- this chunk is AT LuaJIT's 200-local ceiling; see tests/test_renderer_lua.py.
+function keyclaim.block_take(e)
+    if not e or e.event == 'up' then return end
+    local t = e.key_text
+    if not t or t == '' or t:byte(1) < 0x20 then return end
+    -- A focused text box binds its own `any_unicode`, and between two forced
+    -- bindings of one key the LAST one bound wins -- so typing normally
+    -- never reaches here at all. Routing it anyway is what makes the order
+    -- stop mattering: re-installing this block while a box already has
+    -- focus (a live settings change) would otherwise eat every keystroke.
+    if state.focus then return tb_key_text(e) end
+    -- A claim still gets its key. `keyclaim.take` owns the precedence --
+    -- dropdown, menu, modal, focus ring -- and answers false when something
+    -- on screen outranks it, which for a blocked key means "swallow".
+    if state.keys[t] then keyclaim.take(t) end
+end
+
+function keyclaim.block_bind()
+    if state.kb_block or not state.block_keys then return end
+    if state.kb_saved then            -- see bind_nav_keys
+        state.kb_saved.block = true
+        return
+    end
+    mp.add_forced_key_binding('any_unicode', 'mpvtk_block',
+        keyclaim.block_take, { repeatable = true, complex = true })
+    state.kb_block = true
+end
+
+function keyclaim.block_unbind()
+    if not state.kb_block then return end
+    mp.remove_key_binding('mpvtk_block')
+    state.kb_block = false
+end
+
+-- `browse_block_keys`, pushed on ready and again whenever the setting
+-- changes. Its own message for the reason `mpvtk-select-key` gives: the
+-- `mpvtk-hud` opts blob only arrives on HUD engage, and this governs
+-- browse, which is installed by `mpvtk-active` and carries no opts.
+mp.register_script_message('mpvtk-browse-keys', function(on)
+    state.block_keys = (on == 'yes' or on == 'true' or on == '1')
+    if state.block_keys then
+        -- Only where ui_resume would have: browse, never a summoned
+        -- playback HUD, where mpv's keys have their real meaning.
+        if state.active and not state.phud.mode then keyclaim.block_bind() end
+    else
+        keyclaim.block_unbind()
+    end
+end)
+
 -- **While mpv's console has the keyboard on loan, binding is recording an
 -- INTENT, not taking a key.** The lifecycle moves during a loan -- a pointer
 -- movement summons the HUD, playback starts, browse resumes -- and each of
@@ -5623,6 +5687,9 @@ local function ui_resume(no_nav)
     -- hud_grab_keys off — the mouse drives it and the arrows stay
     -- mpv's seek keys. Browse always takes the arrows.
     if not no_nav then bind_nav_keys() end
+    -- Browse only (#730). Over a real video mpv's keys have their real
+    -- meaning, and taking them there is the interception #16 removed.
+    if not state.phud.mode then keyclaim.block_bind() end
     mp.add_forced_key_binding('F12', 'mpvtk_hud', function()
         state.hud = not state.hud
         request_render()
@@ -5633,6 +5700,7 @@ local function ui_suspend()
     blur()                    -- drops the text-edit bindings + caret timer
     stop_repeat()
     unbind_nav_keys()         -- playback needs the arrows (seek/OSC)
+    keyclaim.block_unbind()   -- ...and every other key it binds (#730)
     state.nav = nil
     state.nav_pidx = nil
     state.nav_adjust = nil
@@ -5715,6 +5783,11 @@ mp.register_script_message('mpvtk-active', function(on)
         else
             bind_nav_keys()
         end
+        -- The key block (#730) is a third thing that fails this way, and it
+        -- fails LOUDER than the two above: it is the whole of the feature,
+        -- and the states that skip ui_resume include startup. It records its
+        -- own console-loan intent, so it is called flat.
+        keyclaim.block_bind()
     end
     if want == state.active then return end
     state.active = want
@@ -6716,8 +6789,13 @@ mp.observe_property('user-data/mpv/console/open', 'bool', function(_, open)
         -- handler exists to stop, in the one state nothing described.
         local wake = state.phud.shown and not state.phud.kbd
         state.kb_saved = { nav = state.kb_nav, summon = state.kb_summon,
-                           skip = state.kb_skip, wake = wake }
+                           skip = state.kb_skip, wake = wake,
+                           block = state.kb_block }
         if state.kb_nav then unbind_nav_keys() end
+        -- The block is `any_unicode`: left bound, it would swallow the
+        -- console's own typing, which is the exact theft this handler
+        -- exists to stop.
+        keyclaim.block_unbind()
         if state.kb_summon then phud_unbind_summon() end
         if state.kb_skip then phud_skip_unbind() end
         if wake then mp.remove_key_binding('mpvtk_wake') end
@@ -6748,6 +6826,9 @@ mp.observe_property('user-data/mpv/console/open', 'bool', function(_, open)
         if was.nav and ((state.active and not state.phud.mode)
                         or (state.phud.mode and state.phud.kbd)) then
             bind_nav_keys()
+        end
+        if was.block and state.active and not state.phud.mode then
+            keyclaim.block_bind()
         end
         if was.summon and state.phud.mode and not state.phud.shown then
             phud_bind_summon()

--- a/jellyfin_mpv_shim/mpvtk/renderer.lua
+++ b/jellyfin_mpv_shim/mpvtk/renderer.lua
@@ -234,6 +234,13 @@ local state = {
     dd_open = nil,          -- open dropdown id
     keys = {},              -- key name -> true: claimed by the app (mpvtk-keys)
     keys_bound = {},        -- key name -> true for the ones we forced ourselves
+    -- The key that activates whatever is focused (`ui_select_key`, #717),
+    -- pushed by mpvtk-select-key. A REPLACEMENT for ENTER and not an alias
+    -- [iw]: handing ENTER back to mpv is the whole request, so nothing may
+    -- keep a literal. Everything that names it goes through
+    -- `keyclaim.nav_key`; NAV_KEYS is built once at load and this arrives
+    -- later.
+    select_key = 'ENTER',
     cursor_on = true,
     geo = {},               -- scroll id -> {dx, dy, x1,y1,x2,y2 (clip)}
     bars = {},              -- scroll id -> thumb geometry (for hit test)
@@ -4694,7 +4701,13 @@ local NAV_KEYS = {
     { 'DOWN', function() if not keyclaim.take('DOWN') then nav_move(0, 1) end end },
     { 'LEFT', function() if not keyclaim.take('LEFT') then nav_move(-1, 0) end end },
     { 'RIGHT', function() if not keyclaim.take('RIGHT') then nav_move(1, 0) end end },
-    { 'ENTER', function() if not keyclaim.take('ENTER') then nav_activate() end end },
+    -- Activation. 'ENTER' is this row's DEFAULT, not its binding: the
+    -- third field marks it as following `state.select_key` (#717), and
+    -- every consumer of this table has to resolve it through
+    -- `keyclaim.nav_key` rather than reading k[1].
+    { 'ENTER', function()
+        if not keyclaim.take(state.select_key) then nav_activate() end
+    end, true },
     { 'TAB', function() nav_tab(1) end },
     { 'shift+TAB', function() nav_tab(-1) end },
     { 'MENU', function() nav_context() end },
@@ -4705,13 +4718,33 @@ local NAV_KEYS = {
 
 }
 
+-- The name a NAV_KEYS row is actually bound to. Only the activation row
+-- moves; everything else is fixed. Falls back for the same reason
+-- `conf.select_key` does: a UI with no select key can be operated by
+-- nothing but the mouse, and the settings screen that would fix it is
+-- inside that UI.
+function keyclaim.nav_key(k)
+    return k[3] and (state.select_key or 'ENTER') or k[1]
+end
+
 -- Every key in NAV_KEYS is already force-bound, so claiming one only changes
 -- what its handler does. A claimed key that is NOT in that list needs a
 -- binding of its own, and needs it removed again when the claim is dropped
 -- (SPACE is mpv's pause; leaving it bound after the reader closes would
 -- swallow it for the whole session).
-keyclaim.nav_names = {}
-for _, k in ipairs(NAV_KEYS) do keyclaim.nav_names[k[1]] = true end
+--
+-- So this is derived, not written down: move the select key and ENTER
+-- leaves the set while the new key joins it, in one step. Both halves
+-- matter -- a stale entry for ENTER means a page claiming it gets no
+-- binding at all, and a missing entry for the new key means a second
+-- binding on top of the nav one, which is two events per press.
+function keyclaim.rebuild_nav()
+    keyclaim.nav_names = {}
+    for _, k in ipairs(NAV_KEYS) do
+        keyclaim.nav_names[keyclaim.nav_key(k)] = true
+    end
+end
+keyclaim.rebuild_nav()
 
 -- The wheel is delivered by the `mpvtk_wheel` section, not by a per-key
 -- binding, so a claim on it must NOT add one -- two bindings for one
@@ -4789,7 +4822,8 @@ local function bind_nav_keys()
         return
     end
     for _, k in ipairs(NAV_KEYS) do
-        mp.add_forced_key_binding(k[1], 'mpvtk_nav_' .. k[1], k[2],
+        local name = keyclaim.nav_key(k)
+        mp.add_forced_key_binding(name, 'mpvtk_nav_' .. name, k[2],
             { repeatable = true })
     end
     state.kb_nav = true
@@ -4797,10 +4831,36 @@ end
 
 local function unbind_nav_keys()
     for _, k in ipairs(NAV_KEYS) do
-        mp.remove_key_binding('mpvtk_nav_' .. k[1])
+        mp.remove_key_binding('mpvtk_nav_' .. keyclaim.nav_key(k))
     end
     state.kb_nav = false
 end
+
+-- `ui_select_key` (#717), pushed on ready and again whenever the setting
+-- changes, so a remap applies without a restart. Its own message rather
+-- than a field on the mpvtk-hud opts blob: that blob only arrives on HUD
+-- engage, while browse-mode nav is installed by mpvtk-active, which
+-- carries none -- and this key governs both.
+mp.register_script_message('mpvtk-select-key', function(name)
+    name = (name ~= nil and name ~= '') and name or 'ENTER'
+    if name == state.select_key then return end
+    -- Every teardown below resolves through `state.select_key`, and mpv
+    -- has no "remove whatever is on this key" -- so the OLD name has to
+    -- still be current while they run, and the new one only afterwards.
+    --
+    -- The claim goes through `keyclaim.set` rather than being repaired in
+    -- place: it owns which keys carry a binding of their own, and that
+    -- answer changes in BOTH directions here (see keyclaim.rebuild_nav).
+    local claimed = {}
+    for key in pairs(state.keys or {}) do claimed[#claimed + 1] = key end
+    local held = state.kb_nav
+    if held then unbind_nav_keys() end
+    keyclaim.set({})
+    state.select_key = name
+    keyclaim.rebuild_nav()
+    if held then bind_nav_keys() end
+    keyclaim.set(claimed)
+end)
 
 bind_nav_keys()
 pcall(mp.set_property_native, 'user-data/mpvtk/active', true)
@@ -6189,8 +6249,13 @@ mp.register_script_message('mpvtk-gamepad', function(json)
     -- mpv's own arrows and the left stick would seek. It is the RIGHT
     -- stick that seeks; the left one drives the UI in every mode, which is
     -- the whole point of there being two.
-    local wake = { UP = true, DOWN = true, LEFT = true, RIGHT = true,
-                   ENTER = true }
+    --
+    -- Confirm is not in here: it is `state.select_key`, which the user
+    -- may have moved, and the pushed `arg` moves with it (Python's
+    -- `conf.select_key` builds both). Asked as a literal 'ENTER', a
+    -- remapped pad sent its Confirm down the keypress path below, where
+    -- over a hidden HUD nothing is bound to answer it.
+    local wake = { UP = true, DOWN = true, LEFT = true, RIGHT = true }
     for key in pairs(state.gp_bound or {}) do
         mp.remove_key_binding('mpvtk_gp_' .. key)
     end
@@ -6229,11 +6294,12 @@ mp.register_script_message('mpvtk-gamepad', function(json)
                     send({ t = 'gpseek', dir = arg })
                 elseif kind == 'nav' then
                     send({ t = 'gpnav', a = arg })
-                elseif wake[arg] and state.phud.mode
-                    and not state.phud.shown then
-                    state.phud_wake(arg == 'ENTER' and 'select' or 'nav')
-                elseif wake[arg] and state.phud.mode
-                    and not state.phud.kbd then
+                elseif (wake[arg] or arg == state.select_key)
+                    and state.phud.mode and not state.phud.shown then
+                    state.phud_wake(
+                        arg == state.select_key and 'select' or 'nav')
+                elseif (wake[arg] or arg == state.select_key)
+                    and state.phud.mode and not state.phud.kbd then
                     -- The bar is UP but the MOUSE owns it: a pointer
                     -- summon with hud_grab_keys off (the default) leaves
                     -- the arrows to mpv deliberately, so `shown` is not

--- a/jellyfin_mpv_shim/mpvtk/scaling.py
+++ b/jellyfin_mpv_shim/mpvtk/scaling.py
@@ -71,8 +71,16 @@ def _round(v):
 
 # Pixel geometry, uniform across every node type (audited against
 # layout.py's emission and renderer.lua's reads).
+#
+# `isz` is the icon-trigger dropdown's glyph size, and it is a BOX rather
+# than a type size despite measuring a glyph: the renderer floors it and
+# centres it in the trigger, and a `Button`'s icon reaches the same drawing
+# code through `w`, which rounds here. Exact would put the two families one
+# pixel apart at any fractional scale -- 17 at 1.5x is 25.5, floored to 25
+# against the button's 26 -- which is the drift tests/test_hud_icon_sizes.py
+# is named after (#721).
 _PX_KEYS = ("x", "y", "w", "h", "radius", "bw", "pw", "cw", "ch",
-            "rh", "snap", "snap_off", "off0")
+            "rh", "snap", "snap_off", "off0", "isz")
 
 # Scaled but NOT rounded: a font size is not a box, and rounding one makes
 # the text render wider than the width layout fitted it to. The LINE BOX

--- a/jellyfin_mpv_shim/mpvtk/widgets.py
+++ b/jellyfin_mpv_shim/mpvtk/widgets.py
@@ -851,6 +851,18 @@ class Dialog(Element):
 ICON_TRIGGER = 20
 
 
+def trigger_box(glyph):
+    """The hit box an icon-trigger `Dropdown` builds around a `glyph`-px
+    icon, and the smallest interactive target the playback HUD draws.
+
+    A function rather than an expression inside `Dropdown` because the
+    HUD's accessibility floor solves it backwards -- "how far may the bar
+    shrink before this stops being a reachable target" -- and two copies
+    of the arithmetic would drift the day either changes.
+    """
+    return int(glyph / 1.2 * 1.9)
+
+
 class Dropdown(Element):
     """``trigger_icon`` replaces the boxed control with a bare Material
     icon (translucent hover wash, no border/arrow/label) — the playback
@@ -900,7 +912,7 @@ class Dropdown(Element):
             # (GUIDE.md section 7), which is what keeps it the same size as
             # the HUD transport buttons beside it at every setting.
             glyph = int(icon_size or ICON_TRIGGER * 1.2)
-            box = int(glyph / 1.2 * 1.9)
+            box = trigger_box(glyph)
             kw.setdefault("w", box)
             kw.setdefault("h", box)
             # ...and a FLOOR, because this is a button and layout's

--- a/jellyfin_mpv_shim/mpvtk/widgets.py
+++ b/jellyfin_mpv_shim/mpvtk/widgets.py
@@ -903,6 +903,17 @@ class Dropdown(Element):
             box = int(glyph / 1.2 * 1.9)
             kw.setdefault("w", box)
             kw.setdefault("h", box)
+            # ...and a FLOOR, because this is a button and layout's
+            # shrink pass only knows that about `Box` subclasses (see
+            # layout.py, "buttons floor at natural"). A Dropdown is an
+            # Element, so without this the four HUD track pickers were
+            # the only floorless children of a row that overflows -- they
+            # absorbed the whole overflow, down to zero width, while the
+            # renderer went on centring a full-size `isz` glyph in them.
+            # A glyph is a path, not text: it has no smaller reading, so
+            # it spilled over its neighbours (#721).
+            if isinstance(kw.get("w"), (int, float)):
+                kw.setdefault("min_w", kw["w"])
         super().__init__(id=id, **kw)
         self.items = list(items)
         self.selected = selected

--- a/jellyfin_mpv_shim/mpvtk_browser/app.py
+++ b/jellyfin_mpv_shim/mpvtk_browser/app.py
@@ -207,6 +207,9 @@ class MpvtkBrowser(DialogsMixin, LiveTvDialogsMixin, AuthMixin, SettingsMixin,
         # Latest now-playing snapshot (from on_playstate) for the audio bar,
         # plus the 1s ticker that keeps its clock moving (see _start_np_ticker).
         self._now_playing = None
+        #: Servers whose UserDataChanged events a pending debounce has
+        #: swallowed. Drained by the tick; see `_userdata_target`.
+        self._userdata_servers = set()
         self._np_thread = None
         # Pending drag target on the now-playing bar's seek slider, in
         # seconds (None when not scrubbing) — the elapsed clock reads this
@@ -661,14 +664,42 @@ class MpvtkBrowser(DialogsMixin, LiveTvDialogsMixin, AuthMixin, SettingsMixin,
             # schedules exactly one re-read: the first arrival starts the
             # wait and the rest land while the slot is taken.
             self._shutdown_evt.wait(self.USERDATA_DEBOUNCE)
-            self._refresh_current(USERDATA_KINDS, server)
+            pending, self._userdata_servers = self._userdata_servers, set()
+            self._refresh_current(USERDATA_KINDS,
+                                  self._userdata_target(pending))
 
         # Cheap pre-check so a burst that cannot apply does not take the
         # slot for three seconds; `tick` asks again for real, because the
         # route can change while it waits.
         if self.route.get("kind") not in USERDATA_KINDS or not self._browsing:
             return
+        # Every server in the burst, not just the one that happened to take
+        # the slot. The refresh is server-FILTERED since #722, so a captured
+        # first arrival could coalesce away the event for the page actually
+        # on screen and then filter itself out -- leaving it stale.
+        self._userdata_servers.add(server)
         self._start_daemon("_userdata_thread", "mpvtk-userdata", tick)
+
+    def _userdata_target(self, pending):
+        """Which server to hand `_refresh_current` for a coalesced burst.
+
+        One value, because the route on screen belongs to one server and
+        Home is exempt from the filter -- so refreshing once per server
+        would re-read Home several times for nothing.
+
+        `None` wins outright: it means an event that could not be
+        attributed, which refreshes unfiltered, and swallowing it behind a
+        filtered one would lose the very event we cannot reason about.
+        Otherwise prefer the route's own server when the burst contains it;
+        failing that any of them, which the filter then declines exactly as
+        a single event would have.
+        """
+        if not pending or None in pending:
+            return None
+        route_server = self.route.get("server") or self.server
+        if route_server in pending:
+            return route_server
+        return next(iter(pending))
 
     def _reload_route(self, route):
         """Re-run a route's loader in place: the data changed, the screen did

--- a/jellyfin_mpv_shim/mpvtk_browser/app.py
+++ b/jellyfin_mpv_shim/mpvtk_browser/app.py
@@ -1783,10 +1783,36 @@ class MpvtkBrowser(DialogsMixin, LiveTvDialogsMixin, AuthMixin, SettingsMixin,
         # CALL instead would have broken the release-on-leave the comment
         # above describes.
         page = self._page_for(route) if self._browsing else None
+        keys = tuple(getattr(page, "claimed_keys", ()) or ())
+        keys += self._shell_claimed_keys()
         try:
-            claim(getattr(page, "claimed_keys", ()) or ())
+            claim(keys)
         except Exception:
             log.debug("key claim failed", exc_info=True)
+
+    #: Volume, mute -- the shell's own keys while music is playing, spelled
+    #: with mpv's names so the muscle memory carries over (#730).
+    SHELL_VOLUME_KEYS = {"9": -2.0, "0": 2.0}
+
+    def _shell_claimed_keys(self):
+        """Keys the SHELL takes, on top of whatever the page claimed.
+
+        Only while audio is playing, because that is the whole of the case:
+        `browse_block_keys` swallows mpv's own `9`/`0`/`m` along with every
+        other printable key, and music is the one thing you can be listening
+        to *while looking at the library*. Claiming them back means the
+        now-playing bar's slider tracks the change and the server hears
+        about it, which mpv's own binding did neither of.
+
+        Gated on the setting as well: someone who turned the block off asked
+        for their own keyboard back, and taking three keys out of it anyway
+        would be the same interception with a smaller footprint.
+        """
+        from ..conf import settings
+
+        if self._now_playing is None or not settings.browse_block_keys:
+            return ()
+        return tuple(self.SHELL_VOLUME_KEYS) + ("m",)
 
     def _set_picture_pan(self, config=None):
         """Push (or drop) the renderer's gesture model for a picture."""
@@ -1815,8 +1841,38 @@ class MpvtkBrowser(DialogsMixin, LiveTvDialogsMixin, AuthMixin, SettingsMixin,
         except Exception:
             log.warning("page picture gesture failed", exc_info=True)
 
+    def _shell_key(self, key):
+        """Handle a key the SHELL claimed, and say whether it did.
+
+        Ahead of the page, deliberately: the two claims are unioned into
+        one list, so if a page ever wanted one of these three the renderer
+        would deliver it here with nothing to say whose it was. Looking
+        first is what decides that, once, rather than per page.
+
+        The state is read HERE and not captured at claim time. A claim is
+        installed from a frame and the press arrives later, so between the
+        two the music can have stopped -- the standing footgun of this
+        shell, and the reason there is a test named for it.
+        """
+        if self._now_playing is None or self.controller is None:
+            return False
+        step = self.SHELL_VOLUME_KEYS.get(key)
+        try:
+            if step is not None:
+                self.controller.adjust_volume(step)
+                return True
+            if key == "m":
+                self.controller.toggle_mute()
+                return True
+        except Exception:
+            log.debug("shell volume key failed", exc_info=True)
+            return True
+        return False
+
     def _on_claimed_key(self, key):
         """A key this route claimed. Handed to the page, on the loop thread."""
+        if self._shell_key(key):
+            return
         page = self._page_for(self.route)
         handler = getattr(page, "on_key", None)
         if handler is None:

--- a/jellyfin_mpv_shim/mpvtk_browser/app.py
+++ b/jellyfin_mpv_shim/mpvtk_browser/app.py
@@ -1810,9 +1810,22 @@ class MpvtkBrowser(DialogsMixin, LiveTvDialogsMixin, AuthMixin, SettingsMixin,
         """
         from ..conf import settings
 
-        if self._now_playing is None or not settings.browse_block_keys:
+        # `_browsing` for the reason the caller's comment gives, and it is
+        # the same trap one step over: a playback update on a foreign thread
+        # can flip that flag mid-render, and the claim call is unconditional
+        # on purpose, so it is the ANSWER that has to go empty. Reading only
+        # `_now_playing` happens to agree today -- video clears it -- but by
+        # coincidence of two writers, not by construction.
+        if not self._browsing or self._now_playing is None:
             return ()
-        return tuple(self.SHELL_VOLUME_KEYS) + ("m",)
+        if not settings.browse_block_keys:
+            return ()
+        # SPACE is here for a different reason from the other three, and a
+        # sharper one: the block swallows it like any printable key, and a
+        # forced binding that returns does not hand the key back to the
+        # binding underneath -- so `kb_pause` never saw it and the only
+        # transport key on the keyboard went dead with nothing replacing it.
+        return tuple(self.SHELL_VOLUME_KEYS) + ("m", "SPACE")
 
     def _set_picture_pan(self, config=None):
         """Push (or drop) the renderer's gesture model for a picture."""
@@ -1844,10 +1857,10 @@ class MpvtkBrowser(DialogsMixin, LiveTvDialogsMixin, AuthMixin, SettingsMixin,
     def _shell_key(self, key):
         """Handle a key the SHELL claimed, and say whether it did.
 
-        Ahead of the page, deliberately: the two claims are unioned into
-        one list, so if a page ever wanted one of these three the renderer
-        would deliver it here with nothing to say whose it was. Looking
-        first is what decides that, once, rather than per page.
+        Only for keys the current page did not claim by name -- see
+        `_on_claimed_key`. The two claims are unioned into one list, so the
+        renderer delivers both with nothing to say whose a key was; the
+        caller resolves that, once, rather than each page defending itself.
 
         The state is read HERE and not captured at claim time. A claim is
         installed from a frame and the press arrives later, so between the
@@ -1864,6 +1877,9 @@ class MpvtkBrowser(DialogsMixin, LiveTvDialogsMixin, AuthMixin, SettingsMixin,
             if key == "m":
                 self.controller.toggle_mute()
                 return True
+            if key == "SPACE":
+                self.controller.toggle_pause()
+                return True
         except Exception:
             log.debug("shell volume key failed", exc_info=True)
             return True
@@ -1871,9 +1887,14 @@ class MpvtkBrowser(DialogsMixin, LiveTvDialogsMixin, AuthMixin, SettingsMixin,
 
     def _on_claimed_key(self, key):
         """A key this route claimed. Handed to the page, on the loop thread."""
-        if self._shell_key(key):
-            return
         page = self._page_for(self.route)
+        # The PAGE wins for anything it claimed by name. Both readers claim
+        # SPACE to turn a page, and the shell claims it to pause -- on the
+        # screen that asked for it, the page's meaning is the right one.
+        # Only keys no page named fall through to the shell.
+        if key not in (getattr(page, "claimed_keys", ()) or ()):
+            if self._shell_key(key):
+                return
         handler = getattr(page, "on_key", None)
         if handler is None:
             return

--- a/jellyfin_mpv_shim/mpvtk_browser/app.py
+++ b/jellyfin_mpv_shim/mpvtk_browser/app.py
@@ -127,6 +127,18 @@ NO_NOW_PLAYING = {"login", "locked", "connecting"}
 # is why these also poll.
 LIVE_KINDS = {"livetv", "channel", "program"}
 
+#: Route kinds a `UserDataChanged` event re-reads.
+#:
+#: Home for its Continue Watching / Next Up rows (#560); a series and a
+#: season for the per-season "N episodes remaining" badge, which is the
+#: server-computed `UnplayedItemCount` on the PARENT and so cannot be
+#: patched from here (#722).
+#:
+#: `grid`, `favorites` and `detail` are candidates and are deliberately not
+#: in yet: each needs its refresh-versus-page-in interleaving checked first,
+#: which is what `_refresh_current`'s `_refreshing` marker is for.
+USERDATA_KINDS = {"home", "series", "season"}
+
 #: How often a Live TV route re-reads itself. jellyfin-web's own staleness
 #: guard is five minutes, but it re-renders on every tab change and this
 #: screen is often left sitting on the Guide — a two-minute floor keeps "on
@@ -249,7 +261,7 @@ class MpvtkBrowser(DialogsMixin, LiveTvDialogsMixin, AuthMixin, SettingsMixin,
         self._dl_thread = None
         # Tail poller for the logs tab — see SettingsMixin._poll_logs.
         self._log_thread = None
-        # Debounce slot for UserDataChanged — see refresh_home.
+        # Debounce slot for UserDataChanged — see refresh_userdata.
         self._userdata_thread = None
         # Long job (currently only the download-folder move) — see _run_long.
         self._long_thread = None
@@ -548,35 +560,68 @@ class MpvtkBrowser(DialogsMixin, LiveTvDialogsMixin, AuthMixin, SettingsMixin,
         self._start_daemon("_livetv_poll", "mpvtk-livetv", tick,
                            restartable=True)
 
+    def _refresh_current(self, kinds, server=None):
+        """Re-read the current route in place, if it is one of ``kinds``.
+
+        **The one implementation of "refresh what is on screen".** There were
+        two, and they had drifted: the Live TV one took a `_refreshing` marker
+        and the Home one did not, so only one of them was safe against a
+        scroll paging in against a list about to be replaced. Widening either
+        gate would have made a third copy -- see docs/browser-shell.md
+        section 4.
+
+        Every rule here has a reason and none of them is optional:
+
+        * a **load, not a reload** -- the epoch stays put, nothing in flight
+          is cancelled, and the loaders write in place, so a refresh nobody
+          asked for does not blink a spinner over what is being read;
+        * **deferred, never forced** while a menu or dialog is up: yanking a
+          list out from under someone mid-interaction is worse than being one
+          refresh stale, and the next event is seconds away;
+        * ``_refreshing`` is set here and cleared by ``_route_async``'s
+          ``always`` however the load ends -- `pagination` reads it, so a
+          page-in cannot append to a list this is about to replace;
+        * ``self.server is None`` is refused because ``_load_route`` would
+          not dispatch, and then nothing would ever clear the marker.
+
+        ``server`` filters by the server the event came FROM. Home is exempt:
+        it is assembled from every logged-in server, so an event from any of
+        them can change it. Everything else belongs to one server, and
+        re-fetching a Series page on server B because something happened on
+        server A is at best a wasted round trip and at worst an unrelated
+        event driving the screen into the offline fallback.
+
+        Reached from the websocket thread and from the Live TV poller, so it
+        must be safe off the loop thread and cheap when it does not apply.
+        Returns True if a load was dispatched.
+        """
+        route = self.route
+        if route.get("kind") not in kinds or not self._browsing:
+            return False
+        if self.source is None or self.server is None:
+            return False
+        if (server is not None and route.get("kind") != "home"
+                and (route.get("server") or self.server) != server):
+            return False
+        if self._menu is not None or self._dialog is not None:
+            return False
+        if route.get("_loading") or route.get("_refreshing"):
+            return False
+        route["_refreshing"] = True
+        self._load_route(route)
+        return True
+
     def refresh_live_tv(self, _client=None):
         """Re-fetch the Live TV screen, if that is what is showing.
 
         Reached from the websocket thread (a timer created or cancelled,
-        possibly by another client entirely) and from the poller above, so it
-        must be safe off the loop thread and cheap when it does not apply.
+        possibly by another client entirely) and from the poller above.
 
-        A **load, not a reload**: the epoch stays put, nothing in flight is
-        cancelled, and every Live TV loader writes in place -- a refresh nobody
-        asked for must not blink a spinner over what they are reading.
-
-        **Deferred, never forced, while the user is mid-interaction**, and it
-        marks the route ``_loading`` while it runs so a scroll cannot page in
-        against a list this is about to replace. ``_route_async`` clears it
-        however the load ends. Both halves, and why scroll survives:
-        docs/browser-shell.md section 4.
+        Not filtered by server: a timer event carries no route of its own and
+        the guide is the screen it would affect, so the old unfiltered
+        behaviour is kept deliberately rather than by omission.
         """
-        route = self.route
-        if route.get("kind") not in LIVE_KINDS or self.source is None:
-            return
-        if self.server is None:
-            return          # _load_route would not dispatch, so nothing would
-            #                 clear the marker below
-        if self._menu is not None or self._dialog is not None:
-            return
-        if route.get("_loading") or route.get("_refreshing"):
-            return
-        route["_refreshing"] = True
-        self._load_route(route)
+        self._refresh_current(LIVE_KINDS)
 
     #: How long a UserDataChanged burst settles before Home re-reads.
     #:
@@ -591,27 +636,24 @@ class MpvtkBrowser(DialogsMixin, LiveTvDialogsMixin, AuthMixin, SettingsMixin,
     #: a handful still arrives together and Home is several requests.
     USERDATA_DEBOUNCE = 3.0
 
-    def refresh_home(self, _client=None, now=False):
-        """Re-read the home screen, if that is what is showing.
+    def refresh_userdata(self, server=None, now=False):
+        """Re-read the current screen when watched/favourite state changes.
 
-        Continue Watching and Next Up are the only library rows a *third party*
-        changes while you are looking at them (#560), and a stale one is not
-        cosmetic -- it offers to resume something already watched, and pressing
-        it starts it over.
+        **Every screen that shows it, not only Home.** Home's Continue
+        Watching and Next Up were the reported case (#560) and the gate was
+        written for them; a series page's per-season "N episodes remaining"
+        is the same field from the same event, and it went stale until the
+        app was restarted (#722). `UnplayedItemCount` is computed by the
+        server on the PARENT, so there is nothing to patch client-side --
+        re-reading is the only honest answer, and a client-side aggregate
+        would be a second authority on it.
 
-        A **load, not a reload**, exactly like refresh_live_tv. Reached from the
-        websocket thread, so it must be safe off the loop thread.
-
-        ``now`` skips the debounce, for the caller that is not a burst: coming
-        back from playback (see enter_browse). See docs/browser-shell.md
-        section 4.
+        ``now`` skips the debounce, for the caller that is not a burst:
+        coming back from playback (see enter_browse). ``server`` is the
+        server the event came from; see ``_refresh_current``.
         """
-        if self.route.get("kind") != "home" or not self._browsing:
-            return
         if now:
-            if self._menu is None and self._dialog is None \
-                    and not self.route.get("_loading"):
-                self._load_route(self.route)
+            self._refresh_current(USERDATA_KINDS, server)
             return
 
         def tick():
@@ -619,19 +661,13 @@ class MpvtkBrowser(DialogsMixin, LiveTvDialogsMixin, AuthMixin, SettingsMixin,
             # schedules exactly one re-read: the first arrival starts the
             # wait and the rest land while the slot is taken.
             self._shutdown_evt.wait(self.USERDATA_DEBOUNCE)
-            route = self.route
-            if route.get("kind") != "home" or not self._browsing:
-                return
-            # Deferred, never forced, while the user is mid-interaction --
-            # see refresh_live_tv for the full reasoning. Skipping costs
-            # nothing here: the next event is seconds away, and returning to
-            # Home re-reads anyway.
-            if self._menu is not None or self._dialog is not None:
-                return
-            if route.get("_loading"):
-                return
-            self._load_route(route)
+            self._refresh_current(USERDATA_KINDS, server)
 
+        # Cheap pre-check so a burst that cannot apply does not take the
+        # slot for three seconds; `tick` asks again for real, because the
+        # route can change while it waits.
+        if self.route.get("kind") not in USERDATA_KINDS or not self._browsing:
+            return
         self._start_daemon("_userdata_thread", "mpvtk-userdata", tick)
 
     def _reload_route(self, route):
@@ -1303,7 +1339,7 @@ class MpvtkBrowser(DialogsMixin, LiveTvDialogsMixin, AuthMixin, SettingsMixin,
     #:
     #: NOT the epoch, and the old name (`_load_ep`) is what invited stamping
     #: one. A refresh is deliberately a load rather than a *re*load --
-    #: `refresh_home` calls `_load_route` with no `_bump_epoch()`, since
+    #: `_refresh_current` calls `_load_route` with no `_bump_epoch()`, since
     #: bumping would cancel everything else in flight -- so two loads of the
     #: same route routinely share an epoch, and a guard comparing epochs
     #: cannot tell them apart. This is unique per dispatch.
@@ -1328,7 +1364,7 @@ class MpvtkBrowser(DialogsMixin, LiveTvDialogsMixin, AuthMixin, SettingsMixin,
 
         def landed(data):
             # The success half of the same guard. `run_async` gates on_done by
-            # EPOCH, and a refresh deliberately shares one (`refresh_home`
+            # EPOCH, and a refresh deliberately shares one (`_refresh_current`
             # loads without bumping) -- so an older load answering after a
             # newer one was still applied, putting stale rows back. That is
             # the mirror of the failure case below, and gating only the
@@ -1369,7 +1405,7 @@ class MpvtkBrowser(DialogsMixin, LiveTvDialogsMixin, AuthMixin, SettingsMixin,
                 self._offline_fallback(route)
 
         def settled():
-            # `always`, so a background refresh (refresh_live_tv) releases its
+            # `always`, so a background refresh (`_refresh_current`) releases its
             # marker however this ends — including the epoch-superseded case,
             # which runs neither callback. A marker left set would stop the
             # screen refreshing for the rest of its life.
@@ -2270,7 +2306,7 @@ class MpvtkBrowser(DialogsMixin, LiveTvDialogsMixin, AuthMixin, SettingsMixin,
         # for this reason all along; coming back from PLAYBACK does not go
         # through it, which is why watching something in the shim itself left
         # its own Continue Watching row stale (#560).
-        self.refresh_home(now=True)
+        self.refresh_userdata(now=True)
         self._set_renderer_active(True)
         self.invalidate()
 

--- a/jellyfin_mpv_shim/mpvtk_browser/app.py
+++ b/jellyfin_mpv_shim/mpvtk_browser/app.py
@@ -928,7 +928,15 @@ class MpvtkBrowser(DialogsMixin, LiveTvDialogsMixin, AuthMixin, SettingsMixin,
             if self._minimized or self._browsing:
                 # Idle or already browsing: bring the page forward.
                 self.enter_browse()
-                if self.controller is not None:
+                # Taking the FOREGROUND is the summon, and the window being
+                # on screen already does not make it a cheaper one: on
+                # Windows `raise_window` is a real SetForegroundWindow, so an
+                # already-browsing client stole focus from the very browser
+                # the user was casting from, once per page they opened
+                # (#728). The early return above covers the minimized half of
+                # the same setting; this covers the visible half.
+                if (self.controller is not None
+                        and settings.display_mirror_summon):
                     self._safe(lambda c: c.raise_window())
         self.run_async(work, done, ep)
 

--- a/jellyfin_mpv_shim/mpvtk_browser/config.py
+++ b/jellyfin_mpv_shim/mpvtk_browser/config.py
@@ -95,7 +95,7 @@ BACKGROUND_DEPENDENT = ("start_minimized",)
 #: go when it is left -- which is right: the form describes the
 #: configuration, and the restart banner covers the gap.
 HUD_ONLY = ("hud_grab_keys", "hud_wake_key", "hud_scrim", "hud_autohide",
-            "hud_hide_secs", "mouse_click_pauses")
+            "hud_hide_secs", "hud_auto_scale", "mouse_click_pauses")
 
 
 def hud_style_selected():
@@ -213,6 +213,7 @@ TAB_SECTIONS = {
         # applies at all.
         (_("Player Controls"), ["osc_style", "hud_grab_keys", "hud_wake_key",
                                 "hud_scrim", "hud_autohide", "hud_hide_secs",
+                                "hud_auto_scale",
                                 "mouse_chapter_nav", "mouse_click_pauses",
                                 "trickplay_fast_mode"]),
         (_("Playback"), ["auto_play", "hwdec", "network_buffer",
@@ -641,6 +642,7 @@ LABEL_OVERRIDES = {
     "hud_scrim": _("Shading Behind the Player Controls"),
     "hud_autohide": _("When the Player Controls Hide"),
     "hud_hide_secs": _("Hide the Player Controls After (seconds)"),
+    "hud_auto_scale": _("Shrink the Player Controls on a Narrow Window"),
     "mouse_chapter_nav": _("Mouse Back/Forward Buttons Skip Chapters"),
     "audio_mode": _("Audio Output Mode"),
     "audio_device": _("Audio Output Device"),
@@ -901,6 +903,10 @@ NOTES = {
                       "the pointer is on them, paused or not."),
     "hud_hide_secs": _("0 hides them as soon as the pointer is not on "
                        "them, and forces \"Hide unless hovered\"."),
+    "hud_auto_scale": _("Narrowing the window shrinks the controls until "
+                        "the smallest button reaches the accessibility "
+                        "minimum, instead of dropping buttons sooner. "
+                        "Off keeps the older, larger floor."),
     "mouse_chapter_nav": _(
         "During playback only; in the library those buttons stay Back and "
         "Forward. Off by default because they are easy to hit by accident on "

--- a/jellyfin_mpv_shim/mpvtk_browser/config.py
+++ b/jellyfin_mpv_shim/mpvtk_browser/config.py
@@ -152,7 +152,12 @@ TAB_SECTIONS = {
         # people are looking for, and on Linux desktops that route media
         # keys through MPRIS it is likely broken anyway. Promoting it would
         # be offering a switch we cannot say works.
-        (_("Input"), ["input_gamepad", "gamepad_swap_confirm"]),
+        # `ui_select_key` is here and NOT in HUD_ONLY beside `hud_wake_key`:
+        # it governs the library as much as the player controls, and the
+        # library exists under every osc_style. Under "MPV built-in default"
+        # the row still means something.
+        (_("Input"), ["input_gamepad", "gamepad_swap_confirm",
+                      "ui_select_key"]),
         # Everything about the window itself, in the order you meet it:
         # how it opens, whether it remembers, what closing it means.
         (_("Window"), ["fullscreen", "browser_fullscreen",
@@ -628,6 +633,7 @@ LABEL_OVERRIDES = {
     "browser_fullscreen": _("Fullscreen Library Browser"),
     "hud_grab_keys": _("Always Bind Arrow Keys to Player Controls"),
     "hud_wake_key": _("Player Controls Activation Key"),
+    "ui_select_key": _("Select Key"),
     "segment_intro": _("Skip Intros"),
     # The one segment label that collides with its own Skip BUTTON:
     # gettext keys on the English, the other four are pluralised ("Skip
@@ -692,6 +698,14 @@ NOTES = {
     "gamepad_swap_confirm": _("Turn this on for a controller whose A button "
                               "is on the right rather than at the bottom "
                               "(Switch Pro, most 8BitDo pads)."),
+    # Two things the label cannot carry: that this REPLACES Enter (which is
+    # the reason to change it -- getting Enter back for mpv), and that the
+    # controller and the phone follow it, so nothing is left behind.
+    "ui_select_key": _("Activates whatever is highlighted, in the library "
+                       "and on the player controls. An mpv key name; "
+                       "changing it hands Enter back to MPV. The game "
+                       "controller's Confirm button and a phone's Select "
+                       "follow it."),
     # A blank numeric field meaning "use the setting above" is not
     # guessable from a label, and these three are the ones where leaving
     # them alone is the right answer for almost everybody.

--- a/jellyfin_mpv_shim/mpvtk_browser/config.py
+++ b/jellyfin_mpv_shim/mpvtk_browser/config.py
@@ -157,6 +157,7 @@ TAB_SECTIONS = {
         # how it opens, whether it remembers, what closing it means.
         (_("Window"), ["fullscreen", "browser_fullscreen",
                        "remember_window_size", "window_controls",
+                       "window_controls_fullscreen", "hide_title_bar",
                        "close_to_tray", "allow_background",
                        "start_minimized", "display_mirror_summon"]),
     ],
@@ -273,6 +274,10 @@ TAB_SECTIONS = {
 RESTART_REQUIRED = frozenset({
     # The whole interface geometry is derived once, at startup.
     "ui_scale",
+    # A construction option: `border` is read when the window is made, and
+    # writing it live would fight `window_controls` "auto", which reads the
+    # same property to decide whether to draw its own buttons.
+    "hide_title_bar",
     # `theme` is deliberately NOT here, even though half of it waits for a
     # restart. Colours repaint the moment you pick one, so marking the row
     # "Requires restart" would say nothing happened when something visibly
@@ -595,6 +600,8 @@ LABEL_OVERRIDES = {
     "allow_background": _("Keep Running in Background"),
     "remember_window_size": _("Remember Window Size"),
     "window_controls": _("Window Buttons in the Top Bar"),
+    "window_controls_fullscreen": _("Keep Window Buttons in Full Screen"),
+    "hide_title_bar": _("Hide the Desktop Title Bar"),
     "osc_style": _("Player Controls Style"),
     "trickplay_fast_mode": _("Load All Seek Previews at Once"),
     "discord_presence": _("Show What You're Watching in Discord"),
@@ -792,6 +799,16 @@ NOTES = {
         "drag the window by it. On \"Only when the window has no title bar\", "
         "MPV is asked whether this window got one, so desktops that draw a "
         "title bar are left alone."),
+    "window_controls_fullscreen": _(
+        "Full screen has no title bar anywhere and nothing to move or "
+        "maximize, so the buttons are normally hidden there. Turn this on "
+        "to keep a way out of full screen that is not a keyboard shortcut."),
+    "hide_title_bar": _(
+        "Asks the desktop for no title bar on the player window, so the "
+        "top bar above is the only one. Pairs with the setting above: on "
+        "\"Only when the window has no title bar\" the buttons appear as "
+        "soon as this is on. Leave both off unless you want them, since a "
+        "window with neither can be awkward to move on some desktops."),
     "trickplay_fast_mode": _("Seek previews are normally fetched a few "
                              "minutes at a time around where you are "
                              "seeking, so scrubbing somewhere new waits "

--- a/jellyfin_mpv_shim/mpvtk_browser/config.py
+++ b/jellyfin_mpv_shim/mpvtk_browser/config.py
@@ -77,25 +77,36 @@ BACKGROUND_DEPENDENT = ("start_minimized",)
 #: Every one of them is read in exactly one place --
 #: `gateway/hud.py:hud_key_opts`, which builds the blob sent with the
 #: `mpvtk-hud` engage -- and that message is only ever sent by the HUD
-#: modality. Under "MPV UI with thumbnails" or "MPV built-in default" they
-#: are inert, and offering them there is what #724 reads like from the
-#: outside: "Left Click Pauses Playback" is on, the left button does
-#: nothing over the video, so the client looks broken. It is not; the
-#: setting was simply never going to reach that player.
+#: modality. Under "MPV UI" or "Custom OSC" they are inert, and offering
+#: them there is what #724 reads like from the outside: "Left Click Pauses
+#: Playback" is on, the left button does nothing over the video, so the
+#: client looks broken. It is not; the setting was simply never going to
+#: reach that player.
 #:
 #: `mouse_chapter_nav` is deliberately NOT here despite sitting in the same
 #: group: `player.py` binds the thumb buttons itself, so it works under
-#: every style. Nor is `trickplay_fast_mode` -- thumbfast is loaded for
-#: both OSCs.
+#: every style. Nor are `thumbnail_enable` and `trickplay_fast_mode` --
+#: thumbfast is loaded whatever the style, so the previews reach both
+#: classic OSCs and a thumbfast-aware script of the user's. The second one
+#: has a dependency of its own, on the first: see TRICKPLAY_DEPENDENT.
 #:
 #: Keyed on the RESOLVED style (`mpv_options.resolve_osc_style`), not the
-#: configured one, so the legacy "jellyfin" alias counts and the two
-#: fallbacks that quietly demote "mpvtk" do too. `osc_style` needs a
-#: restart, so these rows appear the moment the Jellyfin UI is chosen and
-#: go when it is left -- which is right: the form describes the
+#: configured one, so the legacy "jellyfin" alias counts and the
+#: `enable_gui` fallback that quietly demotes "mpvtk" does too. `osc_style`
+#: needs a restart, so these rows appear the moment the Jellyfin UI is
+#: chosen and go when it is left -- which is right: the form describes the
 #: configuration, and the restart banner covers the gap.
 HUD_ONLY = ("hud_grab_keys", "hud_wake_key", "hud_scrim", "hud_autohide",
             "hud_hide_secs", "hud_auto_scale", "mouse_click_pauses")
+
+#: Settings that tune trickplay and so do nothing with `thumbnail_enable`
+#: off. Hidden rather than disabled, per docs/settings-curation.md §2.
+#:
+#: `thumbnail_preferred_size` is deliberately not here. It is uncurated, so
+#: hiding it would move it in and out of Advanced -- and Advanced is where
+#: somebody goes to read what a value currently is, which is a reason to
+#: show a setting rather than to hide it.
+TRICKPLAY_DEPENDENT = ("trickplay_fast_mode",)
 
 
 def hud_style_selected():
@@ -223,7 +234,8 @@ TAB_SECTIONS = {
         # The in-player UI leads: it is the thing you are looking at while
         # watching, and osc_style decides whether the rest of the group
         # applies at all.
-        (_("Player Controls"), ["osc_style", "hud_grab_keys", "hud_wake_key",
+        (_("Player Controls"), ["osc_style", "thumbnail_enable",
+                                "hud_grab_keys", "hud_wake_key",
                                 "hud_scrim", "hud_autohide", "hud_hide_secs",
                                 "hud_auto_scale",
                                 "mouse_chapter_nav", "mouse_click_pauses",
@@ -300,6 +312,12 @@ RESTART_REQUIRED = frozenset({
     #
     # Decides which OSC mpv is CONSTRUCTED with.
     "osc_style",
+    # Read once per mpv, in `_init_mpv`: it decides whether the TrickPlay
+    # worker starts, and `mpv_scripts` loads thumbfast only if it did. mpv
+    # is not re-created between queue items, so nothing short of a restart
+    # re-asks -- turning it ON without one leaves the worker fetching for a
+    # script that was never loaded.
+    "thumbnail_enable",
     # mpv reads it exactly once, in mp_input_load_config -- a runtime write
     # succeeds and reads back yes while the SDL thread is never started.
     "input_gamepad",
@@ -616,6 +634,7 @@ LABEL_OVERRIDES = {
     "window_controls_fullscreen": _("Keep Window Buttons in Full Screen"),
     "hide_title_bar": _("Hide the Desktop Title Bar"),
     "osc_style": _("Player Controls Style"),
+    "thumbnail_enable": _("Enable Trickplay Thumbnails"),
     "trickplay_fast_mode": _("Load All Seek Previews at Once"),
     "discord_presence": _("Show What You're Watching in Discord"),
     "ui_scale": _("Interface Scale"),
@@ -846,6 +865,19 @@ NOTES = {
         "\"Only when the window has no title bar\" the buttons appear as "
         "soon as this is on. Leave both off unless you want them, since a "
         "window with neither can be awkward to move on some desktops."),
+    # The cost is the half a label cannot carry, and it is the reason
+    # somebody turns this off: the images are downloaded and uncompressed
+    # per video, which is disk and memory rather than a one-off. Says which
+    # players it reaches, because it sits under a dropdown that decides
+    # which player you get and is the one row in that group that is NOT
+    # about the choice above it.
+    "thumbnail_enable": _("Shows a preview frame while you drag the seek "
+                          "bar. Works with every player control style, "
+                          "including your own OSC script if it supports "
+                          "thumbfast. The images are fetched from the "
+                          "server per video, which costs disk space and "
+                          "memory -- tens of MB for an episode, a few "
+                          "hundred for a long film."),
     "trickplay_fast_mode": _("Seek previews are normally fetched a few "
                              "minutes at a time around where you are "
                              "seeking, so scrubbing somewhere new waits "
@@ -1051,7 +1083,8 @@ def sections(tab=None):
     # it must not reappear under "Advanced" as an uncurated key.
     curated = ({k for _c, k in AUDIO_PASSTHROUGH_KEYS} | set(AUDIO_MODE_ONLY)
                | set(TRAY_DEPENDENT) | set(BACKGROUND_DEPENDENT)
-               | set(HUD_ONLY) | {"audio_exclusive"})
+               | set(HUD_ONLY) | set(TRICKPLAY_DEPENDENT)
+               | {"audio_exclusive"})
     out = []
     try:
         shown = set(visible_passthrough_keys())
@@ -1063,6 +1096,8 @@ def sections(tab=None):
         shown.add("audio_exclusive")
     if hud_style_selected():
         shown.update(HUD_ONLY)
+    if settings.thumbnail_enable:
+        shown.update(TRICKPLAY_DEPENDENT)
     keep_running = "close_to_tray" if tray_available() else "allow_background"
     shown.add(keep_running)
     if getattr(settings, keep_running, False):
@@ -1131,6 +1166,10 @@ SEARCH_ALIASES = {
     # say why. None of those words are in the label or the note.
     "browse_block_keys": "keys keyboard contrast brightness gamma "
                          "saturation hotkey",
+    # "trickplay" is the server's word and is in the label; these are the
+    # words somebody who has never read the server's docs types. "scrubbing"
+    # rather than "scrub", since matching is directional.
+    "thumbnail_enable": "scrubbing seeking bif chapter",
 }
 
 

--- a/jellyfin_mpv_shim/mpvtk_browser/config.py
+++ b/jellyfin_mpv_shim/mpvtk_browser/config.py
@@ -6,11 +6,14 @@ the in-process ``conf.settings`` singleton directly (no IPC — the mpvtk
 browser runs in the player's process).
 """
 
+import logging
 import sys
 import typing
 
 from ..conf import Settings, settings
 from ..i18n import _, _p
+
+log = logging.getLogger("mpvtk_browser.config")
 
 # Structured / non-scalar config that the flat form can't express, plus
 # internal bookkeeping. Everything else is editable.
@@ -67,6 +70,49 @@ EXCLUSIVE_PLATFORMS = ("win32", "darwin")
 # above is on screen permits, so offering it while that one is off is
 # offering a setting that cannot do anything. Shown directly below it.
 BACKGROUND_DEPENDENT = ("start_minimized",)
+
+#: Settings that reach the in-window playback HUD and nothing else, so they
+#: do nothing at all unless `osc_style` resolves to "mpvtk".
+#:
+#: Every one of them is read in exactly one place --
+#: `gateway/hud.py:hud_key_opts`, which builds the blob sent with the
+#: `mpvtk-hud` engage -- and that message is only ever sent by the HUD
+#: modality. Under "MPV UI with thumbnails" or "MPV built-in default" they
+#: are inert, and offering them there is what #724 reads like from the
+#: outside: "Left Click Pauses Playback" is on, the left button does
+#: nothing over the video, so the client looks broken. It is not; the
+#: setting was simply never going to reach that player.
+#:
+#: `mouse_chapter_nav` is deliberately NOT here despite sitting in the same
+#: group: `player.py` binds the thumb buttons itself, so it works under
+#: every style. Nor is `trickplay_fast_mode` -- thumbfast is loaded for
+#: both OSCs.
+#:
+#: Keyed on the RESOLVED style (`mpv_options.resolve_osc_style`), not the
+#: configured one, so the legacy "jellyfin" alias counts and the two
+#: fallbacks that quietly demote "mpvtk" do too. `osc_style` needs a
+#: restart, so these rows appear the moment the Jellyfin UI is chosen and
+#: go when it is left -- which is right: the form describes the
+#: configuration, and the restart banner covers the gap.
+HUD_ONLY = ("hud_grab_keys", "hud_wake_key", "hud_scrim", "hud_autohide",
+            "hud_hide_secs", "mouse_click_pauses")
+
+
+def hud_style_selected():
+    """Whether the in-window playback HUD is what `osc_style` resolves to.
+
+    Guarded like `visible_passthrough_keys` below: this is only ever used to
+    decide whether to DRAW a row, and a settings form that refuses to open
+    is worse than one showing a setting that does nothing.
+    """
+    try:
+        from ..mpv_options import resolve_osc_style
+
+        return resolve_osc_style() == "mpvtk"
+    except Exception:
+        log.debug("could not resolve the OSC style", exc_info=True)
+        return True
+
 
 # Curated groups, per settings tab. Anything not listed shows under
 # "Advanced", which lives on the General tab.
@@ -649,10 +695,16 @@ NOTES = {
     # What turning it OFF buys, since that is the non-obvious half: the
     # left button is what the VO drags the window with, so pausing with it
     # and dragging with it are mutually exclusive.
+    # NOT "right click to pause", which this said and which is no longer
+    # true on the mpv we ship: upstream changed MBTN_RIGHT's default from
+    # `cycle pause` to `script-binding select/context-menu` at 0.41, and
+    # both pins are past that. Naming the effect would go stale again at
+    # the next such change, so it names where the answer comes from.
     "mouse_click_pauses": _("Off gives MPV's own mouse behaviour instead: "
-                            "drag the video to move the window, and right "
-                            "click to pause. Double click is full screen "
-                            "either way."),
+                            "drag the video to move the window, and the "
+                            "right button does whatever your MPV config "
+                            "gives it. Double click is full screen either "
+                            "way."),
     # The reason this is off by default, in the place someone deciding
     # whether to change it is looking. mpv's own manual says to
     # "acknowledge that this may cause problems"; the tail it breaks for
@@ -935,7 +987,7 @@ def sections(tab=None):
     # it must not reappear under "Advanced" as an uncurated key.
     curated = ({k for _c, k in AUDIO_PASSTHROUGH_KEYS} | set(AUDIO_MODE_ONLY)
                | set(TRAY_DEPENDENT) | set(BACKGROUND_DEPENDENT)
-               | {"audio_exclusive"})
+               | set(HUD_ONLY) | {"audio_exclusive"})
     out = []
     try:
         shown = set(visible_passthrough_keys())
@@ -945,6 +997,8 @@ def sections(tab=None):
     shown |= {k for k, modes in AUDIO_MODE_ONLY.items() if mode in modes}
     if sys.platform in EXCLUSIVE_PLATFORMS:
         shown.add("audio_exclusive")
+    if hud_style_selected():
+        shown.update(HUD_ONLY)
     keep_running = "close_to_tray" if tray_available() else "allow_background"
     shown.add(keep_running)
     if getattr(settings, keep_running, False):

--- a/jellyfin_mpv_shim/mpvtk_browser/config.py
+++ b/jellyfin_mpv_shim/mpvtk_browser/config.py
@@ -426,10 +426,16 @@ LABELED_ENUMS = {
         (_("Large (20 seconds)"), "large"),
         (_("Very large (60 seconds)"), "huge"),
     ],
+    # "MPV built-in default" is gone: it and "MPV UI with thumbnails" only
+    # differed in who loaded the OSC, and since the shim uses mpv's OWN OSC
+    # for this style (the 0.41 Preview API) there is one thing to offer.
+    # Whether it shows seek previews is `thumbnail_enable`, which is a
+    # question about trickplay rather than about which controls you want.
+    # Migrated at CONFIG_VERSION 5; `resolve_osc_style` still accepts the
+    # old value.
     "osc_style": [
         (_("Jellyfin UI"), "mpvtk"),
-        (_("MPV UI with thumbnails"), "mpv"),
-        (_("MPV built-in default"), "default"),
+        (_("MPV UI"), "mpv"),
         (_("Custom OSC"), "custom"),
         (_("No player controls"), "none"),
     ],

--- a/jellyfin_mpv_shim/mpvtk_browser/config.py
+++ b/jellyfin_mpv_shim/mpvtk_browser/config.py
@@ -159,7 +159,12 @@ TAB_SECTIONS = {
         # falls through to Advanced, which is a real editable row -- searched
         # like any other (`sections`), labelled and noted below -- so there
         # is still a setting to point at. That is the whole requirement.
-        (_("Input"), ["input_gamepad", "gamepad_swap_confirm"]),
+        (_("Input"), ["input_gamepad", "gamepad_swap_confirm",
+                      # Curated, unlike `ui_select_key` above:
+                      # this is not a remap but a policy, and it is
+                      # what somebody goes looking for after `1`
+                      # dimmed their picture from the library (#730).
+                      "browse_block_keys"]),
         # Everything about the window itself, in the order you meet it:
         # how it opens, whether it remembers, what closing it means.
         (_("Window"), ["fullscreen", "browser_fullscreen",
@@ -633,6 +638,7 @@ LABEL_OVERRIDES = {
     "headless": _("Cast-target mode (no library browsing)"),
     "display_mirror_summon": _("Casting Opens the Library Browser"),
     "browser_fullscreen": _("Fullscreen Library Browser"),
+    "browse_block_keys": _("Block Player Keybinds While Browsing"),
     "hud_grab_keys": _("Always Bind Arrow Keys to Player Controls"),
     "hud_wake_key": _("Player Controls Activation Key"),
     "ui_select_key": _("Select Key"),
@@ -700,6 +706,19 @@ NOTES = {
     "gamepad_swap_confirm": _("Turn this on for a controller whose A button "
                               "is on the right rather than at the bottom "
                               "(Switch Pro, most 8BitDo pads)."),
+    # Names the EFFECTS rather than the keys, and that is the choice: the
+    # keys are whatever the user's input.conf says, so listing `1`-`8`
+    # would be wrong for exactly the person who rebound them. What is
+    # constant is what those commands do -- and "the picture changed" is
+    # what somebody arrives here having seen. `SEARCH_ALIASES` below
+    # carries the key words for the search box, where being literal costs
+    # nothing.
+    "browse_block_keys": _("Stops MPV's own shortcuts -- picture "
+                           "adjustment, screenshots, subtitle and audio "
+                           "switching -- from acting while you are in the "
+                           "library, where there is no video for them to "
+                           "act on. Turn it off to use your own MPV key "
+                           "bindings there."),
     # Two things the label cannot carry: that this REPLACES Enter (which is
     # the reason to change it -- getting Enter back for mpv), and that the
     # controller and the phone follow it, so nothing is left behind.
@@ -1107,6 +1126,11 @@ SEARCH_ALIASES = {
     # what the key does without ever naming the key.
     "ui_select_key": "remap rebind keyboard shortcut",
     "hud_wake_key": "remap rebind keyboard shortcut enter summon",
+    # What somebody types is the SYMPTOM, not the mechanism: they pressed a
+    # key and the picture changed, or the contrast is wrong and they cannot
+    # say why. None of those words are in the label or the note.
+    "browse_block_keys": "keys keyboard contrast brightness gamma "
+                         "saturation hotkey",
 }
 
 

--- a/jellyfin_mpv_shim/mpvtk_browser/config.py
+++ b/jellyfin_mpv_shim/mpvtk_browser/config.py
@@ -152,12 +152,14 @@ TAB_SECTIONS = {
         # people are looking for, and on Linux desktops that route media
         # keys through MPRIS it is likely broken anyway. Promoting it would
         # be offering a switch we cannot say works.
-        # `ui_select_key` is here and NOT in HUD_ONLY beside `hud_wake_key`:
-        # it governs the library as much as the player controls, and the
-        # library exists under every osc_style. Under "MPV built-in default"
-        # the row still means something.
-        (_("Input"), ["input_gamepad", "gamepad_swap_confirm",
-                      "ui_select_key"]),
+        #
+        # `ui_select_key` is deliberately NOT here, and not anywhere else in
+        # a curated group: key remapping is an answer to give somebody who
+        # asks for it, not a control to put in front of everyone [iw]. It
+        # falls through to Advanced, which is a real editable row -- searched
+        # like any other (`sections`), labelled and noted below -- so there
+        # is still a setting to point at. That is the whole requirement.
+        (_("Input"), ["input_gamepad", "gamepad_swap_confirm"]),
         # Everything about the window itself, in the order you meet it:
         # how it opens, whether it remembers, what closing it means.
         (_("Window"), ["fullscreen", "browser_fullscreen",
@@ -1096,6 +1098,15 @@ SEARCH_ALIASES = {
     # "am" and "24" are what somebody types and neither is in the label or
     # the note; "pm", "clock" and "time" would be redundant with them.
     "clock_12h": "am 24 format",
+    # The two ENTER keys. Neither is in a curated group any more --
+    # `ui_select_key` by choice [iw], `hud_wake_key` only under the mpvtk
+    # OSC -- so search is how somebody sent looking for "the Enter setting"
+    # arrives, and "remap"/"rebind"/"keyboard"/"shortcut" were measured
+    # misses for both. `hud_wake_key` also missed **enter** itself, which is
+    # the word that brings anyone here at all: its note is the one that says
+    # what the key does without ever naming the key.
+    "ui_select_key": "remap rebind keyboard shortcut",
+    "hud_wake_key": "remap rebind keyboard shortcut enter summon",
 }
 
 

--- a/jellyfin_mpv_shim/mpvtk_browser/gateway/playback.py
+++ b/jellyfin_mpv_shim/mpvtk_browser/gateway/playback.py
@@ -33,6 +33,15 @@ class PlaybackMixin(GatewayCore):
         # places it ends. The other is on_minimize; see there.
         playerManager.clear_deinterlace_override()
 
+    def apply_browser_fullscreen(self):
+        """Push a just-written ``browser_fullscreen`` at the window (#729).
+
+        Through ``_act`` like every other player call from this thread: the
+        settings page runs on the browser's loop, and the player's lock can
+        be held by a playback start.
+        """
+        self._act(lambda pm: pm.apply_browser_fullscreen())
+
     def on_minimize(self):
         """Drop to the windowless state. set_browse_window(False) releases
         force_window when nothing is playing; if a cast is in flight it

--- a/jellyfin_mpv_shim/mpvtk_browser/gateway/transport.py
+++ b/jellyfin_mpv_shim/mpvtk_browser/gateway/transport.py
@@ -124,6 +124,22 @@ class TransportMixin(GatewayCore):
     def set_volume(self, pct, notify=True):
         self._act(lambda pm: pm.set_volume(float(pct), notify=notify))
 
+    def adjust_volume(self, delta):
+        """Step the volume by ``delta`` percent, clamped to 0-100 (#730).
+
+        The read and the write happen together on the PLAYER thread rather
+        than from the pushed now-playing snapshot. That snapshot arrives by
+        playstate push, so under key repeat several presses would each
+        compute from the same stale base and the volume would stick a
+        notch below where it was asked to go.
+        """
+        def step(pm):
+            current = pm.get_volume(True)
+            if current is None:
+                return
+            pm.set_volume(max(0.0, min(100.0, float(current) + delta)))
+        self._act(step)
+
     def set_repeat(self, mode):
         self._act(lambda pm: pm.set_repeat(mode))
 

--- a/jellyfin_mpv_shim/mpvtk_browser/hud.py
+++ b/jellyfin_mpv_shim/mpvtk_browser/hud.py
@@ -1014,11 +1014,19 @@ def build_hud(b, size):
         # characters at the hour mark -- and it is measured like
         # everything else, so that shift flipped a shed decision: the
         # favourite button vanished at 1:00:00 with nothing on screen to
-        # explain it. Position can only reach the duration and the
-        # remaining form only adds a minus, so this is the ceiling. It
-        # also stops the whole bar shifting once a second.
+        # explain it. It also stops the whole bar shifting once a second.
+        #
+        # The ceiling is the LARGER of duration and position. Duration alone
+        # is right whenever there is one -- position can only reach it, and
+        # the remaining form only adds a minus -- but Live TV and unbounded
+        # streams report 0, and there the box was pinned to "0:00 / -0:00"
+        # while the position went on growing: past an hour it was narrower
+        # than its own text, which the non-wrapping Text then ellipsized
+        # ("1:02:03 / 0…"). Either way it moves only at a digit-count
+        # boundary, never once a second.
         clock_pad = 4
-        widest = "%s / -%s" % (_clock(dur), _clock(dur))
+        ceiling = max(dur, shown_pos)
+        widest = "%s / -%s" % (_clock(ceiling), _clock(ceiling))
         items.append(("clock", Box(
             [Text("%s / %s" % (_clock(shown_pos), end_part),
                   size=sz(17),

--- a/jellyfin_mpv_shim/mpvtk_browser/hud.py
+++ b/jellyfin_mpv_shim/mpvtk_browser/hud.py
@@ -15,6 +15,7 @@ from typing import Optional
 
 from ..conf import settings
 from ..i18n import _
+from ..mpvtk.layout import natural_size
 from ..mpvtk.widgets import (
     Box,
     Button,
@@ -196,12 +197,17 @@ def _chapter_jump(b, direction):
     b._ctl(lambda c: c.chapter_seek(direction))
 
 
-def _pickers(b, menu_state, pos, chapters, tiers, icon_size=None):
-    """Right-aligned controls: chapters, audio/subtitle tracks, quality
-    — each only when there is a real choice to make (and the viewport
-    has room for it)."""
+def _pickers(b, menu_state, pos, chapters, icon_size=None):
+    """Right-aligned controls: chapters, audio/subtitle tracks, quality —
+    each only when there is a real choice to make.
+
+    Returns (shed key or None, widget) pairs, in display order: whether
+    there is *room* is no longer decided here but by `_shed`, once the
+    whole row can be measured. The track pickers are None because a file
+    with two audio languages and no way to pick between them is not a
+    narrower bar, it is a broken one."""
     out = []
-    if chapters and tiers["chapters"]:
+    if chapters:
         cur = 0
         for i, ch in enumerate(chapters):
             if ch["time"] <= pos:
@@ -211,28 +217,28 @@ def _pickers(b, menu_state, pos, chapters, tiers, icon_size=None):
                         ch["title"] or _("Chapter %d") % (i + 1))
             for i, ch in enumerate(chapters)
         ]
-        out.append(Dropdown(
+        out.append(("chapters", Dropdown(
             "hud-chapters", labels, selected=cur, force=True,
             trigger_icon="bookmark", tip=_("Chapters"),
             icon_size=icon_size,
             on_select=lambda i, v, chs=chapters: b._ctl(
-                lambda c: c.seek(chs[i]["time"]))))
+                lambda c: c.seek(chs[i]["time"])))))
     st = menu_state if menu_state and menu_state.get("has_media") else None
     if st is None:
         return out
     audio = st.get("audio") or []
     if len(audio) > 1:
-        out.append(_option_picker(b, "hud-audio", "audiotrack",
-                                  _("Audio Track"), audio, "set-audio",
-                                  icon_size=icon_size))
+        out.append((None, _option_picker(
+            b, "hud-audio", "audiotrack", _("Audio Track"), audio,
+            "set-audio", icon_size=icon_size)))
     subs = st.get("subtitles") or []
     if len(subs) > 1:  # more than just "None"
-        out.append(_subtitle_picker(b, st, subs, icon_size))
+        out.append((None, _subtitle_picker(b, st, subs, icon_size)))
     quality = st.get("quality") or {}
-    if quality.get("options") and tiers["quality"]:
-        out.append(_option_picker(b, "hud-quality", "hd",
-                                  _("Video Quality"), quality["options"],
-                                  "set-quality", icon_size=icon_size))
+    if quality.get("options"):
+        out.append(("quality", _option_picker(
+            b, "hud-quality", "hd", _("Video Quality"),
+            quality["options"], "set-quality", icon_size=icon_size)))
     return out
 
 
@@ -289,20 +295,92 @@ def _ctl_get(b, name, default):
         return default
 
 
-#: Width at which the bar grows its own Video Quality button. Read by both
-#: build_hud's tiers and _menu_rows, because "is that button on screen?" is
-#: exactly the question the gear's Quality row has to answer.
-QUALITY_BTN_W = 560
+#: Optional controls, in the order the bar gives them up as it narrows.
+#:
+#: It SHRINKS first -- `build_hud`'s `scale` -- and only sheds once
+#: everything is as small as it is allowed to get, so this is an order of
+#: last resort and not a layout.
+#:
+#: The order is the one the old pixel breakpoints encoded [iw]: `ends_at`
+#: went at 1000, `volbar` at 760, the chapter pair at 700, favourite and
+#: quality at 560, the clock and the seek pair at 500. Where two shared a
+#: breakpoint they are separated here in favour of the more capable one --
+#: the chapter DROPDOWN reaches any chapter and so outlives its two step
+#: buttons, quality outlives favourite, and the seek buttons are the only
+#: precise +-10s without dragging, so they outlive a clock whose reading
+#: the seek bar already gives approximately.
+#:
+#: **A key is a group, not an icon.** `seek_btns` is *both* step buttons
+#: and `ch_btns` is *both* chapter buttons: half of a symmetric pair is
+#: worse than neither of it, and tagging both halves with one key is what
+#: makes that structural instead of remembered.
+SHED_ORDER = ("ends_at", "volbar", "ch_btns", "chapters",
+              "favorite", "quality", "clock", "seek_btns")
 
 
-def _menu_rows(b, st, w=None):
+def _shed(items, avail, gap):
+    """Which of ``items``' optional controls to give up so the row fits.
+
+    ``items`` is the whole transport row as (shed key or None, widget) in
+    display order; the answer is the shortest prefix of `SHED_ORDER` that
+    makes it fit, so nothing is sacrificed for room that was already
+    there.
+
+    **This replaced five hand-tuned pixel breakpoints, which had drifted
+    out of true.** Measured across 400-1400px, the bar overflowed its own
+    window at every width between ~700 and ~1000 -- by up to 113px --
+    because controls were added to it over time and the numbers never
+    moved. Nothing showed it, because the overflow was being absorbed by
+    the four track pickers (the only children of the row with no shrink
+    floor), which collapsed to zero width while the renderer went on
+    drawing their full-size glyphs across each other: #721.
+
+    `natural_size` exists for exactly this and says so -- "no hardcoded
+    breakpoints" -- and this bar was the one that never took it up.
+
+    **The now-playing bar already worked this way** (`music._np_plan`,
+    whose docstring reports the same discovery: "thresholds are guesses
+    about a sum, and they were wrong"). Two bars, one lesson, learnt once
+    -- which is why the second one still had the bug. That bar estimates
+    the sum from per-control width constants rather than measuring; it
+    fits at every width today, so it is left alone, but the constants are
+    a second authority on how wide a control is and would drift the same
+    way the breakpoints did.
+    """
+    width = {}
+    for _key, el in items:
+        width[id(el)] = natural_size(el)[0]
+
+    def fits(dropped):
+        keep = [el for key, el in items if key not in dropped]
+        if not keep:
+            return True
+        return (sum(width[id(el)] for el in keep)
+                + gap * (len(keep) - 1)) <= avail
+
+    present = {key for key, _el in items if key}
+    dropped = set()
+    for key in SHED_ORDER:
+        if fits(dropped):
+            break
+        if key in present:
+            dropped.add(key)
+    return dropped
+
+
+def _menu_rows(b, st, shed=None):
     """(label, icon, action) rows for the open settings-menu level.
     ``st`` is the osc_bridge state blob ({} when unavailable).
 
-    ``w`` is the window width, for the one row whose presence depends on
-    whether the bar already has a button for it. Without it (a caller that
-    does not know) the row is kept: an unreachable setting is worse than a
-    duplicated one."""
+    ``shed`` is what the bar gave up on its last build (`_shed`), for the
+    one row whose presence depends on whether the bar already has a button
+    for it. ``None`` means a caller that does not know, and then the row is
+    kept: an unreachable setting is worse than a duplicated one.
+
+    The window width used to answer this, against the breakpoint that
+    decided the button. There is no such breakpoint now, and width was
+    always the weaker question -- at 600px it said the Video Quality button
+    was on screen while the bar it sat in overflowed by 36."""
     kind = b.hud.menu
     rows = []
     # Declared up front because the name is reused by two loops with
@@ -331,10 +409,10 @@ def _menu_rows(b, st, w=None):
     if kind == "root":
         quality = st.get("quality") or {}
         # Only when the bar's own Video Quality button is NOT on screen.
-        # It drops out below QUALITY_BTN_W, and there the gear is the only
-        # way to reach the setting; above it, this row is a second door to
-        # a sheet whose button is a few pixels away.
-        if quality.get("options") and (w is None or w < QUALITY_BTN_W):
+        # Where it has been shed the gear is the only way to reach the
+        # setting; where it survives, this row is a second door to a sheet
+        # whose button is a few pixels away.
+        if quality.get("options") and (shed is None or "quality" in shed):
             rows.append((with_current(_("Change Video Quality"),
                                       quality.get("current")), None,
                          lambda: _open_hud_menu(b, "quality")))
@@ -477,7 +555,7 @@ def _settings_menu(b, menu_state, size):
         return None
     st = menu_state if menu_state and menu_state.get("has_media") else {}
     w, h = size
-    rows = _menu_rows(b, st, w)
+    rows = _menu_rows(b, st, b.hud.shed)
     if not rows:
         return None
     x, y = w - 300, h - 160
@@ -784,17 +862,6 @@ def build_hud(b, size):
     # What survives is what an album needs: pause (stop it moving on), and
     # prev/next (move through it).
     photo = bool(st.get("is_photo"))
-    tiers = {
-        "seek_btns": w >= 500 and not photo,   # ±10s/±30s step buttons
-        "clock": w >= 500 and not photo,
-        "quality": w >= QUALITY_BTN_W,
-        "favorite": w >= 560,
-        "ch_btns": w >= 700,     # chapter prev/next buttons
-        "chapters": w >= 700,    # chapter list dropdown
-        "volume": not photo,     # mute button
-        "volbar": w >= 760 and not photo,      # volume slider
-        "ends_at": w >= 1000 and not photo,    # wall-clock end time
-    }
 
     def tbtn(icon, node_id, cb, autofocus=False, icon_size=HUD_ICON,
              tip=None,
@@ -839,20 +906,28 @@ def build_hud(b, size):
         except Exception:
             menu_state = None
 
-    controls = [
-        tbtn("skip_previous", "hud-prev",
-             lambda: b._ctl(lambda c: c.prev()), tip=_("Previous")),
-    ]
-    if chapters and tiers["ch_btns"]:
-        controls.append(tbtn(
+    # The whole transport row, tagged: a key is what `_shed` may give up
+    # when the row does not fit, None is not up for negotiation. Every
+    # optional control is BUILT either way -- shedding is decided by
+    # measuring them, so they have to exist first. They are cheap objects
+    # and this runs once per repaint.
+    #
+    # A condition that is not about ROOM stays a condition: a photo has no
+    # seek row and no sound, and there are no chapter buttons for a file
+    # with no chapters.
+    items = [(None, tbtn("skip_previous", "hud-prev",
+                         lambda: b._ctl(lambda c: c.prev()),
+                         tip=_("Previous")))]
+    if chapters:
+        items.append(("ch_btns", tbtn(
             "undo", "hud-ch-prev",
             lambda: _chapter_jump(b, -1),
-            tip=_("Previous chapter")))
-    if tiers["seek_btns"]:
-        controls.append(tbtn(
+            tip=_("Previous chapter"))))
+    if not photo:
+        items.append(("seek_btns", tbtn(
             "replay_10", "hud-seek-back",
             lambda: b._ctl(lambda c: c.seek_relative(-10)),
-            tip=_("Back 10 Seconds"), repeat=True))
+            tip=_("Back 10 Seconds"), repeat=True)))
     # DOWN off the seek bar lands here, whatever else the current width
     # is drawing beside it. Without the gravity the arrow picks whichever
     # button happens to sit nearest the middle, and which one that is
@@ -867,77 +942,93 @@ def build_hud(b, size):
     # pixels left onto play/pause, and UP would not bring it back. The
     # rationale for the gravity is the full-width seek bar; where there
     # is no seek bar there is nothing to disambiguate.
-    controls.append(tbtn(
+    items.append((None, tbtn(
         pp, "hud-pp", lambda: b._ctl(lambda c: c.toggle_pause()),
-        icon_size=36, nav_gravity=not photo))
-    if tiers["seek_btns"]:
-        controls.append(tbtn(
+        icon_size=36, nav_gravity=not photo)))
+    if not photo:
+        items.append(("seek_btns", tbtn(
             "forward_30", "hud-seek-fwd",
             lambda: b._ctl(lambda c: c.seek_relative(30)),
-            tip=_("Forward 30 Seconds"), repeat=True))
-    if chapters and tiers["ch_btns"]:
-        controls.append(tbtn(
+            tip=_("Forward 30 Seconds"), repeat=True)))
+    if chapters:
+        items.append(("ch_btns", tbtn(
             "redo", "hud-ch-next",
             lambda: _chapter_jump(b, 1),
-            tip=_("Next chapter")))
-    controls.append(tbtn(
+            tip=_("Next chapter"))))
+    items.append((None, tbtn(
         "skip_next", "hud-next",
-        lambda: b._ctl(lambda c: c.next()), tip=_("Next")))
+        lambda: b._ctl(lambda c: c.next()), tip=_("Next"))))
     # (no stop button: the top bar's back arrow yields to the library)
     shown_pos = pos if scrub is None else scrub
-    if tiers["clock"]:
+    if not photo:
         # click toggles total <-> negative-remaining (the lua tc_right)
         if b.hud.tc_remaining and dur > 0:
             end_part = "-" + _clock(max(0.0, dur - shown_pos))
         else:
             end_part = _clock(dur)
-        controls.append(Box(
+        # **Sized for the widest reading it can ever have**, not for the
+        # one it currently shows. The clock is the only control whose
+        # width changes DURING an item -- "59:59 / 2:00:00" gains two
+        # characters at the hour mark -- and it is measured like
+        # everything else, so that shift flipped a shed decision: the
+        # favourite button vanished at 1:00:00 with nothing on screen to
+        # explain it. Position can only reach the duration and the
+        # remaining form only adds a minus, so this is the ceiling. It
+        # also stops the whole bar shifting once a second.
+        clock_pad = 4
+        widest = "%s / -%s" % (_clock(dur), _clock(dur))
+        items.append(("clock", Box(
             [Text("%s / %s" % (_clock(shown_pos), end_part),
                   size=sz(17),
                   color="ffffff" if scrub is not None else "dddddd")],
-            id="hud-clock", pad=4, align="center", direction="row",
-            on_click=lambda: _toggle_tc(b)))
-    if tiers["ends_at"] and dur > 0:
+            id="hud-clock", pad=clock_pad, align="center", direction="row",
+            w=natural_size(Text(widest, size=sz(17)))[0] + 2 * clock_pad,
+            on_click=lambda: _toggle_tc(b))))
+    if dur > 0 and not photo:
         speed = max(0.01, float(_ctl_get(b, "get_speed", 1.0)))
         ends = timefmt.clock_epoch(
             time.time() + max(0.0, dur - pos) / speed)
-        controls.append(Text(_("Ends at {0}").format(ends),
-                             size=sz(16), color="aaaaaa"))
-    controls.append(Spacer())
+        items.append(("ends_at", Text(_("Ends at {0}").format(ends),
+                                      size=sz(16), color="aaaaaa")))
+    items.append((None, Spacer()))
 
-    right = []
-    if tiers["favorite"]:
-        fav = bool(st.get("favorite"))
-        right.append(tbtn(
-            "favorite" if fav else "favorite_border", "hud-fav",
-            lambda: _toggle_hud_favorite(b),
-            tip=_("Favorite"), fg=theme.FAV_RED if fav else "eeeeee"))
-    right.extend(_pickers(b, menu_state, pos, chapters, tiers,
-                          picker_icon))
+    fav = bool(st.get("favorite"))
+    items.append(("favorite", tbtn(
+        "favorite" if fav else "favorite_border", "hud-fav",
+        lambda: _toggle_hud_favorite(b),
+        tip=_("Favorite"), fg=theme.FAV_RED if fav else "eeeeee")))
+    items.extend(_pickers(b, menu_state, pos, chapters, picker_icon))
     muted = bool(st.get("muted"))
     vol = st.get("volume", 100) or 0
-    if tiers["volume"]:
-        right.append(tbtn(
+    if not photo:
+        items.append((None, tbtn(
             "volume_off" if muted else
             ("volume_up" if vol >= 50 else "volume_down"),
             "hud-mute", lambda: _toggle_hud_mute(b),
-            tip=_("Mute")))
-    if tiers["volbar"]:
-        right.append(Slider(
+            tip=_("Mute"))))
+        items.append(("volbar", Slider(
             "hud-vol", value=0 if muted else vol, min=0, max=100,
             on_video=True,   # drawn over the picture; see widgets.Slider
             w=sz(110), force=True,
-            on_change=lambda v: b._ctl(lambda c: c.set_volume(v))))
-    right.append(tbtn(
+            on_change=lambda v: b._ctl(lambda c: c.set_volume(v)))))
+    items.append((None, tbtn(
         "settings", "hud-settings",
         lambda: _open_hud_menu(b, "root", anchor="hud-settings"),
-        tip=_("Settings")))
-    right.append(tbtn(
+        tip=_("Settings"))))
+    items.append((None, tbtn(
         "fullscreen_exit" if st.get("fullscreen") else "fullscreen",
         "hud-fs", lambda: b._ctl(lambda c: c.toggle_fullscreen()),
-        tip=_("Fullscreen")))
+        tip=_("Fullscreen"))))
 
-    transport = Row(controls + right, gap=sz(6), align="center")
+    # `pad` is (x, y) -- layout._pad2 -- so the row gets the bar's width
+    # less its horizontal padding, and the gap it is about to be built
+    # with. Recorded on the HUD state because the gear menu asks what was
+    # given up (see `_menu_rows`); it is read later in THIS build, so it
+    # cannot be stale for the menu that reads it.
+    gap = sz(6)
+    b.hud.shed = _shed(items, w - 2 * sz(24), gap)
+    transport = Row([el for key, el in items if key not in b.hud.shed],
+                    gap=gap, align="center")
 
     # A photo has a duration -- mpv's --image-display-duration, i.e. when the
     # next one arrives -- but scrubbing inside it means nothing, and a

--- a/jellyfin_mpv_shim/mpvtk_browser/hud.py
+++ b/jellyfin_mpv_shim/mpvtk_browser/hud.py
@@ -16,6 +16,7 @@ from typing import Optional
 from ..conf import settings
 from ..i18n import _
 from ..mpvtk.layout import natural_size
+from ..mpvtk.widgets import trigger_box
 from ..mpvtk.widgets import (
     Box,
     Button,
@@ -122,6 +123,46 @@ def _hud_action(b, verb, arg=None):
 #: responsive shrink. The transport buttons were already 30; the track
 #: pickers derived theirs from the type size and came out at 24.
 HUD_ICON = 30
+
+#: The smallest a hit target on the bar may get, in LOGICAL px. WCAG 2.2
+#: SC 2.5.8 (AA), which is 24x24 CSS px.
+#:
+#: **Logical, and deliberately not divided by `ui_scale`** -- the natural
+#: idea, and wrong in both directions. `ui_scale` is either mpv's
+#: `display-hidpi-scale` (the default) or a number the user forced. On the
+#: first, logical px are ALREADY density-independent, so dividing would let
+#: the bar shrink to a quarter size with ~12 CSS px targets -- below the
+#: minimum this constant exists to enforce, on exactly the HiDPI machines
+#: #721 was reported from. On the second, someone who sets `ui_scale=2`
+#: ("readable on a TV across the room", per docs/configuration.md) is
+#: asking for BIGGER, and shrinking back to a 24px target undoes the need
+#: they just expressed. Expressed in logical units the physical target
+#: comes out right on every display, which is the DPI-dependence that was
+#: actually wanted.
+#:
+#: 44/48 (AAA, Apple HIG, Material) were measured and rejected: at
+#: HUD_ICON they floor at 0.94-1.02, i.e. a refusal to scale at all,
+#: which does nothing on the 1x displays where this was reported.
+MIN_TARGET_PX = 24
+
+#: The floor before `hud_auto_scale`, kept as the OFF branch. Not "no
+#: scaling": off is the compatibility setting, and someone who turns it
+#: off is asking for what the previous release did, not for a third
+#: behaviour nobody has seen.
+LEGACY_SCALE_FLOOR = 0.72
+
+
+def hud_scale_floor():
+    """How far the bar may shrink before controls are given up instead.
+
+    The trigger box is the smallest interactive thing on the bar -- a
+    transport button is its glyph plus `Button`'s 10px padding either
+    side, which does not shrink -- so it is what the target applies to,
+    and `widgets.trigger_box` is asked rather than the ratio copied.
+    """
+    if not settings.hud_auto_scale:
+        return LEGACY_SCALE_FLOOR
+    return MIN_TARGET_PX / trigger_box(HUD_ICON)
 
 
 def _option_picker(b, node_id, icon, tip, options, verb,
@@ -836,11 +877,12 @@ def build_hud(b, size):
     dur = st.get("duration", 0) or 0
     pp = "play_arrow" if st.get("paused") else "pause"
     scrub = b.hud.scrub
-    # Responsive shrink, mirroring the lua OSC's jellyfin layout:
-    # everything scales down to 72% as the window narrows, and the
-    # less essential controls drop out at breakpoints (in the spirit
-    # of jellyfin-web's).
-    scale = min(1.0, max(0.72, w / 900.0))
+    # Responsive shrink, in the spirit of jellyfin-web's: everything
+    # scales down as the window narrows, and only once it has reached the
+    # floor are controls given up (`_shed`). Shrink first, sacrifice
+    # second -- 900 is the width at which the bar is drawn full size.
+    floor = hud_scale_floor()
+    scale = min(1.0, max(floor, w / 900.0))
 
     def sz(v):
         return int(v * scale + 0.5)
@@ -1020,13 +1062,54 @@ def build_hud(b, size):
         "hud-fs", lambda: b._ctl(lambda c: c.toggle_fullscreen()),
         tip=_("Fullscreen"))))
 
+    # **Decided at the NARROWEST window that draws this same glyph**, not
+    # at the actual one, and that is what keeps a control from blinking as
+    # the window is dragged.
+    #
+    # Every control on the bar takes its size from one `sz(HUD_ICON)`, so
+    # they all round down together: crossing scale 0.75 takes ~16px off
+    # the row in a single 10px step of window width, while the width
+    # available to it falls smoothly. Slack therefore sawtooths -- it
+    # climbs through a step and drops at the edge of one -- so a control
+    # sitting near zero is shed at 680, back at 670, and shed again at
+    # 630. Measured; not a rounding accident, and it recurs at every glyph
+    # step for whichever control is on the boundary. (`music.py`'s
+    # NP_TITLE_W comment describes the same class of bug from the other
+    # bar: "three widths where controls popped in as you dragged the edge
+    # inwards".)
+    #
+    # Snapping the decision to the bottom of the step makes the answer
+    # constant within one, which HALVES it -- 6 widths to 3, over a 2px
+    # sweep of 511. **It does not remove it**: the clock and the "Ends at"
+    # label step on font metrics, on a different period again, and closing
+    # that would mean measuring the row twice per repaint. The residual is
+    # bounded by a test instead (MAX_NON_MONOTONE), so do not read this as
+    # a guarantee. Conservative by at most one step (~30px), which is less
+    # than the control it would otherwise drop -- and conservative is the
+    # safe direction, since the optimistic one is the overflow this whole
+    # mechanism exists to prevent. Below the floor there is no staircase
+    # at all -- the glyph has stopped shrinking -- so the guard below
+    # leaves the real width alone there.
+    #
     # `pad` is (x, y) -- layout._pad2 -- so the row gets the bar's width
     # less its horizontal padding, and the gap it is about to be built
     # with. Recorded on the HUD state because the gear menu asks what was
     # given up (see `_menu_rows`); it is read later in THIS build, so it
     # cannot be stale for the menu that reads it.
     gap = sz(6)
-    b.hud.shed = _shed(items, w - 2 * sz(24), gap)
+    step_w = w
+    if floor < w / 900.0 < 1.0:
+        # ...and ONLY in that band. Above it the glyph is pinned at full
+        # size and below it at the floor, so in both the row's width is
+        # constant while the room for it grows with the window -- already
+        # monotone, and snapping there would report a 1920px window as
+        # having 885px and shed controls with half the bar empty. Found by
+        # the "nothing is given up that did not need to be" test; the
+        # width sweep did not see it, because shedding the same wrong set
+        # at every wide width is perfectly monotone.
+        step_w = max(900.0 * floor,
+                     900.0 * (sz(HUD_ICON) - 0.5) / HUD_ICON)
+    b.hud.shed = _shed(items, step_w - 2 * sz(24), gap)
     transport = Row([el for key, el in items if key not in b.hud.shed],
                     gap=gap, align="center")
 

--- a/jellyfin_mpv_shim/mpvtk_browser/hud_control.py
+++ b/jellyfin_mpv_shim/mpvtk_browser/hud_control.py
@@ -56,6 +56,11 @@ class HudController:
         #: renderer is showing no HUD, so it is showing no panel either.
         self.info = False
         self.tc_remaining = False
+        #: Which optional transport controls the last bar build gave up
+        #: (``hud._shed``), so the gear menu can offer a row for what is
+        #: not on screen. ``None`` until a bar has been built, which the
+        #: menu reads as "unknown" and fails open.
+        self.shed = None
 
     # -- is the HUD in play at all ----------------------------------------
 

--- a/jellyfin_mpv_shim/mpvtk_browser/repository.py
+++ b/jellyfin_mpv_shim/mpvtk_browser/repository.py
@@ -2492,6 +2492,32 @@ class LibrarySource:
                                   fields=LIST_FIELDS, limit=limit) or {}
         return result.get("Items", [])
 
+    def get_season_queue(self, server_uuid, series_id, season_id):
+        """One season's episodes, in aired order, as a play queue.
+
+        Separate from :meth:`get_episodes`, which the season SCREEN uses,
+        because the two want different rows: a listing shows missing and
+        unaired episodes so you can see the gaps, and a queue must not try to
+        play them. Those are jellyfin-web's own filters for this exact
+        gesture (``playbackmanager.js``'s ``getSeriesOrSeasonPlaybackPromise``
+        sends ``IsVirtualUnaired: false, IsMissing: false``), and folding
+        them into the shared method would quietly hide the gaps from the
+        screen.
+
+        Issued through ``api.shows`` rather than ``api.get_episodes`` for the
+        same reason :meth:`get_seasons` is: the apiclient helper takes no
+        filter arguments, and this is the same request with two more.
+        """
+        api = self._conn(server_uuid).api
+        result = api.shows("/%s/Episodes" % series_id, params={
+            "UserId": "{UserId}",
+            "SeasonId": season_id,
+            "IsVirtualUnaired": False,
+            "IsMissing": False,
+            "Fields": LIST_FIELDS,
+        }) or {}
+        return result.get("Items", [])
+
     def get_next_up(self, server_uuid, series_id):
         """The next episode to watch for a series (resume or next unwatched)."""
         api = self._conn(server_uuid).api
@@ -3485,6 +3511,13 @@ class OfflineLibrarySource:
             if start_item_id in ids:
                 eps = eps[ids.index(start_item_id):]
         return eps[:limit]
+
+    def get_season_queue(self, server_uuid, series_id, season_id):
+        """Signature parity with the live source. The catalog holds only what
+        was actually downloaded, so there is nothing missing or unaired in it
+        to filter out -- `get_episodes` already returns the season in order.
+        """
+        return self.get_episodes(server_uuid, series_id, season_id)
 
     def get_by_name_sections(self, server_uuid, spec, limit=20):
         """Empty offline: every row is a server-side predicate over the

--- a/jellyfin_mpv_shim/mpvtk_browser/settings/base.py
+++ b/jellyfin_mpv_shim/mpvtk_browser/settings/base.py
@@ -118,6 +118,17 @@ class SettingsBase:
             # need a restart; mpv reads that one once, at startup.)
             if self.app is not None and hasattr(self.app, "push_gamepad"):
                 self.app.push_gamepad()
+        if ok and key == "ui_select_key":
+            # BOTH pushes, always. The keyboard's binding and the pad's
+            # are two spellings of one key (`conf.select_key`), and the
+            # pad's is a literal baked into the table it was pushed with
+            # -- so a re-push of one without the other is exactly the
+            # disagreement #717 is about, with the gamepad left pressing
+            # a key nothing listens for.
+            for name in ("push_select_key", "push_gamepad"):
+                push = getattr(self.app, name, None) if self.app else None
+                if push is not None:
+                    push()
         if ok and key == "poster_scale":
             # Applies live, unlike the theme's own cover size below: this
             # control is *labelled* Cover Size, so watching it happen is the

--- a/jellyfin_mpv_shim/mpvtk_browser/settings/base.py
+++ b/jellyfin_mpv_shim/mpvtk_browser/settings/base.py
@@ -94,6 +94,17 @@ class SettingsBase:
             refresh = getattr(self, "refresh_window_controls", None)
             if refresh is not None:
                 refresh()
+        if ok and key == "browse_block_keys":
+            # Live, because the switch is one somebody flips to find out
+            # what it does -- and the renderer only binds or removes one
+            # key binding, so there is nothing to rebuild. The volume claim
+            # reads the same setting, so ask for a frame: `_claim_page_keys`
+            # runs from build().
+            push = getattr(self.app, "push_browse_keys", None) if self.app \
+                else None
+            if push is not None:
+                push()
+            self.invalidate()
         if ok and key == "browser_fullscreen":
             # #729: this was read only on a browse TRANSITION, so it took
             # effect after the next thing you played -- which from inside

--- a/jellyfin_mpv_shim/mpvtk_browser/settings/base.py
+++ b/jellyfin_mpv_shim/mpvtk_browser/settings/base.py
@@ -84,6 +84,16 @@ class SettingsBase:
                     _("Saved: %(key)s (also turned off \"%(other)s\")")
                     % {"key": key,
                        "other": cfg.label_for("start_minimized")})
+        if ok and key in ("window_controls", "window_controls_fullscreen"):
+            # The chrome snapshot is PUSHED, on decoration changes only
+            # (`playerManager.on_decorations_changed`), and editing the
+            # setting is not one. Without this the new answer waits for the
+            # next fullscreen, maximize or border event -- so the row looks
+            # like it did nothing. True of `window_controls` before
+            # `window_controls_fullscreen` joined it; both are live now.
+            refresh = getattr(self, "refresh_window_controls", None)
+            if refresh is not None:
+                refresh()
         if ok and key == "work_offline":
             self._apply_work_offline(bool(value))
         if ok and key == "auto_download_enable" and value:

--- a/jellyfin_mpv_shim/mpvtk_browser/settings/base.py
+++ b/jellyfin_mpv_shim/mpvtk_browser/settings/base.py
@@ -94,6 +94,15 @@ class SettingsBase:
             refresh = getattr(self, "refresh_window_controls", None)
             if refresh is not None:
                 refresh()
+        if ok and key == "browser_fullscreen":
+            # #729: this was read only on a browse TRANSITION, so it took
+            # effect after the next thing you played -- which from inside
+            # Settings looks exactly like a switch that does nothing, and is
+            # not something the restart banner could honestly say either.
+            ctl = getattr(self, "controller", None)
+            apply_fs = getattr(ctl, "apply_browser_fullscreen", None)
+            if apply_fs is not None:
+                apply_fs()
         if ok and key == "work_offline":
             self._apply_work_offline(bool(value))
         if ok and key == "auto_download_enable" and value:

--- a/jellyfin_mpv_shim/mpvtk_browser/tiles.py
+++ b/jellyfin_mpv_shim/mpvtk_browser/tiles.py
@@ -612,13 +612,52 @@ class TilesMixin:
             if t == "MusicGenre":
                 return [i.get("Id") for i in self.source.get_genre_songs(
                     server, parent_id, iid)]
-            if t in ("Series", "Season"):
+            if t == "Season":
+                return [i.get("Id") for i in
+                        self._season_queue(item, server)]
+            if t == "Series":
                 return [i.get("Id") for i in
                         self.source.get_series_queue(server, iid)]
         except Exception:
             log.warning("could not resolve %s for playback", t, exc_info=True)
             return []
         return [iid]
+
+    def _season_queue(self, item, server):
+        """A season's episodes, in order. Runs off the loop thread.
+
+        **A Season is not a Series id.** This used to go through
+        `get_series_queue`, which asks `Shows/{id}/Episodes` -- and a season
+        id there is not a series, so the server answered with nothing, and
+        `_menu_play`'s empty-result branch fell through to `_open_item`. The
+        play chip on a season opened the season, which is #720.
+        """
+        series_id = item.get("SeriesId")
+        if not series_id:
+            # Nothing to scope the query by. Better an empty queue (the
+            # caller says so) than the whole show under a season's button.
+            log.warning("season %s carries no SeriesId", item.get("Id"))
+            return []
+        return self.source.get_season_queue(server, series_id, item.get("Id"))
+
+    @staticmethod
+    def _first_unplayed(items):
+        """Index of the first unwatched entry, or 0 if they all are.
+
+        jellyfin-web's rule for a season's Play button
+        (`playbackmanager.js`, `getSeriesOrSeasonPlaybackPromise`): a season
+        queues WHOLE and starts at the first unplayed episode. Deliberately
+        not Next Up -- web skips that lookup when a season is named, because
+        "play this season" and "carry on with this show" are different
+        questions and only the second one may leave the season.
+
+        Web spells the fallback `StartIndex || seasonStartIndex || 0`, which
+        works only because index 0 is falsy; this returns the real index.
+        """
+        for i, e in enumerate(items or ()):
+            if not ((e.get("UserData") or {}).get("Played")):
+                return i
+        return 0
 
     def _menu_play(self, item, server, resume=True):
         t = item.get("Type")
@@ -644,6 +683,15 @@ class TilesMixin:
                           .get("PlaybackPositionTicks")) or None
             self._play(item, server, offset_ticks=offset)
             return
+        if t == "Season":
+            # The one container whose queue does not start at the top: the
+            # season plays whole, from its first unplayed episode. Its own
+            # path because it needs the DTOs, not just the ids -- both to
+            # find that episode and to carry its resume offset -- and
+            # `_resolve_play_ids` cannot hand those back: `_menu_queue`
+            # shares it and passes the result straight to `_queue_items`.
+            self._play_season(item, server)
+            return
         # A container: resolve it to its items and play those, rather than
         # navigating (a "Play" that browses instead is just a lie).
         ep = self._epoch
@@ -658,6 +706,31 @@ class TilesMixin:
                 self._play_list(ids, server, 0, audio=audio)
             else:
                 self._open_item(item)
+        self.run_async(work, done, ep)
+
+    def _play_season(self, item, server):
+        """Play a whole season from its first unplayed episode (#720)."""
+        ep = self._epoch
+
+        def work():
+            try:
+                return self._season_queue(item, server)
+            except Exception:
+                log.warning("could not resolve the season for playback",
+                            exc_info=True)
+                return []
+
+        def done(eps):
+            eps = [e for e in (eps or ()) if e.get("Id")]
+            if not eps:
+                # Same fallback as every other container: opening it is at
+                # least honest about having nothing to play.
+                self._open_item(item)
+                return
+            # `items=` is what gives the started episode its resume offset,
+            # exactly as it does for a playlist entry.
+            self._play_list([e["Id"] for e in eps], server,
+                            self._first_unplayed(eps), items=eps)
         self.run_async(work, done, ep)
 
 

--- a/jellyfin_mpv_shim/mpvtk_browser/tiles.py
+++ b/jellyfin_mpv_shim/mpvtk_browser/tiles.py
@@ -310,6 +310,28 @@ class TilesMixin:
             # queue can empty between the menu being drawn and pressed.
             if self._is_playing():
                 out.append((_("Play next"), "queue_play_next", "queuenext"))
+        # jellyfin-web's card has three hit regions -- the play chip, the
+        # image, and the series title -- and ours has the first two: our
+        # captions are BAKED into the strip bitmap, so the series name an
+        # episode tile already draws (components.episode_subtitle) is not a
+        # node anything can click. This is the reachable version of that
+        # third region (#719).
+        #
+        # Gated on SeriesId rather than on Type == "Episode": a Season
+        # carries one too, and "go up to the show" is as wanted from a
+        # season tile. The detail page gates on Episode only because that
+        # is the one type it renders.
+        #
+        # Suppressed when the show is already the page you are on, where
+        # the entry would navigate to where you are.
+        #
+        # Same verb and icon as `pages/detail.py`'s button, deliberately:
+        # gettext keys on the English, so a second spelling would be a
+        # second entry for every translator to find.
+        if (item.get("SeriesId")
+                and not (self.route.get("kind") == "series"
+                         and self.route.get("item_id") == item["SeriesId"])):
+            out.append((_("Go to Series"), "movie", "goseries"))
         if t in self.MENU_WATCHED:
             out.append((_("Mark unplayed") if watched
                         else _("Mark played"), "check", "watched"))
@@ -412,6 +434,10 @@ class TilesMixin:
             self._close_menu()
             self._open_add_to(item)
             return
+        elif action == "goseries":
+            self._close_menu()
+            self._go_to_series(item, server)
+            return
         elif action == "read":
             self._close_menu()
             self._menu_read(item, server)
@@ -445,6 +471,18 @@ class TilesMixin:
             self._live_menu_action(action, item, server)
             return
         self._close_menu()
+
+    def _go_to_series(self, item, server):
+        """Open the show an episode or season belongs to (#719).
+
+        The same route `pages/detail.py`'s "Go to Series" button builds, so
+        the two doors land on the same page -- and `SeriesName` for the
+        title, because the route's title is what the top bar shows before
+        the series DTO has loaded.
+        """
+        self.navigate({"kind": "series", "server": server,
+                       "item_id": item["SeriesId"],
+                       "title": item.get("SeriesName", "")})
 
     def _menu_read(self, item, server):
         """Open a book from its tile.

--- a/jellyfin_mpv_shim/mpvtk_browser/ui.py
+++ b/jellyfin_mpv_shim/mpvtk_browser/ui.py
@@ -93,16 +93,27 @@ class UserInterface:
         self.activate()
         self._browser.open_settings(tab)
 
+    @staticmethod
+    def _server_uuid(client):
+        """Which connected server a websocket event came from, or None.
+
+        Identity, not equality: `clientManager.clients` is keyed by uuid and
+        the values are the `JellyfinClient` objects the events are raised
+        on.
+        """
+        if client is None:
+            return None
+        return next((u for u, c in clientManager.clients.items()
+                     if c is client), None)
+
     def _display_content(self, client, item_id):
         """Route a remote's DisplayContent to the browser, resolving which
         connected server it came from."""
         if self._browser is None:
             return
-        uuid = next((u for u, c in clientManager.clients.items()
-                     if c is client), None)
         # display_item decides whether to take the window — it must not
         # interrupt playback, so waking the client is its call, not ours.
-        self._browser.display_item(uuid, item_id)
+        self._browser.display_item(self._server_uuid(client), item_id)
 
     def _live_tv_changed(self, _client=None):
         """Forward a timer websocket event to the browser.
@@ -117,16 +128,25 @@ class UserInterface:
             return
         self._browser.refresh_live_tv()
 
-    def _user_data_changed(self, _client=None):
+    def _user_data_changed(self, client=None):
         """Forward a UserDataChanged websocket event to the browser.
 
-        Unfiltered by server for the same reason as the timer events above:
-        the browser refreshes whatever is on screen, and the event only ever
-        comes from a server this client is logged into.
+        **Filtered by server, unlike the timer events above**, and the
+        difference is which screens answer. A timer event only ever affects
+        Live TV, which is one screen. This one now re-reads a series or a
+        season as well as Home (#722), and those belong to ONE server -- so
+        in a two-server session, activity on A would otherwise re-fetch a
+        Series page on B: a wasted round trip at best, and at worst an
+        unrelated event driving the screen into the offline fallback when B
+        is unreachable. Home is exempt inside `_refresh_current`, because it
+        is assembled from every logged-in server.
+
+        A client we cannot resolve gives None, which refreshes as before --
+        no worse than the unfiltered behaviour this replaces.
         """
         if self._browser is None:
             return
-        self._browser.refresh_home()
+        self._browser.refresh_userdata(self._server_uuid(client))
 
     def _open_config_folder(self):
         PlayerGateway().open_config_folder()

--- a/jellyfin_mpv_shim/player.py
+++ b/jellyfin_mpv_shim/player.py
@@ -38,6 +38,7 @@ from .player_reporting import ReportingMixin
 from . import player_window
 from .player_window import WindowMixin, wlog
 from .mpv_options import (REPLACES_OSC, build_mpv_options, mpv_scripts,
+                          osc_script_opts,
                           resolve_osc_style)
 from .session_reporter import SessionReporter
 from . import conf
@@ -1105,37 +1106,19 @@ class PlayerManager(AudioMixin, ReportingMixin, WindowMixin):
         # construction rather than in time. Measured: the OSC starts with
         # `idlescreen = true` without it and `false` with it.
         #
-        # Unconditional, and that is the point -- it has to cover the styles
-        # where mpv loads the OSC itself (the legacy `thumbnail_osc_builtin`
-        # resolution) as well as the one we load by hand. It is inert for a
-        # style with no OSC and for a third-party one that reads a different
-        # prefix.
-        #
         # `change-list ... append`, never a whole-property write:
         # `script-opts` is shared with the user's own scripts, and replacing
         # it would take their options with it (verified: an unrelated entry
         # survives the append). Same rule as never writing over their
         # `mpv.conf`.
         #
-        # `osc-windowcontrols` rides the same append, and is the "push the
-        # window controls option to other OSCs where possible" half of #727.
-        # Our own answer is `window_controls_wanted`, which a classic OSC
-        # cannot see; the stock OSC and its forks read this opt and default
-        # it to "auto", which shows THEIR buttons whenever the window has no
-        # border -- so with `hide_title_bar` on, a user would get two sets.
-        # We draw ours, so theirs are always off.
-        #
-        # It carries only that one axis. The OSC's own
-        # `window_controls_enabled` consults `windowcontrols` and `border`
-        # and never fullscreen, so `window_controls_fullscreen` has no
-        # spelling here and is scoped to the in-window UI; saying "yes"
-        # would show their buttons fullscreen too, which is the opposite of
-        # what that setting is for when it is off.
+        # WHICH options, and which styles get them, is `osc_script_opts` --
+        # `osc-windowcontrols` is not unconditional, and the reasoning for
+        # that lives with the decision rather than here.
         try:
-            self._player.command("change-list", "script-opts", "append",
-                                 "osc-idlescreen=no")
-            self._player.command("change-list", "script-opts", "append",
-                                 "osc-windowcontrols=no")
+            for _opt in osc_script_opts(osc_style):
+                self._player.command("change-list", "script-opts", "append",
+                                     _opt)
         except Exception:
             log.debug("could not pre-set the OSC script options",
                       exc_info=True)

--- a/jellyfin_mpv_shim/player.py
+++ b/jellyfin_mpv_shim/player.py
@@ -4756,8 +4756,13 @@ class PlayerManager(AudioMixin, ReportingMixin, WindowMixin):
                 self._osc_suppressed = False
             # Mpv's own, held off against an mpv.conf `osc=yes` -- which a
             # construction option cannot do (build_mpv_options). Not keyed
-            # on `enabled`: these styles never want it back. "default" is
-            # the user's option and is never written.
+            # on `enabled`: these styles never want it back.
+            #
+            # The membership test reads as vacuous now that every style
+            # `resolve_osc_style` can return is in REPLACES_OSC -- "default"
+            # left that set of answers with `thumbnail_osc_builtin`. It is
+            # not: `style` is read with a None default, so this also covers
+            # a call before _init_mpv has recorded one.
             if style in REPLACES_OSC and hasattr(self._player, "osc"):
                 self._player.osc = False
         except _mpv_errors:

--- a/jellyfin_mpv_shim/player.py
+++ b/jellyfin_mpv_shim/player.py
@@ -4866,8 +4866,13 @@ class PlayerManager(AudioMixin, ReportingMixin, WindowMixin):
     # client) -> mpv key names. While the mpvtk browser owns input its
     # forced nav bindings catch these; during video playback they fall
     # through to kb_seek as before.
+    #: The remote's directional verbs as the keys the renderer's spatial
+    #: navigation is bound to. "ok" is absent on purpose: it is the one
+    #: the user may remap, so it is resolved per press by
+    #: `_nav_select_key` rather than frozen into a class attribute that
+    #: is built once at import.
     _NAV_KEYPRESS = {"up": "UP", "down": "DOWN", "left": "LEFT",
-                     "right": "RIGHT", "ok": "ENTER", "back": "ESC",
+                     "right": "RIGHT", "back": "ESC",
                      # jellyfin-web's hamburger, while the library is up:
                      # the context menu of whatever is focused. That menu
                      # holds Play / Queue / Watched / Favorite / Download,
@@ -4991,11 +4996,17 @@ class PlayerManager(AudioMixin, ReportingMixin, WindowMixin):
             self.menu.menu_action(self._MENU_ALIAS.get(action, action))
         elif action in self._NAV_COMMANDS and self._nav_command(action):
             pass    # the in-window UI has its own home / settings pages
-        elif action in self._NAV_KEYPRESS and self._mpvtk_input_active():
+        elif ((action in self._NAV_KEYPRESS or action == "ok")
+                and self._mpvtk_input_active()):
             # remote drives the UI's spatial navigation
             try:
+                # `select_key()` per press, not a `_NAV_KEYPRESS` entry:
+                # that dict is a class attribute built at import, so a
+                # value read there would be whatever the setting said when
+                # `player` was first imported.
                 self._player.command(
-                    "keypress", self._NAV_KEYPRESS[action])
+                    "keypress",
+                    self._NAV_KEYPRESS.get(action) or conf.select_key())
             except Exception:
                 log.debug("nav keypress failed", exc_info=True)
         elif action == "settings":

--- a/jellyfin_mpv_shim/player.py
+++ b/jellyfin_mpv_shim/player.py
@@ -1088,6 +1088,40 @@ class PlayerManager(AudioMixin, ReportingMixin, WindowMixin):
             log.info("This mpv cannot give up its window on request "
                      "(needs 0.41+); minimizing will quit mpv instead.")
 
+        # **Before any OSC draws, as an OPTION, not after it as a message.**
+        #
+        # `enable_osc` broadcasts `osc-idlescreen no` and says in its own
+        # comment that it "has to land BEFORE the OSC's first draw". A
+        # message cannot promise that: against an OSC mpv loaded at
+        # construction it races the script's own startup, and against one we
+        # `load-script` it races that too, because `load-script` is
+        # asynchronous. Lose either race and mpv's "Drop files or URLs to
+        # play" logo is drawn once and then sits behind the library for the
+        # session -- which is what [iw] hit under the styles that let mpv
+        # load its own OSC.
+        #
+        # Every osc.lua and every fork of it reads `script-opts` under the
+        # `osc` prefix at startup, so setting it here is read by
+        # construction rather than in time. Measured: the OSC starts with
+        # `idlescreen = true` without it and `false` with it.
+        #
+        # Unconditional, and that is the point -- it has to cover the styles
+        # where mpv loads the OSC itself (the legacy `thumbnail_osc_builtin`
+        # resolution) as well as the one we load by hand. It is inert for a
+        # style with no OSC and for a third-party one that reads a different
+        # prefix.
+        #
+        # `change-list ... append`, never a whole-property write:
+        # `script-opts` is shared with the user's own scripts, and replacing
+        # it would take their options with it (verified: an unrelated entry
+        # survives the append). Same rule as never writing over their
+        # `mpv.conf`.
+        try:
+            self._player.command("change-list", "script-opts", "append",
+                                 "osc-idlescreen=no")
+        except Exception:
+            log.debug("could not pre-set osc-idlescreen", exc_info=True)
+
         # The classic OSC, chosen against this mpv rather than at option-build
         # time -- which is why it is a `load-script` here and not an entry in
         # `mpv_scripts`. Nothing is on screen yet, so the gap costs nothing.
@@ -1257,29 +1291,6 @@ class PlayerManager(AudioMixin, ReportingMixin, WindowMixin):
         rather than a documented one, so the failure it could produce -- an
         OSC style with no OSC at all -- is caught rather than shipped.
         """
-        # **Before the script loads, as an OPTION, not after it as a message.**
-        # `enable_osc` broadcasts `osc-idlescreen no` and says in its own
-        # comment that it "has to land BEFORE the OSC's first draw" -- but
-        # `load-script` is asynchronous, so a message sent after it races the
-        # script's `register_script_message`. Lose that race and mpv's "Drop
-        # files or URLs to play" logo is drawn once and then sits behind the
-        # library for the session.
-        #
-        # Every osc.lua and every fork of it reads `script-opts` under the
-        # `osc` prefix at startup, so setting it first is read by
-        # construction rather than in time. Measured: without it the OSC
-        # starts with `idlescreen = true`, with it `false`.
-        #
-        # `change-list ... append`, never a whole-property write:
-        # `script-opts` is shared with the user's own scripts, and replacing
-        # it would take their options with it (verified: an unrelated entry
-        # survives the append). Same rule as never writing over their
-        # `mpv.conf`.
-        try:
-            self._player.command("change-list", "script-opts", "append",
-                                 "osc-idlescreen=no")
-        except Exception:
-            log.debug("could not pre-set osc-idlescreen", exc_info=True)
         if osc_preview_api_works(getattr(self._player, "mpv_version", "")):
             try:
                 self._player.command("load-script", BUILTIN_OSC)

--- a/jellyfin_mpv_shim/player.py
+++ b/jellyfin_mpv_shim/player.py
@@ -296,6 +296,42 @@ def runtime_force_window_works(version):
     return (int(m.group(1)), int(m.group(2))) >= (0, 41)
 
 
+#: mpv's own name for the builtin OSC (`player/scripting.c`:
+#: `load_builtin_script(..., "@osc.lua")`). `load-script` takes it, which is
+#: how the stock OSC can be loaded *after* construction even though `--osc=no`
+#: stopped it loading itself. Not a documented public API, which is why the
+#: caller falls back to our fork rather than trusting it.
+BUILTIN_OSC = "@osc.lua"
+
+
+def osc_preview_api_works(version):
+    """Whether mpv's own OSC can drive our seek previews.
+
+    mpv 0.41 added the **OSC Preview API** (``DOCS/man/osc.rst``): the OSC
+    publishes ``user-data/osc/draw-preview`` -- ``{x, y, w, h, hover-sec,
+    ass}`` -- and any thumbnailer script draws into it, clearing when the
+    property goes nil.
+
+    That is the hook `trickplay-osc.lua` was forked to work around; its own
+    header says "sadly there is no way to do this without forking the entire
+    OSC script", and as of 0.41 there is. So on a new enough mpv we load the
+    STOCK OSC and answer its requests, and the fork is only for older ones --
+    Debian and others still ship 0.40.
+
+    Same threshold as `runtime_force_window_works` and deliberately its own
+    predicate: they are two different questions that happen to share an
+    answer today, and folding them would make a backport of either a silent
+    lie about the other.
+
+    An unreadable version is treated as old, which costs a fork that works
+    everywhere (measured on 0.41+) rather than an OSC with no previews.
+    """
+    m = re.search(r"(\d+)\.(\d+)", version or "")
+    if not m:
+        return False
+    return (int(m.group(1)), int(m.group(2))) >= (0, 41)
+
+
 SUBTITLE_POS = {
     "top": 0,
     "bottom": 100,
@@ -1052,6 +1088,12 @@ class PlayerManager(AudioMixin, ReportingMixin, WindowMixin):
             log.info("This mpv cannot give up its window on request "
                      "(needs 0.41+); minimizing will quit mpv instead.")
 
+        # The classic OSC, chosen against this mpv rather than at option-build
+        # time -- which is why it is a `load-script` here and not an entry in
+        # `mpv_scripts`. Nothing is on screen yet, so the gap costs nothing.
+        if osc_style == "mpv":
+            self._load_classic_osc()
+
         # The menu object must survive mpv re-creation (crash recovery,
         # idle-quit): its is_menu_shown state gates idle_quit, and callers
         # outside this class hold on to it. A fresh OSDMenu here used to reset
@@ -1198,6 +1240,66 @@ class PlayerManager(AudioMixin, ReportingMixin, WindowMixin):
         token; nothing here unregisters, because mpv is torn down whole.
         """
         return observe_property(self._player, prop, handler)
+
+    def _load_classic_osc(self):
+        """Load the OSC for ``osc_style`` "mpv": the stock one where it can
+        drive our previews, our fork where it cannot.
+
+        `trickplay-osc.lua` is a fork of mpv 0.38's `osc.lua` whose only
+        purpose is seek-bar thumbnails -- its whole patch set is six
+        thumbfast blocks and one compatibility fix. mpv 0.41 made that
+        unnecessary by publishing the OSC Preview API, so a modern mpv gets
+        its own OSC (upstream fixes, upstream look) and `thumbfast.lua`
+        answers the property instead.
+
+        The fork stays for older builds, and it is also the fallback if the
+        builtin name is ever refused: `@osc.lua` is mpv's internal spelling
+        rather than a documented one, so the failure it could produce -- an
+        OSC style with no OSC at all -- is caught rather than shipped.
+        """
+        # **Before the script loads, as an OPTION, not after it as a message.**
+        # `enable_osc` broadcasts `osc-idlescreen no` and says in its own
+        # comment that it "has to land BEFORE the OSC's first draw" -- but
+        # `load-script` is asynchronous, so a message sent after it races the
+        # script's `register_script_message`. Lose that race and mpv's "Drop
+        # files or URLs to play" logo is drawn once and then sits behind the
+        # library for the session.
+        #
+        # Every osc.lua and every fork of it reads `script-opts` under the
+        # `osc` prefix at startup, so setting it first is read by
+        # construction rather than in time. Measured: without it the OSC
+        # starts with `idlescreen = true`, with it `false`.
+        #
+        # `change-list ... append`, never a whole-property write:
+        # `script-opts` is shared with the user's own scripts, and replacing
+        # it would take their options with it (verified: an unrelated entry
+        # survives the append). Same rule as never writing over their
+        # `mpv.conf`.
+        try:
+            self._player.command("change-list", "script-opts", "append",
+                                 "osc-idlescreen=no")
+        except Exception:
+            log.debug("could not pre-set osc-idlescreen", exc_info=True)
+        if osc_preview_api_works(getattr(self._player, "mpv_version", "")):
+            try:
+                self._player.command("load-script", BUILTIN_OSC)
+                log.info("Using mpv's own OSC; previews go through its "
+                         "Preview API.")
+                return
+            except Exception:
+                log.warning("mpv refused %s; falling back to the bundled OSC.",
+                            BUILTIN_OSC, exc_info=True)
+        else:
+            log.info("This mpv has no OSC Preview API (needs 0.41+); using "
+                     "the bundled OSC so seek previews still work.")
+        try:
+            self._player.command("load-script",
+                                 get_resource("trickplay-osc.lua"))
+        except Exception:
+            # An OSC style with no OSC is a worse outcome than a logged
+            # failure, but there is nothing further to try.
+            log.error("Could not load an OSC for the 'mpv' style.",
+                      exc_info=True)
 
     def _bind_mpv_handlers(self):
         """Attach every key binding and event handler to the current mpv."""

--- a/jellyfin_mpv_shim/player.py
+++ b/jellyfin_mpv_shim/player.py
@@ -1116,11 +1116,29 @@ class PlayerManager(AudioMixin, ReportingMixin, WindowMixin):
         # it would take their options with it (verified: an unrelated entry
         # survives the append). Same rule as never writing over their
         # `mpv.conf`.
+        #
+        # `osc-windowcontrols` rides the same append, and is the "push the
+        # window controls option to other OSCs where possible" half of #727.
+        # Our own answer is `window_controls_wanted`, which a classic OSC
+        # cannot see; the stock OSC and its forks read this opt and default
+        # it to "auto", which shows THEIR buttons whenever the window has no
+        # border -- so with `hide_title_bar` on, a user would get two sets.
+        # We draw ours, so theirs are always off.
+        #
+        # It carries only that one axis. The OSC's own
+        # `window_controls_enabled` consults `windowcontrols` and `border`
+        # and never fullscreen, so `window_controls_fullscreen` has no
+        # spelling here and is scoped to the in-window UI; saying "yes"
+        # would show their buttons fullscreen too, which is the opposite of
+        # what that setting is for when it is off.
         try:
             self._player.command("change-list", "script-opts", "append",
                                  "osc-idlescreen=no")
+            self._player.command("change-list", "script-opts", "append",
+                                 "osc-windowcontrols=no")
         except Exception:
-            log.debug("could not pre-set osc-idlescreen", exc_info=True)
+            log.debug("could not pre-set the OSC script options",
+                      exc_info=True)
 
         # The classic OSC, chosen against this mpv rather than at option-build
         # time -- which is why it is a `load-script` here and not an entry in

--- a/jellyfin_mpv_shim/player_window.py
+++ b/jellyfin_mpv_shim/player_window.py
@@ -769,11 +769,17 @@ class WindowMixin:
         # minimize, maximize or drag. Checked ahead of "always" because
         # "always" is an answer to "does this desktop decorate my windows",
         # not a request for furniture over the top of a fullscreen video.
-        try:
-            if self._player is not None and self._player.fullscreen:
-                return False
-        except Exception:
-            pass
+        #
+        # `window_controls_fullscreen` is the opt-in for the other reading
+        # (#727): with no title bar and no keyboard, fullscreen is a room
+        # with no door. Still off by default -- the buttons are over the
+        # picture, and every other way out still works.
+        if not settings.window_controls_fullscreen:
+            try:
+                if self._player is not None and self._player.fullscreen:
+                    return False
+            except Exception:
+                pass
         if mode == "always":
             return True
         # "auto" and anything unrecognised: ask mpv. An unanswerable question

--- a/jellyfin_mpv_shim/player_window.py
+++ b/jellyfin_mpv_shim/player_window.py
@@ -313,6 +313,55 @@ class WindowMixin:
     def toggle_fullscreen(self):
         self.set_fullscreen(not self._player.fs, persist=True)
 
+    def _apply_browse_fullscreen(self):
+        """Put the browse window at the size ``browser_fullscreen`` asks for.
+
+        Browsing is a desktop-UI activity: only go fullscreen if the user
+        explicitly asked for a fullscreen browser. ``settings.fullscreen``
+        still applies when playback starts.
+
+        headless is a kiosk: the cast screen IS the display, so it stays
+        fullscreen throughout. Without this, stopping playback dropped a
+        cast-target box back to a window whenever ``browser_fullscreen`` was
+        off — and ``browser_fullscreen`` is about the library, which headless
+        does not even have.
+
+        The `elif` is what keeps audio out of it: music leaves `_video` set
+        and keeps the library on screen, and the fullscreen the *video*
+        session chose outranks this one.
+
+        Called on every browse transition and, since #729, whenever the
+        setting itself is written — one decision in one place, because two
+        copies of it would disagree the first time either moved.
+        """
+        if settings.browser_fullscreen or settings.headless:
+            self._player.fs = True
+        elif not self._video:
+            self._player.fs = False
+
+    @synchronous("_lock")
+    def apply_browser_fullscreen(self):
+        """Live-apply ``browser_fullscreen`` from the settings page (#729).
+
+        The setting used to wait for the next browse transition, which for
+        someone sitting in Settings is indistinguishable from a control that
+        does nothing.
+
+        **Not `set_fullscreen()`**, which is the other plausible way to write
+        this and is wrong: that one also records `fullscreen_disable`, a
+        *user intent* flag read at the next playback start — so turning the
+        library's fullscreen off would quietly turn off auto-fullscreen for
+        the next video too.
+        """
+        from .player import _mpv_errors
+
+        if not self._mpv_alive:
+            return
+        try:
+            self._apply_browse_fullscreen()
+        except _mpv_errors:
+            self._handle_mpv_disconnect()
+
     @synchronous("_lock")
     def set_fullscreen(self, enabled: bool, persist: bool = False):
         """``persist`` remembers the choice, for toggles the *user* made (a
@@ -649,20 +698,7 @@ class WindowMixin:
                         self._player.command("stop")
                         self._showing_browse_bg = True
                         self._browse_bg_deferred = False
-                # Browsing is a desktop-UI activity: only go fullscreen if the
-                # user explicitly asked for a fullscreen browser. settings.
-                # fullscreen still applies when playback starts.
-                #
-                # headless is a kiosk: the cast screen IS the display, so it
-                # stays fullscreen throughout. Without this, stopping
-                # playback dropped a cast-target box back to a window
-                # whenever browser_fullscreen was off — and browser_
-                # fullscreen is about the library, which headless does not
-                # even have.
-                if settings.browser_fullscreen or settings.headless:
-                    self._player.fs = True
-                elif not self._video:
-                    self._player.fs = False
+                self._apply_browse_fullscreen()
             else:
                 try:
                     self._player.keepaspect = True

--- a/jellyfin_mpv_shim/player_window.py
+++ b/jellyfin_mpv_shim/player_window.py
@@ -97,10 +97,16 @@ class WindowMixin:
         fullscreen_disable: bool
         on_decorations_changed: Any
 
-        # Provided by siblings on the composed PlayerManager. Three, and the
+        # Provided by siblings on the composed PlayerManager. Four, and the
         # count is the point: if it grows, the window concern is drifting back
         # into the lifecycle it was separated from.
         def _init_mpv(self) -> None: ...
+
+        # Grown deliberately, for `apply_browser_fullscreen`: "is the library
+        # on screen" is a question about what is PLAYING, which this mixin
+        # does not own and must not answer with a local approximation --
+        # `_video is None` is the wrong answer during music.
+        def _library_showing(self) -> bool: ...
 
         def idle_quit(self, reason: str = ...) -> None: ...
 
@@ -356,6 +362,18 @@ class WindowMixin:
         from .player import _mpv_errors
 
         if not self._mpv_alive:
+            return
+        # **Only while the library actually owns the window.** The gateway's
+        # `_act` defers through `run_action`, so a write made while the
+        # player lock was held by a playback start lands AFTER that start --
+        # and `_apply_browse_fullscreen`'s `_video` guard protects only the
+        # OFF direction, so `browser_fullscreen` would have taken a playing
+        # video fullscreen against the user's choice.
+        #
+        # `_library_showing()`, never `_video is None`: music keeps `_video`
+        # set and keeps the library up, and that is the case this whole
+        # method exists to serve.
+        if not self._library_showing():
             return
         try:
             self._apply_browse_fullscreen()

--- a/jellyfin_mpv_shim/restart.py
+++ b/jellyfin_mpv_shim/restart.py
@@ -75,7 +75,7 @@ def _durable_flags():
     Everything else is left out by construction -- see the module docstring
     for why the allowlist is the safe direction.
     """
-    from .args import get_args
+    from .args import CLI_OVERRIDES, get_args
 
     try:
         args = get_args()
@@ -100,18 +100,18 @@ def _durable_flags():
     # Only for the settings being restarted for, not always: somebody who
     # passed `--scale 2.0` and restarts for an unrelated reason still means
     # it for this sitting.
+    #
+    # Driven from `args.CLI_OVERRIDES` rather than a list written out here,
+    # because this is the THIRD place that has to know which flag shadows
+    # which setting -- the other two being where they are applied
+    # (`mpv_shim.main`) and where they are kept out of the config file
+    # (`settings_base.apply_cli_override`). Three hand-maintained copies of
+    # one pairing is three chances to add a flag to two of them.
     pending = _pending_settings
-    enable_gui = getattr(args, "enable_gui", None)
-    if enable_gui is not None and "enable_gui" not in pending:
-        out.append("--gui" if enable_gui else "--no-gui")
-    minimized = getattr(args, "start_minimized", None)
-    if minimized is not None and "start_minimized" not in pending:
-        out.append("--minimized" if minimized else "--no-minimized")
-    if getattr(args, "mpv_loglevel", None) and "mpv_log_level" not in pending:
-        out += ["--mpv-loglevel", args.mpv_loglevel]
-    if (getattr(args, "ui_scale", None) is not None
-            and "ui_scale" not in pending):
-        out += ["--scale", str(args.ui_scale)]
+    for override in CLI_OVERRIDES:
+        value = getattr(args, override.dest, None)
+        if value is not None and override.key not in pending:
+            out += override.spell(value)
     if getattr(args, "disable_hwdec", False):
         # Kept unconditionally, unlike the four above, and the difference is
         # what dropping it costs: this is the recovery flag for hardware

--- a/jellyfin_mpv_shim/settings_base.py
+++ b/jellyfin_mpv_shim/settings_base.py
@@ -55,6 +55,10 @@ object_types = {
 
 class SettingsBase:
     def __init__(self):
+        #: Fields a command-line flag is overriding FOR THIS RUN, mapped to
+        #: the value that was on disk. See `apply_cli_override`. First,
+        #: because `__setattr__` reads it.
+        self.__cli_overrides__ = {}
         self.__fields_set__ = set()
         self.__fields__ = []
         for attr in self.__class__.__annotations__.keys():
@@ -64,10 +68,58 @@ class SettingsBase:
             self.__fields__.append(attr)
             setattr(self, attr, getattr(self.__class__, attr))
 
+    def __setattr__(self, name, value):
+        """Any ordinary write drops a CLI override on that field.
+
+        The user has now stated an intent for it -- from the settings
+        screen, or from one of the several places that persist a value as a
+        side effect -- and that outranks a flag which only ever applied to
+        this run.
+
+        Here rather than at the writers, because there are eight of them and
+        one of them is "whatever gets added next". `self.__dict__.get` and
+        not `getattr`: this runs on every attribute set including the ones
+        in `__init__` before the record exists, and it must not recurse.
+        """
+        overrides = self.__dict__.get("__cli_overrides__")
+        if overrides:
+            overrides.pop(name, None)
+        object.__setattr__(self, name, value)
+
+    def apply_cli_override(self, key, value):
+        """Set ``key`` for this run without letting it reach the config file.
+
+        `save()` serializes `dict()`, and `dict()` walks every field -- so a
+        flag assigned straight onto the settings object is written out by the
+        next save from anywhere, and there are many: window geometry (with
+        `remember_window_size` on by default), audio device, shader profile,
+        every settings-screen edit. One run with `--minimized` and the option
+        was on for good.
+
+        So the on-disk value is remembered here and handed back by `dict()`
+        instead of the live one. `--scale` used to dodge this with a comment
+        asking callers not to save; three sibling flags had the same shape
+        and no such comment.
+        """
+        if key not in self.__fields__:
+            raise KeyError(key)
+        was = getattr(self, key)
+        setattr(self, key, value)          # clears any earlier record
+        self.__cli_overrides__[key] = was
+
     def dict(self):
+        """The settings as they should be PERSISTED and presented.
+
+        Not quite "as they are in effect": a field under a CLI override
+        reports the value from the config file. That is what keeps
+        `--minimized` out of `conf.json`, and it is also the honest answer
+        for the settings screen, which is showing what is configured rather
+        than what this particular launch was told to do.
+        """
+        overrides = self.__cli_overrides__
         result = {}
         for attr in self.__fields__:
-            value = getattr(self, attr)
+            value = overrides[attr] if attr in overrides else getattr(self, attr)
             # Structured fields opt in by exposing _to_dict() on their items.
             if isinstance(value, list) and value and hasattr(value[0], "_to_dict"):
                 result[attr] = [item._to_dict() for item in value]

--- a/jellyfin_mpv_shim/single_instance.py
+++ b/jellyfin_mpv_shim/single_instance.py
@@ -84,6 +84,9 @@ class SingleInstance:
         return True
 
     def release(self):
+        # Whether this instance is the one that WROTE the endpoint file, read
+        # before the flag is cleared below. See the removal at the end.
+        owned = self.holds_lock
         if self._sock is not None:
             try:
                 self._sock.close()
@@ -102,10 +105,24 @@ class SingleInstance:
                 pass
             self._guard_fd = None
         self.holds_lock = False
-        try:
-            os.remove(self._lockpath)
-        except OSError:
-            pass
+        # **Only the instance that wrote it may remove it.** The endpoint file
+        # is how a later launch finds the running copy to ask it to show its
+        # window; deleting it belongs to whoever owns the port it names. A
+        # non-primary release() used to unlink it anyway, and the damage is
+        # invisible and permanent: the primary keeps running and keeps
+        # listening, but nothing can find it any more, so every launch from
+        # then on silently declines to start AND fails to surface the window
+        # somebody launched it to get at.
+        #
+        # `main` returns without releasing on the blocked path, so nothing
+        # shipped hits this today -- which is exactly why it needs the guard
+        # rather than a promise, and it is the same ownership argument the
+        # guard file above already makes for itself.
+        if owned:
+            try:
+                os.remove(self._lockpath)
+            except OSError:
+                pass
 
     # -- internals ---------------------------------------------------------
 

--- a/jellyfin_mpv_shim/thumbfast.lua
+++ b/jellyfin_mpv_shim/thumbfast.lua
@@ -179,3 +179,59 @@ function client_message_handler(event)
     end
 end
 mp.register_event("client-message", client_message_handler)
+
+-- mpv's OSC Preview API (0.41+, DOCS/man/osc.rst).
+--
+-- The stock OSC publishes `user-data/osc/draw-preview` -- a table of
+-- {x, y, w, h, hover-sec, ass} -- when the pointer is over the seekbar, and
+-- sets it to nil to say "take it down". That is exactly the hook
+-- trickplay-osc.lua was forked to work around, so on a new enough mpv the
+-- player loads mpv's OWN OSC and we answer this instead.
+--
+-- Both paths live side by side on purpose and cannot both be live: the
+-- property only ever appears when the stock OSC is running, and the
+-- client-messages only ever arrive from our fork, which is loaded only when
+-- the stock one cannot do this. Neither needs to know about the other.
+--
+-- The coordinates are OSD pixels, which is what `overlay-add` wants -- the
+-- fork had to divide by the virtual scale factor to get here. `w`/`h` are
+-- the box the OSC reserved, and the docs say "the actual backing thumbnail
+-- size may differ", so our own frame is centred in it rather than stretched
+-- to it.
+--
+-- `ass` (a border to draw around the preview) is deliberately ignored: it is
+-- sized to the OSC's box rather than to our frame, so drawing it would put a
+-- rectangle around something the wrong size. A preview without a border is
+-- the lesser of the two.
+local function on_draw_preview(_, req)
+    dbg("draw-preview -> " .. type(req))
+    if type(req) ~= "table" then
+        if img_is_shown then
+            mp.commandv("overlay-remove", img_overlay_id)
+            img_is_shown = false
+            img_last_frame = -1
+            img_last_x = nil
+            img_last_y = nil
+        end
+        return
+    end
+    local secs = tonumber(req["hover-sec"])
+    local x, y = tonumber(req.x), tonumber(req.y)
+    if secs == nil or x == nil or y == nil then
+        return
+    end
+    local w, h = tonumber(req.w) or 0, tonumber(req.h) or 0
+    if img_width > 0 and w > 0 then
+        x = x + math.floor((w - img_width) / 2)
+    end
+    if img_height > 0 and h > 0 then
+        y = y + math.floor((h - img_height) / 2)
+    end
+    -- Straight into the handler the fork's message lands in, so there is one
+    -- implementation of "draw the frame for this timestamp here" and the two
+    -- front doors cannot drift.
+    client_message_handler({args = {"thumb", tostring(secs),
+                                    tostring(x), tostring(y)}})
+end
+
+mp.observe_property("user-data/osc/draw-preview", "native", on_draw_preview)

--- a/jellyfin_mpv_shim/trickplay-osc.lua
+++ b/jellyfin_mpv_shim/trickplay-osc.lua
@@ -2923,9 +2923,19 @@ function visibility_mode(mode, no_osd)
     elseif mode == "never" then
         enable_osc(false)
         -- BEGIN patch add thumbnails
-        if img_is_shown then
-            mp.commandv("overlay-remove", 46)
-        end
+        -- `thumbfast_clear()`, NOT a local `overlay-remove 46`.
+        --
+        -- This used to read `img_is_shown`, which is a global in
+        -- thumbfast.lua -- a DIFFERENT script, so a different Lua
+        -- environment. Here it was always nil, so the branch never ran and
+        -- a preview left on screen when visibility went to "never" stayed
+        -- there. It also hardcoded the overlay id, which thumbfast owns.
+        --
+        -- Clearing through the message thumbfast already answers fixes both:
+        -- it is guarded by `thumb_requested`, which is state this script
+        -- actually has, and thumbfast removes its own overlay and resets its
+        -- own bookkeeping.
+        thumbfast_clear()
         -- END patch add thumbnails
     else
         msg.warn("Ignoring unknown visibility mode '" .. mode .. "'")

--- a/tests/_shell_harness.py
+++ b/tests/_shell_harness.py
@@ -687,6 +687,9 @@ class FakeController:
         self.raised = 0
         self.played = []
         self.transport = []
+        #: Volume state the browser's own volume keys move (#730).
+        self.volume_level = 100.0
+        self.muted = False
         #: item_id -> (status, absolute path or None), as the real gateway
         #: answers. Tests set entries to put a book on disk.
         self.book_downloads = {}
@@ -780,6 +783,21 @@ class FakeController:
 
     def on_minimize(self):
         self.minimized += 1
+
+    def adjust_volume(self, delta):
+        """Record it AND apply it, like toggle_deinterlace above.
+
+        The volume is the thing the keys are named after, so a fake that
+        recorded the call without moving the number could not tell a step
+        that lands from one that is clamped away -- or two presses from
+        one.
+        """
+        self.volume_level = max(0.0, min(100.0, self.volume_level + delta))
+        self.transport.append(("adjust_volume", (delta,)))
+
+    def toggle_mute(self):
+        self.muted = not self.muted
+        self.transport.append(("toggle_mute", ()))
 
     def raise_window(self):
         # Modelled, not omitted: `_safe` swallows an AttributeError, so a

--- a/tests/_shell_harness.py
+++ b/tests/_shell_harness.py
@@ -684,6 +684,7 @@ class FakeController:
         self.entered = 0
         self.left = 0
         self.minimized = 0
+        self.raised = 0
         self.played = []
         self.transport = []
         #: item_id -> (status, absolute path or None), as the real gateway
@@ -779,6 +780,13 @@ class FakeController:
 
     def on_minimize(self):
         self.minimized += 1
+
+    def raise_window(self):
+        # Modelled, not omitted: `_safe` swallows an AttributeError, so a
+        # fake without this method makes every "did we take the foreground"
+        # question answer "no" whatever the app did -- which is how #728
+        # went untested through the summon test that sits right beside it.
+        self.raised += 1
 
     def play(self, item, server_uuid, offset_ticks=None, srcid=None,
              aid=None, sid=None):

--- a/tests/_shell_harness.py
+++ b/tests/_shell_harness.py
@@ -393,6 +393,28 @@ class FakeSource:
         return [{"Id": "e%d" % i, "Name": "Ep %d" % i, "Type": "Episode",
                  "ParentIndexNumber": 1, "IndexNumber": i} for i in range(5)]
 
+    #: How many of `get_season_queue`'s episodes come back watched. A test
+    #: moves it to put the first unplayed episode somewhere specific.
+    season_watched = 2
+
+    def get_season_queue(self, server_uuid, series_id, season_id):
+        """A season, as a play queue.
+
+        **UserData.Played is on every row on purpose.** The season play
+        chip's whole behaviour is "start at the first unplayed episode"
+        (#720), so a stand-in without that field would make the rule
+        unreachable while a test named after it still passed -- and
+        `get_series_queue` above, which this one is NOT, is exactly that
+        shape. `SeasonId` for the same reason: it is what distinguishes
+        this query from the series-wide one.
+        """
+        return [{"Id": "e%d" % i, "Name": "Ep %d" % i, "Type": "Episode",
+                 "SeriesId": series_id, "SeasonId": season_id,
+                 "ParentIndexNumber": 1, "IndexNumber": i,
+                 "UserData": {"Played": i < self.season_watched,
+                              "PlaybackPositionTicks": 0}}
+                for i in range(5)]
+
     def search(self, server_uuid, term, limit=60):
         return [{"Id": "r1", "Name": "Movie " + term, "Type": "Movie"},
                 {"Id": "r2", "Name": "Ep", "Type": "Episode"},

--- a/tests/_shell_harness.py
+++ b/tests/_shell_harness.py
@@ -690,6 +690,7 @@ class FakeController:
         #: Volume state the browser's own volume keys move (#730).
         self.volume_level = 100.0
         self.muted = False
+        self.paused = False
         #: item_id -> (status, absolute path or None), as the real gateway
         #: answers. Tests set entries to put a book on disk.
         self.book_downloads = {}
@@ -798,6 +799,10 @@ class FakeController:
     def toggle_mute(self):
         self.muted = not self.muted
         self.transport.append(("toggle_mute", ()))
+
+    def toggle_pause(self):
+        self.paused = not self.paused
+        self.transport.append(("toggle_pause", ()))
 
     def raise_window(self):
         # Modelled, not omitted: `_safe` swallows an AttributeError, so a

--- a/tests/integration/_si_child.py
+++ b/tests/integration/_si_child.py
@@ -1,9 +1,9 @@
 """Child process used by test_single_instance_multiproc.
 
-Parameters come via env (SI_HOLD seconds, SI_WEDGE=1); config dir via
-XDG_CONFIG_HOME. argv is deliberately kept clean: the app parses sys.argv the
-first time it resolves the config dir, so any extra token there would blow up
-the arg parser.
+Parameters come via env (SI_HOLD seconds, SI_WEDGE=1, SI_ACTIVATE_LOG path);
+config dir via XDG_CONFIG_HOME. argv is deliberately kept clean: the app parses
+sys.argv the first time it resolves the config dir, so any extra token there
+would blow up the arg parser.
 
 Attempts the single-instance election, prints exactly one line (``PRIMARY`` or
 ``SECONDARY``) and flushes it, then — if primary and asked to hold — keeps the
@@ -11,9 +11,16 @@ lock for SI_HOLD seconds so the parent can race other launches against a live
 primary. SI_WEDGE closes the activation socket right after winning, modelling a
 primary whose listener died (the election lock, not the handoff, must still
 block duplicates).
+
+SI_ACTIVATE_LOG names a file the primary appends to from its ``on_activate``
+and ``on_stop`` handlers — one line per delivery. That is the half of this
+protocol the election tests never exercised: a blocked launch is supposed to
+*surface the running copy's window*, and a primary that elects correctly but
+never runs the handler looks identical from the outside (#718).
 """
 
 import os
+import socket
 import sys
 import time
 
@@ -32,10 +39,38 @@ def main():
     wedge = os.environ.get("SI_WEDGE") == "1"
 
     si = SingleInstance()
+
+    log_path = os.environ.get("SI_ACTIVATE_LOG")
+    if log_path:
+        def record(what):
+            # Opened per delivery and O_APPEND: the listener serves each
+            # connection on its own thread, so two near-simultaneous
+            # activations would interleave on a shared handle. A short
+            # append under O_APPEND is atomic enough for one line.
+            with open(log_path, "a", encoding="utf-8") as fh:
+                fh.write(what + "\n")
+                fh.flush()
+
+        # Installed BEFORE acquire(): the listener thread starts inside it,
+        # so a handler assigned afterwards can miss a fast activation.
+        si.on_activate = lambda: record("SHOW")
+        si.on_stop = lambda: record("STOP")
+
     ok = si.acquire()
     if ok and wedge and si._sock is not None:
+        # **shutdown BEFORE close, or the listener does not die.** A plain
+        # close() leaves the thread already blocked in accept() able to
+        # complete the connection anyway (measured: the client connects and
+        # is served), so SI_WEDGE modelled nothing and the test named after
+        # it passed on the election alone. shutdown() breaks the accept and
+        # the port then refuses, which is the state being modelled: guard-fd
+        # lock still held, activation socket gone.
         try:
-            si._sock.close()   # listener dies; guard-fd lock is still held
+            si._sock.shutdown(socket.SHUT_RDWR)
+        except OSError:
+            pass
+        try:
+            si._sock.close()
         except OSError:
             pass
     sys.stdout.write("PRIMARY\n" if ok else "SECONDARY\n")

--- a/tests/integration/test_mpvtk_browser.py
+++ b/tests/integration/test_mpvtk_browser.py
@@ -898,6 +898,27 @@ class BrowseKeyBlockTest(unittest.TestCase):
         self.assertEqual(len(live), 1, live)
         self.assertIn("renderer", (live[0].get("section") or ""))
 
+    def test_a_claimed_key_still_arrives_through_the_block(self):
+        """The block must ROUTE a claim, not eat it -- and the lookup has to
+        use mpv's key NAME, not the text.
+
+        SPACE is the whole reason: `key_name` is "SPACE" while `key_text` is
+        " ", and claims are pushed as names (`reader.py` and `comic.py` both
+        claim "SPACE"). Keying the lookup on the text meant a claimed SPACE
+        matched nothing and was swallowed -- taking page-turn with it, and
+        pause along with it, since a forced binding that returns does not
+        pass the key on to the binding underneath.
+        """
+        handle = self._up(blocked=True)
+        got = []
+        self._app.on_key = lambda k: got.append(k)
+        self._app.claim_keys(("SPACE", "9"))
+        time.sleep(0.6)
+        self._press(handle, "SPACE")
+        self._press(handle, "9")
+        self.assertEqual(got, ["SPACE", "9"],
+                         "a claimed key was swallowed by the block")
+
     def test_the_opt_out_binds_nothing(self):
         """Off means the keyboard really is given back -- not intercepted
         and forwarded, which would still take it from the user's own

--- a/tests/integration/test_mpvtk_browser.py
+++ b/tests/integration/test_mpvtk_browser.py
@@ -808,6 +808,106 @@ class ClassicOscReleasesTheMouseTest(unittest.TestCase):
                                 "round %d came back without the mouse"
                                 % round_no)
 
+@h.require_real_mpv
+class BrowseKeyBlockTest(unittest.TestCase):
+    """#730: mpv's own shortcuts must not act while the library is up.
+
+    mpv is constructed with `input_default_bindings=yes` for the life of the
+    process, so every key the shim has not taken is still mpv's -- and in the
+    library they act on a video that is not there, persist into the next
+    thing played, and report themselves in ASS OSD *underneath* the overlay
+    bitmaps the UI is drawn with.
+
+    Measured here rather than asserted in a unit test because the whole
+    mechanism is a claim about mpv's binding precedence: one forced
+    `any_unicode` binding outranks every exact-key default. Nothing on the
+    Python side can see whether that is true -- the Lua call "succeeds"
+    either way, and `contrast` is the only witness.
+
+    The OFF leg is not decoration. Without it, "the key did nothing" is
+    equally consistent with a keypress that never arrived, which is exactly
+    how this measurement first went wrong.
+    """
+
+    def _up(self, blocked):
+        from jellyfin_mpv_shim.conf import settings
+        from jellyfin_mpv_shim.mpvtk.app import MpvtkApp
+        from jellyfin_mpv_shim.mpvtk.widgets import Text
+
+        saved = settings.browse_block_keys
+        self.addCleanup(
+            lambda: setattr(settings, "browse_block_keys", saved))
+        settings.browse_block_keys = blocked
+
+        # The PLAYER's options, not the toolkit demo's: `_SPAWN_OPTS` sets
+        # `input_default_bindings: no`, under which mpv reports every builtin
+        # at priority -1 and there is nothing to block. See
+        # ClassicOscReleasesTheMouseTest._player_like_handle, which this is.
+        handle, ext = ClassicOscReleasesTheMouseTest._player_like_handle()
+        self.addCleanup(lambda: self._teardown(handle))
+        app = MpvtkApp.attach(handle, ext=ext)
+        self._app = app
+        thread = threading.Thread(
+            target=lambda: app.run(lambda b: [Text("library", 0, 0)]),
+            daemon=True)
+        thread.start()
+        self.assertTrue(app.ready.wait(15), "renderer never came up")
+        time.sleep(0.8)
+        return handle
+
+    def _teardown(self, handle):
+        try:
+            self._app.quit()
+        except Exception:
+            pass
+        try:
+            handle.terminate()
+        except Exception:
+            pass
+
+    @staticmethod
+    def _press(handle, key):
+        handle.command("keypress", key)
+        time.sleep(0.4)
+
+    def test_the_defaults_fire_with_the_block_off(self):
+        """The premise. A swallowed key and a key that never arrived look
+        identical from here, so this is what tells them apart."""
+        handle = self._up(blocked=False)
+        before = handle.contrast
+        self._press(handle, "1")
+        self.assertNotEqual(handle.contrast, before,
+                            "mpv never saw the keypress, so the ON leg "
+                            "below would prove nothing")
+
+    def test_the_block_swallows_mpv_s_picture_keys(self):
+        handle = self._up(blocked=True)
+        before = handle.contrast
+        self._press(handle, "1")
+        self.assertEqual(handle.contrast, before,
+                         "`1` still moved the picture from the library")
+
+    def test_it_is_one_any_unicode_binding_and_it_is_ours(self):
+        """`priority >= 0` is mpv's own word for "this section is active"
+        (`mp_input_get_bindings`), and the section name is what says the
+        binding is the renderer's rather than something else's."""
+        handle = self._up(blocked=True)
+        live = [r for r in (handle.input_bindings or ())
+                if (r.get("key") or "").lower() == "any_unicode"
+                and int(r.get("priority", -1)) >= 0]
+        self.assertEqual(len(live), 1, live)
+        self.assertIn("renderer", (live[0].get("section") or ""))
+
+    def test_the_opt_out_binds_nothing(self):
+        """Off means the keyboard really is given back -- not intercepted
+        and forwarded, which would still take it from the user's own
+        input.conf."""
+        handle = self._up(blocked=False)
+        live = [r for r in (handle.input_bindings or ())
+                if (r.get("key") or "").lower() == "any_unicode"
+                and int(r.get("priority", -1)) >= 0]
+        self.assertEqual(live, [])
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/tests/integration/test_mpvtk_browser.py
+++ b/tests/integration/test_mpvtk_browser.py
@@ -660,5 +660,154 @@ class TestRealMousePosPath(unittest.TestCase):
                         "a real left click never reached the button")
 
 
+@h.require_real_mpv
+class ClassicOscReleasesTheMouseTest(unittest.TestCase):
+    """With a classic OSC on screen the renderer must own no mouse at all.
+
+    #724: with `osc_style` "mpv" or "default", neither button did anything
+    over the video. The mechanism is mpv's section precedence --
+    `mpvtk_mouse` sets no mouse area, so mpv gives it `{INT_MIN..INT_MAX}`
+    (`input.c: get_bind_section`) and prefers it over the builtin binding,
+    while both of the renderer's bare-video fall-throughs gate on
+    `state.phud.mode`, which classic modality never enters. A live section
+    there swallows both buttons and answers with nothing.
+
+    The behaviour is correct today and this is what keeps it correct: the
+    property is invisible from the Python side, since every one of these
+    calls "succeeds" whether or not mpv actually let go. `input-bindings`
+    is the only place that says, and `priority == -1` is mpv's own word for
+    "the owning section is not active" (`mp_input_get_bindings`).
+
+    Read `tools/probe_classic_osc_mouse.py` for the same measurement with
+    the stock OSC loaded alongside, which is what a real classic-OSC
+    session has.
+    """
+
+    MOUSE_SECTIONS = ("mpvtk_mouse", "mpvtk_thumb", "mpvtk_wheel")
+
+    @staticmethod
+    def _player_like_handle():
+        """A handle with the PLAYER's options, not the toolkit demo's.
+
+        `_spawn_handle` above uses `_SPAWN_OPTS`, which sets
+        `input_default_bindings: no` -- right for the standalone demo and
+        wrong here, because mpv then reports every builtin binding at
+        priority -1 (`mp_input_get_bindings`: `if (b->is_builtin &&
+        !default_bindings) b_priority = -1`). The question this class asks
+        is what the USER's button does once we let go, and that is only a
+        question at all when mpv's own bindings are on -- which the player
+        sets (`player.py`: `input_default_bindings=True`).
+        """
+        opts = {
+            "idle": "yes", "force_window": "yes",
+            "osc": "no",                     # REPLACES_OSC, as osc_style does
+            "input_default_bindings": "yes",
+            "config": "no", "keepaspect_window": "no",
+        }
+        if h.BACKEND == "jsonipc":
+            import python_mpv_jsonipc
+            return python_mpv_jsonipc.MPV(start_mpv=True, geometry="1280x720",
+                                          **opts), True
+        import mpv as libmpv
+        return libmpv.MPV(geometry="1280x720",
+                          **{k.replace("_", "-"): v
+                             for k, v in opts.items()}), False
+
+    def setUp(self):
+        from jellyfin_mpv_shim.mpvtk.app import MpvtkApp
+
+        self.handle, ext = self._player_like_handle()
+        self.app = MpvtkApp.attach(self.handle, ext=ext)
+        self._thread = threading.Thread(
+            target=lambda: self.app.run(lambda b: []), daemon=True)
+        self._thread.start()
+        self.assertTrue(self.app.ready.wait(15), "renderer never came up")
+        time.sleep(0.5)
+
+    def tearDown(self):
+        try:
+            self.app.quit()
+            self._thread.join(timeout=5)
+        finally:
+            try:
+                self.handle.terminate()
+            except Exception:
+                pass
+
+    def _claims(self, key="MBTN_RIGHT"):
+        """``{section: priority}`` for everything binding ``key``.
+
+        Through the property ACCESSOR, not `command("get_property", ...)`:
+        libmpv rejects the command form of a node-returning property with
+        MPV_ERROR_PROPERTY_FORMAT (measured -- "Invalid value for mpv
+        parameter", -4). Both bindings expose the attribute, so this is the
+        form that works on either backend.
+        """
+        rows = self.handle.input_bindings or ()
+        return {r.get("section") or "": int(r.get("priority", -1))
+                for r in rows if (r.get("key") or "").upper() == key}
+
+    def _ours_are_live(self, key="MBTN_RIGHT"):
+        claims = self._claims(key)
+        return [s for s in self.MOUSE_SECTIONS if claims.get(s, -1) >= 0]
+
+    def test_browse_owns_the_mouse(self):
+        """The premise: without this the release below proves nothing,
+        because a section that was never enabled is trivially released."""
+        self.assertTrue(self._ours_are_live(),
+                        "the renderer never claimed the right button")
+
+    def test_yielding_releases_every_mouse_section(self):
+        for key in ("MBTN_LEFT", "MBTN_RIGHT", "MBTN_BACK", "WHEEL_UP"):
+            self.app.set_active(False)
+            time.sleep(0.4)
+            with self.subTest(key=key):
+                self.assertEqual(self._ours_are_live(key), [],
+                                 "%s is still ours over a classic OSC" % key)
+
+    def test_mpvs_own_binding_wins_once_we_let_go(self):
+        """What the user is actually owed: whatever their mpv says the
+        button means. NOT asserted as "pause" -- mpv changed MBTN_RIGHT's
+        default from `cycle pause` to `script-binding select/context-menu`
+        at 0.41, and both shipped pins are past that, so hardcoding the
+        effect would fail on the next pin move for reasons unrelated to
+        this bug."""
+        self.app.set_active(False)
+        time.sleep(0.4)
+        claims = self._claims("MBTN_RIGHT")
+        self.assertGreaterEqual(claims.get("default", -1), 0,
+                                "mpv's own binding is not reachable")
+
+    def test_it_hands_back_the_built_in_dragging(self):
+        """The classic-OSC half of #726. The renderer turns mpv's built-in
+        dragging off while it owns the pointer -- its own sections would
+        otherwise make mpv refuse every VO drag -- so a yield that forgot
+        to restore it would leave a video window that cannot be dragged at
+        all, with nothing on screen to explain why."""
+        try:
+            before = self.handle.input_builtin_dragging
+        except Exception:
+            self.skipTest("input-builtin-dragging is mpv 0.39+")
+        self.assertIs(before, False, "the renderer did not take dragging")
+        self.app.set_active(False)
+        time.sleep(0.4)
+        self.assertIs(self.handle.input_builtin_dragging, True)
+
+    def test_browse_takes_it_all_back_afterwards(self):
+        """Three rounds: the library is dead to the pointer if a return
+        from playback ever fails to re-take the sections, and that is the
+        half a single yield-and-check cannot see."""
+        for round_no in range(1, 4):
+            with self.subTest(round=round_no):
+                self.app.set_active(False)
+                time.sleep(0.4)
+                self.assertEqual(self._ours_are_live(), [])
+                self.app.set_active(True)
+                time.sleep(0.4)
+                self.assertTrue(self._ours_are_live(),
+                                "round %d came back without the mouse"
+                                % round_no)
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/tests/integration/test_single_instance_multiproc.py
+++ b/tests/integration/test_single_instance_multiproc.py
@@ -39,7 +39,8 @@ def _prep_config_dir(base):
     return base
 
 
-def _spawn(config_dir, hold=0.0, wedge=False, new_session=False):
+def _spawn(config_dir, hold=0.0, wedge=False, new_session=False,
+           activate_log=None):
     env = dict(os.environ)
     env["XDG_CONFIG_HOME"] = config_dir
     # conffile.win32 reads APPDATA and knows nothing about XDG_CONFIG_HOME, so
@@ -50,6 +51,10 @@ def _spawn(config_dir, hold=0.0, wedge=False, new_session=False):
     env["APPDATA"] = config_dir
     env["SI_HOLD"] = str(hold)
     env["SI_WEDGE"] = "1" if wedge else "0"
+    if activate_log:
+        env["SI_ACTIVATE_LOG"] = activate_log
+    else:
+        env.pop("SI_ACTIVATE_LOG", None)
     # start_new_session makes the child a session/process-group leader, so its
     # pgid == its pid; any grandchild it leaks inherits that group and can be
     # spotted even after being reparented to init (see OrphanedChildOnExitTest).
@@ -97,7 +102,14 @@ def _first_line(proc, timeout=15):
     return line
 
 
-class SingleInstanceMultiprocTest(unittest.TestCase):
+class _MultiprocBase:
+    """setUp and spawn bookkeeping, shared by the two test classes below.
+
+    A plain mixin rather than a base TestCase: subclassing a TestCase makes
+    unittest collect and RUN the parent's tests again under the child's
+    name, so the five election tests would be paid for twice.
+    """
+
     def setUp(self):
         self._cfg = _prep_config_dir(tempfile.mkdtemp(prefix="jms-si-"))
         self.addCleanup(self._rmtree, self._cfg)
@@ -122,6 +134,8 @@ class SingleInstanceMultiprocTest(unittest.TestCase):
         self._procs.append(p)
         return p
 
+
+class SingleInstanceMultiprocTest(_MultiprocBase, unittest.TestCase):
     def test_exactly_one_primary_when_processes_race(self):
         # N processes launched at once against one config dir: flock must grant
         # exactly one primary; everyone else refuses to run.
@@ -160,6 +174,92 @@ class SingleInstanceMultiprocTest(unittest.TestCase):
         first.wait(10)
         second = self._spawn(self._cfg, hold=0)
         self.assertEqual(_first_line(second), "PRIMARY")
+
+
+class ActivationHandoffTest(_MultiprocBase, unittest.TestCase):
+    """A blocked launch must SURFACE the running copy, not just decline.
+
+    The tests above prove the election: exactly one primary, everyone else
+    refuses to run. None of them proves the other half -- that the refusal
+    reaches the primary and runs `on_activate`, which is what puts the
+    window back in front of somebody who double-clicked the icon because
+    they could not see the app (#718). A primary that elects correctly and
+    never runs the handler is indistinguishable from the outside, and the
+    app it leaves you with is one you cannot get at.
+
+    The handler is deliberately not `ui.activate()` here: what this file can
+    say something about is the CROSS-PROCESS delivery. What activate() then
+    does with a minimized browser is a different question, asked against a
+    real player in test_startup_window.py.
+    """
+
+    def _deliveries(self, path, want=1, timeout=15):
+        """Lines in the activation log, once there are ``want`` of them.
+
+        Polled rather than read once, and the reason is in the protocol:
+        `_serve_one` acknowledges BEFORE calling the handler, so the second
+        launch can have exited before the primary has recorded anything.
+        A single read here would be a race that passes on a fast machine.
+        """
+        deadline = time.time() + timeout
+        while time.time() < deadline:
+            try:
+                with open(path, encoding="utf-8") as fh:
+                    lines = fh.read().split()
+            except OSError:
+                lines = []
+            if len(lines) >= want:
+                return lines
+            time.sleep(0.05)
+        return lines
+
+    def _log_path(self):
+        return os.path.join(self._cfg, "activations.log")
+
+    def test_a_blocked_launch_activates_the_primary(self):
+        log = self._log_path()
+        primary = self._spawn(self._cfg, hold=8, activate_log=log)
+        self.assertEqual(_first_line(primary), "PRIMARY")
+        second = self._spawn(self._cfg, hold=0)
+        self.assertEqual(_first_line(second), "SECONDARY")
+        self.assertEqual(self._deliveries(log), ["SHOW"])
+
+    def test_a_lone_primary_is_never_activated(self):
+        """So the assertion above is about the handoff and not about the
+        handler running at startup."""
+        log = self._log_path()
+        primary = self._spawn(self._cfg, hold=2, activate_log=log)
+        self.assertEqual(_first_line(primary), "PRIMARY")
+        primary.wait(15)
+        self.assertEqual(self._deliveries(log, want=1, timeout=0.5), [])
+
+    def test_every_repeat_launch_activates_it_again(self):
+        """Three, not one. The listener serves each connection on its own
+        thread and the socket outlives the handoff; a primary that handed
+        off once and then stopped listening -- a closed socket, a thread
+        that died on an exception -- would pass a single-shot test and
+        leave the user pressing a shortcut that does nothing from the
+        second press onwards."""
+        log = self._log_path()
+        primary = self._spawn(self._cfg, hold=12, activate_log=log)
+        self.assertEqual(_first_line(primary), "PRIMARY")
+        for n in range(1, 4):
+            later = self._spawn(self._cfg, hold=0)
+            self.assertEqual(_first_line(later), "SECONDARY")
+            self.assertEqual(self._deliveries(log, want=n), ["SHOW"] * n)
+
+    def test_a_wedged_primary_blocks_without_activating(self):
+        """The state the election test already covers, from the other side:
+        the duplicate is still refused, and nothing is surfaced because
+        there is no listener to ask. Blocking is the lock's job and
+        surfacing is the socket's, and this is what says so."""
+        log = self._log_path()
+        primary = self._spawn(self._cfg, hold=6, wedge=True, activate_log=log)
+        self.assertEqual(_first_line(primary), "PRIMARY")
+        time.sleep(0.3)
+        second = self._spawn(self._cfg, hold=0)
+        self.assertEqual(_first_line(second), "SECONDARY")
+        self.assertEqual(self._deliveries(log, want=1, timeout=1.0), [])
 
 
 @unittest.skipUnless(sys.platform.startswith("linux"),

--- a/tests/integration/test_startup_window.py
+++ b/tests/integration/test_startup_window.py
@@ -50,7 +50,7 @@ class StartupForceWindowTest(unittest.TestCase):
         with mock.patch.object(settings, "osc_style", osc_style), \
                 mock.patch.object(settings, "start_minimized", start_minimized), \
                 mock.patch.object(settings, "enable_gui", True), \
-                mock.patch.object(settings, "thumbnail_osc_builtin", True):
+                mock.patch.object(settings, "thumbnail_enable", False):
             pm._ensure_mpv()
         return pm._player.init_options
 

--- a/tests/integration/test_startup_window.py
+++ b/tests/integration/test_startup_window.py
@@ -64,6 +64,93 @@ class StartupForceWindowTest(unittest.TestCase):
         self.assertNotIn("force_window",
                          self._init_options(start_minimized=True))
 
+    def test_a_minimized_start_gets_a_window_when_it_is_activated(self):
+        """The other half, and the one a user notices (#718).
+
+        Launched minimized there is no window at all -- so the app somebody
+        launches a SECOND time to "open it" has nothing to raise, and
+        `raise_window` cannot help: it un-minimizes a window, and there is
+        none. What puts one back is the browse path -- `activate()` ->
+        `enter_browse()` -> `on_browse_enter` -> `set_browse_window(True)` --
+        which builds an mpv when none is alive.
+
+        The test above pins that we take no window at startup. Without this
+        one, "took no window" and "can never take a window" are the same
+        passing result.
+        """
+        pm = h.build_player(player_module)
+        pm._player = None
+        pm._mpv_alive = False
+        with mock.patch.object(settings, "enable_gui", True), \
+                mock.patch.object(settings, "osc_style", "mpvtk"):
+            pm.set_browse_window(True)
+        self.assertIsNotNone(pm._player, "no mpv was built to show")
+        self.assertTrue(pm._player.init_options.get("force_window"),
+                        "the browser was given no window to draw into")
+
+    def test_the_window_it_gets_is_the_library_browser_state(self):
+        """`set_browse_window`'s own table: the library browser is
+        playback_abort=yes AND force_window=yes. Asserting the pair rather
+        than force_window alone, because force_window with playback_abort
+        off is the *playing* row -- a window, but one waiting for video."""
+        pm = h.build_player(player_module)
+        pm._player = None
+        pm._mpv_alive = False
+        with mock.patch.object(settings, "enable_gui", True), \
+                mock.patch.object(settings, "osc_style", "mpvtk"):
+            pm.set_browse_window(True)
+        self.assertIs(pm._player.force_window, True)
+        self.assertIs(pm._player.playback_abort, True)
+
+    def test_minimizing_with_no_window_does_not_build_one(self):
+        """The guard the test above must not have broken: dropping to the
+        windowless state when there is already no window is a no-op, not a
+        reason to start mpv."""
+        pm = h.build_player(player_module)
+        pm._player = None
+        pm._mpv_alive = False
+        with mock.patch.object(settings, "enable_gui", True):
+            pm.set_browse_window(False)
+        self.assertIsNone(pm._player, "minimizing started a player")
+
+    def test_it_survives_being_minimized_and_reopened_repeatedly(self):
+        """Three rounds, because one cannot see state feeding back.
+
+        Every activation after the first runs against whatever the previous
+        minimize left behind -- and here that is nothing at all: releasing
+        the window with nothing playing lets mpv go, so round two is
+        `_init_mpv` again with a whole session's worth of state carried
+        across.
+
+        **Asserted on the live properties, not on `init_options`.** The
+        window arrives two different ways: built into the FIRST mpv's
+        construction, and written onto a REBUILT one afterwards (a reopen
+        only passes `force_window` up front when the browser is already on
+        screen -- see the reopen test above). A test that reads the
+        construction options sees the second round as a failure and the
+        product is fine; what the user has either way is a window.
+        """
+        pm = h.build_player(player_module)
+        pm._player = None
+        pm._mpv_alive = False
+        with mock.patch.object(settings, "enable_gui", True), \
+                mock.patch.object(settings, "osc_style", "mpvtk"):
+            for round_no in range(1, 4):
+                with self.subTest(round=round_no):
+                    pm.set_browse_window(True)
+                    self.assertTrue(pm._mpv_alive,
+                                    "round %d has no mpv" % round_no)
+                    self.assertIs(pm._player.force_window, True,
+                                  "round %d came back with no window"
+                                  % round_no)
+                    self.assertIs(pm._player.playback_abort, True)
+                    pm.set_browse_window(False)
+                    # ...and the minimize really released it, or "the window
+                    # came back" above would be "the window never left".
+                    self.assertIs(pm._player.force_window, False,
+                                  "round %d did not release the window"
+                                  % round_no)
+
     def test_a_reopen_takes_the_window_only_if_the_browser_is_on_screen(self):
         # Re-opened from the tray with the library up.
         self.assertTrue(

--- a/tests/lua/test_renderer.lua
+++ b/tests/lua/test_renderer.lua
@@ -3485,6 +3485,116 @@ fake.advance(1)
 fake.fire_timers()
 eq(fake.osd.z, 0, "mpvtk-z no did not put the z order back")
 
+-- ================================================ the configurable Select key
+
+-- #717: ENTER was hardcoded here while `ui_select_key` moved the gamepad
+-- and the remote, so a remap left the keyboard behind. It is a REPLACEMENT,
+-- not an alias [iw] -- yielding ENTER back to mpv is the whole request --
+-- so every assertion below has a negative half.
+
+fake.send("mpvtk-hud", "no")
+fake.send("mpvtk-active", "yes")
+fake.send("mpvtk-keys", fake.token({ keys = {} }))
+
+ok(fake.log.keybinds["mpvtk_nav_ENTER"] ~= nil,
+   "sanity: browse does not hold ENTER to begin with")
+
+fake.send("mpvtk-select-key", "k")
+ok(fake.log.keybinds["mpvtk_nav_k"] ~= nil,
+   "the configured key was never bound")
+ok(fake.log.keybinds["mpvtk_nav_ENTER"] == nil,
+   "ENTER was not yielded -- the setting is an alias, not a replacement")
+eq(fake.log.keykeys["mpvtk_nav_k"], "k",
+   "the binding was made under the wrong key name")
+
+-- ...and it ACTIVATES. A binding that exists and does nothing is the
+-- failure this whole item is about.
+scene({ tile("sel1", 0, 0), tile("sel2", 0, 100) })
+fake.key("mpvtk_nav_DOWN")
+fake.reset_events()
+fake.key("mpvtk_nav_k")
+ok(last_event("click") ~= nil, "the configured key did not activate focus")
+
+-- The claim table has to move with it, and the invariant it protects is
+-- the comment above `keyclaim.nav_names`: a claimed key OUTSIDE the nav
+-- set needs a binding of its own. ENTER is now outside it.
+fake.send("mpvtk-keys", fake.token({ keys = { "ENTER" } }))
+ok(fake.log.keybinds["mpvtk_key_ENTER"] ~= nil,
+   "a page claiming ENTER got no binding: nav_names still calls it a nav key")
+-- No focus ring while the claim is tested: a ring outranks a claim (see
+-- `keyclaim.take`), so leaving the one the activation test just raised
+-- would prove nothing about the binding.
+scene({})
+fake.reset_events()
+fake.key("mpvtk_key_ENTER")
+local claimed = last_event("key")
+eq(claimed and claimed.key, "ENTER", "the claimed ENTER was not delivered")
+
+-- The symmetric half, which is the one a rebuild that only ADDS would
+-- fail: the select key is inside the set, so claiming it must NOT add a
+-- second binding on top of the nav one. Two bindings for one press is
+-- two events.
+fake.send("mpvtk-keys", fake.token({ keys = { "k" } }))
+ok(fake.log.keybinds["mpvtk_key_k"] == nil,
+   "claiming the select key bound it twice")
+
+-- A claim held ACROSS the move is the case no single-direction rebuild
+-- covers: `mpvtk_key_j` is live, and then j becomes the select key.
+fake.send("mpvtk-keys", fake.token({ keys = { "j" } }))
+ok(fake.log.keybinds["mpvtk_key_j"] ~= nil, "sanity: the claim on j is live")
+fake.send("mpvtk-select-key", "j")
+ok(fake.log.keybinds["mpvtk_key_j"] == nil,
+   "the claim binding survived the move, so j now fires twice")
+ok(fake.log.keybinds["mpvtk_nav_j"] ~= nil, "j did not become the nav binding")
+ok(fake.log.keybinds["mpvtk_nav_k"] == nil, "the previous select key was left bound")
+fake.send("mpvtk-keys", fake.token({ keys = {} }))
+
+-- It survives the playback round trip, because `bind_nav_keys` runs again
+-- on every resume and would otherwise put ENTER back.
+fake.send("mpvtk-active", "no")
+eq(fake.log.keybinds["mpvtk_nav_j"], nil, "playback kept the select key")
+fake.send("mpvtk-active", "yes")
+ok(fake.log.keybinds["mpvtk_nav_j"] ~= nil, "browse resumed without the select key")
+ok(fake.log.keybinds["mpvtk_nav_ENTER"] == nil, "browse resumed holding ENTER again")
+
+-- A summoned HUD is the OTHER installer of these bindings, and the two
+-- are why the key rides its own message: the `mpvtk-hud` opts blob would
+-- have covered this case and not the browse one above it, since
+-- `mpvtk-active` carries no opts at all.
+fake.send("mpvtk-active", "no")
+fake.send("mpvtk-hud", "yes", fake.token({ hide = 4, mode = "hover", grab = true }))
+fake.key("mpvtk_wake")
+ok(fake.log.keybinds["mpvtk_nav_j"] ~= nil,
+   "a keyboard-summoned HUD bound ENTER instead of the select key")
+ok(fake.log.keybinds["mpvtk_nav_ENTER"] == nil,
+   "a keyboard-summoned HUD took ENTER back")
+
+-- The gamepad's Confirm sends the CONFIGURED key (conf.select_key, the
+-- Python half), so the renderer's own "is this Select?" test has to ask
+-- the same question. Asking `arg == 'ENTER'` sent A over a hidden HUD to
+-- mpv's own keypress path, where nothing is listening.
+fake.send("mpvtk-hud", "no")
+fake.send("mpvtk-hud", "yes", fake.token({ hide = 4, mode = "hover" }))
+fake.send("mpvtk-gamepad", fake.token({
+    { "GAMEPAD_ACTION_DOWN", "key", "j", 0 },
+}))
+fake.send("mpvtk-hud-skip", "Skip Intro")
+fake.advance(1)
+fake.reset_events()
+fake.key("mpvtk_gp_GAMEPAD_ACTION_DOWN")
+ok(last_event("hudskip") ~= nil,
+   "gamepad Confirm on the remapped key did not mean Select")
+
+-- Cleared falls back rather than unbinding, for the reason conf.select_key
+-- gives: a UI with no select key is one only the mouse can operate, and
+-- the settings screen that would fix it is inside it.
+fake.send("mpvtk-hud", "no")
+fake.send("mpvtk-active", "yes")
+fake.send("mpvtk-select-key", "")
+ok(fake.log.keybinds["mpvtk_nav_ENTER"] ~= nil,
+   "a cleared select key left nothing bound")
+ok(fake.log.keybinds["mpvtk_nav_j"] == nil, "the old select key was left bound")
+
 -- ========================================================== teardown
 
 scene({})

--- a/tests/snapshots/settings.jsonl
+++ b/tests/snapshots/settings.jsonl
@@ -27,7 +27,7 @@
 {"click": true, "fill": "2e3138", "h": 41.2, "hover": {"fill": "3a3e46"}, "id": "stab-logs", "radius": 6, "t": "rect", "w": 56.7, "x": 676.3, "y": 76.0}
 {"align": "center", "c": "e8e8e8", "h": 21.2, "id": "r.1.0.0.6.0", "size": 17, "t": "text", "text": "Logs", "w": 36.7, "x": 686.3, "y": 86.0}
 {"force": true, "h": 32.3, "id": "set-search-box", "ph": "Search settings\u2026", "size": 17, "t": "textbox", "text": "", "w": 320.0, "x": 16.0, "y": 149.2}
-{"axis": "y", "bar": true, "ch": 1236.9, "cw": 1270.0, "h": 522.5, "id": "settings", "t": "scroll", "w": 1280.0, "x": 0.0, "y": 197.6}
+{"axis": "y", "bar": true, "ch": 1136.1, "cw": 1270.0, "h": 522.5, "id": "settings", "t": "scroll", "w": 1280.0, "x": 0.0, "y": 197.6}
 {"align": "left", "bold": true, "c": "e8e8e8", "h": 30.0, "id": "r.1.2.0.0", "sc": "settings", "size": 24, "t": "text", "text": "This Device", "w": 1238.0, "x": 16.0, "y": 213.6}
 {"align": "left", "c": "9aa0a6", "h": 21.2, "id": "r.1.2.0.1.0", "sc": "settings", "size": 17, "t": "text", "text": "Player Name", "w": 340.0, "x": 16.0, "y": 257.1}
 {"h": 32.3, "id": "set-player_name", "ph": "", "sc": "settings", "size": 17, "t": "textbox", "text": "jms-test-host", "w": 340.0, "x": 368.0, "y": 251.6}
@@ -63,50 +63,45 @@
 {"align": "left", "c": "e8e8e8", "h": 21.2, "id": "r.1.2.0.13.1", "sc": "settings", "size": 17, "t": "text", "text": "Swap Confirm and Back Buttons", "w": 243.4, "x": 46.0, "y": 656.1}
 {"align": "left", "c": "9aa0a6", "h": 17.5, "id": "r.1.2.0.14", "sc": "settings", "size": 14, "t": "text", "text": "Turn this on for a controller whose A button is on the right rather than at the bottom (Switch Pro, most", "w": 665.3, "x": 16.0, "y": 685.4}
 {"align": "left", "c": "9aa0a6", "h": 17.5, "id": "r.1.2.0.14.l1", "sc": "settings", "size": 14, "t": "text", "text": "8BitDo pads).", "w": 665.3, "x": 16.0, "y": 702.9}
-{"align": "left", "c": "9aa0a6", "h": 21.2, "id": "r.1.2.0.15.0", "sc": "settings", "size": 17, "t": "text", "text": "Select Key", "w": 340.0, "x": 16.0, "y": 733.9}
-{"h": 32.3, "id": "set-ui_select_key", "ph": "", "sc": "settings", "size": 17, "t": "textbox", "text": "ENTER", "w": 340.0, "x": 368.0, "y": 728.4}
-{"align": "left", "c": "9aa0a6", "h": 17.5, "id": "r.1.2.0.16", "sc": "settings", "size": 14, "t": "text", "text": "Activates whatever is highlighted, in the library and on the player controls. An mpv key name;", "w": 665.3, "x": 16.0, "y": 768.6}
-{"align": "left", "c": "9aa0a6", "h": 17.5, "id": "r.1.2.0.16.l1", "sc": "settings", "size": 14, "t": "text", "text": "changing it hands Enter back to MPV. The game controller's Confirm button and a phone's Select follow", "w": 665.3, "x": 16.0, "y": 786.1}
-{"align": "left", "c": "9aa0a6", "h": 17.5, "id": "r.1.2.0.16.l2", "sc": "settings", "size": 14, "t": "text", "text": "it.", "w": 665.3, "x": 16.0, "y": 803.6}
-{"align": "left", "bold": true, "c": "e8e8e8", "h": 30.0, "id": "r.1.2.0.17", "sc": "settings", "size": 24, "t": "text", "text": "Window", "w": 1238.0, "x": 16.0, "y": 829.1}
-{"click": true, "h": 21.2, "hover": {"c": "747474"}, "id": "set-fullscreen", "sc": "settings", "t": "rect", "w": 1238.0, "x": 16.0, "y": 867.1}
-{"bc": "3a3d42", "bw": 1, "fill": "2a2d33", "h": 20.0, "id": "r.1.2.0.18.0", "radius": 5, "sc": "settings", "t": "rect", "w": 20.0, "x": 16.0, "y": 867.8}
-{"align": "left", "c": "e8e8e8", "h": 21.2, "id": "r.1.2.0.18.1", "sc": "settings", "size": 17, "t": "text", "text": "Fullscreen", "w": 81.6, "x": 46.0, "y": 867.1}
-{"click": true, "h": 21.2, "hover": {"c": "747474"}, "id": "set-browser_fullscreen", "sc": "settings", "t": "rect", "w": 1238.0, "x": 16.0, "y": 896.4}
-{"bc": "3a3d42", "bw": 1, "fill": "2a2d33", "h": 20.0, "id": "r.1.2.0.19.0", "radius": 5, "sc": "settings", "t": "rect", "w": 20.0, "x": 16.0, "y": 897.0}
-{"align": "left", "c": "e8e8e8", "h": 21.2, "id": "r.1.2.0.19.1", "sc": "settings", "size": 17, "t": "text", "text": "Fullscreen Library Browser", "w": 208.6, "x": 46.0, "y": 896.4}
-{"click": true, "h": 21.2, "hover": {"c": "747474"}, "id": "set-remember_window_size", "sc": "settings", "t": "rect", "w": 1238.0, "x": 16.0, "y": 925.6}
-{"fill": "00a4dc", "h": 20.0, "id": "r.1.2.0.20.0", "radius": 5, "sc": "settings", "t": "rect", "w": 20.0, "x": 16.0, "y": 926.3}
-{"align": "center", "c": "ffffff", "h": 18.8, "id": "r.1.2.0.20.0.0", "sc": "settings", "size": 15, "t": "text", "text": "\u2713", "w": 20.0, "x": 16.0, "y": 926.9}
-{"align": "left", "c": "e8e8e8", "h": 21.2, "id": "r.1.2.0.20.1", "sc": "settings", "size": 17, "t": "text", "text": "Remember Window Size", "w": 186.3, "x": 46.0, "y": 925.6}
-{"align": "left", "c": "9aa0a6", "h": 21.2, "id": "r.1.2.0.21.0", "sc": "settings", "size": 17, "t": "text", "text": "Window Buttons in the Top Bar", "w": 340.0, "x": 16.0, "y": 960.4}
-{"force": true, "h": 32.3, "id": "set-window_controls", "items": ["Only when the window has no title bar", "Always", "Never"], "sc": "settings", "sel": 0, "size": 17, "t": "dropdown", "w": 340.0, "x": 368.0, "y": 954.9}
-{"align": "left", "c": "9aa0a6", "h": 17.5, "id": "r.1.2.0.22", "sc": "settings", "size": 14, "t": "text", "text": "Some desktops, GNOME on Wayland in particular, draw no title bar on the player window, leaving no", "w": 665.3, "x": 16.0, "y": 995.2}
-{"align": "left", "c": "9aa0a6", "h": 17.5, "id": "r.1.2.0.22.l1", "sc": "settings", "size": 14, "t": "text", "text": "way to move or close it. This puts minimize, maximize and close in the top bar instead, and lets you", "w": 665.3, "x": 16.0, "y": 1012.7}
-{"align": "left", "c": "9aa0a6", "h": 17.5, "id": "r.1.2.0.22.l2", "sc": "settings", "size": 14, "t": "text", "text": "drag the window by it. On \"Only when the window has no title bar\", MPV is asked whether this window", "w": 665.3, "x": 16.0, "y": 1030.2}
-{"align": "left", "c": "9aa0a6", "h": 17.5, "id": "r.1.2.0.22.l3", "sc": "settings", "size": 14, "t": "text", "text": "got one, so desktops that draw a title bar are left alone.", "w": 665.3, "x": 16.0, "y": 1047.7}
-{"click": true, "h": 21.2, "hover": {"c": "747474"}, "id": "set-window_controls_fullscreen", "sc": "settings", "t": "rect", "w": 1238.0, "x": 16.0, "y": 1073.2}
-{"bc": "3a3d42", "bw": 1, "fill": "2a2d33", "h": 20.0, "id": "r.1.2.0.23.0", "radius": 5, "sc": "settings", "t": "rect", "w": 20.0, "x": 16.0, "y": 1073.8}
-{"align": "left", "c": "e8e8e8", "h": 21.2, "id": "r.1.2.0.23.1", "sc": "settings", "size": 17, "t": "text", "text": "Keep Window Buttons in Full Screen", "w": 278.5, "x": 46.0, "y": 1073.2}
-{"align": "left", "c": "9aa0a6", "h": 17.5, "id": "r.1.2.0.24", "sc": "settings", "size": 14, "t": "text", "text": "Full screen has no title bar anywhere and nothing to move or maximize, so the buttons are normally", "w": 665.3, "x": 16.0, "y": 1102.4}
-{"align": "left", "c": "9aa0a6", "h": 17.5, "id": "r.1.2.0.24.l1", "sc": "settings", "size": 14, "t": "text", "text": "hidden there. Turn this on to keep a way out of full screen that is not a keyboard shortcut.", "w": 665.3, "x": 16.0, "y": 1119.9}
-{"click": true, "h": 21.2, "hover": {"c": "747474"}, "id": "set-hide_title_bar", "sc": "settings", "t": "rect", "w": 1238.0, "x": 16.0, "y": 1145.4}
-{"bc": "3a3d42", "bw": 1, "fill": "2a2d33", "h": 20.0, "id": "r.1.2.0.25.0", "radius": 5, "sc": "settings", "t": "rect", "w": 20.0, "x": 16.0, "y": 1146.1}
-{"align": "left", "c": "e8e8e8", "h": 21.2, "id": "r.1.2.0.25.1", "sc": "settings", "size": 17, "t": "text", "text": "Hide the Desktop Title Bar", "w": 198.6, "x": 46.0, "y": 1145.4}
-{"align": "left", "c": "e5c07b", "h": 17.5, "id": "r.1.2.0.26", "sc": "settings", "size": 14, "t": "text", "text": "Requires restart", "w": 1238.0, "x": 16.0, "y": 1174.7}
-{"align": "left", "c": "9aa0a6", "h": 17.5, "id": "r.1.2.0.27", "sc": "settings", "size": 14, "t": "text", "text": "Asks the desktop for no title bar on the player window, so the top bar above is the only one. Pairs with", "w": 665.3, "x": 16.0, "y": 1200.2}
-{"align": "left", "c": "9aa0a6", "h": 17.5, "id": "r.1.2.0.27.l1", "sc": "settings", "size": 14, "t": "text", "text": "the setting above: on \"Only when the window has no title bar\" the buttons appear as soon as this is on.", "w": 665.3, "x": 16.0, "y": 1217.7}
-{"align": "left", "c": "9aa0a6", "h": 17.5, "id": "r.1.2.0.27.l2", "sc": "settings", "size": 14, "t": "text", "text": "Leave both off unless you want them, since a window with neither can be awkward to move on some", "w": 665.3, "x": 16.0, "y": 1235.2}
-{"align": "left", "c": "9aa0a6", "h": 17.5, "id": "r.1.2.0.27.l3", "sc": "settings", "size": 14, "t": "text", "text": "desktops.", "w": 665.3, "x": 16.0, "y": 1252.7}
-{"click": true, "h": 21.2, "hover": {"c": "747474"}, "id": "set-allow_background", "sc": "settings", "t": "rect", "w": 1238.0, "x": 16.0, "y": 1278.2}
-{"bc": "3a3d42", "bw": 1, "fill": "2a2d33", "h": 20.0, "id": "r.1.2.0.28.0", "radius": 5, "sc": "settings", "t": "rect", "w": 20.0, "x": 16.0, "y": 1278.8}
-{"align": "left", "c": "e8e8e8", "h": 21.2, "id": "r.1.2.0.28.1", "sc": "settings", "size": 17, "t": "text", "text": "Keep Running in Background", "w": 216.2, "x": 46.0, "y": 1278.2}
-{"align": "left", "c": "9aa0a6", "h": 17.5, "id": "r.1.2.0.29", "sc": "settings", "size": 14, "t": "text", "text": "With \"Start Minimized\" and \"Fullscreen\" this is the classic cast-target setup: the app waits out of the", "w": 665.3, "x": 16.0, "y": 1307.4}
-{"align": "left", "c": "9aa0a6", "h": 17.5, "id": "r.1.2.0.29.l1", "sc": "settings", "size": 14, "t": "text", "text": "way, plays fullscreen when something casts to it, and goes back to waiting when the video ends or", "w": 665.3, "x": 16.0, "y": 1324.9}
-{"align": "left", "c": "9aa0a6", "h": 17.5, "id": "r.1.2.0.29.l2", "sc": "settings", "size": 14, "t": "text", "text": "you press Q.", "w": 665.3, "x": 16.0, "y": 1342.4}
-{"click": true, "h": 21.2, "hover": {"c": "747474"}, "id": "set-display_mirror_summon", "sc": "settings", "t": "rect", "w": 1238.0, "x": 16.0, "y": 1367.9}
-{"bc": "3a3d42", "bw": 1, "fill": "2a2d33", "h": 20.0, "id": "r.1.2.0.30.0", "radius": 5, "sc": "settings", "t": "rect", "w": 20.0, "x": 16.0, "y": 1368.6}
-{"align": "left", "c": "e8e8e8", "h": 21.2, "id": "r.1.2.0.30.1", "sc": "settings", "size": 17, "t": "text", "text": "Casting Opens the Library Browser", "w": 264.7, "x": 46.0, "y": 1367.9}
-{"click": true, "h": 21.2, "hover": {"c": "747474"}, "id": "set-adv", "sc": "settings", "t": "rect", "w": 1238.0, "x": 16.0, "y": 1397.2}
-{"bc": "3a3d42", "bw": 1, "fill": "2a2d33", "h": 20.0, "id": "r.1.2.0.31.0", "radius": 5, "sc": "settings", "t": "rect", "w": 20.0, "x": 16.0, "y": 1397.8}
-{"align": "left", "c": "e8e8e8", "h": 21.2, "id": "r.1.2.0.31.1", "sc": "settings", "size": 17, "t": "text", "text": "Show advanced settings", "w": 188.9, "x": 46.0, "y": 1397.2}
+{"align": "left", "bold": true, "c": "e8e8e8", "h": 30.0, "id": "r.1.2.0.15", "sc": "settings", "size": 24, "t": "text", "text": "Window", "w": 1238.0, "x": 16.0, "y": 728.4}
+{"click": true, "h": 21.2, "hover": {"c": "747474"}, "id": "set-fullscreen", "sc": "settings", "t": "rect", "w": 1238.0, "x": 16.0, "y": 766.4}
+{"bc": "3a3d42", "bw": 1, "fill": "2a2d33", "h": 20.0, "id": "r.1.2.0.16.0", "radius": 5, "sc": "settings", "t": "rect", "w": 20.0, "x": 16.0, "y": 767.0}
+{"align": "left", "c": "e8e8e8", "h": 21.2, "id": "r.1.2.0.16.1", "sc": "settings", "size": 17, "t": "text", "text": "Fullscreen", "w": 81.6, "x": 46.0, "y": 766.4}
+{"click": true, "h": 21.2, "hover": {"c": "747474"}, "id": "set-browser_fullscreen", "sc": "settings", "t": "rect", "w": 1238.0, "x": 16.0, "y": 795.6}
+{"bc": "3a3d42", "bw": 1, "fill": "2a2d33", "h": 20.0, "id": "r.1.2.0.17.0", "radius": 5, "sc": "settings", "t": "rect", "w": 20.0, "x": 16.0, "y": 796.2}
+{"align": "left", "c": "e8e8e8", "h": 21.2, "id": "r.1.2.0.17.1", "sc": "settings", "size": 17, "t": "text", "text": "Fullscreen Library Browser", "w": 208.6, "x": 46.0, "y": 795.6}
+{"click": true, "h": 21.2, "hover": {"c": "747474"}, "id": "set-remember_window_size", "sc": "settings", "t": "rect", "w": 1238.0, "x": 16.0, "y": 824.9}
+{"fill": "00a4dc", "h": 20.0, "id": "r.1.2.0.18.0", "radius": 5, "sc": "settings", "t": "rect", "w": 20.0, "x": 16.0, "y": 825.5}
+{"align": "center", "c": "ffffff", "h": 18.8, "id": "r.1.2.0.18.0.0", "sc": "settings", "size": 15, "t": "text", "text": "\u2713", "w": 20.0, "x": 16.0, "y": 826.1}
+{"align": "left", "c": "e8e8e8", "h": 21.2, "id": "r.1.2.0.18.1", "sc": "settings", "size": 17, "t": "text", "text": "Remember Window Size", "w": 186.3, "x": 46.0, "y": 824.9}
+{"align": "left", "c": "9aa0a6", "h": 21.2, "id": "r.1.2.0.19.0", "sc": "settings", "size": 17, "t": "text", "text": "Window Buttons in the Top Bar", "w": 340.0, "x": 16.0, "y": 859.6}
+{"force": true, "h": 32.3, "id": "set-window_controls", "items": ["Only when the window has no title bar", "Always", "Never"], "sc": "settings", "sel": 0, "size": 17, "t": "dropdown", "w": 340.0, "x": 368.0, "y": 854.1}
+{"align": "left", "c": "9aa0a6", "h": 17.5, "id": "r.1.2.0.20", "sc": "settings", "size": 14, "t": "text", "text": "Some desktops, GNOME on Wayland in particular, draw no title bar on the player window, leaving no", "w": 665.3, "x": 16.0, "y": 894.4}
+{"align": "left", "c": "9aa0a6", "h": 17.5, "id": "r.1.2.0.20.l1", "sc": "settings", "size": 14, "t": "text", "text": "way to move or close it. This puts minimize, maximize and close in the top bar instead, and lets you", "w": 665.3, "x": 16.0, "y": 911.9}
+{"align": "left", "c": "9aa0a6", "h": 17.5, "id": "r.1.2.0.20.l2", "sc": "settings", "size": 14, "t": "text", "text": "drag the window by it. On \"Only when the window has no title bar\", MPV is asked whether this window", "w": 665.3, "x": 16.0, "y": 929.4}
+{"align": "left", "c": "9aa0a6", "h": 17.5, "id": "r.1.2.0.20.l3", "sc": "settings", "size": 14, "t": "text", "text": "got one, so desktops that draw a title bar are left alone.", "w": 665.3, "x": 16.0, "y": 946.9}
+{"click": true, "h": 21.2, "hover": {"c": "747474"}, "id": "set-window_controls_fullscreen", "sc": "settings", "t": "rect", "w": 1238.0, "x": 16.0, "y": 972.4}
+{"bc": "3a3d42", "bw": 1, "fill": "2a2d33", "h": 20.0, "id": "r.1.2.0.21.0", "radius": 5, "sc": "settings", "t": "rect", "w": 20.0, "x": 16.0, "y": 973.0}
+{"align": "left", "c": "e8e8e8", "h": 21.2, "id": "r.1.2.0.21.1", "sc": "settings", "size": 17, "t": "text", "text": "Keep Window Buttons in Full Screen", "w": 278.5, "x": 46.0, "y": 972.4}
+{"align": "left", "c": "9aa0a6", "h": 17.5, "id": "r.1.2.0.22", "sc": "settings", "size": 14, "t": "text", "text": "Full screen has no title bar anywhere and nothing to move or maximize, so the buttons are normally", "w": 665.3, "x": 16.0, "y": 1001.6}
+{"align": "left", "c": "9aa0a6", "h": 17.5, "id": "r.1.2.0.22.l1", "sc": "settings", "size": 14, "t": "text", "text": "hidden there. Turn this on to keep a way out of full screen that is not a keyboard shortcut.", "w": 665.3, "x": 16.0, "y": 1019.1}
+{"click": true, "h": 21.2, "hover": {"c": "747474"}, "id": "set-hide_title_bar", "sc": "settings", "t": "rect", "w": 1238.0, "x": 16.0, "y": 1044.7}
+{"bc": "3a3d42", "bw": 1, "fill": "2a2d33", "h": 20.0, "id": "r.1.2.0.23.0", "radius": 5, "sc": "settings", "t": "rect", "w": 20.0, "x": 16.0, "y": 1045.3}
+{"align": "left", "c": "e8e8e8", "h": 21.2, "id": "r.1.2.0.23.1", "sc": "settings", "size": 17, "t": "text", "text": "Hide the Desktop Title Bar", "w": 198.6, "x": 46.0, "y": 1044.7}
+{"align": "left", "c": "e5c07b", "h": 17.5, "id": "r.1.2.0.24", "sc": "settings", "size": 14, "t": "text", "text": "Requires restart", "w": 1238.0, "x": 16.0, "y": 1073.9}
+{"align": "left", "c": "9aa0a6", "h": 17.5, "id": "r.1.2.0.25", "sc": "settings", "size": 14, "t": "text", "text": "Asks the desktop for no title bar on the player window, so the top bar above is the only one. Pairs with", "w": 665.3, "x": 16.0, "y": 1099.4}
+{"align": "left", "c": "9aa0a6", "h": 17.5, "id": "r.1.2.0.25.l1", "sc": "settings", "size": 14, "t": "text", "text": "the setting above: on \"Only when the window has no title bar\" the buttons appear as soon as this is on.", "w": 665.3, "x": 16.0, "y": 1116.9}
+{"align": "left", "c": "9aa0a6", "h": 17.5, "id": "r.1.2.0.25.l2", "sc": "settings", "size": 14, "t": "text", "text": "Leave both off unless you want them, since a window with neither can be awkward to move on some", "w": 665.3, "x": 16.0, "y": 1134.4}
+{"align": "left", "c": "9aa0a6", "h": 17.5, "id": "r.1.2.0.25.l3", "sc": "settings", "size": 14, "t": "text", "text": "desktops.", "w": 665.3, "x": 16.0, "y": 1151.9}
+{"click": true, "h": 21.2, "hover": {"c": "747474"}, "id": "set-allow_background", "sc": "settings", "t": "rect", "w": 1238.0, "x": 16.0, "y": 1177.4}
+{"bc": "3a3d42", "bw": 1, "fill": "2a2d33", "h": 20.0, "id": "r.1.2.0.26.0", "radius": 5, "sc": "settings", "t": "rect", "w": 20.0, "x": 16.0, "y": 1178.0}
+{"align": "left", "c": "e8e8e8", "h": 21.2, "id": "r.1.2.0.26.1", "sc": "settings", "size": 17, "t": "text", "text": "Keep Running in Background", "w": 216.2, "x": 46.0, "y": 1177.4}
+{"align": "left", "c": "9aa0a6", "h": 17.5, "id": "r.1.2.0.27", "sc": "settings", "size": 14, "t": "text", "text": "With \"Start Minimized\" and \"Fullscreen\" this is the classic cast-target setup: the app waits out of the", "w": 665.3, "x": 16.0, "y": 1206.7}
+{"align": "left", "c": "9aa0a6", "h": 17.5, "id": "r.1.2.0.27.l1", "sc": "settings", "size": 14, "t": "text", "text": "way, plays fullscreen when something casts to it, and goes back to waiting when the video ends or", "w": 665.3, "x": 16.0, "y": 1224.2}
+{"align": "left", "c": "9aa0a6", "h": 17.5, "id": "r.1.2.0.27.l2", "sc": "settings", "size": 14, "t": "text", "text": "you press Q.", "w": 665.3, "x": 16.0, "y": 1241.7}
+{"click": true, "h": 21.2, "hover": {"c": "747474"}, "id": "set-display_mirror_summon", "sc": "settings", "t": "rect", "w": 1238.0, "x": 16.0, "y": 1267.2}
+{"bc": "3a3d42", "bw": 1, "fill": "2a2d33", "h": 20.0, "id": "r.1.2.0.28.0", "radius": 5, "sc": "settings", "t": "rect", "w": 20.0, "x": 16.0, "y": 1267.8}
+{"align": "left", "c": "e8e8e8", "h": 21.2, "id": "r.1.2.0.28.1", "sc": "settings", "size": 17, "t": "text", "text": "Casting Opens the Library Browser", "w": 264.7, "x": 46.0, "y": 1267.2}
+{"click": true, "h": 21.2, "hover": {"c": "747474"}, "id": "set-adv", "sc": "settings", "t": "rect", "w": 1238.0, "x": 16.0, "y": 1296.4}
+{"bc": "3a3d42", "bw": 1, "fill": "2a2d33", "h": 20.0, "id": "r.1.2.0.29.0", "radius": 5, "sc": "settings", "t": "rect", "w": 20.0, "x": 16.0, "y": 1297.0}
+{"align": "left", "c": "e8e8e8", "h": 21.2, "id": "r.1.2.0.29.1", "sc": "settings", "size": 17, "t": "text", "text": "Show advanced settings", "w": 188.9, "x": 46.0, "y": 1296.4}

--- a/tests/snapshots/settings.jsonl
+++ b/tests/snapshots/settings.jsonl
@@ -27,7 +27,7 @@
 {"click": true, "fill": "2e3138", "h": 41.2, "hover": {"fill": "3a3e46"}, "id": "stab-logs", "radius": 6, "t": "rect", "w": 56.7, "x": 676.3, "y": 76.0}
 {"align": "center", "c": "e8e8e8", "h": 21.2, "id": "r.1.0.0.6.0", "size": 17, "t": "text", "text": "Logs", "w": 36.7, "x": 686.3, "y": 86.0}
 {"force": true, "h": 32.3, "id": "set-search-box", "ph": "Search settings\u2026", "size": 17, "t": "textbox", "text": "", "w": 320.0, "x": 16.0, "y": 149.2}
-{"axis": "y", "bar": true, "ch": 1136.1, "cw": 1270.0, "h": 522.5, "id": "settings", "t": "scroll", "w": 1280.0, "x": 0.0, "y": 197.6}
+{"axis": "y", "bar": true, "ch": 1236.9, "cw": 1270.0, "h": 522.5, "id": "settings", "t": "scroll", "w": 1280.0, "x": 0.0, "y": 197.6}
 {"align": "left", "bold": true, "c": "e8e8e8", "h": 30.0, "id": "r.1.2.0.0", "sc": "settings", "size": 24, "t": "text", "text": "This Device", "w": 1238.0, "x": 16.0, "y": 213.6}
 {"align": "left", "c": "9aa0a6", "h": 21.2, "id": "r.1.2.0.1.0", "sc": "settings", "size": 17, "t": "text", "text": "Player Name", "w": 340.0, "x": 16.0, "y": 257.1}
 {"h": 32.3, "id": "set-player_name", "ph": "", "sc": "settings", "size": 17, "t": "textbox", "text": "jms-test-host", "w": 340.0, "x": 368.0, "y": 251.6}
@@ -63,45 +63,50 @@
 {"align": "left", "c": "e8e8e8", "h": 21.2, "id": "r.1.2.0.13.1", "sc": "settings", "size": 17, "t": "text", "text": "Swap Confirm and Back Buttons", "w": 243.4, "x": 46.0, "y": 656.1}
 {"align": "left", "c": "9aa0a6", "h": 17.5, "id": "r.1.2.0.14", "sc": "settings", "size": 14, "t": "text", "text": "Turn this on for a controller whose A button is on the right rather than at the bottom (Switch Pro, most", "w": 665.3, "x": 16.0, "y": 685.4}
 {"align": "left", "c": "9aa0a6", "h": 17.5, "id": "r.1.2.0.14.l1", "sc": "settings", "size": 14, "t": "text", "text": "8BitDo pads).", "w": 665.3, "x": 16.0, "y": 702.9}
-{"align": "left", "bold": true, "c": "e8e8e8", "h": 30.0, "id": "r.1.2.0.15", "sc": "settings", "size": 24, "t": "text", "text": "Window", "w": 1238.0, "x": 16.0, "y": 728.4}
-{"click": true, "h": 21.2, "hover": {"c": "747474"}, "id": "set-fullscreen", "sc": "settings", "t": "rect", "w": 1238.0, "x": 16.0, "y": 766.4}
-{"bc": "3a3d42", "bw": 1, "fill": "2a2d33", "h": 20.0, "id": "r.1.2.0.16.0", "radius": 5, "sc": "settings", "t": "rect", "w": 20.0, "x": 16.0, "y": 767.0}
-{"align": "left", "c": "e8e8e8", "h": 21.2, "id": "r.1.2.0.16.1", "sc": "settings", "size": 17, "t": "text", "text": "Fullscreen", "w": 81.6, "x": 46.0, "y": 766.4}
-{"click": true, "h": 21.2, "hover": {"c": "747474"}, "id": "set-browser_fullscreen", "sc": "settings", "t": "rect", "w": 1238.0, "x": 16.0, "y": 795.6}
-{"bc": "3a3d42", "bw": 1, "fill": "2a2d33", "h": 20.0, "id": "r.1.2.0.17.0", "radius": 5, "sc": "settings", "t": "rect", "w": 20.0, "x": 16.0, "y": 796.2}
-{"align": "left", "c": "e8e8e8", "h": 21.2, "id": "r.1.2.0.17.1", "sc": "settings", "size": 17, "t": "text", "text": "Fullscreen Library Browser", "w": 208.6, "x": 46.0, "y": 795.6}
-{"click": true, "h": 21.2, "hover": {"c": "747474"}, "id": "set-remember_window_size", "sc": "settings", "t": "rect", "w": 1238.0, "x": 16.0, "y": 824.9}
-{"fill": "00a4dc", "h": 20.0, "id": "r.1.2.0.18.0", "radius": 5, "sc": "settings", "t": "rect", "w": 20.0, "x": 16.0, "y": 825.5}
-{"align": "center", "c": "ffffff", "h": 18.8, "id": "r.1.2.0.18.0.0", "sc": "settings", "size": 15, "t": "text", "text": "\u2713", "w": 20.0, "x": 16.0, "y": 826.1}
-{"align": "left", "c": "e8e8e8", "h": 21.2, "id": "r.1.2.0.18.1", "sc": "settings", "size": 17, "t": "text", "text": "Remember Window Size", "w": 186.3, "x": 46.0, "y": 824.9}
-{"align": "left", "c": "9aa0a6", "h": 21.2, "id": "r.1.2.0.19.0", "sc": "settings", "size": 17, "t": "text", "text": "Window Buttons in the Top Bar", "w": 340.0, "x": 16.0, "y": 859.6}
-{"force": true, "h": 32.3, "id": "set-window_controls", "items": ["Only when the window has no title bar", "Always", "Never"], "sc": "settings", "sel": 0, "size": 17, "t": "dropdown", "w": 340.0, "x": 368.0, "y": 854.1}
-{"align": "left", "c": "9aa0a6", "h": 17.5, "id": "r.1.2.0.20", "sc": "settings", "size": 14, "t": "text", "text": "Some desktops, GNOME on Wayland in particular, draw no title bar on the player window, leaving no", "w": 665.3, "x": 16.0, "y": 894.4}
-{"align": "left", "c": "9aa0a6", "h": 17.5, "id": "r.1.2.0.20.l1", "sc": "settings", "size": 14, "t": "text", "text": "way to move or close it. This puts minimize, maximize and close in the top bar instead, and lets you", "w": 665.3, "x": 16.0, "y": 911.9}
-{"align": "left", "c": "9aa0a6", "h": 17.5, "id": "r.1.2.0.20.l2", "sc": "settings", "size": 14, "t": "text", "text": "drag the window by it. On \"Only when the window has no title bar\", MPV is asked whether this window", "w": 665.3, "x": 16.0, "y": 929.4}
-{"align": "left", "c": "9aa0a6", "h": 17.5, "id": "r.1.2.0.20.l3", "sc": "settings", "size": 14, "t": "text", "text": "got one, so desktops that draw a title bar are left alone.", "w": 665.3, "x": 16.0, "y": 946.9}
-{"click": true, "h": 21.2, "hover": {"c": "747474"}, "id": "set-window_controls_fullscreen", "sc": "settings", "t": "rect", "w": 1238.0, "x": 16.0, "y": 972.4}
-{"bc": "3a3d42", "bw": 1, "fill": "2a2d33", "h": 20.0, "id": "r.1.2.0.21.0", "radius": 5, "sc": "settings", "t": "rect", "w": 20.0, "x": 16.0, "y": 973.0}
-{"align": "left", "c": "e8e8e8", "h": 21.2, "id": "r.1.2.0.21.1", "sc": "settings", "size": 17, "t": "text", "text": "Keep Window Buttons in Full Screen", "w": 278.5, "x": 46.0, "y": 972.4}
-{"align": "left", "c": "9aa0a6", "h": 17.5, "id": "r.1.2.0.22", "sc": "settings", "size": 14, "t": "text", "text": "Full screen has no title bar anywhere and nothing to move or maximize, so the buttons are normally", "w": 665.3, "x": 16.0, "y": 1001.6}
-{"align": "left", "c": "9aa0a6", "h": 17.5, "id": "r.1.2.0.22.l1", "sc": "settings", "size": 14, "t": "text", "text": "hidden there. Turn this on to keep a way out of full screen that is not a keyboard shortcut.", "w": 665.3, "x": 16.0, "y": 1019.1}
-{"click": true, "h": 21.2, "hover": {"c": "747474"}, "id": "set-hide_title_bar", "sc": "settings", "t": "rect", "w": 1238.0, "x": 16.0, "y": 1044.7}
-{"bc": "3a3d42", "bw": 1, "fill": "2a2d33", "h": 20.0, "id": "r.1.2.0.23.0", "radius": 5, "sc": "settings", "t": "rect", "w": 20.0, "x": 16.0, "y": 1045.3}
-{"align": "left", "c": "e8e8e8", "h": 21.2, "id": "r.1.2.0.23.1", "sc": "settings", "size": 17, "t": "text", "text": "Hide the Desktop Title Bar", "w": 198.6, "x": 46.0, "y": 1044.7}
-{"align": "left", "c": "e5c07b", "h": 17.5, "id": "r.1.2.0.24", "sc": "settings", "size": 14, "t": "text", "text": "Requires restart", "w": 1238.0, "x": 16.0, "y": 1073.9}
-{"align": "left", "c": "9aa0a6", "h": 17.5, "id": "r.1.2.0.25", "sc": "settings", "size": 14, "t": "text", "text": "Asks the desktop for no title bar on the player window, so the top bar above is the only one. Pairs with", "w": 665.3, "x": 16.0, "y": 1099.4}
-{"align": "left", "c": "9aa0a6", "h": 17.5, "id": "r.1.2.0.25.l1", "sc": "settings", "size": 14, "t": "text", "text": "the setting above: on \"Only when the window has no title bar\" the buttons appear as soon as this is on.", "w": 665.3, "x": 16.0, "y": 1116.9}
-{"align": "left", "c": "9aa0a6", "h": 17.5, "id": "r.1.2.0.25.l2", "sc": "settings", "size": 14, "t": "text", "text": "Leave both off unless you want them, since a window with neither can be awkward to move on some", "w": 665.3, "x": 16.0, "y": 1134.4}
-{"align": "left", "c": "9aa0a6", "h": 17.5, "id": "r.1.2.0.25.l3", "sc": "settings", "size": 14, "t": "text", "text": "desktops.", "w": 665.3, "x": 16.0, "y": 1151.9}
-{"click": true, "h": 21.2, "hover": {"c": "747474"}, "id": "set-allow_background", "sc": "settings", "t": "rect", "w": 1238.0, "x": 16.0, "y": 1177.4}
-{"bc": "3a3d42", "bw": 1, "fill": "2a2d33", "h": 20.0, "id": "r.1.2.0.26.0", "radius": 5, "sc": "settings", "t": "rect", "w": 20.0, "x": 16.0, "y": 1178.0}
-{"align": "left", "c": "e8e8e8", "h": 21.2, "id": "r.1.2.0.26.1", "sc": "settings", "size": 17, "t": "text", "text": "Keep Running in Background", "w": 216.2, "x": 46.0, "y": 1177.4}
-{"align": "left", "c": "9aa0a6", "h": 17.5, "id": "r.1.2.0.27", "sc": "settings", "size": 14, "t": "text", "text": "With \"Start Minimized\" and \"Fullscreen\" this is the classic cast-target setup: the app waits out of the", "w": 665.3, "x": 16.0, "y": 1206.7}
-{"align": "left", "c": "9aa0a6", "h": 17.5, "id": "r.1.2.0.27.l1", "sc": "settings", "size": 14, "t": "text", "text": "way, plays fullscreen when something casts to it, and goes back to waiting when the video ends or", "w": 665.3, "x": 16.0, "y": 1224.2}
-{"align": "left", "c": "9aa0a6", "h": 17.5, "id": "r.1.2.0.27.l2", "sc": "settings", "size": 14, "t": "text", "text": "you press Q.", "w": 665.3, "x": 16.0, "y": 1241.7}
-{"click": true, "h": 21.2, "hover": {"c": "747474"}, "id": "set-display_mirror_summon", "sc": "settings", "t": "rect", "w": 1238.0, "x": 16.0, "y": 1267.2}
-{"bc": "3a3d42", "bw": 1, "fill": "2a2d33", "h": 20.0, "id": "r.1.2.0.28.0", "radius": 5, "sc": "settings", "t": "rect", "w": 20.0, "x": 16.0, "y": 1267.8}
-{"align": "left", "c": "e8e8e8", "h": 21.2, "id": "r.1.2.0.28.1", "sc": "settings", "size": 17, "t": "text", "text": "Casting Opens the Library Browser", "w": 264.7, "x": 46.0, "y": 1267.2}
-{"click": true, "h": 21.2, "hover": {"c": "747474"}, "id": "set-adv", "sc": "settings", "t": "rect", "w": 1238.0, "x": 16.0, "y": 1296.4}
-{"bc": "3a3d42", "bw": 1, "fill": "2a2d33", "h": 20.0, "id": "r.1.2.0.29.0", "radius": 5, "sc": "settings", "t": "rect", "w": 20.0, "x": 16.0, "y": 1297.0}
-{"align": "left", "c": "e8e8e8", "h": 21.2, "id": "r.1.2.0.29.1", "sc": "settings", "size": 17, "t": "text", "text": "Show advanced settings", "w": 188.9, "x": 46.0, "y": 1296.4}
+{"align": "left", "c": "9aa0a6", "h": 21.2, "id": "r.1.2.0.15.0", "sc": "settings", "size": 17, "t": "text", "text": "Select Key", "w": 340.0, "x": 16.0, "y": 733.9}
+{"h": 32.3, "id": "set-ui_select_key", "ph": "", "sc": "settings", "size": 17, "t": "textbox", "text": "ENTER", "w": 340.0, "x": 368.0, "y": 728.4}
+{"align": "left", "c": "9aa0a6", "h": 17.5, "id": "r.1.2.0.16", "sc": "settings", "size": 14, "t": "text", "text": "Activates whatever is highlighted, in the library and on the player controls. An mpv key name;", "w": 665.3, "x": 16.0, "y": 768.6}
+{"align": "left", "c": "9aa0a6", "h": 17.5, "id": "r.1.2.0.16.l1", "sc": "settings", "size": 14, "t": "text", "text": "changing it hands Enter back to MPV. The game controller's Confirm button and a phone's Select follow", "w": 665.3, "x": 16.0, "y": 786.1}
+{"align": "left", "c": "9aa0a6", "h": 17.5, "id": "r.1.2.0.16.l2", "sc": "settings", "size": 14, "t": "text", "text": "it.", "w": 665.3, "x": 16.0, "y": 803.6}
+{"align": "left", "bold": true, "c": "e8e8e8", "h": 30.0, "id": "r.1.2.0.17", "sc": "settings", "size": 24, "t": "text", "text": "Window", "w": 1238.0, "x": 16.0, "y": 829.1}
+{"click": true, "h": 21.2, "hover": {"c": "747474"}, "id": "set-fullscreen", "sc": "settings", "t": "rect", "w": 1238.0, "x": 16.0, "y": 867.1}
+{"bc": "3a3d42", "bw": 1, "fill": "2a2d33", "h": 20.0, "id": "r.1.2.0.18.0", "radius": 5, "sc": "settings", "t": "rect", "w": 20.0, "x": 16.0, "y": 867.8}
+{"align": "left", "c": "e8e8e8", "h": 21.2, "id": "r.1.2.0.18.1", "sc": "settings", "size": 17, "t": "text", "text": "Fullscreen", "w": 81.6, "x": 46.0, "y": 867.1}
+{"click": true, "h": 21.2, "hover": {"c": "747474"}, "id": "set-browser_fullscreen", "sc": "settings", "t": "rect", "w": 1238.0, "x": 16.0, "y": 896.4}
+{"bc": "3a3d42", "bw": 1, "fill": "2a2d33", "h": 20.0, "id": "r.1.2.0.19.0", "radius": 5, "sc": "settings", "t": "rect", "w": 20.0, "x": 16.0, "y": 897.0}
+{"align": "left", "c": "e8e8e8", "h": 21.2, "id": "r.1.2.0.19.1", "sc": "settings", "size": 17, "t": "text", "text": "Fullscreen Library Browser", "w": 208.6, "x": 46.0, "y": 896.4}
+{"click": true, "h": 21.2, "hover": {"c": "747474"}, "id": "set-remember_window_size", "sc": "settings", "t": "rect", "w": 1238.0, "x": 16.0, "y": 925.6}
+{"fill": "00a4dc", "h": 20.0, "id": "r.1.2.0.20.0", "radius": 5, "sc": "settings", "t": "rect", "w": 20.0, "x": 16.0, "y": 926.3}
+{"align": "center", "c": "ffffff", "h": 18.8, "id": "r.1.2.0.20.0.0", "sc": "settings", "size": 15, "t": "text", "text": "\u2713", "w": 20.0, "x": 16.0, "y": 926.9}
+{"align": "left", "c": "e8e8e8", "h": 21.2, "id": "r.1.2.0.20.1", "sc": "settings", "size": 17, "t": "text", "text": "Remember Window Size", "w": 186.3, "x": 46.0, "y": 925.6}
+{"align": "left", "c": "9aa0a6", "h": 21.2, "id": "r.1.2.0.21.0", "sc": "settings", "size": 17, "t": "text", "text": "Window Buttons in the Top Bar", "w": 340.0, "x": 16.0, "y": 960.4}
+{"force": true, "h": 32.3, "id": "set-window_controls", "items": ["Only when the window has no title bar", "Always", "Never"], "sc": "settings", "sel": 0, "size": 17, "t": "dropdown", "w": 340.0, "x": 368.0, "y": 954.9}
+{"align": "left", "c": "9aa0a6", "h": 17.5, "id": "r.1.2.0.22", "sc": "settings", "size": 14, "t": "text", "text": "Some desktops, GNOME on Wayland in particular, draw no title bar on the player window, leaving no", "w": 665.3, "x": 16.0, "y": 995.2}
+{"align": "left", "c": "9aa0a6", "h": 17.5, "id": "r.1.2.0.22.l1", "sc": "settings", "size": 14, "t": "text", "text": "way to move or close it. This puts minimize, maximize and close in the top bar instead, and lets you", "w": 665.3, "x": 16.0, "y": 1012.7}
+{"align": "left", "c": "9aa0a6", "h": 17.5, "id": "r.1.2.0.22.l2", "sc": "settings", "size": 14, "t": "text", "text": "drag the window by it. On \"Only when the window has no title bar\", MPV is asked whether this window", "w": 665.3, "x": 16.0, "y": 1030.2}
+{"align": "left", "c": "9aa0a6", "h": 17.5, "id": "r.1.2.0.22.l3", "sc": "settings", "size": 14, "t": "text", "text": "got one, so desktops that draw a title bar are left alone.", "w": 665.3, "x": 16.0, "y": 1047.7}
+{"click": true, "h": 21.2, "hover": {"c": "747474"}, "id": "set-window_controls_fullscreen", "sc": "settings", "t": "rect", "w": 1238.0, "x": 16.0, "y": 1073.2}
+{"bc": "3a3d42", "bw": 1, "fill": "2a2d33", "h": 20.0, "id": "r.1.2.0.23.0", "radius": 5, "sc": "settings", "t": "rect", "w": 20.0, "x": 16.0, "y": 1073.8}
+{"align": "left", "c": "e8e8e8", "h": 21.2, "id": "r.1.2.0.23.1", "sc": "settings", "size": 17, "t": "text", "text": "Keep Window Buttons in Full Screen", "w": 278.5, "x": 46.0, "y": 1073.2}
+{"align": "left", "c": "9aa0a6", "h": 17.5, "id": "r.1.2.0.24", "sc": "settings", "size": 14, "t": "text", "text": "Full screen has no title bar anywhere and nothing to move or maximize, so the buttons are normally", "w": 665.3, "x": 16.0, "y": 1102.4}
+{"align": "left", "c": "9aa0a6", "h": 17.5, "id": "r.1.2.0.24.l1", "sc": "settings", "size": 14, "t": "text", "text": "hidden there. Turn this on to keep a way out of full screen that is not a keyboard shortcut.", "w": 665.3, "x": 16.0, "y": 1119.9}
+{"click": true, "h": 21.2, "hover": {"c": "747474"}, "id": "set-hide_title_bar", "sc": "settings", "t": "rect", "w": 1238.0, "x": 16.0, "y": 1145.4}
+{"bc": "3a3d42", "bw": 1, "fill": "2a2d33", "h": 20.0, "id": "r.1.2.0.25.0", "radius": 5, "sc": "settings", "t": "rect", "w": 20.0, "x": 16.0, "y": 1146.1}
+{"align": "left", "c": "e8e8e8", "h": 21.2, "id": "r.1.2.0.25.1", "sc": "settings", "size": 17, "t": "text", "text": "Hide the Desktop Title Bar", "w": 198.6, "x": 46.0, "y": 1145.4}
+{"align": "left", "c": "e5c07b", "h": 17.5, "id": "r.1.2.0.26", "sc": "settings", "size": 14, "t": "text", "text": "Requires restart", "w": 1238.0, "x": 16.0, "y": 1174.7}
+{"align": "left", "c": "9aa0a6", "h": 17.5, "id": "r.1.2.0.27", "sc": "settings", "size": 14, "t": "text", "text": "Asks the desktop for no title bar on the player window, so the top bar above is the only one. Pairs with", "w": 665.3, "x": 16.0, "y": 1200.2}
+{"align": "left", "c": "9aa0a6", "h": 17.5, "id": "r.1.2.0.27.l1", "sc": "settings", "size": 14, "t": "text", "text": "the setting above: on \"Only when the window has no title bar\" the buttons appear as soon as this is on.", "w": 665.3, "x": 16.0, "y": 1217.7}
+{"align": "left", "c": "9aa0a6", "h": 17.5, "id": "r.1.2.0.27.l2", "sc": "settings", "size": 14, "t": "text", "text": "Leave both off unless you want them, since a window with neither can be awkward to move on some", "w": 665.3, "x": 16.0, "y": 1235.2}
+{"align": "left", "c": "9aa0a6", "h": 17.5, "id": "r.1.2.0.27.l3", "sc": "settings", "size": 14, "t": "text", "text": "desktops.", "w": 665.3, "x": 16.0, "y": 1252.7}
+{"click": true, "h": 21.2, "hover": {"c": "747474"}, "id": "set-allow_background", "sc": "settings", "t": "rect", "w": 1238.0, "x": 16.0, "y": 1278.2}
+{"bc": "3a3d42", "bw": 1, "fill": "2a2d33", "h": 20.0, "id": "r.1.2.0.28.0", "radius": 5, "sc": "settings", "t": "rect", "w": 20.0, "x": 16.0, "y": 1278.8}
+{"align": "left", "c": "e8e8e8", "h": 21.2, "id": "r.1.2.0.28.1", "sc": "settings", "size": 17, "t": "text", "text": "Keep Running in Background", "w": 216.2, "x": 46.0, "y": 1278.2}
+{"align": "left", "c": "9aa0a6", "h": 17.5, "id": "r.1.2.0.29", "sc": "settings", "size": 14, "t": "text", "text": "With \"Start Minimized\" and \"Fullscreen\" this is the classic cast-target setup: the app waits out of the", "w": 665.3, "x": 16.0, "y": 1307.4}
+{"align": "left", "c": "9aa0a6", "h": 17.5, "id": "r.1.2.0.29.l1", "sc": "settings", "size": 14, "t": "text", "text": "way, plays fullscreen when something casts to it, and goes back to waiting when the video ends or", "w": 665.3, "x": 16.0, "y": 1324.9}
+{"align": "left", "c": "9aa0a6", "h": 17.5, "id": "r.1.2.0.29.l2", "sc": "settings", "size": 14, "t": "text", "text": "you press Q.", "w": 665.3, "x": 16.0, "y": 1342.4}
+{"click": true, "h": 21.2, "hover": {"c": "747474"}, "id": "set-display_mirror_summon", "sc": "settings", "t": "rect", "w": 1238.0, "x": 16.0, "y": 1367.9}
+{"bc": "3a3d42", "bw": 1, "fill": "2a2d33", "h": 20.0, "id": "r.1.2.0.30.0", "radius": 5, "sc": "settings", "t": "rect", "w": 20.0, "x": 16.0, "y": 1368.6}
+{"align": "left", "c": "e8e8e8", "h": 21.2, "id": "r.1.2.0.30.1", "sc": "settings", "size": 17, "t": "text", "text": "Casting Opens the Library Browser", "w": 264.7, "x": 46.0, "y": 1367.9}
+{"click": true, "h": 21.2, "hover": {"c": "747474"}, "id": "set-adv", "sc": "settings", "t": "rect", "w": 1238.0, "x": 16.0, "y": 1397.2}
+{"bc": "3a3d42", "bw": 1, "fill": "2a2d33", "h": 20.0, "id": "r.1.2.0.31.0", "radius": 5, "sc": "settings", "t": "rect", "w": 20.0, "x": 16.0, "y": 1397.8}
+{"align": "left", "c": "e8e8e8", "h": 21.2, "id": "r.1.2.0.31.1", "sc": "settings", "size": 17, "t": "text", "text": "Show advanced settings", "w": 188.9, "x": 46.0, "y": 1397.2}

--- a/tests/snapshots/settings.jsonl
+++ b/tests/snapshots/settings.jsonl
@@ -27,7 +27,7 @@
 {"click": true, "fill": "2e3138", "h": 41.2, "hover": {"fill": "3a3e46"}, "id": "stab-logs", "radius": 6, "t": "rect", "w": 56.7, "x": 676.3, "y": 76.0}
 {"align": "center", "c": "e8e8e8", "h": 21.2, "id": "r.1.0.0.6.0", "size": 17, "t": "text", "text": "Logs", "w": 36.7, "x": 686.3, "y": 86.0}
 {"force": true, "h": 32.3, "id": "set-search-box", "ph": "Search settings\u2026", "size": 17, "t": "textbox", "text": "", "w": 320.0, "x": 16.0, "y": 149.2}
-{"axis": "y", "bar": true, "ch": 931.1, "cw": 1270.0, "h": 522.5, "id": "settings", "t": "scroll", "w": 1280.0, "x": 0.0, "y": 197.6}
+{"axis": "y", "bar": true, "ch": 1136.1, "cw": 1270.0, "h": 522.5, "id": "settings", "t": "scroll", "w": 1280.0, "x": 0.0, "y": 197.6}
 {"align": "left", "bold": true, "c": "e8e8e8", "h": 30.0, "id": "r.1.2.0.0", "sc": "settings", "size": 24, "t": "text", "text": "This Device", "w": 1238.0, "x": 16.0, "y": 213.6}
 {"align": "left", "c": "9aa0a6", "h": 21.2, "id": "r.1.2.0.1.0", "sc": "settings", "size": 17, "t": "text", "text": "Player Name", "w": 340.0, "x": 16.0, "y": 257.1}
 {"h": 32.3, "id": "set-player_name", "ph": "", "sc": "settings", "size": 17, "t": "textbox", "text": "jms-test-host", "w": 340.0, "x": 368.0, "y": 251.6}
@@ -80,15 +80,28 @@
 {"align": "left", "c": "9aa0a6", "h": 17.5, "id": "r.1.2.0.20.l1", "sc": "settings", "size": 14, "t": "text", "text": "way to move or close it. This puts minimize, maximize and close in the top bar instead, and lets you", "w": 665.3, "x": 16.0, "y": 911.9}
 {"align": "left", "c": "9aa0a6", "h": 17.5, "id": "r.1.2.0.20.l2", "sc": "settings", "size": 14, "t": "text", "text": "drag the window by it. On \"Only when the window has no title bar\", MPV is asked whether this window", "w": 665.3, "x": 16.0, "y": 929.4}
 {"align": "left", "c": "9aa0a6", "h": 17.5, "id": "r.1.2.0.20.l3", "sc": "settings", "size": 14, "t": "text", "text": "got one, so desktops that draw a title bar are left alone.", "w": 665.3, "x": 16.0, "y": 946.9}
-{"click": true, "h": 21.2, "hover": {"c": "747474"}, "id": "set-allow_background", "sc": "settings", "t": "rect", "w": 1238.0, "x": 16.0, "y": 972.4}
+{"click": true, "h": 21.2, "hover": {"c": "747474"}, "id": "set-window_controls_fullscreen", "sc": "settings", "t": "rect", "w": 1238.0, "x": 16.0, "y": 972.4}
 {"bc": "3a3d42", "bw": 1, "fill": "2a2d33", "h": 20.0, "id": "r.1.2.0.21.0", "radius": 5, "sc": "settings", "t": "rect", "w": 20.0, "x": 16.0, "y": 973.0}
-{"align": "left", "c": "e8e8e8", "h": 21.2, "id": "r.1.2.0.21.1", "sc": "settings", "size": 17, "t": "text", "text": "Keep Running in Background", "w": 216.2, "x": 46.0, "y": 972.4}
-{"align": "left", "c": "9aa0a6", "h": 17.5, "id": "r.1.2.0.22", "sc": "settings", "size": 14, "t": "text", "text": "With \"Start Minimized\" and \"Fullscreen\" this is the classic cast-target setup: the app waits out of the", "w": 665.3, "x": 16.0, "y": 1001.6}
-{"align": "left", "c": "9aa0a6", "h": 17.5, "id": "r.1.2.0.22.l1", "sc": "settings", "size": 14, "t": "text", "text": "way, plays fullscreen when something casts to it, and goes back to waiting when the video ends or", "w": 665.3, "x": 16.0, "y": 1019.1}
-{"align": "left", "c": "9aa0a6", "h": 17.5, "id": "r.1.2.0.22.l2", "sc": "settings", "size": 14, "t": "text", "text": "you press Q.", "w": 665.3, "x": 16.0, "y": 1036.7}
-{"click": true, "h": 21.2, "hover": {"c": "747474"}, "id": "set-display_mirror_summon", "sc": "settings", "t": "rect", "w": 1238.0, "x": 16.0, "y": 1062.2}
-{"bc": "3a3d42", "bw": 1, "fill": "2a2d33", "h": 20.0, "id": "r.1.2.0.23.0", "radius": 5, "sc": "settings", "t": "rect", "w": 20.0, "x": 16.0, "y": 1062.8}
-{"align": "left", "c": "e8e8e8", "h": 21.2, "id": "r.1.2.0.23.1", "sc": "settings", "size": 17, "t": "text", "text": "Casting Opens the Library Browser", "w": 264.7, "x": 46.0, "y": 1062.2}
-{"click": true, "h": 21.2, "hover": {"c": "747474"}, "id": "set-adv", "sc": "settings", "t": "rect", "w": 1238.0, "x": 16.0, "y": 1091.4}
-{"bc": "3a3d42", "bw": 1, "fill": "2a2d33", "h": 20.0, "id": "r.1.2.0.24.0", "radius": 5, "sc": "settings", "t": "rect", "w": 20.0, "x": 16.0, "y": 1092.0}
-{"align": "left", "c": "e8e8e8", "h": 21.2, "id": "r.1.2.0.24.1", "sc": "settings", "size": 17, "t": "text", "text": "Show advanced settings", "w": 188.9, "x": 46.0, "y": 1091.4}
+{"align": "left", "c": "e8e8e8", "h": 21.2, "id": "r.1.2.0.21.1", "sc": "settings", "size": 17, "t": "text", "text": "Keep Window Buttons in Full Screen", "w": 278.5, "x": 46.0, "y": 972.4}
+{"align": "left", "c": "9aa0a6", "h": 17.5, "id": "r.1.2.0.22", "sc": "settings", "size": 14, "t": "text", "text": "Full screen has no title bar anywhere and nothing to move or maximize, so the buttons are normally", "w": 665.3, "x": 16.0, "y": 1001.6}
+{"align": "left", "c": "9aa0a6", "h": 17.5, "id": "r.1.2.0.22.l1", "sc": "settings", "size": 14, "t": "text", "text": "hidden there. Turn this on to keep a way out of full screen that is not a keyboard shortcut.", "w": 665.3, "x": 16.0, "y": 1019.1}
+{"click": true, "h": 21.2, "hover": {"c": "747474"}, "id": "set-hide_title_bar", "sc": "settings", "t": "rect", "w": 1238.0, "x": 16.0, "y": 1044.7}
+{"bc": "3a3d42", "bw": 1, "fill": "2a2d33", "h": 20.0, "id": "r.1.2.0.23.0", "radius": 5, "sc": "settings", "t": "rect", "w": 20.0, "x": 16.0, "y": 1045.3}
+{"align": "left", "c": "e8e8e8", "h": 21.2, "id": "r.1.2.0.23.1", "sc": "settings", "size": 17, "t": "text", "text": "Hide the Desktop Title Bar", "w": 198.6, "x": 46.0, "y": 1044.7}
+{"align": "left", "c": "e5c07b", "h": 17.5, "id": "r.1.2.0.24", "sc": "settings", "size": 14, "t": "text", "text": "Requires restart", "w": 1238.0, "x": 16.0, "y": 1073.9}
+{"align": "left", "c": "9aa0a6", "h": 17.5, "id": "r.1.2.0.25", "sc": "settings", "size": 14, "t": "text", "text": "Asks the desktop for no title bar on the player window, so the top bar above is the only one. Pairs with", "w": 665.3, "x": 16.0, "y": 1099.4}
+{"align": "left", "c": "9aa0a6", "h": 17.5, "id": "r.1.2.0.25.l1", "sc": "settings", "size": 14, "t": "text", "text": "the setting above: on \"Only when the window has no title bar\" the buttons appear as soon as this is on.", "w": 665.3, "x": 16.0, "y": 1116.9}
+{"align": "left", "c": "9aa0a6", "h": 17.5, "id": "r.1.2.0.25.l2", "sc": "settings", "size": 14, "t": "text", "text": "Leave both off unless you want them, since a window with neither can be awkward to move on some", "w": 665.3, "x": 16.0, "y": 1134.4}
+{"align": "left", "c": "9aa0a6", "h": 17.5, "id": "r.1.2.0.25.l3", "sc": "settings", "size": 14, "t": "text", "text": "desktops.", "w": 665.3, "x": 16.0, "y": 1151.9}
+{"click": true, "h": 21.2, "hover": {"c": "747474"}, "id": "set-allow_background", "sc": "settings", "t": "rect", "w": 1238.0, "x": 16.0, "y": 1177.4}
+{"bc": "3a3d42", "bw": 1, "fill": "2a2d33", "h": 20.0, "id": "r.1.2.0.26.0", "radius": 5, "sc": "settings", "t": "rect", "w": 20.0, "x": 16.0, "y": 1178.0}
+{"align": "left", "c": "e8e8e8", "h": 21.2, "id": "r.1.2.0.26.1", "sc": "settings", "size": 17, "t": "text", "text": "Keep Running in Background", "w": 216.2, "x": 46.0, "y": 1177.4}
+{"align": "left", "c": "9aa0a6", "h": 17.5, "id": "r.1.2.0.27", "sc": "settings", "size": 14, "t": "text", "text": "With \"Start Minimized\" and \"Fullscreen\" this is the classic cast-target setup: the app waits out of the", "w": 665.3, "x": 16.0, "y": 1206.7}
+{"align": "left", "c": "9aa0a6", "h": 17.5, "id": "r.1.2.0.27.l1", "sc": "settings", "size": 14, "t": "text", "text": "way, plays fullscreen when something casts to it, and goes back to waiting when the video ends or", "w": 665.3, "x": 16.0, "y": 1224.2}
+{"align": "left", "c": "9aa0a6", "h": 17.5, "id": "r.1.2.0.27.l2", "sc": "settings", "size": 14, "t": "text", "text": "you press Q.", "w": 665.3, "x": 16.0, "y": 1241.7}
+{"click": true, "h": 21.2, "hover": {"c": "747474"}, "id": "set-display_mirror_summon", "sc": "settings", "t": "rect", "w": 1238.0, "x": 16.0, "y": 1267.2}
+{"bc": "3a3d42", "bw": 1, "fill": "2a2d33", "h": 20.0, "id": "r.1.2.0.28.0", "radius": 5, "sc": "settings", "t": "rect", "w": 20.0, "x": 16.0, "y": 1267.8}
+{"align": "left", "c": "e8e8e8", "h": 21.2, "id": "r.1.2.0.28.1", "sc": "settings", "size": 17, "t": "text", "text": "Casting Opens the Library Browser", "w": 264.7, "x": 46.0, "y": 1267.2}
+{"click": true, "h": 21.2, "hover": {"c": "747474"}, "id": "set-adv", "sc": "settings", "t": "rect", "w": 1238.0, "x": 16.0, "y": 1296.4}
+{"bc": "3a3d42", "bw": 1, "fill": "2a2d33", "h": 20.0, "id": "r.1.2.0.29.0", "radius": 5, "sc": "settings", "t": "rect", "w": 20.0, "x": 16.0, "y": 1297.0}
+{"align": "left", "c": "e8e8e8", "h": 21.2, "id": "r.1.2.0.29.1", "sc": "settings", "size": 17, "t": "text", "text": "Show advanced settings", "w": 188.9, "x": 46.0, "y": 1296.4}

--- a/tests/snapshots/settings.jsonl
+++ b/tests/snapshots/settings.jsonl
@@ -27,7 +27,7 @@
 {"click": true, "fill": "2e3138", "h": 41.2, "hover": {"fill": "3a3e46"}, "id": "stab-logs", "radius": 6, "t": "rect", "w": 56.7, "x": 676.3, "y": 76.0}
 {"align": "center", "c": "e8e8e8", "h": 21.2, "id": "r.1.0.0.6.0", "size": 17, "t": "text", "text": "Logs", "w": 36.7, "x": 686.3, "y": 86.0}
 {"force": true, "h": 32.3, "id": "set-search-box", "ph": "Search settings\u2026", "size": 17, "t": "textbox", "text": "", "w": 320.0, "x": 16.0, "y": 149.2}
-{"axis": "y", "bar": true, "ch": 1136.1, "cw": 1270.0, "h": 522.5, "id": "settings", "t": "scroll", "w": 1280.0, "x": 0.0, "y": 197.6}
+{"axis": "y", "bar": true, "ch": 1225.8, "cw": 1270.0, "h": 522.5, "id": "settings", "t": "scroll", "w": 1280.0, "x": 0.0, "y": 197.6}
 {"align": "left", "bold": true, "c": "e8e8e8", "h": 30.0, "id": "r.1.2.0.0", "sc": "settings", "size": 24, "t": "text", "text": "This Device", "w": 1238.0, "x": 16.0, "y": 213.6}
 {"align": "left", "c": "9aa0a6", "h": 21.2, "id": "r.1.2.0.1.0", "sc": "settings", "size": 17, "t": "text", "text": "Player Name", "w": 340.0, "x": 16.0, "y": 257.1}
 {"h": 32.3, "id": "set-player_name", "ph": "", "sc": "settings", "size": 17, "t": "textbox", "text": "jms-test-host", "w": 340.0, "x": 368.0, "y": 251.6}
@@ -63,45 +63,52 @@
 {"align": "left", "c": "e8e8e8", "h": 21.2, "id": "r.1.2.0.13.1", "sc": "settings", "size": 17, "t": "text", "text": "Swap Confirm and Back Buttons", "w": 243.4, "x": 46.0, "y": 656.1}
 {"align": "left", "c": "9aa0a6", "h": 17.5, "id": "r.1.2.0.14", "sc": "settings", "size": 14, "t": "text", "text": "Turn this on for a controller whose A button is on the right rather than at the bottom (Switch Pro, most", "w": 665.3, "x": 16.0, "y": 685.4}
 {"align": "left", "c": "9aa0a6", "h": 17.5, "id": "r.1.2.0.14.l1", "sc": "settings", "size": 14, "t": "text", "text": "8BitDo pads).", "w": 665.3, "x": 16.0, "y": 702.9}
-{"align": "left", "bold": true, "c": "e8e8e8", "h": 30.0, "id": "r.1.2.0.15", "sc": "settings", "size": 24, "t": "text", "text": "Window", "w": 1238.0, "x": 16.0, "y": 728.4}
-{"click": true, "h": 21.2, "hover": {"c": "747474"}, "id": "set-fullscreen", "sc": "settings", "t": "rect", "w": 1238.0, "x": 16.0, "y": 766.4}
-{"bc": "3a3d42", "bw": 1, "fill": "2a2d33", "h": 20.0, "id": "r.1.2.0.16.0", "radius": 5, "sc": "settings", "t": "rect", "w": 20.0, "x": 16.0, "y": 767.0}
-{"align": "left", "c": "e8e8e8", "h": 21.2, "id": "r.1.2.0.16.1", "sc": "settings", "size": 17, "t": "text", "text": "Fullscreen", "w": 81.6, "x": 46.0, "y": 766.4}
-{"click": true, "h": 21.2, "hover": {"c": "747474"}, "id": "set-browser_fullscreen", "sc": "settings", "t": "rect", "w": 1238.0, "x": 16.0, "y": 795.6}
-{"bc": "3a3d42", "bw": 1, "fill": "2a2d33", "h": 20.0, "id": "r.1.2.0.17.0", "radius": 5, "sc": "settings", "t": "rect", "w": 20.0, "x": 16.0, "y": 796.2}
-{"align": "left", "c": "e8e8e8", "h": 21.2, "id": "r.1.2.0.17.1", "sc": "settings", "size": 17, "t": "text", "text": "Fullscreen Library Browser", "w": 208.6, "x": 46.0, "y": 795.6}
-{"click": true, "h": 21.2, "hover": {"c": "747474"}, "id": "set-remember_window_size", "sc": "settings", "t": "rect", "w": 1238.0, "x": 16.0, "y": 824.9}
-{"fill": "00a4dc", "h": 20.0, "id": "r.1.2.0.18.0", "radius": 5, "sc": "settings", "t": "rect", "w": 20.0, "x": 16.0, "y": 825.5}
-{"align": "center", "c": "ffffff", "h": 18.8, "id": "r.1.2.0.18.0.0", "sc": "settings", "size": 15, "t": "text", "text": "\u2713", "w": 20.0, "x": 16.0, "y": 826.1}
-{"align": "left", "c": "e8e8e8", "h": 21.2, "id": "r.1.2.0.18.1", "sc": "settings", "size": 17, "t": "text", "text": "Remember Window Size", "w": 186.3, "x": 46.0, "y": 824.9}
-{"align": "left", "c": "9aa0a6", "h": 21.2, "id": "r.1.2.0.19.0", "sc": "settings", "size": 17, "t": "text", "text": "Window Buttons in the Top Bar", "w": 340.0, "x": 16.0, "y": 859.6}
-{"force": true, "h": 32.3, "id": "set-window_controls", "items": ["Only when the window has no title bar", "Always", "Never"], "sc": "settings", "sel": 0, "size": 17, "t": "dropdown", "w": 340.0, "x": 368.0, "y": 854.1}
-{"align": "left", "c": "9aa0a6", "h": 17.5, "id": "r.1.2.0.20", "sc": "settings", "size": 14, "t": "text", "text": "Some desktops, GNOME on Wayland in particular, draw no title bar on the player window, leaving no", "w": 665.3, "x": 16.0, "y": 894.4}
-{"align": "left", "c": "9aa0a6", "h": 17.5, "id": "r.1.2.0.20.l1", "sc": "settings", "size": 14, "t": "text", "text": "way to move or close it. This puts minimize, maximize and close in the top bar instead, and lets you", "w": 665.3, "x": 16.0, "y": 911.9}
-{"align": "left", "c": "9aa0a6", "h": 17.5, "id": "r.1.2.0.20.l2", "sc": "settings", "size": 14, "t": "text", "text": "drag the window by it. On \"Only when the window has no title bar\", MPV is asked whether this window", "w": 665.3, "x": 16.0, "y": 929.4}
-{"align": "left", "c": "9aa0a6", "h": 17.5, "id": "r.1.2.0.20.l3", "sc": "settings", "size": 14, "t": "text", "text": "got one, so desktops that draw a title bar are left alone.", "w": 665.3, "x": 16.0, "y": 946.9}
-{"click": true, "h": 21.2, "hover": {"c": "747474"}, "id": "set-window_controls_fullscreen", "sc": "settings", "t": "rect", "w": 1238.0, "x": 16.0, "y": 972.4}
-{"bc": "3a3d42", "bw": 1, "fill": "2a2d33", "h": 20.0, "id": "r.1.2.0.21.0", "radius": 5, "sc": "settings", "t": "rect", "w": 20.0, "x": 16.0, "y": 973.0}
-{"align": "left", "c": "e8e8e8", "h": 21.2, "id": "r.1.2.0.21.1", "sc": "settings", "size": 17, "t": "text", "text": "Keep Window Buttons in Full Screen", "w": 278.5, "x": 46.0, "y": 972.4}
-{"align": "left", "c": "9aa0a6", "h": 17.5, "id": "r.1.2.0.22", "sc": "settings", "size": 14, "t": "text", "text": "Full screen has no title bar anywhere and nothing to move or maximize, so the buttons are normally", "w": 665.3, "x": 16.0, "y": 1001.6}
-{"align": "left", "c": "9aa0a6", "h": 17.5, "id": "r.1.2.0.22.l1", "sc": "settings", "size": 14, "t": "text", "text": "hidden there. Turn this on to keep a way out of full screen that is not a keyboard shortcut.", "w": 665.3, "x": 16.0, "y": 1019.1}
-{"click": true, "h": 21.2, "hover": {"c": "747474"}, "id": "set-hide_title_bar", "sc": "settings", "t": "rect", "w": 1238.0, "x": 16.0, "y": 1044.7}
-{"bc": "3a3d42", "bw": 1, "fill": "2a2d33", "h": 20.0, "id": "r.1.2.0.23.0", "radius": 5, "sc": "settings", "t": "rect", "w": 20.0, "x": 16.0, "y": 1045.3}
-{"align": "left", "c": "e8e8e8", "h": 21.2, "id": "r.1.2.0.23.1", "sc": "settings", "size": 17, "t": "text", "text": "Hide the Desktop Title Bar", "w": 198.6, "x": 46.0, "y": 1044.7}
-{"align": "left", "c": "e5c07b", "h": 17.5, "id": "r.1.2.0.24", "sc": "settings", "size": 14, "t": "text", "text": "Requires restart", "w": 1238.0, "x": 16.0, "y": 1073.9}
-{"align": "left", "c": "9aa0a6", "h": 17.5, "id": "r.1.2.0.25", "sc": "settings", "size": 14, "t": "text", "text": "Asks the desktop for no title bar on the player window, so the top bar above is the only one. Pairs with", "w": 665.3, "x": 16.0, "y": 1099.4}
-{"align": "left", "c": "9aa0a6", "h": 17.5, "id": "r.1.2.0.25.l1", "sc": "settings", "size": 14, "t": "text", "text": "the setting above: on \"Only when the window has no title bar\" the buttons appear as soon as this is on.", "w": 665.3, "x": 16.0, "y": 1116.9}
-{"align": "left", "c": "9aa0a6", "h": 17.5, "id": "r.1.2.0.25.l2", "sc": "settings", "size": 14, "t": "text", "text": "Leave both off unless you want them, since a window with neither can be awkward to move on some", "w": 665.3, "x": 16.0, "y": 1134.4}
-{"align": "left", "c": "9aa0a6", "h": 17.5, "id": "r.1.2.0.25.l3", "sc": "settings", "size": 14, "t": "text", "text": "desktops.", "w": 665.3, "x": 16.0, "y": 1151.9}
-{"click": true, "h": 21.2, "hover": {"c": "747474"}, "id": "set-allow_background", "sc": "settings", "t": "rect", "w": 1238.0, "x": 16.0, "y": 1177.4}
-{"bc": "3a3d42", "bw": 1, "fill": "2a2d33", "h": 20.0, "id": "r.1.2.0.26.0", "radius": 5, "sc": "settings", "t": "rect", "w": 20.0, "x": 16.0, "y": 1178.0}
-{"align": "left", "c": "e8e8e8", "h": 21.2, "id": "r.1.2.0.26.1", "sc": "settings", "size": 17, "t": "text", "text": "Keep Running in Background", "w": 216.2, "x": 46.0, "y": 1177.4}
-{"align": "left", "c": "9aa0a6", "h": 17.5, "id": "r.1.2.0.27", "sc": "settings", "size": 14, "t": "text", "text": "With \"Start Minimized\" and \"Fullscreen\" this is the classic cast-target setup: the app waits out of the", "w": 665.3, "x": 16.0, "y": 1206.7}
-{"align": "left", "c": "9aa0a6", "h": 17.5, "id": "r.1.2.0.27.l1", "sc": "settings", "size": 14, "t": "text", "text": "way, plays fullscreen when something casts to it, and goes back to waiting when the video ends or", "w": 665.3, "x": 16.0, "y": 1224.2}
-{"align": "left", "c": "9aa0a6", "h": 17.5, "id": "r.1.2.0.27.l2", "sc": "settings", "size": 14, "t": "text", "text": "you press Q.", "w": 665.3, "x": 16.0, "y": 1241.7}
-{"click": true, "h": 21.2, "hover": {"c": "747474"}, "id": "set-display_mirror_summon", "sc": "settings", "t": "rect", "w": 1238.0, "x": 16.0, "y": 1267.2}
+{"click": true, "h": 21.2, "hover": {"c": "747474"}, "id": "set-browse_block_keys", "sc": "settings", "t": "rect", "w": 1238.0, "x": 16.0, "y": 728.4}
+{"fill": "00a4dc", "h": 20.0, "id": "r.1.2.0.15.0", "radius": 5, "sc": "settings", "t": "rect", "w": 20.0, "x": 16.0, "y": 729.0}
+{"align": "center", "c": "ffffff", "h": 18.8, "id": "r.1.2.0.15.0.0", "sc": "settings", "size": 15, "t": "text", "text": "\u2713", "w": 20.0, "x": 16.0, "y": 729.6}
+{"align": "left", "c": "e8e8e8", "h": 21.2, "id": "r.1.2.0.15.1", "sc": "settings", "size": 17, "t": "text", "text": "Block Player Keybinds While Browsing", "w": 297.5, "x": 46.0, "y": 728.4}
+{"align": "left", "c": "9aa0a6", "h": 17.5, "id": "r.1.2.0.16", "sc": "settings", "size": 14, "t": "text", "text": "Stops MPV's own shortcuts -- picture adjustment, screenshots, subtitle and audio switching -- from", "w": 665.3, "x": 16.0, "y": 757.6}
+{"align": "left", "c": "9aa0a6", "h": 17.5, "id": "r.1.2.0.16.l1", "sc": "settings", "size": 14, "t": "text", "text": "acting while you are in the library, where there is no video for them to act on. Turn it off to use your", "w": 665.3, "x": 16.0, "y": 775.1}
+{"align": "left", "c": "9aa0a6", "h": 17.5, "id": "r.1.2.0.16.l2", "sc": "settings", "size": 14, "t": "text", "text": "own MPV key bindings there.", "w": 665.3, "x": 16.0, "y": 792.6}
+{"align": "left", "bold": true, "c": "e8e8e8", "h": 30.0, "id": "r.1.2.0.17", "sc": "settings", "size": 24, "t": "text", "text": "Window", "w": 1238.0, "x": 16.0, "y": 818.1}
+{"click": true, "h": 21.2, "hover": {"c": "747474"}, "id": "set-fullscreen", "sc": "settings", "t": "rect", "w": 1238.0, "x": 16.0, "y": 856.1}
+{"bc": "3a3d42", "bw": 1, "fill": "2a2d33", "h": 20.0, "id": "r.1.2.0.18.0", "radius": 5, "sc": "settings", "t": "rect", "w": 20.0, "x": 16.0, "y": 856.7}
+{"align": "left", "c": "e8e8e8", "h": 21.2, "id": "r.1.2.0.18.1", "sc": "settings", "size": 17, "t": "text", "text": "Fullscreen", "w": 81.6, "x": 46.0, "y": 856.1}
+{"click": true, "h": 21.2, "hover": {"c": "747474"}, "id": "set-browser_fullscreen", "sc": "settings", "t": "rect", "w": 1238.0, "x": 16.0, "y": 885.4}
+{"bc": "3a3d42", "bw": 1, "fill": "2a2d33", "h": 20.0, "id": "r.1.2.0.19.0", "radius": 5, "sc": "settings", "t": "rect", "w": 20.0, "x": 16.0, "y": 886.0}
+{"align": "left", "c": "e8e8e8", "h": 21.2, "id": "r.1.2.0.19.1", "sc": "settings", "size": 17, "t": "text", "text": "Fullscreen Library Browser", "w": 208.6, "x": 46.0, "y": 885.4}
+{"click": true, "h": 21.2, "hover": {"c": "747474"}, "id": "set-remember_window_size", "sc": "settings", "t": "rect", "w": 1238.0, "x": 16.0, "y": 914.6}
+{"fill": "00a4dc", "h": 20.0, "id": "r.1.2.0.20.0", "radius": 5, "sc": "settings", "t": "rect", "w": 20.0, "x": 16.0, "y": 915.2}
+{"align": "center", "c": "ffffff", "h": 18.8, "id": "r.1.2.0.20.0.0", "sc": "settings", "size": 15, "t": "text", "text": "\u2713", "w": 20.0, "x": 16.0, "y": 915.9}
+{"align": "left", "c": "e8e8e8", "h": 21.2, "id": "r.1.2.0.20.1", "sc": "settings", "size": 17, "t": "text", "text": "Remember Window Size", "w": 186.3, "x": 46.0, "y": 914.6}
+{"align": "left", "c": "9aa0a6", "h": 21.2, "id": "r.1.2.0.21.0", "sc": "settings", "size": 17, "t": "text", "text": "Window Buttons in the Top Bar", "w": 340.0, "x": 16.0, "y": 949.4}
+{"force": true, "h": 32.3, "id": "set-window_controls", "items": ["Only when the window has no title bar", "Always", "Never"], "sc": "settings", "sel": 0, "size": 17, "t": "dropdown", "w": 340.0, "x": 368.0, "y": 943.9}
+{"align": "left", "c": "9aa0a6", "h": 17.5, "id": "r.1.2.0.22", "sc": "settings", "size": 14, "t": "text", "text": "Some desktops, GNOME on Wayland in particular, draw no title bar on the player window, leaving no", "w": 665.3, "x": 16.0, "y": 984.1}
+{"align": "left", "c": "9aa0a6", "h": 17.5, "id": "r.1.2.0.22.l1", "sc": "settings", "size": 14, "t": "text", "text": "way to move or close it. This puts minimize, maximize and close in the top bar instead, and lets you", "w": 665.3, "x": 16.0, "y": 1001.6}
+{"align": "left", "c": "9aa0a6", "h": 17.5, "id": "r.1.2.0.22.l2", "sc": "settings", "size": 14, "t": "text", "text": "drag the window by it. On \"Only when the window has no title bar\", MPV is asked whether this window", "w": 665.3, "x": 16.0, "y": 1019.1}
+{"align": "left", "c": "9aa0a6", "h": 17.5, "id": "r.1.2.0.22.l3", "sc": "settings", "size": 14, "t": "text", "text": "got one, so desktops that draw a title bar are left alone.", "w": 665.3, "x": 16.0, "y": 1036.7}
+{"click": true, "h": 21.2, "hover": {"c": "747474"}, "id": "set-window_controls_fullscreen", "sc": "settings", "t": "rect", "w": 1238.0, "x": 16.0, "y": 1062.2}
+{"bc": "3a3d42", "bw": 1, "fill": "2a2d33", "h": 20.0, "id": "r.1.2.0.23.0", "radius": 5, "sc": "settings", "t": "rect", "w": 20.0, "x": 16.0, "y": 1062.8}
+{"align": "left", "c": "e8e8e8", "h": 21.2, "id": "r.1.2.0.23.1", "sc": "settings", "size": 17, "t": "text", "text": "Keep Window Buttons in Full Screen", "w": 278.5, "x": 46.0, "y": 1062.2}
+{"align": "left", "c": "9aa0a6", "h": 17.5, "id": "r.1.2.0.24", "sc": "settings", "size": 14, "t": "text", "text": "Full screen has no title bar anywhere and nothing to move or maximize, so the buttons are normally", "w": 665.3, "x": 16.0, "y": 1091.4}
+{"align": "left", "c": "9aa0a6", "h": 17.5, "id": "r.1.2.0.24.l1", "sc": "settings", "size": 14, "t": "text", "text": "hidden there. Turn this on to keep a way out of full screen that is not a keyboard shortcut.", "w": 665.3, "x": 16.0, "y": 1108.9}
+{"click": true, "h": 21.2, "hover": {"c": "747474"}, "id": "set-hide_title_bar", "sc": "settings", "t": "rect", "w": 1238.0, "x": 16.0, "y": 1134.4}
+{"bc": "3a3d42", "bw": 1, "fill": "2a2d33", "h": 20.0, "id": "r.1.2.0.25.0", "radius": 5, "sc": "settings", "t": "rect", "w": 20.0, "x": 16.0, "y": 1135.0}
+{"align": "left", "c": "e8e8e8", "h": 21.2, "id": "r.1.2.0.25.1", "sc": "settings", "size": 17, "t": "text", "text": "Hide the Desktop Title Bar", "w": 198.6, "x": 46.0, "y": 1134.4}
+{"align": "left", "c": "e5c07b", "h": 17.5, "id": "r.1.2.0.26", "sc": "settings", "size": 14, "t": "text", "text": "Requires restart", "w": 1238.0, "x": 16.0, "y": 1163.7}
+{"align": "left", "c": "9aa0a6", "h": 17.5, "id": "r.1.2.0.27", "sc": "settings", "size": 14, "t": "text", "text": "Asks the desktop for no title bar on the player window, so the top bar above is the only one. Pairs with", "w": 665.3, "x": 16.0, "y": 1189.2}
+{"align": "left", "c": "9aa0a6", "h": 17.5, "id": "r.1.2.0.27.l1", "sc": "settings", "size": 14, "t": "text", "text": "the setting above: on \"Only when the window has no title bar\" the buttons appear as soon as this is on.", "w": 665.3, "x": 16.0, "y": 1206.7}
+{"align": "left", "c": "9aa0a6", "h": 17.5, "id": "r.1.2.0.27.l2", "sc": "settings", "size": 14, "t": "text", "text": "Leave both off unless you want them, since a window with neither can be awkward to move on some", "w": 665.3, "x": 16.0, "y": 1224.2}
+{"align": "left", "c": "9aa0a6", "h": 17.5, "id": "r.1.2.0.27.l3", "sc": "settings", "size": 14, "t": "text", "text": "desktops.", "w": 665.3, "x": 16.0, "y": 1241.7}
+{"click": true, "h": 21.2, "hover": {"c": "747474"}, "id": "set-allow_background", "sc": "settings", "t": "rect", "w": 1238.0, "x": 16.0, "y": 1267.2}
 {"bc": "3a3d42", "bw": 1, "fill": "2a2d33", "h": 20.0, "id": "r.1.2.0.28.0", "radius": 5, "sc": "settings", "t": "rect", "w": 20.0, "x": 16.0, "y": 1267.8}
-{"align": "left", "c": "e8e8e8", "h": 21.2, "id": "r.1.2.0.28.1", "sc": "settings", "size": 17, "t": "text", "text": "Casting Opens the Library Browser", "w": 264.7, "x": 46.0, "y": 1267.2}
-{"click": true, "h": 21.2, "hover": {"c": "747474"}, "id": "set-adv", "sc": "settings", "t": "rect", "w": 1238.0, "x": 16.0, "y": 1296.4}
-{"bc": "3a3d42", "bw": 1, "fill": "2a2d33", "h": 20.0, "id": "r.1.2.0.29.0", "radius": 5, "sc": "settings", "t": "rect", "w": 20.0, "x": 16.0, "y": 1297.0}
-{"align": "left", "c": "e8e8e8", "h": 21.2, "id": "r.1.2.0.29.1", "sc": "settings", "size": 17, "t": "text", "text": "Show advanced settings", "w": 188.9, "x": 46.0, "y": 1296.4}
+{"align": "left", "c": "e8e8e8", "h": 21.2, "id": "r.1.2.0.28.1", "sc": "settings", "size": 17, "t": "text", "text": "Keep Running in Background", "w": 216.2, "x": 46.0, "y": 1267.2}
+{"align": "left", "c": "9aa0a6", "h": 17.5, "id": "r.1.2.0.29", "sc": "settings", "size": 14, "t": "text", "text": "With \"Start Minimized\" and \"Fullscreen\" this is the classic cast-target setup: the app waits out of the", "w": 665.3, "x": 16.0, "y": 1296.4}
+{"align": "left", "c": "9aa0a6", "h": 17.5, "id": "r.1.2.0.29.l1", "sc": "settings", "size": 14, "t": "text", "text": "way, plays fullscreen when something casts to it, and goes back to waiting when the video ends or", "w": 665.3, "x": 16.0, "y": 1313.9}
+{"align": "left", "c": "9aa0a6", "h": 17.5, "id": "r.1.2.0.29.l2", "sc": "settings", "size": 14, "t": "text", "text": "you press Q.", "w": 665.3, "x": 16.0, "y": 1331.4}
+{"click": true, "h": 21.2, "hover": {"c": "747474"}, "id": "set-display_mirror_summon", "sc": "settings", "t": "rect", "w": 1238.0, "x": 16.0, "y": 1356.9}
+{"bc": "3a3d42", "bw": 1, "fill": "2a2d33", "h": 20.0, "id": "r.1.2.0.30.0", "radius": 5, "sc": "settings", "t": "rect", "w": 20.0, "x": 16.0, "y": 1357.5}
+{"align": "left", "c": "e8e8e8", "h": 21.2, "id": "r.1.2.0.30.1", "sc": "settings", "size": 17, "t": "text", "text": "Casting Opens the Library Browser", "w": 264.7, "x": 46.0, "y": 1356.9}
+{"click": true, "h": 21.2, "hover": {"c": "747474"}, "id": "set-adv", "sc": "settings", "t": "rect", "w": 1238.0, "x": 16.0, "y": 1386.2}
+{"bc": "3a3d42", "bw": 1, "fill": "2a2d33", "h": 20.0, "id": "r.1.2.0.31.0", "radius": 5, "sc": "settings", "t": "rect", "w": 20.0, "x": 16.0, "y": 1386.8}
+{"align": "left", "c": "e8e8e8", "h": 21.2, "id": "r.1.2.0.31.1", "sc": "settings", "size": 17, "t": "text", "text": "Show advanced settings", "w": 188.9, "x": 46.0, "y": 1386.2}

--- a/tests/test_browse_key_block.py
+++ b/tests/test_browse_key_block.py
@@ -1,0 +1,239 @@
+"""Blocking mpv's own keyboard shortcuts while the library is on screen.
+
+#730. mpv is constructed with ``input_default_bindings=True`` for the life
+of the process (``player.py`` ``_init_mpv``), so in the library every key
+the shim has not taken is still mpv's. Measured against a real mpv with the
+browser up, before any of this existed: `1` moved contrast 0.0 -> -1.0, `9`
+moved the volume and `m` muted, with mpv's own OSD as the only feedback --
+and that OSD is ASS, so it draws *underneath* the overlay bitmaps the
+library is made of, which is what the report is a screenshot of.
+
+Two halves, and they are tested in different places:
+
+* **The block itself is one forced ``any_unicode`` binding**, which outranks
+  every exact-key default across the printable range. That is a claim about
+  mpv, so it is measured against a real one in
+  ``tests/integration/test_mpvtk_browser.py``. What is here is the Python
+  side: whether the flag is pushed, and when.
+* **The volume keys the browser claims back** while music is playing, so
+  `9`/`0`/`m` keep working -- through the shell rather than through mpv, so
+  the now-playing bar's slider moves with them.
+"""
+
+# Run as a script, this is what puts the repo root on sys.path -- without
+# it `jellyfin_mpv_shim` resolves to whatever is pip-installed. A no-op
+# under `discover`; tests/test_module_paths.py is the guard.
+if __name__ == "__main__":
+    import os
+    import sys
+
+    sys.path.insert(0, os.path.dirname(
+        os.path.dirname(os.path.abspath(__file__))))
+
+import sys
+import unittest
+from unittest import mock
+
+sys.argv = [sys.argv[0]]
+
+from jellyfin_mpv_shim.conf import settings  # noqa: E402
+from jellyfin_mpv_shim.mpvtk_browser.app import MpvtkBrowser  # noqa: E402
+from tests._shell_harness import (  # noqa: E402
+    FakeConfig,
+    FakeController,
+    FakeSource,
+    _SyncPool,
+)
+
+
+class _Base(unittest.TestCase):
+    def _block(self, enabled):
+        saved = settings.browse_block_keys
+        self.addCleanup(
+            lambda: setattr(settings, "browse_block_keys", saved))
+        settings.browse_block_keys = enabled
+
+    def _browser(self, playing_audio=False):
+        self.ctl = FakeController()
+        b = MpvtkBrowser(app=mock.Mock(), source=FakeSource(),
+                         controller=self.ctl, config=FakeConfig())
+        b._pool = _SyncPool()
+        b._now_playing = {"id": "t1", "volume": 100} if playing_audio else None
+        return b
+
+
+class ShellVolumeClaimTest(_Base):
+    """Which keys the shell takes on top of the page's own."""
+
+    def test_music_playing_claims_volume_and_mute(self):
+        self._block(True)
+        b = self._browser(playing_audio=True)
+        self.assertEqual(set(b._shell_claimed_keys()), {"9", "0", "m"})
+
+    def test_nothing_playing_claims_nothing(self):
+        """The keys exist to serve the now-playing bar. With no bar there is
+        nothing for them to move, and mpv's own volume is what the block is
+        taking away in the first place."""
+        self._block(True)
+        b = self._browser(playing_audio=False)
+        self.assertEqual(b._shell_claimed_keys(), ())
+
+    def test_the_opt_out_gives_these_back_too(self):
+        """Somebody who turned the block off asked for their own keyboard.
+        Taking three keys out of it anyway would be the same interception
+        with a smaller footprint."""
+        self._block(False)
+        b = self._browser(playing_audio=True)
+        self.assertEqual(b._shell_claimed_keys(), ())
+
+    def test_the_claim_reaches_the_renderer_beside_the_page_s_own(self):
+        """Union, not replacement: a page that claims keys still gets them
+        while music plays."""
+        self._block(True)
+        b = self._browser(playing_audio=True)
+        b._browsing = True
+        page = mock.Mock()
+        page.claimed_keys = ("LEFT", "RIGHT")
+        with mock.patch.object(b, "_page_for", return_value=page):
+            b._claim_page_keys(b.route)
+        pushed = set(b.app.claim_keys.call_args[0][0])
+        self.assertEqual(pushed, {"LEFT", "RIGHT", "9", "0", "m"})
+
+
+class ShellVolumeKeyTest(_Base):
+    """What the claimed keys do when they arrive."""
+
+    def _press(self, b, key):
+        b._on_claimed_key(key)
+        return [c for c in self.ctl.transport
+                if c[0] in ("adjust_volume", "toggle_mute")]
+
+    def test_the_keys_step_the_volume_mpv_s_own_way(self):
+        """Same direction and same step as mpv's `9`/`0`, so the muscle
+        memory the block took away still works."""
+        self._block(True)
+        b = self._browser(playing_audio=True)
+        self.assertEqual(self._press(b, "9"), [("adjust_volume", (-2.0,))])
+        self.assertEqual(self.ctl.volume_level, 98.0)
+        b._on_claimed_key("0")
+        self.assertEqual(self.ctl.volume_level, 100.0)
+
+    def test_m_mutes(self):
+        self._block(True)
+        b = self._browser(playing_audio=True)
+        self.assertEqual(self._press(b, "m"), [("toggle_mute", ())])
+        self.assertTrue(self.ctl.muted)
+
+    def test_repeated_presses_keep_moving(self):
+        """The step is computed on the PLAYER thread, not from the pushed
+        now-playing snapshot -- which arrives by playstate push, so under
+        key repeat every press would otherwise compute from the same stale
+        base and the volume would stick one notch down."""
+        self._block(True)
+        b = self._browser(playing_audio=True)
+        for _ in range(4):
+            b._on_claimed_key("9")
+        self.assertEqual(self.ctl.volume_level, 92.0)
+
+    def test_music_stopping_stops_the_keys(self):
+        """The standing footgun of this shell: a claim is installed from a
+        frame, the press arrives later, and the state read at BUILD time is
+        whatever it was then. Read in the handler -- so a key still bound
+        from the last frame does nothing once the bar is gone."""
+        self._block(True)
+        b = self._browser(playing_audio=True)
+        b._now_playing = None
+        before = list(self.ctl.transport)
+        b._on_claimed_key("9")
+        self.assertEqual(self.ctl.transport, before)
+        self.assertEqual(self.ctl.volume_level, 100.0)
+
+    def test_an_unclaimed_key_still_reaches_the_page(self):
+        """The shell looks first, but only at its own three."""
+        self._block(True)
+        b = self._browser(playing_audio=True)
+        page = mock.Mock()
+        with mock.patch.object(b, "_page_for", return_value=page):
+            b._on_claimed_key("LEFT")
+        page.on_key.assert_called_once_with("LEFT")
+
+    def test_a_volume_key_does_not_also_reach_the_page(self):
+        self._block(True)
+        b = self._browser(playing_audio=True)
+        page = mock.Mock()
+        with mock.patch.object(b, "_page_for", return_value=page):
+            b._on_claimed_key("m")
+        page.on_key.assert_not_called()
+
+
+class PushTest(unittest.TestCase):
+    """The flag the renderer acts on."""
+
+    def _app(self):
+        from jellyfin_mpv_shim.mpvtk.app import MpvtkApp
+
+        app = MpvtkApp.__new__(MpvtkApp)
+        app.backend = mock.Mock()
+        return app
+
+    def _pushed(self, enabled):
+        saved = settings.browse_block_keys
+        self.addCleanup(
+            lambda: setattr(settings, "browse_block_keys", saved))
+        settings.browse_block_keys = enabled
+        app = self._app()
+        app.push_browse_keys()
+        return app.backend.command.call_args[0]
+
+    def test_on(self):
+        self.assertEqual(self._pushed(True),
+                         ("script-message", "mpvtk-browse-keys", "yes"))
+
+    def test_off(self):
+        self.assertEqual(self._pushed(False),
+                         ("script-message", "mpvtk-browse-keys", "no"))
+
+    def test_it_is_pushed_at_startup(self):
+        """`ui_resume` does not run on the app's first `mpvtk-active yes`
+        (state.active begins true), so the push is what installs the block
+        for the whole first browse session."""
+        import inspect
+
+        from jellyfin_mpv_shim.mpvtk.app import MpvtkApp
+
+        src = inspect.getsource(MpvtkApp._dispatch)
+        self.assertIn("push_browse_keys()", src)
+
+
+class LiveApplyTest(unittest.TestCase):
+    """It has to take effect on the screen the user is looking at."""
+
+    def _browser(self):
+        cfg = FakeConfig()
+        cfg.schema["browse_block_keys"] = "bool"
+        cfg.values["browse_block_keys"] = True
+        cfg.schema["player_name"] = "str"
+        cfg.values["player_name"] = "x"
+        b = MpvtkBrowser(app=mock.Mock(), source=FakeSource(),
+                         controller=mock.Mock(), config=cfg)
+        b._pool = _SyncPool()
+        b.app.push_browse_keys.reset_mock()
+        return b
+
+    def test_saving_it_re_pushes(self):
+        b = self._browser()
+        b._set_setting("browse_block_keys", False)
+        b.app.push_browse_keys.assert_called_once_with()
+
+    def test_an_unrelated_setting_does_not(self):
+        b = self._browser()
+        b._set_setting("player_name", "Bud")
+        b.app.push_browse_keys.assert_not_called()
+
+    def test_it_is_not_marked_as_needing_a_restart(self):
+        from jellyfin_mpv_shim.mpvtk_browser import config as cfg
+        self.assertNotIn("browse_block_keys", cfg.RESTART_REQUIRED)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_browse_key_block.py
+++ b/tests/test_browse_key_block.py
@@ -68,7 +68,8 @@ class ShellVolumeClaimTest(_Base):
     def test_music_playing_claims_volume_and_mute(self):
         self._block(True)
         b = self._browser(playing_audio=True)
-        self.assertEqual(set(b._shell_claimed_keys()), {"9", "0", "m"})
+        self.assertEqual(set(b._shell_claimed_keys()),
+                         {"9", "0", "m", "SPACE"})
 
     def test_nothing_playing_claims_nothing(self):
         """The keys exist to serve the now-playing bar. With no bar there is
@@ -86,6 +87,28 @@ class ShellVolumeClaimTest(_Base):
         b = self._browser(playing_audio=True)
         self.assertEqual(b._shell_claimed_keys(), ())
 
+    def test_a_stale_frame_after_yielding_claims_nothing(self):
+        """`_claim_page_keys` answers "no keys" when the browser is not
+        browsing, and that is not an optimisation -- it is the whole of the
+        fix for a frame still in flight when playback took the window. A
+        playback update arrives on a foreign thread and can flip `_browsing`
+        DURING the render, so the claim call is deliberately unconditional
+        and its ANSWER is what has to go empty. The page half already did
+        that; the shell half has to as well, or the stale frame installs
+        keys on a renderer that has yielded -- which is how SPACE stopped
+        pausing video for a whole session last time.
+        """
+        self._block(True)
+        b = self._browser(playing_audio=True)
+        b._browsing = False          # playback took the window mid-render
+        self.assertEqual(b._shell_claimed_keys(), ())
+        page = mock.Mock()
+        page.claimed_keys = ("LEFT",)
+        with mock.patch.object(b, "_page_for", return_value=page):
+            b._claim_page_keys(b.route)
+        self.assertEqual(b.app.claim_keys.call_args[0][0], (),
+                         "a stale frame re-installed keys after yielding")
+
     def test_the_claim_reaches_the_renderer_beside_the_page_s_own(self):
         """Union, not replacement: a page that claims keys still gets them
         while music plays."""
@@ -97,7 +120,7 @@ class ShellVolumeClaimTest(_Base):
         with mock.patch.object(b, "_page_for", return_value=page):
             b._claim_page_keys(b.route)
         pushed = set(b.app.claim_keys.call_args[0][0])
-        self.assertEqual(pushed, {"LEFT", "RIGHT", "9", "0", "m"})
+        self.assertEqual(pushed, {"LEFT", "RIGHT", "9", "0", "m", "SPACE"})
 
 
 class ShellVolumeKeyTest(_Base):
@@ -106,7 +129,7 @@ class ShellVolumeKeyTest(_Base):
     def _press(self, b, key):
         b._on_claimed_key(key)
         return [c for c in self.ctl.transport
-                if c[0] in ("adjust_volume", "toggle_mute")]
+                if c[0] in ("adjust_volume", "toggle_mute", "toggle_pause")]
 
     def test_the_keys_step_the_volume_mpv_s_own_way(self):
         """Same direction and same step as mpv's `9`/`0`, so the muscle
@@ -117,6 +140,33 @@ class ShellVolumeKeyTest(_Base):
         self.assertEqual(self.ctl.volume_level, 98.0)
         b._on_claimed_key("0")
         self.assertEqual(self.ctl.volume_level, 100.0)
+
+    def test_space_still_pauses_the_music(self):
+        """The block swallows SPACE like every other printable key, and a
+        forced binding that returns does not hand the key back -- so the one
+        transport key on the keyboard was dead with nothing replacing it.
+        Measured: with the block installed mpv's `cycle pause` never fired.
+        """
+        self._block(True)
+        b = self._browser(playing_audio=True)
+        self.assertIn("SPACE", b._shell_claimed_keys())
+        self.assertEqual(self._press(b, "SPACE"), [("toggle_pause", ())])
+        self.assertTrue(self.ctl.paused)
+
+    def test_a_page_that_claims_space_outranks_the_shell(self):
+        """Both readers claim SPACE to turn a page (`reader.py`,
+        `comic.py`). The shell's transport meaning must not take it on the
+        one screen that asked for it -- and the shell looks first, so
+        without this the page turn would silently become a pause.
+        """
+        self._block(True)
+        b = self._browser(playing_audio=True)
+        page = mock.Mock()
+        page.claimed_keys = ("SPACE", "LEFT")
+        with mock.patch.object(b, "_page_for", return_value=page):
+            b._on_claimed_key("SPACE")
+        page.on_key.assert_called_once_with("SPACE")
+        self.assertFalse(self.ctl.paused, "the shell took the reader's key")
 
     def test_m_mutes(self):
         self._block(True)
@@ -153,6 +203,7 @@ class ShellVolumeKeyTest(_Base):
         self._block(True)
         b = self._browser(playing_audio=True)
         page = mock.Mock()
+        page.claimed_keys = ("LEFT",)
         with mock.patch.object(b, "_page_for", return_value=page):
             b._on_claimed_key("LEFT")
         page.on_key.assert_called_once_with("LEFT")
@@ -161,6 +212,7 @@ class ShellVolumeKeyTest(_Base):
         self._block(True)
         b = self._browser(playing_audio=True)
         page = mock.Mock()
+        page.claimed_keys = ()      # a real Page's default
         with mock.patch.object(b, "_page_for", return_value=page):
             b._on_claimed_key("m")
         page.on_key.assert_not_called()

--- a/tests/test_classic_osc_choice.py
+++ b/tests/test_classic_osc_choice.py
@@ -157,38 +157,41 @@ class IdleScreenTest(unittest.TestCase):
             __file__).resolve().parent.parent.joinpath(
                 "jellyfin_mpv_shim", "player.py").read_text()
 
-    def test_the_option_is_set_before_the_script_is_loaded(self):
+    def _init_mpv_body(self):
         src = self._src()
-        body = src[src.index("def _load_classic_osc"):]
-        body = body[:body.index("def _bind_mpv_handlers")]
-        # The CALL, not the word: the comment above it explains why
-        # `load-script` being asynchronous is the problem, and matching the
-        # prose found that sentence instead of the code.
+        body = src[src.index("    def _init_mpv(self):"):]
+        return body[:body.index("\n    def ")]
+
+    def test_the_option_is_set_before_any_osc_is_chosen(self):
+        body = self._init_mpv_body()
         opt = body.index('"osc-idlescreen=no"')
-        load = body.index('command("load-script"')
+        load = body.index("_load_classic_osc()")
         self.assertLess(opt, load,
-                        "the idlescreen option must be set before either "
-                        "OSC is loaded, or it races the script's handlers")
+                        "the idlescreen option must be set before an OSC is "
+                        "loaded, or it races the script's own startup")
+
+    def test_it_is_set_for_every_style_not_just_the_one_we_load(self):
+        """The styles where MPV loads the OSC itself need it most -- there
+        is no `load-script` of ours to order against, so the broadcast has
+        nothing to beat the race with. Asserted structurally: the call sits
+        outside the `if osc_style ==` guard."""
+        body = self._init_mpv_body()
+        opt = body.index('"osc-idlescreen=no"')
+        guard = body.index('if osc_style == "mpv":')
+        self.assertLess(opt, guard,
+                        "the option is inside the style guard, so a style "
+                        "that loads its own OSC never gets it")
 
     def test_it_appends_rather_than_replacing_script_opts(self):
         """`script-opts` is shared with the user's own scripts. A whole
         write would take their options with it -- the same rule as never
         writing over their mpv.conf."""
-        src = self._src()
-        body = src[src.index("def _load_classic_osc"):]
-        body = body[:body.index("def _bind_mpv_handlers")]
-        self.assertIn('"change-list", "script-opts", "append"', body)
+        self.assertIn('"change-list", "script-opts", "append"',
+                      self._init_mpv_body())
 
-    def test_it_covers_the_fork_path_too(self):
-        """Both OSCs read the same prefix, so the option is set once above
-        the branch rather than in each arm -- and the fork had the same race
-        the moment it stopped being a construction-time script."""
-        src = self._src()
-        body = src[src.index("def _load_classic_osc"):]
-        body = body[:body.index("def _bind_mpv_handlers")]
-        self.assertEqual(body.count("osc-idlescreen=no"), 1)
-        self.assertLess(body.index("osc-idlescreen=no"),
-                        body.index("osc_preview_api_works"))
+    def test_it_is_set_exactly_once(self):
+        """One place that knows, so the two OSC paths cannot drift."""
+        self.assertEqual(self._src().count('"osc-idlescreen=no"'), 1)
 
 
 class ThumbfastAnswersBothDoorsTest(unittest.TestCase):

--- a/tests/test_classic_osc_choice.py
+++ b/tests/test_classic_osc_choice.py
@@ -32,6 +32,7 @@ if __name__ == "__main__":
     sys.path.insert(0, os.path.dirname(
         os.path.dirname(os.path.abspath(__file__))))
 
+import os
 import sys
 import unittest
 
@@ -56,7 +57,7 @@ def _preview_api(version):
 
     src = pathlib.Path(
         __file__).resolve().parent.parent.joinpath(
-            "jellyfin_mpv_shim", "player.py").read_text()
+            "jellyfin_mpv_shim", "player.py").read_text(encoding="utf-8")
     tree = ast.parse(src)
     fn = next(n for n in tree.body
               if isinstance(n, ast.FunctionDef)
@@ -98,10 +99,23 @@ class PreviewApiVersionTest(unittest.TestCase):
 
         src = pathlib.Path(
             __file__).resolve().parent.parent.joinpath(
-                "jellyfin_mpv_shim", "player.py").read_text()
+                "jellyfin_mpv_shim", "player.py").read_text(encoding="utf-8")
         self.assertIn("def osc_preview_api_works", src)
         self.assertIn("def runtime_force_window_works", src)
 
+
+def script_names(style, trickplay):
+    """The basenames mpv is told to load, for the running platform.
+
+    `os.path.basename`, not `rsplit("/")`: `mpv_scripts` returns native
+    paths, so on Windows every one of these came back as the whole
+    `C:\\...\\thumbfast.lua` and the comparisons below stopped meaning
+    anything. The `assertIn` failed and said so; the two `assertNotIn`
+    passed, because a full path is never equal to a bare filename either
+    -- so the checks that guard "two OSCs at once" were vacuously green on
+    Windows rather than broken-looking.
+    """
+    return [os.path.basename(p) for p in mpv_scripts(style, trickplay)]
 
 class ConstructionScriptsTest(unittest.TestCase):
     def test_no_osc_is_loaded_at_construction(self):
@@ -110,8 +124,7 @@ class ConstructionScriptsTest(unittest.TestCase):
         whichever it chose on top of it."""
         for style in ("mpv", "mpvtk", "default", "none"):
             with self.subTest(style=style):
-                names = [p.rsplit("/", 1)[-1]
-                         for p in mpv_scripts(style, True)]
+                names = script_names(style, True)
                 self.assertNotIn("trickplay-osc.lua", names)
 
     def test_thumbfast_is_still_loaded_for_every_style(self):
@@ -120,12 +133,11 @@ class ConstructionScriptsTest(unittest.TestCase):
         become conditional on the OSC choice."""
         for style in ("mpv", "mpvtk", "default"):
             with self.subTest(style=style):
-                names = [p.rsplit("/", 1)[-1]
-                         for p in mpv_scripts(style, True)]
+                names = script_names(style, True)
                 self.assertIn("thumbfast.lua", names)
 
     def test_and_not_when_trickplay_never_started(self):
-        names = [p.rsplit("/", 1)[-1] for p in mpv_scripts("mpv", False)]
+        names = script_names("mpv", False)
         self.assertNotIn("thumbfast.lua", names)
 
 
@@ -155,7 +167,7 @@ class IdleScreenTest(unittest.TestCase):
 
         return pathlib.Path(
             __file__).resolve().parent.parent.joinpath(
-                "jellyfin_mpv_shim", "player.py").read_text()
+                "jellyfin_mpv_shim", "player.py").read_text(encoding="utf-8")
 
     def _init_mpv_body(self):
         src = self._src()
@@ -202,7 +214,8 @@ class ThumbfastAnswersBothDoorsTest(unittest.TestCase):
 
         return pathlib.Path(
             __file__).resolve().parent.parent.joinpath(
-                "jellyfin_mpv_shim", "thumbfast.lua").read_text()
+                "jellyfin_mpv_shim", "thumbfast.lua").read_text(
+                    encoding="utf-8")
 
     def test_it_observes_the_preview_property(self):
         self.assertIn("user-data/osc/draw-preview", self._src())

--- a/tests/test_classic_osc_choice.py
+++ b/tests/test_classic_osc_choice.py
@@ -1,0 +1,224 @@
+"""Which classic OSC gets loaded, and why it is a runtime choice.
+
+`trickplay-osc.lua` is a fork of mpv 0.38's `osc.lua` whose entire purpose is
+seek-bar thumbnails -- its own header says "sadly there is no way to do this
+without forking the entire OSC script", and its whole patch set is six
+thumbfast blocks plus one compatibility fix.
+
+mpv 0.41 made that unnecessary. The **OSC Preview API**
+(`DOCS/man/osc.rst`) has the OSC publish `user-data/osc/draw-preview` --
+{x, y, w, h, hover-sec, ass} -- for any thumbnailer script to draw into, and
+nil to clear. Measured against a real mpv: hovering the seekbar sets it to
+`{x:147, y:350, w:120, h:90, hover-sec:12.15, ass:'...'}`.
+
+So a modern mpv gets mpv's OWN OSC -- upstream's fixes, upstream's look, no
+fork to maintain -- and `thumbfast.lua` answers the property. The fork stays
+for older builds, because Debian and others still ship 0.40.
+
+**Why the choice cannot be made at option-build time**, which is where every
+other script is chosen: it depends on the version of the mpv about to be
+constructed, and nothing knows that yet. The libmpv client API cannot stand
+in either -- 0.40 and 0.41 both report 2.5 -- so this is a `load-script`
+immediately after construction, while nothing is on screen.
+"""
+
+# Run as a script, this is what puts the repo root on sys.path -- without
+# it `jellyfin_mpv_shim` resolves to whatever is pip-installed. A no-op
+# under `discover`; tests/test_module_paths.py is the guard.
+if __name__ == "__main__":
+    import os
+    import sys
+
+    sys.path.insert(0, os.path.dirname(
+        os.path.dirname(os.path.abspath(__file__))))
+
+import sys
+import unittest
+
+sys.argv = ["test"]
+
+from jellyfin_mpv_shim.mpv_options import mpv_scripts  # noqa: E402
+
+
+def _preview_api(version):
+    """`player.osc_preview_api_works` without importing player.
+
+    Importing `jellyfin_mpv_shim.player` builds its module-level singleton
+    and opens a real mpv window (see CLAUDE.md), which is not something a
+    unit test about a version string should cost. The predicate is pure, so
+    it is read out of the source and executed on its own -- the same trick
+    `test_mpv_options` uses to keep option behaviour testable without a
+    player.
+    """
+    import ast
+    import pathlib
+    import re
+
+    src = pathlib.Path(
+        __file__).resolve().parent.parent.joinpath(
+            "jellyfin_mpv_shim", "player.py").read_text()
+    tree = ast.parse(src)
+    fn = next(n for n in tree.body
+              if isinstance(n, ast.FunctionDef)
+              and n.name == "osc_preview_api_works")
+    ns = {"re": re}
+    exec(compile(ast.Module([fn], []), "<player>", "exec"), ns)
+    return ns["osc_preview_api_works"](version)
+
+
+class PreviewApiVersionTest(unittest.TestCase):
+    def test_041_and_newer_have_it(self):
+        for version in ("mpv 0.41.0", "mpv v0.41.0",
+                        "mpv v0.41.0-1011-g182fa6ca4", "mpv 0.42.0",
+                        "mpv 1.0.0"):
+            with self.subTest(version=version):
+                self.assertTrue(_preview_api(version))
+
+    def test_040_and_older_do_not(self):
+        """The versions that keep the fork. Debian ships 0.40."""
+        for version in ("mpv 0.40.0", "mpv v0.40.0-99-gabcdef",
+                        "mpv 0.38.0", "mpv 0.29.1"):
+            with self.subTest(version=version):
+                self.assertFalse(_preview_api(version))
+
+    def test_an_unreadable_version_is_treated_as_old(self):
+        """Fail-safe in the direction that works everywhere: the fork runs
+        on every mpv we have measured, while an OSC with no previews is a
+        feature silently missing under a style named for it."""
+        for version in ("", None, "mpv git-2026-08-28", "unknown"):
+            with self.subTest(version=repr(version)):
+                self.assertFalse(_preview_api(version))
+
+    def test_it_is_its_own_predicate(self):
+        """Same 0.41 threshold as `runtime_force_window_works` and
+        deliberately not the same function: two different questions that
+        happen to share an answer today, and folding them would make a
+        backport of either a silent lie about the other."""
+        import pathlib
+
+        src = pathlib.Path(
+            __file__).resolve().parent.parent.joinpath(
+                "jellyfin_mpv_shim", "player.py").read_text()
+        self.assertIn("def osc_preview_api_works", src)
+        self.assertIn("def runtime_force_window_works", src)
+
+
+class ConstructionScriptsTest(unittest.TestCase):
+    def test_no_osc_is_loaded_at_construction(self):
+        """Two OSCs at once is the failure this prevents: a construction
+        entry would load the fork, and `_load_classic_osc` would then load
+        whichever it chose on top of it."""
+        for style in ("mpv", "mpvtk", "default", "none"):
+            with self.subTest(style=style):
+                names = [p.rsplit("/", 1)[-1]
+                         for p in mpv_scripts(style, True)]
+                self.assertNotIn("trickplay-osc.lua", names)
+
+    def test_thumbfast_is_still_loaded_for_every_style(self):
+        """It is the thumbnailer for BOTH paths now -- the fork's
+        client-messages and the stock OSC's property -- so it must not have
+        become conditional on the OSC choice."""
+        for style in ("mpv", "mpvtk", "default"):
+            with self.subTest(style=style):
+                names = [p.rsplit("/", 1)[-1]
+                         for p in mpv_scripts(style, True)]
+                self.assertIn("thumbfast.lua", names)
+
+    def test_and_not_when_trickplay_never_started(self):
+        names = [p.rsplit("/", 1)[-1] for p in mpv_scripts("mpv", False)]
+        self.assertNotIn("thumbfast.lua", names)
+
+
+class IdleScreenTest(unittest.TestCase):
+    """mpv's "Drop files or URLs to play" logo must never be drawn.
+
+    The shim always draws its own idle window, so the OSC's logo is never
+    wanted -- and once an OSC has drawn it, asking it to stop can leave the
+    logo parked on a second overlay for the session (the measurement behind
+    `enable_osc`'s comment).
+
+    `enable_osc` broadcasts `osc-idlescreen no` and notes it "has to land
+    BEFORE the OSC's first draw". That held while every OSC was loaded at
+    construction. It stopped holding when the classic OSC became a runtime
+    `load-script`, because that is asynchronous: the message races the
+    script's `register_script_message`, and losing the race puts the logo
+    behind the library. Found by hand-testing, not by this suite.
+
+    Setting it as a SCRIPT-OPT instead is read by construction rather than
+    in time -- every osc.lua and every fork reads `script-opts` under the
+    `osc` prefix at startup. Measured against a real mpv: without it the OSC
+    starts with `idlescreen = true`, with it `false`.
+    """
+
+    def _src(self):
+        import pathlib
+
+        return pathlib.Path(
+            __file__).resolve().parent.parent.joinpath(
+                "jellyfin_mpv_shim", "player.py").read_text()
+
+    def test_the_option_is_set_before_the_script_is_loaded(self):
+        src = self._src()
+        body = src[src.index("def _load_classic_osc"):]
+        body = body[:body.index("def _bind_mpv_handlers")]
+        # The CALL, not the word: the comment above it explains why
+        # `load-script` being asynchronous is the problem, and matching the
+        # prose found that sentence instead of the code.
+        opt = body.index('"osc-idlescreen=no"')
+        load = body.index('command("load-script"')
+        self.assertLess(opt, load,
+                        "the idlescreen option must be set before either "
+                        "OSC is loaded, or it races the script's handlers")
+
+    def test_it_appends_rather_than_replacing_script_opts(self):
+        """`script-opts` is shared with the user's own scripts. A whole
+        write would take their options with it -- the same rule as never
+        writing over their mpv.conf."""
+        src = self._src()
+        body = src[src.index("def _load_classic_osc"):]
+        body = body[:body.index("def _bind_mpv_handlers")]
+        self.assertIn('"change-list", "script-opts", "append"', body)
+
+    def test_it_covers_the_fork_path_too(self):
+        """Both OSCs read the same prefix, so the option is set once above
+        the branch rather than in each arm -- and the fork had the same race
+        the moment it stopped being a construction-time script."""
+        src = self._src()
+        body = src[src.index("def _load_classic_osc"):]
+        body = body[:body.index("def _bind_mpv_handlers")]
+        self.assertEqual(body.count("osc-idlescreen=no"), 1)
+        self.assertLess(body.index("osc-idlescreen=no"),
+                        body.index("osc_preview_api_works"))
+
+
+class ThumbfastAnswersBothDoorsTest(unittest.TestCase):
+    """Read from the lua source: the two front doors, one handler."""
+
+    def _src(self):
+        import pathlib
+
+        return pathlib.Path(
+            __file__).resolve().parent.parent.joinpath(
+                "jellyfin_mpv_shim", "thumbfast.lua").read_text()
+
+    def test_it_observes_the_preview_property(self):
+        self.assertIn("user-data/osc/draw-preview", self._src())
+
+    def test_it_still_answers_the_forks_client_message(self):
+        """Both paths stay, and cannot both be live: the property only
+        appears when the stock OSC runs, and the messages only come from the
+        fork, which is loaded only when the stock one cannot do this."""
+        src = self._src()
+        self.assertIn('event_name == "thumb"', src)
+        self.assertIn('event_name == "clear"', src)
+
+    def test_the_preview_path_reuses_the_message_handler(self):
+        """One implementation of "draw the frame for this timestamp here".
+        Two copies would drift, and the fork's path is the one nobody runs
+        on a modern machine -- so it is the copy that would rot unseen."""
+        self.assertIn("client_message_handler({args = {\"thumb\"",
+                      self._src())
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_classic_osc_choice.py
+++ b/tests/test_classic_osc_choice.py
@@ -176,7 +176,7 @@ class IdleScreenTest(unittest.TestCase):
 
     def test_the_option_is_set_before_any_osc_is_chosen(self):
         body = self._init_mpv_body()
-        opt = body.index('"osc-idlescreen=no"')
+        opt = body.index("osc_script_opts(")
         load = body.index("_load_classic_osc()")
         self.assertLess(opt, load,
                         "the idlescreen option must be set before an OSC is "
@@ -185,14 +185,18 @@ class IdleScreenTest(unittest.TestCase):
     def test_it_is_set_for_every_style_not_just_the_one_we_load(self):
         """The styles where MPV loads the OSC itself need it most -- there
         is no `load-script` of ours to order against, so the broadcast has
-        nothing to beat the race with. Asserted structurally: the call sits
-        outside the `if osc_style ==` guard."""
-        body = self._init_mpv_body()
-        opt = body.index('"osc-idlescreen=no"')
-        guard = body.index('if osc_style == "mpv":')
-        self.assertLess(opt, guard,
-                        "the option is inside the style guard, so a style "
-                        "that loads its own OSC never gets it")
+        nothing to beat the race with.
+
+        Asserted on the VALUE now, not on where the push sits relative to
+        the `if osc_style ==` guard: the options moved into
+        `mpv_options.osc_script_opts`, which is the thing that decides, and
+        the structural reading would go on passing whatever it decided.
+        """
+        from jellyfin_mpv_shim.mpv_options import osc_script_opts
+
+        for style in ("mpv", "mpvtk", "default", "custom", "none"):
+            with self.subTest(style=style):
+                self.assertIn("osc-idlescreen=no", osc_script_opts(style))
 
     def test_it_appends_rather_than_replacing_script_opts(self):
         """`script-opts` is shared with the user's own scripts. A whole
@@ -203,7 +207,15 @@ class IdleScreenTest(unittest.TestCase):
 
     def test_it_is_set_exactly_once(self):
         """One place that knows, so the two OSC paths cannot drift."""
-        self.assertEqual(self._src().count('"osc-idlescreen=no"'), 1)
+        import inspect
+
+        from jellyfin_mpv_shim import mpv_options
+
+        src = inspect.getsource(mpv_options)
+        self.assertEqual(src.count('"osc-idlescreen=no"'), 1)
+        self.assertEqual(self._src().count('"osc-idlescreen=no"'), 0,
+                         "player.py should push what osc_script_opts "
+                         "decides, not spell an option itself")
 
 
 class ThumbfastAnswersBothDoorsTest(unittest.TestCase):

--- a/tests/test_classic_osc_mouse.py
+++ b/tests/test_classic_osc_mouse.py
@@ -1,0 +1,181 @@
+"""The renderer must let go of the mouse when a classic OSC owns the window.
+
+**Question B of two** (#724). `tools/probe_classic_osc_mouse.py` answers A
+against a real mpv and this answers B against the fakes; neither is much use
+alone.
+
+The mechanism, established against mpv's source and then measured: the
+renderer's `mpvtk_mouse` section claims mbtn_left/mbtn_right and sets no
+mouse area, so mpv treats it as covering the whole screen
+(`input.c: get_bind_section` -> `{INT_MIN..INT_MAX}`) and prefers it over the
+builtin binding (`get_cmd_from_keys`). Both of the renderer's bare-video
+fall-throughs gate on `state.phud.mode`, which classic-OSC modality never
+enters -- so while that section is live, both buttons are swallowed and do
+nothing at all.
+
+**A said the renderer is fine.** Told `mpvtk-active no`, it drops
+`mpvtk_mouse`, `mpvtk_thumb` and `mpvtk_wheel` to priority -1 and mpv's own
+default section wins every mouse key. So the whole question is whether the
+app SENDS it -- which is what these pin, on the transitions a video actually
+goes through rather than on the one method that looks like the handoff.
+
+The trap those transitions carry: `_start` clears `_browsing` before playback
+reports in, so `on_playstate`'s `if self._browsing: self._yield()` cannot
+fire for video. The real handoff is `LoadFeedback.clear()`, and it returns
+early when `starting` is None. Anything that reaches playback without going
+through `begin()` therefore never yields, and the renderer keeps the mouse
+over a classic OSC.
+"""
+
+# Run as a script, this is what puts the repo root on sys.path -- without
+# it `jellyfin_mpv_shim` resolves to whatever is pip-installed. A no-op
+# under `discover`; tests/test_module_paths.py is the guard.
+if __name__ == "__main__":
+    import os
+    import sys
+
+    sys.path.insert(0, os.path.dirname(
+        os.path.dirname(os.path.abspath(__file__))))
+
+import sys
+import unittest
+
+sys.argv = ["test"]
+
+from jellyfin_mpv_shim.mpvtk_browser.app import MpvtkBrowser  # noqa: E402
+
+from tests._shell_harness import (  # noqa: E402
+    FakeController, FakeSource, StubHudApp, _SyncPool)
+from tests._shell_harness import HudController as _HudModeController  # noqa: E402
+
+
+class _ClassicOscController(FakeController):
+    """A controller in classic-OSC modality.
+
+    `use_hud()` is what `hud.available()` asks, and it is False for every
+    `osc_style` but "mpvtk". Spelled out rather than left to
+    `FakeController.__getattr__`, which would record the call and hand back
+    None -- falsy, so the tests below would pass, but by accident and
+    identically for both modalities. The mpvtk control beside it is the
+    harness's own `HudController`, which answers True.
+    """
+
+    def use_hud(self):
+        return False
+
+
+def _browser(classic=True):
+    app = StubHudApp()
+    ctl = _ClassicOscController() if classic else _HudModeController()
+    b = MpvtkBrowser(app=app, source=FakeSource(), controller=ctl)
+    b._pool = _SyncPool()
+    b.server = "srv1"
+    b.navigate({"kind": "home", "server": "srv1"})
+    b._browsing = True
+    del app.calls[:]
+    return b, app
+
+
+def _active_calls(app):
+    return [value for name, value in app.calls if name == "active"]
+
+
+class HandoffTest(unittest.TestCase):
+    def test_the_hud_is_not_available_in_classic_modality(self):
+        """The premise the rest of this file rests on. If this ever answers
+        True the branch under test is unreachable and everything below
+        passes vacuously."""
+        b, _app = _browser()
+        self.assertFalse(b.hud.available())
+
+    def test_and_it_IS_available_in_mpvtk_modality(self):
+        """The other half of that premise, and the one that matters: with
+        both fakes answering falsy, every test here would pass while
+        measuring nothing. That is what `test_the_mpvtk_hud_still_keeps_it`
+        caught on this file's first run."""
+        b, _app = _browser(classic=False)
+        self.assertTrue(b.hud.available())
+
+    def test_yielding_to_video_releases_the_renderer(self):
+        b, app = _browser()
+        b._yield()
+        self.assertIn(False, _active_calls(app),
+                      "the renderer kept the mouse over a classic OSC")
+
+    def test_it_does_not_engage_the_hud_instead(self):
+        """The mpvtk branch keeps the renderer attached-but-idle, which
+        keeps `mpvtk_mouse` live. That is right for the in-window HUD and
+        wrong for every other osc_style."""
+        b, app = _browser()
+        b._yield()
+        self.assertEqual([c for c in app.calls if c[0] == "hud"], [])
+
+    def test_the_mpvtk_hud_still_keeps_it(self):
+        """The other side of the same switch, so this file cannot pass by
+        releasing the mouse in both modes."""
+        b, app = _browser(classic=False)
+        b._yield()
+        self.assertNotIn(False, _active_calls(app))
+        self.assertIn(("hud", True), app.calls)
+
+
+class StartToPlaybackTest(unittest.TestCase):
+    """The transition a video actually takes, not the method named after it.
+
+    `_start` clears `_browsing` so the loading spinner can draw, which makes
+    `on_playstate`'s `if self._browsing: self._yield()` dead for video. The
+    handoff really happens in `LoadFeedback.clear()`.
+    """
+
+    def _play_a_video(self, b):
+        b._start(audio=False, title="A Film")
+        b.load.clear()
+
+    def test_a_normal_video_start_releases_the_mouse(self):
+        b, app = _browser()
+        self._play_a_video(b)
+        self.assertIn(False, _active_calls(app))
+
+    def test_the_spinner_holds_the_renderer_until_playback_reports(self):
+        """Between `_start` and `clear` the browser is still drawing -- the
+        loading screen is its own scene -- so releasing there would throw it
+        away. This is why the yield is deferred, and why the deferral is
+        the thing that can be missed."""
+        b, app = _browser()
+        b._start(audio=False, title="A Film")
+        self.assertNotIn(False, _active_calls(app))
+
+    def test_audio_keeps_the_window_and_the_mouse(self):
+        """Music plays with the library still up, so the renderer must NOT
+        let go -- the now-playing bar is a scene and needs its clicks."""
+        b, app = _browser()
+        b._start(audio=True, title="A Song")
+        b.load.clear()
+        self.assertNotIn(False, _active_calls(app))
+
+    def test_three_videos_in_a_row_each_release_it(self):
+        """State feeding back: every start after the first runs against
+        whatever the previous one left in `LoadFeedback`, and `clear()`
+        returns early when `starting` is None -- so a start that failed to
+        arm it would silently stop yielding from then on."""
+        b, app = _browser()
+        for round_no in range(1, 4):
+            with self.subTest(round=round_no):
+                del app.calls[:]
+                b.enter_browse()
+                self._play_a_video(b)
+                self.assertIn(False, _active_calls(app),
+                              "video %d kept the mouse" % round_no)
+
+    def test_coming_back_from_playback_takes_it_again(self):
+        """...and the browser needs the mouse back, or the library is dead
+        to the pointer after the first film."""
+        b, app = _browser()
+        self._play_a_video(b)
+        del app.calls[:]
+        b.enter_browse()
+        self.assertIn(True, _active_calls(app))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_cli_overrides.py
+++ b/tests/test_cli_overrides.py
@@ -173,7 +173,7 @@ class WiringTest(unittest.TestCase):
 
         from jellyfin_mpv_shim import mpv_shim
 
-        src = pathlib.Path(mpv_shim.__file__).read_text()
+        src = pathlib.Path(mpv_shim.__file__).read_text(encoding="utf-8")
         for _flag, key, _value in FLAGS:
             with self.subTest(key=key):
                 self.assertNotIn("settings.%s = args" % key, src)
@@ -187,7 +187,7 @@ class WiringTest(unittest.TestCase):
 
         from jellyfin_mpv_shim import restart
 
-        src = pathlib.Path(restart.__file__).read_text()
+        src = pathlib.Path(restart.__file__).read_text(encoding="utf-8")
         self.assertIn("CLI_OVERRIDES", src)
         for _flag, key, _value in FLAGS:
             with self.subTest(key=key):

--- a/tests/test_cli_overrides.py
+++ b/tests/test_cli_overrides.py
@@ -1,0 +1,241 @@
+"""A command-line flag applies to one run and must not reach conf.json.
+
+`save()` serializes `dict()`, and `dict()` walks EVERY field -- so a flag
+assigned straight onto the settings object is written out by the next save
+from anywhere. Saves are not rare: window geometry (`remember_window_size`
+is on by default), audio device, shader profile, the deband/tone-mapping
+writes, and every settings-screen edit. One launch with `--minimized` plus
+one window resize and the option was on for good (#718).
+
+Four flags have this shape and only `--scale` had a guard, which was a
+comment asking future callers not to save. This is the mechanism that
+replaces it, so a fifth flag is covered by construction.
+
+**The half that is easy to get wrong.** The obvious repair -- have `dict()`
+substitute the on-disk value for overridden fields -- is not enough on its
+own, because `dict()` is not only the persistence boundary:
+`mpvtk_browser.config.get_settings` uses it to populate the settings
+screen, and `set_setting` writes the same field and saves immediately. So
+an override needs a LIFETIME: the moment the user states an intent for that
+key, the flag stops speaking for it. Otherwise launching with `--scale 2`
+and then choosing 1.5 in Settings silently reverts to what was on disk --
+a worse bug than the one being fixed, because it discards a deliberate act
+rather than persisting an accidental one.
+"""
+
+# Run as a script, this is what puts the repo root on sys.path -- without
+# it `jellyfin_mpv_shim` resolves to whatever is pip-installed. A no-op
+# under `discover`; tests/test_module_paths.py is the guard.
+if __name__ == "__main__":
+    import os
+    import sys
+
+    sys.path.insert(0, os.path.dirname(
+        os.path.dirname(os.path.abspath(__file__))))
+
+import sys
+import unittest
+
+sys.argv = ["test"]
+
+from jellyfin_mpv_shim.conf import Settings  # noqa: E402
+
+
+#: (flag dest on `args`, settings key, a value that is not the default).
+#: Every CLI flag that overrides a config key belongs here; the pairing is
+#: asserted against mpv_shim.py below, so adding a flag without adding it
+#: here fails rather than going quietly uncovered.
+FLAGS = (
+    ("enable_gui", "enable_gui", False),
+    ("start_minimized", "start_minimized", True),
+    ("mpv_loglevel", "mpv_log_level", "debug"),
+    ("ui_scale", "ui_scale", 2.0),
+)
+
+
+def _loaded(**on_disk):
+    """A Settings as if `load()` had just read these values from a file."""
+    s = Settings()
+    for key, value in on_disk.items():
+        setattr(s, key, value)
+    return s
+
+
+class PersistenceTest(unittest.TestCase):
+    def test_an_override_does_not_reach_the_serialized_form(self):
+        for _flag, key, value in FLAGS:
+            with self.subTest(key=key):
+                s = _loaded()
+                on_disk = getattr(s, key)
+                s.apply_cli_override(key, value)
+                self.assertNotEqual(value, on_disk, "fixture value is the "
+                                    "default, so this cannot fail")
+                self.assertEqual(s.dict()[key], on_disk)
+
+    def test_but_it_is_live_on_the_object(self):
+        """The run still gets what it was told. This is the whole point of
+        the flag, and a `dict()` shadow that also changed the live value
+        would be a different bug."""
+        for _flag, key, value in FLAGS:
+            with self.subTest(key=key):
+                s = _loaded()
+                s.apply_cli_override(key, value)
+                self.assertEqual(getattr(s, key), value)
+
+    def test_an_unrelated_save_leaves_the_disk_value_alone(self):
+        """The reported shape: launch with --minimized, resize the window
+        (which persists geometry), and the flag has become the setting."""
+        s = _loaded(start_minimized=False)
+        s.apply_cli_override("start_minimized", True)
+        s.window_width = 1280            # what a geometry save writes
+        self.assertIs(s.dict()["start_minimized"], False)
+
+    def test_every_other_field_still_serializes_live(self):
+        s = _loaded()
+        s.apply_cli_override("start_minimized", True)
+        s.window_width = 1234
+        self.assertEqual(s.dict()["window_width"], 1234)
+
+    def test_with_no_overrides_dict_is_unchanged(self):
+        """The overwhelmingly common path must not move at all."""
+        s = _loaded()
+        self.assertEqual(s.dict(), Settings().dict())
+
+
+class OverrideLifetimeTest(unittest.TestCase):
+    """The half a `dict()` shadow alone gets wrong."""
+
+    def test_an_explicit_edit_of_an_overridden_key_persists(self):
+        """Launch with --scale 2, then choose 1.5 in Settings. Without a
+        lifetime the shadow writes back the on-disk 1.0 and the user's
+        choice is discarded."""
+        s = _loaded(ui_scale=1.0)
+        s.apply_cli_override("ui_scale", 2.0)
+        s.ui_scale = 1.5                 # what set_setting does
+        self.assertEqual(s.dict()["ui_scale"], 1.5)
+
+    def test_and_the_flag_stops_speaking_for_it_from_then_on(self):
+        s = _loaded(start_minimized=False)
+        s.apply_cli_override("start_minimized", True)
+        s.start_minimized = True         # the user turns it on for real
+        s.window_width = 900             # some later unrelated save
+        self.assertIs(s.dict()["start_minimized"], True)
+
+    def test_editing_one_key_does_not_release_another(self):
+        s = _loaded(start_minimized=False, ui_scale=1.0)
+        s.apply_cli_override("start_minimized", True)
+        s.apply_cli_override("ui_scale", 2.0)
+        s.ui_scale = 1.5
+        self.assertIs(s.dict()["start_minimized"], False)
+        self.assertEqual(s.dict()["ui_scale"], 1.5)
+
+    def test_the_settings_screen_is_shown_what_is_configured(self):
+        """`config.get_settings()` returns `dict()`. Showing the flag's
+        value would tell the user they had configured something they had
+        not, and the next edit would fight it."""
+        from jellyfin_mpv_shim.mpvtk_browser import config as cfg
+
+        s = cfg.settings
+        was = s.start_minimized
+        try:
+            s.start_minimized = False
+            s.apply_cli_override("start_minimized", True)
+            self.assertIs(cfg.get_settings()["start_minimized"], False)
+        finally:
+            s.__cli_overrides__.pop("start_minimized", None)
+            s.start_minimized = was
+
+
+class WiringTest(unittest.TestCase):
+    """One table, three consumers.
+
+    The pairing "flag X shadows setting Y" is needed in three places --
+    where the flags are APPLIED (`mpv_shim.main`), where they are kept OUT
+    of the config file (`settings_base.apply_cli_override`), and where they
+    are re-passed across a self-RESTART (`restart._durable_flags`). It used
+    to be written out by hand in two of them and implied in the third,
+    which is three chances to add a flag to some of them.
+    """
+
+    def test_this_files_table_is_the_shipped_one(self):
+        """So a fifth flag cannot be added without a test value for it."""
+        from jellyfin_mpv_shim.args import CLI_OVERRIDES
+
+        self.assertEqual([o.dest for o in CLI_OVERRIDES],
+                         [f[0] for f in FLAGS])
+        self.assertEqual([o.key for o in CLI_OVERRIDES],
+                         [f[1] for f in FLAGS])
+
+    def test_mpv_shim_routes_every_flag_through_the_override(self):
+        """A flag assigned with `settings.x = ...` is the bug. Read from
+        the source, because the alternative is launching the app."""
+        import pathlib
+
+        from jellyfin_mpv_shim import mpv_shim
+
+        src = pathlib.Path(mpv_shim.__file__).read_text()
+        for _flag, key, _value in FLAGS:
+            with self.subTest(key=key):
+                self.assertNotIn("settings.%s = args" % key, src)
+        self.assertIn("CLI_OVERRIDES", src)
+        self.assertIn("apply_cli_override", src)
+
+    def test_restart_reads_the_same_table(self):
+        """`restart._durable_flags` re-passes these across a self-restart.
+        A hand-written list there drifts from the one that applies them."""
+        import pathlib
+
+        from jellyfin_mpv_shim import restart
+
+        src = pathlib.Path(restart.__file__).read_text()
+        self.assertIn("CLI_OVERRIDES", src)
+        for _flag, key, _value in FLAGS:
+            with self.subTest(key=key):
+                self.assertNotIn('"%s" not in pending' % key, src)
+
+    def test_every_overridable_key_is_a_real_setting(self):
+        s = Settings()
+        for _flag, key, _value in FLAGS:
+            with self.subTest(key=key):
+                self.assertIn(key, s.__fields__)
+
+    def test_an_unknown_key_is_refused(self):
+        """A typo'd key would otherwise record an override nothing reads,
+        and the flag would silently persist after all."""
+        with self.assertRaises(KeyError):
+            Settings().apply_cli_override("not_a_setting", 1)
+
+
+class SpellingTest(unittest.TestCase):
+    """`CliOverride.spell` is what a restart re-passes on the command line,
+    so it has to round-trip through the parser it came from."""
+
+    def test_a_boolean_flag_spells_both_ways(self):
+        from jellyfin_mpv_shim.args import CLI_OVERRIDES
+
+        gui = next(o for o in CLI_OVERRIDES if o.dest == "enable_gui")
+        self.assertEqual(gui.spell(True), ["--gui"])
+        self.assertEqual(gui.spell(False), ["--no-gui"])
+
+    def test_a_value_flag_carries_its_value(self):
+        from jellyfin_mpv_shim.args import CLI_OVERRIDES
+
+        scale = next(o for o in CLI_OVERRIDES if o.dest == "ui_scale")
+        self.assertEqual(scale.spell(2.0), ["--scale", "2.0"])
+
+    def test_every_spelling_parses_back_to_the_same_value(self):
+        """The round trip, against the real parser: a restart that emits a
+        flag the parser rejects would not come back at all."""
+        from jellyfin_mpv_shim import args as args_mod
+
+        parser = args_mod._build_parser()
+        for override, (_flag, _key, value) in zip(args_mod.CLI_OVERRIDES,
+                                                  FLAGS):
+            with self.subTest(dest=override.dest):
+                parsed = parser.parse_args(override.spell(value))
+                got = getattr(parsed, override.dest)
+                self.assertEqual(got, value)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_gateway_mixins.py
+++ b/tests/test_gateway_mixins.py
@@ -53,6 +53,7 @@ PKG = os.path.dirname(inspect.getfile(gw))
 #: Anything else disappearing is the bug this is here to catch.
 BEFORE_SPLIT = {
     "add_server", "add_user", "any_client", "apply_audio_settings",
+    "apply_browser_fullscreen",
     "cancel_load", "chapters", "check_updates", "client_for",
     "collection_add", "collection_new", "collection_remove", "config_dir",
     "connect_and_rebuild", "copy_text", "delete_download", "delete_user",

--- a/tests/test_go_to_series.py
+++ b/tests/test_go_to_series.py
@@ -163,7 +163,7 @@ class VerbTest(unittest.TestCase):
 
         from jellyfin_mpv_shim.mpvtk_browser.pages import detail
 
-        src = pathlib.Path(detail.__file__).read_text()
+        src = pathlib.Path(detail.__file__).read_text(encoding="utf-8")
         self.assertIn('_("Go to Series")', src)
         self.assertIn('"movie"', src)
 

--- a/tests/test_go_to_series.py
+++ b/tests/test_go_to_series.py
@@ -1,0 +1,178 @@
+""""Go to Series" on a tile (#719).
+
+jellyfin-web's Next Up / Continue Watching card has three hit regions: the
+play chip plays, the image opens the item, and the series title opens the
+show. Ours had the first two, so correcting a Next Up entry that sits on
+the wrong episode meant opening the episode, finding the button on its
+detail page, and coming back.
+
+Our captions are baked into the strip bitmap -- `TileRenderer` hands the
+compositor `Tile(title=…, subtitle=…)` and the whole row becomes one image
+-- so the series name an episode tile already draws is not a node anything
+can click. The context menu is the reachable version of web's third
+region, and it is the better half of the two: it works on every episode and
+season tile anywhere (search results, a genre grid, favourites), and it is
+the only one a keyboard or remote user can reach at all.
+"""
+
+# Run as a script, this is what puts the repo root on sys.path -- without
+# it `jellyfin_mpv_shim` resolves to whatever is pip-installed. A no-op
+# under `discover`; tests/test_module_paths.py is the guard.
+if __name__ == "__main__":
+    import os
+    import sys
+
+    sys.path.insert(0, os.path.dirname(
+        os.path.dirname(os.path.abspath(__file__))))
+
+import sys
+import unittest
+
+sys.argv = ["test"]
+
+from jellyfin_mpv_shim.mpvtk_browser.app import MpvtkBrowser  # noqa: E402
+
+from tests._shell_harness import (  # noqa: E402
+    FakeController, FakeSource, _SyncPool)
+
+
+EPISODE = {"Id": "e1", "Name": "Ep 1", "Type": "Episode",
+           "SeriesId": "sh1", "SeriesName": "A Show",
+           "ParentIndexNumber": 1, "IndexNumber": 1}
+SEASON = {"Id": "se1", "Name": "Season 1", "Type": "Season",
+          "SeriesId": "sh1", "SeriesName": "A Show"}
+MOVIE = {"Id": "m1", "Name": "A Film", "Type": "Movie"}
+
+
+def _browser():
+    b = MpvtkBrowser(app=None, source=FakeSource(),
+                     controller=FakeController())
+    b._pool = _SyncPool()
+    b.server = "srv1"
+    return b
+
+
+def _labels(b, item):
+    return [e[0] for e in b._tile_menu_entries(item)]
+
+
+def _action_for(b, item, label):
+    for e in b._tile_menu_entries(item):
+        if e[0] == label:
+            return e[2]
+    return None
+
+
+class EntryPresenceTest(unittest.TestCase):
+    def test_an_episode_tile_offers_it(self):
+        b = _browser()
+        self.assertIn("Go to Series", _labels(b, dict(EPISODE)))
+
+    def test_a_season_tile_offers_it_too(self):
+        """Gated on SeriesId, not on Type == "Episode". A season carries
+        one, and "go up to the show" is as wanted from a season tile --
+        the detail page gates on Episode only because that is the single
+        type it renders."""
+        b = _browser()
+        self.assertIn("Go to Series", _labels(b, dict(SEASON)))
+
+    def test_a_movie_does_not(self):
+        b = _browser()
+        self.assertNotIn("Go to Series", _labels(b, dict(MOVIE)))
+
+    def test_an_episode_with_no_series_id_does_not(self):
+        """A dead entry reads as a broken client, and the handler would
+        KeyError on SeriesId."""
+        b = _browser()
+        orphan = {k: v for k, v in EPISODE.items() if k != "SeriesId"}
+        self.assertNotIn("Go to Series", _labels(b, orphan))
+
+    def test_it_is_suppressed_on_that_series_own_page(self):
+        """Where it would navigate to the page you are looking at."""
+        b = _browser()
+        b.route.update({"kind": "series", "item_id": "sh1"})
+        self.assertNotIn("Go to Series", _labels(b, dict(SEASON)))
+
+    def test_but_not_on_a_DIFFERENT_series_page(self):
+        """A series page can show episodes of another show -- a guest
+        appearance in a Special, a mixed search result reached from here.
+        The suppression is about identity, not about the route kind."""
+        b = _browser()
+        b.route.update({"kind": "series", "item_id": "OTHER"})
+        self.assertIn("Go to Series", _labels(b, dict(EPISODE)))
+
+    def test_it_survives_on_a_season_page(self):
+        """The place the reporter actually wants it: you are inside a
+        season and need the show to pick a different one."""
+        b = _browser()
+        b.route.update({"kind": "season", "item_id": "se1",
+                        "series_id": "sh1"})
+        self.assertIn("Go to Series", _labels(b, dict(EPISODE)))
+
+
+class NavigationTest(unittest.TestCase):
+    def _fire(self, b, item):
+        entries = b._tile_menu_entries(item)
+        idx = next(i for i, e in enumerate(entries) if e[2] == "goseries")
+        b._menu = {"item": item, "server": "srv1", "x": 0, "y": 0}
+        b._menu_action(idx, entries[idx][0])
+
+    def test_it_opens_the_series_route(self):
+        b = _browser()
+        self._fire(b, dict(EPISODE))
+        self.assertEqual(b.route.get("kind"), "series")
+        self.assertEqual(b.route.get("item_id"), "sh1")
+
+    def test_it_carries_the_series_name_as_the_title(self):
+        """The route title is what the top bar shows before the series DTO
+        arrives; without it the bar is blank on the way in."""
+        b = _browser()
+        self._fire(b, dict(EPISODE))
+        self.assertEqual(b.route.get("title"), "A Show")
+
+    def test_it_closes_the_menu(self):
+        b = _browser()
+        self._fire(b, dict(EPISODE))
+        self.assertIsNone(b._menu)
+
+    def test_it_goes_to_the_series_and_not_the_episode(self):
+        """The failure mode if the handler reached for `Id`: it would open
+        the episode's own detail page, which is where you already were."""
+        b = _browser()
+        self._fire(b, dict(EPISODE))
+        self.assertNotEqual(b.route.get("item_id"), "e1")
+
+    def test_the_route_matches_the_detail_pages_own_button(self):
+        """Two doors, one page. `pages/detail.py` builds
+        {kind, server, item_id, title} and this must not drift from it --
+        a route missing a key lands on a screen that loads differently."""
+        b = _browser()
+        self._fire(b, dict(EPISODE))
+        for key, want in (("kind", "series"), ("server", "srv1"),
+                          ("item_id", "sh1"), ("title", "A Show")):
+            with self.subTest(key=key):
+                self.assertEqual(b.route.get(key), want)
+
+
+class VerbTest(unittest.TestCase):
+    def test_it_reuses_the_detail_pages_string_and_icon(self):
+        """gettext keys on the English, so a second spelling would be a
+        second entry for all 86 locales to translate -- and the icon is
+        what makes the two doors recognisably the same door."""
+        import pathlib
+
+        from jellyfin_mpv_shim.mpvtk_browser.pages import detail
+
+        src = pathlib.Path(detail.__file__).read_text()
+        self.assertIn('_("Go to Series")', src)
+        self.assertIn('"movie"', src)
+
+        b = _browser()
+        entry = next(e for e in b._tile_menu_entries(dict(EPISODE))
+                     if e[2] == "goseries")
+        self.assertEqual(entry[0], "Go to Series")
+        self.assertEqual(entry[1], "movie")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_home_rows.py
+++ b/tests/test_home_rows.py
@@ -472,7 +472,7 @@ class ContinueWatchingStaysCurrentTest(unittest.TestCase):
         b, loads = self._browser()
         b.USERDATA_DEBOUNCE = 0.01
         for _ in range(20):
-            b.refresh_home()
+            b.refresh_userdata()
         for _ in range(200):
             if loads:
                 break
@@ -482,14 +482,14 @@ class ContinueWatchingStaysCurrentTest(unittest.TestCase):
     def test_nothing_happens_off_the_home_screen(self):
         b, loads = self._browser()
         b.route["kind"] = "grid"
-        b.refresh_home()
-        b.refresh_home(now=True)
+        b.refresh_userdata()
+        b.refresh_userdata(now=True)
         self.assertEqual(loads, [])
 
     def test_nothing_happens_while_playback_owns_the_window(self):
         b, loads = self._browser()
         b._browsing = False
-        b.refresh_home()
+        b.refresh_userdata()
         self.assertEqual(loads, [])
 
     def test_an_open_menu_defers_it(self):
@@ -497,11 +497,11 @@ class ContinueWatchingStaysCurrentTest(unittest.TestCase):
         on -- the rule refresh_live_tv established."""
         b, loads = self._browser()
         b._menu = {"kind": "history"}
-        b.refresh_home(now=True)
+        b.refresh_userdata(now=True)
         self.assertEqual(loads, [])
         b._menu = None
         b._dialog = lambda: None
-        b.refresh_home(now=True)
+        b.refresh_userdata(now=True)
         self.assertEqual(loads, [])
 
     def _live_browser(self):

--- a/tests/test_hud_icon_sizes.py
+++ b/tests/test_hud_icon_sizes.py
@@ -32,6 +32,7 @@ import unittest
 
 sys.argv = [sys.argv[0]]
 
+from jellyfin_mpv_shim.mpvtk import scaling                      # noqa: E402
 from jellyfin_mpv_shim.mpvtk import theme as tk                  # noqa: E402
 from jellyfin_mpv_shim.mpvtk import widgets                      # noqa: E402
 from jellyfin_mpv_shim.mpvtk.layout import layout                # noqa: E402
@@ -97,6 +98,92 @@ class TriggerGlyphTest(unittest.TestCase):
         # behaviour, so this fix is additive.
         tk.set_type_scale(None)
         self.assertIsNone(_glyph("d").get("isz"))
+
+
+class TriggerGlyphUiScaleTest(unittest.TestCase):
+    """The glyph follows `ui_scale`, which is the axis the rest of this
+    file does not test -- and #721 is what lived in the gap.
+
+    The three tests above assert `isz` is 30 no matter what the TYPE scale
+    or the text multiplier does, which is right and is what this file is
+    named after. But they all read `layout()` output *before*
+    `scale_scene`, so none of them can see the logical -> physical
+    conversion, and `isz` was in none of `scaling.py`'s tables. At
+    `ui_scale` 2 the trigger's box went 47 -> 94 and the glyph stayed 30:
+    three HUD controls drawing a small icon in a big hit box, on exactly
+    the HiDPI displays the setting exists for.
+    """
+
+    def tearDown(self):
+        tk.set_type_scale(None)
+        scaling.set_scale(1.0)
+
+    @staticmethod
+    def _physical(scale, icon_size=30):
+        """The dropdown trigger and a Button's icon, in PHYSICAL px.
+
+        Laid out inside a Row because a widget laid out alone stretches to
+        the viewport, and the trigger's box is the number under test.
+        """
+        scaling.set_scale(scale)
+        try:
+            row = widgets.Row([
+                widgets.Dropdown("dd", ["a", "b"], trigger_icon="bookmark",
+                                 icon_size=icon_size),
+                widgets.Button("", icon="hd", icon_size=icon_size, id="btn",
+                               on_click=lambda: None),
+            ], gap=6, align="center")
+            nodes, _h = layout(row, 900, 400)
+            scaling.scale_scene(nodes)
+            dd = next(n for n in nodes if n.get("t") == "dropdown")
+            icon = next(n for n in nodes if n.get("t") == "icon")
+            return dd, icon
+        finally:
+            scaling.set_scale(1.0)
+
+    def test_the_glyph_grows_with_the_interface(self):
+        for scale in (1.0, 1.5, 2.0, 3.5):
+            with self.subTest(scale=scale):
+                dd, _icon = self._physical(scale)
+                self.assertAlmostEqual(dd["isz"], 30 * scale, delta=1.0)
+
+    def test_the_glyph_still_fits_the_box_it_sits_in(self):
+        """The visible symptom, stated as a ratio rather than a number.
+
+        The renderer centres the glyph in the trigger
+        (`renderer.lua`: `ex + (node.w - isz) / 2`), so what the eye reads
+        is `isz / w`. That ratio is what went from 0.64 to 0.32.
+        """
+        base = None
+        for scale in (1.0, 1.5, 2.0, 3.5):
+            with self.subTest(scale=scale):
+                dd, _icon = self._physical(scale)
+                ratio = dd["isz"] / dd["w"]
+                if base is None:
+                    base = ratio
+                self.assertAlmostEqual(ratio, base, delta=0.03)
+
+    def test_it_still_matches_a_button_icon_after_conversion(self):
+        """The same claim `test_it_matches_a_button_icon_at_every_setting`
+        makes about the type scale, one axis over -- and this is the one
+        that has to survive rounding, since a Button's icon goes through
+        `_PX_KEYS` and must land on the same integer."""
+        for scale in (1.0, 1.5, 2.0, 3.5):
+            with self.subTest(scale=scale):
+                dd, icon = self._physical(scale)
+                self.assertEqual(dd["isz"], icon["w"])
+
+    def test_an_odd_size_rounds_the_way_a_box_does(self):
+        """`isz` is a BOX, not a font size: 17 at 1.5x is 25.5, and the
+        renderer floors whatever it is handed. Rounded (26) it matches the
+        Button's icon; left exact (25.5) the renderer floors to 25 and the
+        two families are one pixel apart again -- which is the bug this
+        file exists for, in miniature. This is why `isz` belongs in
+        `_PX_KEYS` and not in `_EXACT_KEYS`.
+        """
+        dd, icon = self._physical(1.5, icon_size=17)
+        self.assertEqual(dd["isz"], icon["w"])
+        self.assertEqual(dd["isz"], int(dd["isz"]), "a box is a whole pixel")
 
 
 class HudUsesOneSizeTest(unittest.TestCase):

--- a/tests/test_hud_icon_sizes.py
+++ b/tests/test_hud_icon_sizes.py
@@ -218,7 +218,7 @@ class HudUsesOneSizeTest(unittest.TestCase):
     def test_it_is_the_same_size_the_buttons_use(self):
         """`HUD_ICON` is the one number, so the two families cannot drift
         apart again -- which is how they were 30 and 24 to begin with."""
-        src = pathlib.Path(hud.__file__).read_text()
+        src = pathlib.Path(hud.__file__).read_text(encoding="utf-8")
         self.assertIn("icon_size=HUD_ICON", src,
                       "the transport buttons no longer use HUD_ICON")
         self.assertIn("picker_icon = sz(HUD_ICON)", src,
@@ -230,7 +230,7 @@ class TriggerColourTest(unittest.TestCase):
         """Read from renderer.lua: the colour is chosen there, and there
         is no scene field to assert on."""
         src = (pathlib.Path(hud.__file__).parent.parent
-               / "mpvtk" / "renderer.lua").read_text()
+               / "mpvtk" / "renderer.lua").read_text(encoding="utf-8")
         block = src[src.index("chromeless icon trigger"):]
         block = block[:block.index("return")]
         # The draw call, not the whole block: the comment beside it names

--- a/tests/test_hud_icon_sizes.py
+++ b/tests/test_hud_icon_sizes.py
@@ -199,14 +199,14 @@ class HudUsesOneSizeTest(unittest.TestCase):
                                  "selected": True},
                                 {"id": "b", "label": "720"}]},
     }
-    TIERS = {"chapters": True, "quality": True, "audio": True,
-             "subs": True, "fav": True}
-
     def _pickers(self, size):
-        return [p for p in hud._pickers(
+        """`_pickers` returns (shed key, widget) pairs now: whether there
+        is room is decided by `_shed` once the whole row can be measured,
+        not by a breakpoint inside the builder."""
+        return [w for _key, w in hud._pickers(
             None, dict(self.STATE), 0,
             [{"time": 0, "title": "One"}, {"time": 90, "title": "Two"}],
-            self.TIERS, size) if getattr(p, "trigger_icon", None)]
+            size) if getattr(w, "trigger_icon", None)]
 
     def test_every_picker_takes_the_size_it_is_given(self):
         got = self._pickers(30)
@@ -241,6 +241,81 @@ class TriggerColourTest(unittest.TestCase):
                       "the HUD's track pickers are drawn with a muted "
                       "chrome token over video")
         self.assertNotIn("on_surface_muted", call)
+
+
+class TriggerBoxNeverSmallerThanItsGlyphTest(unittest.TestCase):
+    """A squeezed trigger draws its glyph outside itself (#721, part 2).
+
+    The transport row overflows on a narrow window -- that is what the
+    width tiers exist to manage, and they do not manage it completely.
+    When it overflows, `layout`'s flex-shrink pass distributes the
+    negative slack among the children that have no floor, and the floor
+    rule reads:
+
+        if lo is None and isinstance(c, Box) and (c.on_click or c.on_dbl):
+            lo = s      # "buttons floor at natural"
+
+    `Button` is a `Box`. `Dropdown` is an `Element`, so the four track
+    pickers -- which are buttons in every way a user can perceive -- have
+    **no floor at all** and absorb the entire overflow, down to and
+    including zero width. Their glyph does not shrink with them: the
+    renderer centres `isz` in the box (`draw_dropdown`), so at w=0 a
+    60px glyph is drawn 30px either side of nothing, straight across its
+    neighbour.
+
+    Measured before the repair, at the real HUD: 34x47 at 900px, 26x34 at
+    640, and at `ui_scale` 2 a 0x68 trigger with a 60px glyph overlapping
+    the next one by 36px. The scaling fix earlier in this file is what
+    made it visible -- the glyph used to stay small while the box
+    collapsed -- which is why it arrives as a second part of the same
+    issue rather than a regression of it.
+
+    The invariant is asserted in LOGICAL space, before `scale_scene`,
+    because that is where it is decided; `ui_scale` then multiplies both
+    sides equally and can neither cause nor cure it.
+    """
+
+    def _triggers(self, width):
+        from tests._shell_harness import HudController, FakeSource, build_scene
+        from jellyfin_mpv_shim.mpvtk_browser.app import MpvtkBrowser
+
+        b = MpvtkBrowser(app=None, source=FakeSource(),
+                         controller=HudController())
+        b._browsing = False
+        b.hud.shown = True
+        b.hud.state = {"stopped": False, "is_audio": False,
+                       "title": "Movie", "position": 50.0,
+                       "duration": 100.0, "paused": False}
+        nodes, _handlers = build_scene(b, (width, 720))
+        return [n for n in nodes
+                if n.get("t") == "dropdown" and n.get("isz")]
+
+    def test_the_box_always_contains_the_glyph(self):
+        for width in (1920, 1280, 1024, 960, 900, 800, 760, 720, 640, 560):
+            triggers = self._triggers(width)
+            self.assertTrue(triggers,
+                            "no icon triggers at %dpx; fixture drifted"
+                            % width)
+            for n in triggers:
+                with self.subTest(width=width, id=n.get("id")):
+                    self.assertGreaterEqual(
+                        n["w"], n["isz"],
+                        "%s is %sx%s around a %spx glyph -- it spills "
+                        "%.1fpx each side onto its neighbours"
+                        % (n.get("id"), n["w"], n["h"], n["isz"],
+                           (n["isz"] - n["w"]) / 2))
+
+    def test_and_stays_square_like_the_buttons_beside_it(self):
+        """The box is `int(glyph / 1.2 * 1.9)` on BOTH axes
+        (widgets.Dropdown). A row shrinks the main axis only, so a
+        trigger that is taller than it is wide is the squeeze, visible
+        before any glyph spills."""
+        for width in (1920, 1280, 1024, 960, 900, 800, 720, 640):
+            for n in self._triggers(width):
+                with self.subTest(width=width, id=n.get("id")):
+                    self.assertEqual(n["w"], n["h"],
+                                     "%s squeezed to %sx%s"
+                                     % (n.get("id"), n["w"], n["h"]))
 
 
 if __name__ == "__main__":

--- a/tests/test_hud_only_settings.py
+++ b/tests/test_hud_only_settings.py
@@ -42,7 +42,7 @@ from jellyfin_mpv_shim.mpvtk_browser import config as cfg  # noqa: E402
 def _shown(style, **overrides):
     """Every key the settings form would draw under ``style``."""
     patches = {"osc_style": style, "enable_gui": True,
-               "thumbnail_osc_builtin": True}
+               "thumbnail_enable": True}
     patches.update(overrides)
     with mock.patch.multiple(settings, **patches):
         return {k for _title, keys in cfg.sections() for k in keys}
@@ -76,11 +76,15 @@ class VisibilityTest(unittest.TestCase):
         self.assertTrue(set(cfg.HUD_ONLY) <= _shown("jellyfin"))
 
     def test_a_fallback_that_demotes_mpvtk_hides_them_too(self):
-        """`resolve_osc_style` demotes "mpvtk" when the GUI is off or the
-        legacy `thumbnail_osc_builtin` opt-out is set. The HUD does not run
-        in either case, so neither should its settings appear."""
+        """`resolve_osc_style` demotes "mpvtk" when the GUI is off: the
+        browser renders the HUD, so there is nothing to run it. The HUD
+        does not run, so neither should its settings appear.
+
+        This read `thumbnail_osc_builtin=False` until that flag was
+        deleted. `enable_gui` is the surviving fallback and the assertion
+        is about fallbacks, not about which flag drove one."""
         self.assertFalse(set(cfg.HUD_ONLY)
-                         & _shown("mpvtk", thumbnail_osc_builtin=False))
+                         & _shown("mpvtk", enable_gui=False))
 
 
 class NotHiddenTest(unittest.TestCase):
@@ -123,7 +127,7 @@ class SeedingTest(unittest.TestCase):
 
     def test_hud_only_is_seeded_so_the_filter_can_reach_it(self):
         with mock.patch.multiple(settings, osc_style="mpv", enable_gui=True,
-                                 thumbnail_osc_builtin=True):
+                                 thumbnail_enable=True):
             groups = dict(cfg.sections())
         drawn = {k for keys in groups.values() for k in keys}
         self.assertFalse(set(cfg.HUD_ONLY) & drawn,
@@ -134,7 +138,7 @@ class SeedingTest(unittest.TestCase):
         """Seeding must not become hiding-forever: with the HUD selected
         they belong in their real group, not nowhere."""
         with mock.patch.multiple(settings, osc_style="mpvtk", enable_gui=True,
-                                 thumbnail_osc_builtin=True):
+                                 thumbnail_enable=True):
             groups = dict(cfg.sections())
         controls = set(groups.get("Player Controls", ()))
         self.assertTrue(set(cfg.HUD_ONLY) <= controls)
@@ -145,7 +149,7 @@ class SeedingTest(unittest.TestCase):
         that filters a group WITHOUT seeding is caught here rather than
         shipping rows nobody can explain."""
         with mock.patch.multiple(settings, osc_style="mpv", enable_gui=True,
-                                 thumbnail_osc_builtin=True):
+                                 thumbnail_enable=True):
             groups = dict(cfg.sections())
         advanced = set(groups.get("Advanced", ()))
         curated = {k for title, keys in groups.items()

--- a/tests/test_hud_only_settings.py
+++ b/tests/test_hud_only_settings.py
@@ -1,0 +1,187 @@
+"""HUD-only settings are not offered where they cannot do anything (#724).
+
+Six settings reach the in-window playback HUD and nothing else -- they are
+read in one place, `gateway/hud.py:hud_key_opts`, which builds the blob sent
+with the `mpvtk-hud` engage, and that message is only ever sent by the HUD
+modality. Under "MPV UI with thumbnails" or "MPV built-in default" they are
+inert.
+
+They were offered anyway, and that is what the report reads like from the
+outside: "Left Click Pauses Playback" is on, the left button does nothing
+over the video, "appears to be completely broken". The client was working
+as designed -- the setting was never going to reach that player -- which is
+the worst kind of correct.
+
+`SECTIONS` already said so in a comment ("osc_style decides whether the rest
+of the group applies at all") and nothing acted on it. The mechanism to act
+on it also already existed: `sections()` hides the audio passthrough toggles
+the selected `audio_mode` cannot carry, and `audio_exclusive` on platforms
+mpv ignores it on.
+"""
+
+# Run as a script, this is what puts the repo root on sys.path -- without
+# it `jellyfin_mpv_shim` resolves to whatever is pip-installed. A no-op
+# under `discover`; tests/test_module_paths.py is the guard.
+if __name__ == "__main__":
+    import os
+    import sys
+
+    sys.path.insert(0, os.path.dirname(
+        os.path.dirname(os.path.abspath(__file__))))
+
+import sys
+import unittest
+from unittest import mock
+
+sys.argv = ["test"]
+
+from jellyfin_mpv_shim.conf import settings  # noqa: E402
+from jellyfin_mpv_shim.mpvtk_browser import config as cfg  # noqa: E402
+
+
+def _shown(style, **overrides):
+    """Every key the settings form would draw under ``style``."""
+    patches = {"osc_style": style, "enable_gui": True,
+               "thumbnail_osc_builtin": True}
+    patches.update(overrides)
+    with mock.patch.multiple(settings, **patches):
+        return {k for _title, keys in cfg.sections() for k in keys}
+
+
+class VisibilityTest(unittest.TestCase):
+    def test_the_jellyfin_ui_offers_them(self):
+        shown = _shown("mpvtk")
+        for key in cfg.HUD_ONLY:
+            with self.subTest(key=key):
+                self.assertIn(key, shown)
+
+    def test_the_mpv_osc_does_not(self):
+        shown = _shown("mpv")
+        for key in cfg.HUD_ONLY:
+            with self.subTest(key=key):
+                self.assertNotIn(key, shown)
+
+    def test_nor_the_builtin_default(self):
+        shown = _shown("default")
+        self.assertFalse(set(cfg.HUD_ONLY) & shown)
+
+    def test_nor_no_controls_at_all(self):
+        self.assertFalse(set(cfg.HUD_ONLY) & _shown("none"))
+
+    def test_the_legacy_alias_counts_as_the_jellyfin_ui(self):
+        """"jellyfin" is what the retired lua OSC was called and is still a
+        valid value in an old conf.json. Reading `settings.osc_style`
+        directly instead of resolving it would hide the HUD's own settings
+        from exactly the users who have had it longest."""
+        self.assertTrue(set(cfg.HUD_ONLY) <= _shown("jellyfin"))
+
+    def test_a_fallback_that_demotes_mpvtk_hides_them_too(self):
+        """`resolve_osc_style` demotes "mpvtk" when the GUI is off or the
+        legacy `thumbnail_osc_builtin` opt-out is set. The HUD does not run
+        in either case, so neither should its settings appear."""
+        self.assertFalse(set(cfg.HUD_ONLY)
+                         & _shown("mpvtk", thumbnail_osc_builtin=False))
+
+
+class NotHiddenTest(unittest.TestCase):
+    """The neighbours in the same group that DO work under every style."""
+
+    def test_the_style_picker_itself_always_shows(self):
+        for style in ("mpvtk", "mpv", "default", "none"):
+            with self.subTest(style=style):
+                self.assertIn("osc_style", _shown(style))
+
+    def test_mouse_chapter_nav_always_shows(self):
+        """Bound by `player.py`, not by the renderer, so the thumb buttons
+        seek chapters under every style. It sits in the same group as the
+        six above and is the easiest thing to hide by accident."""
+        for style in ("mpvtk", "mpv", "default"):
+            with self.subTest(style=style):
+                self.assertIn("mouse_chapter_nav", _shown(style))
+
+    def test_trickplay_fast_mode_always_shows(self):
+        """thumbfast is loaded for both OSCs."""
+        self.assertIn("trickplay_fast_mode", _shown("mpv"))
+
+
+class SeedingTest(unittest.TestCase):
+    """A hideable set has to be SEEDED into `curated`, or it cannot hide.
+
+    `sections()` computes `hidden = curated - shown`, so a key that is not
+    in `curated` can never be in `hidden` and the filter simply passes it
+    through. That is why `HUD_ONLY` joins the seed beside the audio sets --
+    and it is worth stating, because the failure is silent: the rows carry
+    on being drawn and nothing says why.
+
+    **The leak this class was first written to catch cannot happen.**
+    `hidden` is a subset of `curated` by construction, so a hidden key is
+    always claimed and can never reappear under "Advanced". Measured
+    against the unseeded mutation: the keys stay in Player Controls rather
+    than moving. The test asserting otherwise passed either way and is gone;
+    what is left is the property that actually breaks.
+    """
+
+    def test_hud_only_is_seeded_so_the_filter_can_reach_it(self):
+        with mock.patch.multiple(settings, osc_style="mpv", enable_gui=True,
+                                 thumbnail_osc_builtin=True):
+            groups = dict(cfg.sections())
+        drawn = {k for keys in groups.values() for k in keys}
+        self.assertFalse(set(cfg.HUD_ONLY) & drawn,
+                         "HUD_ONLY is not reaching `hidden` -- check it is "
+                         "in the `curated` seed in sections()")
+
+    def test_they_are_still_reachable_when_the_hud_is_on(self):
+        """Seeding must not become hiding-forever: with the HUD selected
+        they belong in their real group, not nowhere."""
+        with mock.patch.multiple(settings, osc_style="mpvtk", enable_gui=True,
+                                 thumbnail_osc_builtin=True):
+            groups = dict(cfg.sections())
+        controls = set(groups.get("Player Controls", ()))
+        self.assertTrue(set(cfg.HUD_ONLY) <= controls)
+
+    def test_advanced_never_holds_a_hidden_key(self):
+        """Not the leak test that could not fail -- this one names the
+        invariant that makes the leak impossible, so a future `sections()`
+        that filters a group WITHOUT seeding is caught here rather than
+        shipping rows nobody can explain."""
+        with mock.patch.multiple(settings, osc_style="mpv", enable_gui=True,
+                                 thumbnail_osc_builtin=True):
+            groups = dict(cfg.sections())
+        advanced = set(groups.get("Advanced", ()))
+        curated = {k for title, keys in groups.items()
+                   if title != "Advanced" for k in keys}
+        self.assertFalse(advanced & curated,
+                         "a key is drawn twice: in a group and in Advanced")
+
+
+class ResolverTest(unittest.TestCase):
+    def test_it_never_takes_the_form_down(self):
+        """`hud_style_selected` is only ever used to decide whether to draw
+        a row; a settings screen that refuses to open is worse than one
+        showing a setting that does nothing, so it fails open."""
+        with mock.patch("jellyfin_mpv_shim.mpv_options.resolve_osc_style",
+                        side_effect=RuntimeError("boom")):
+            self.assertTrue(cfg.hud_style_selected())
+
+    def test_every_hud_only_key_is_a_real_setting(self):
+        for key in cfg.HUD_ONLY:
+            with self.subTest(key=key):
+                self.assertIn(key, cfg.settings_schema())
+
+    def test_every_hud_only_key_is_read_by_the_hud_gateway(self):
+        """The claim that earns the hiding: these reach the HUD and nothing
+        else. Read from the source, so adding a key to HUD_ONLY that some
+        other module also consumes fails here rather than silently hiding a
+        setting that did something."""
+        import pathlib
+
+        from jellyfin_mpv_shim.mpvtk_browser.gateway import hud as hud_gw
+
+        src = pathlib.Path(hud_gw.__file__).read_text()
+        for key in cfg.HUD_ONLY:
+            with self.subTest(key=key):
+                self.assertIn("settings.%s" % key, src)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_hud_only_settings.py
+++ b/tests/test_hud_only_settings.py
@@ -186,7 +186,7 @@ class ResolverTest(unittest.TestCase):
         from jellyfin_mpv_shim.mpvtk_browser import hud as hud_ui
         from jellyfin_mpv_shim.mpvtk_browser.gateway import hud as hud_gw
 
-        src = "".join(pathlib.Path(m.__file__).read_text()
+        src = "".join(pathlib.Path(m.__file__).read_text(encoding="utf-8")
                       for m in (hud_gw, hud_ui))
         for key in cfg.HUD_ONLY:
             with self.subTest(key=key):
@@ -214,7 +214,7 @@ class ResolverTest(unittest.TestCase):
             for path in root.rglob("*.py"):
                 if path.resolve() in allowed:
                     continue
-                if "settings.%s" % key in path.read_text():
+                if "settings.%s" % key in path.read_text(encoding="utf-8"):
                     offenders.append(path.relative_to(root).as_posix())
             with self.subTest(key=key):
                 self.assertEqual(offenders, [],

--- a/tests/test_hud_only_settings.py
+++ b/tests/test_hud_only_settings.py
@@ -168,19 +168,58 @@ class ResolverTest(unittest.TestCase):
             with self.subTest(key=key):
                 self.assertIn(key, cfg.settings_schema())
 
-    def test_every_hud_only_key_is_read_by_the_hud_gateway(self):
+    def test_every_hud_only_key_is_read_by_the_hud(self):
         """The claim that earns the hiding: these reach the HUD and nothing
         else. Read from the source, so adding a key to HUD_ONLY that some
         other module also consumes fails here rather than silently hiding a
-        setting that did something."""
+        setting that did something.
+
+        **Two modules, not one.** This asked only the gateway until
+        `hud_auto_scale` arrived, which was true of the five keys it
+        started with by coincidence: they are all pushed to the renderer,
+        which is the gateway's job. A key the HUD reads while BUILDING its
+        widget tree is just as HUD-only, and asking only the gateway would
+        have forced a real HUD setting to be shown to classic-OSC users --
+        the #724 complaint this whole mechanism exists to answer."""
         import pathlib
 
+        from jellyfin_mpv_shim.mpvtk_browser import hud as hud_ui
         from jellyfin_mpv_shim.mpvtk_browser.gateway import hud as hud_gw
 
-        src = pathlib.Path(hud_gw.__file__).read_text()
+        src = "".join(pathlib.Path(m.__file__).read_text()
+                      for m in (hud_gw, hud_ui))
         for key in cfg.HUD_ONLY:
             with self.subTest(key=key):
                 self.assertIn("settings.%s" % key, src)
+
+    def test_and_by_nothing_outside_it(self):
+        """The other half, and the one that makes hiding honest: a key
+        read anywhere else does something a classic-OSC user can see, so
+        hiding it from them is a lie. Scans the package for reads outside
+        the two HUD modules and the settings plumbing itself."""
+        import pathlib
+
+        from jellyfin_mpv_shim.mpvtk_browser import hud as hud_ui
+        from jellyfin_mpv_shim.mpvtk_browser.gateway import hud as hud_gw
+
+        allowed = {pathlib.Path(hud_gw.__file__).resolve(),
+                   pathlib.Path(hud_ui.__file__).resolve()}
+        root = pathlib.Path(hud_ui.__file__).resolve().parent.parent
+        # conf.py declares them and config.py curates them; neither is a
+        # behaviour that a classic OSC would show.
+        allowed |= {(root / "conf.py").resolve(),
+                    (root / "mpvtk_browser" / "config.py").resolve()}
+        for key in cfg.HUD_ONLY:
+            offenders = []
+            for path in root.rglob("*.py"):
+                if path.resolve() in allowed:
+                    continue
+                if "settings.%s" % key in path.read_text():
+                    offenders.append(path.relative_to(root).as_posix())
+            with self.subTest(key=key):
+                self.assertEqual(offenders, [],
+                                 "%s is hidden from classic-OSC users but "
+                                 "read outside the HUD" % key)
 
 
 if __name__ == "__main__":

--- a/tests/test_kiosk_fullscreen.py
+++ b/tests/test_kiosk_fullscreen.py
@@ -8,7 +8,9 @@ browser and the wrong one for a cast target: headless has no library, so
 space would fall out of fullscreen the moment a cast finished.
 
 Exercised through the real `set_browse_window` against a fake mpv, because
-the whole bug lives in that method's branching.
+the whole bug lives in that method's branching -- which #729 then gave a
+second caller, so `LiveApplyBrowserFullscreenTest` below runs the same table
+through the settings page's entry point.
 """
 
 # Run as a script, this is what puts the repo root on sys.path -- without
@@ -104,6 +106,80 @@ class KioskFullscreenTest(unittest.TestCase):
         pm._player.fs = True
         pm.set_browse_window(True)
         self.assertTrue(pm._player.fs)
+
+
+class LiveApplyBrowserFullscreenTest(unittest.TestCase):
+    """#729: the setting has to move the window it is named after, now.
+
+    It used to be read only on a browse TRANSITION, so it took effect after
+    the next thing you played -- which from inside Settings is not
+    distinguishable from a switch that does nothing.
+
+    The branching itself is `KioskFullscreenTest` above; both entry points
+    share `_apply_browse_fullscreen`, and the table below is what says so.
+    A second copy of that decision is the failure this guards: it would
+    agree on the day it was written and drift on the first change.
+    """
+
+    _pm = KioskFullscreenTest._pm
+    _settings = KioskFullscreenTest._settings
+
+    def _live(self, video=None, **kw):
+        from threading import RLock
+
+        self._settings(**kw)
+        pm = self._pm(video)
+        pm._lock = RLock()          # apply_browser_fullscreen is synchronous
+        pm.fullscreen_disable = False
+        return pm
+
+    def test_it_agrees_with_a_browse_transition_on_every_branch(self):
+        for browser_fs, headless, video, want in (
+                (True, False, None, True),
+                (False, False, None, False),
+                (True, True, None, True),
+                (False, True, None, True),      # kiosk: see the class above
+                (False, False, object(), True),  # a video owns fullscreen
+        ):
+            with self.subTest(browser_fullscreen=browser_fs,
+                              headless=headless, playing=video is not None):
+                pm = self._live(video=video, browser_fullscreen=browser_fs,
+                                headless=headless)
+                pm._player.fs = True if video is not None else not want
+                pm.apply_browser_fullscreen()
+                self.assertEqual(pm._player.fs, want)
+
+    def test_toggling_it_on_takes_the_window_without_a_browse_transition(self):
+        """The report: it did nothing until the app was started again."""
+        pm = self._live(browser_fullscreen=True, headless=False)
+        pm._player.fs = False
+        pm.apply_browser_fullscreen()
+        self.assertTrue(pm._player.fs)
+
+    def test_toggling_it_off_gives_the_window_back(self):
+        pm = self._live(browser_fullscreen=False, headless=False)
+        pm._player.fs = True
+        pm.apply_browser_fullscreen()
+        self.assertFalse(pm._player.fs)
+
+    def test_it_does_not_record_a_playback_fullscreen_intent(self):
+        """The trap `set_fullscreen` would have walked into: that method
+        also writes `fullscreen_disable`, which is read at the NEXT playback
+        start -- so turning the library's fullscreen off would have turned
+        auto-fullscreen off for videos too, with nothing on screen saying
+        so."""
+        pm = self._live(browser_fullscreen=False, headless=False)
+        pm._player.fs = True
+        pm.apply_browser_fullscreen()
+        self.assertFalse(pm.fullscreen_disable,
+                         "a browse-window change wrote the video's intent")
+
+    def test_a_dead_mpv_is_left_alone(self):
+        pm = self._live(browser_fullscreen=True, headless=False)
+        pm._mpv_alive = False
+        pm._player.fs = False
+        pm.apply_browser_fullscreen()
+        self.assertFalse(pm._player.fs)
 
 
 if __name__ == "__main__":

--- a/tests/test_kiosk_fullscreen.py
+++ b/tests/test_kiosk_fullscreen.py
@@ -124,14 +124,42 @@ class LiveApplyBrowserFullscreenTest(unittest.TestCase):
     _pm = KioskFullscreenTest._pm
     _settings = KioskFullscreenTest._settings
 
-    def _live(self, video=None, **kw):
+    def _live(self, video=None, audio=False, **kw):
         from threading import RLock
 
         self._settings(**kw)
         pm = self._pm(video)
         pm._lock = RLock()          # apply_browser_fullscreen is synchronous
         pm.fullscreen_disable = False
+        # Music keeps `_video` set AND keeps the library on screen; a video
+        # takes the window. That is the distinction the live apply turns on,
+        # so the stand-in has to model it rather than assume one answer.
+        pm._current_is_audio = lambda: audio
         return pm
+
+    def test_a_deferred_apply_does_not_fullscreen_a_playing_video(self):
+        """The gateway's `_act` DEFERS through `run_action`, so a write made
+        while the player lock was held by a playback start lands AFTER that
+        start. By then the library does not own the window, and
+        `browser_fullscreen` must not be applied to the video that took it
+        -- the `_video` guard only ever protected the OFF direction.
+        """
+        pm = self._live(video=object(), audio=False,
+                        browser_fullscreen=True, headless=False)
+        pm._player.fs = False           # the video is playing windowed
+        pm.apply_browser_fullscreen()
+        self.assertFalse(pm._player.fs,
+                         "a late browser-fullscreen write took the video "
+                         "fullscreen against the user's choice")
+
+    def test_music_still_gets_it_because_the_library_is_on_screen(self):
+        """The other side of the same predicate, and why it cannot just be
+        `_video is None`: audio keeps `_video` set with the library up."""
+        pm = self._live(video=object(), audio=True,
+                        browser_fullscreen=True, headless=False)
+        pm._player.fs = False
+        pm.apply_browser_fullscreen()
+        self.assertTrue(pm._player.fs)
 
     def test_it_agrees_with_a_browse_transition_on_every_branch(self):
         for browser_fs, headless, video, want in (
@@ -139,7 +167,7 @@ class LiveApplyBrowserFullscreenTest(unittest.TestCase):
                 (False, False, None, False),
                 (True, True, None, True),
                 (False, True, None, True),      # kiosk: see the class above
-                (False, False, object(), True),  # a video owns fullscreen
+                (False, False, object(), True),  # playing: left alone
         ):
             with self.subTest(browser_fullscreen=browser_fs,
                               headless=headless, playing=video is not None):

--- a/tests/test_mpv_options.py
+++ b/tests/test_mpv_options.py
@@ -86,9 +86,38 @@ class ResolveOscStyleTest(SettingsCase):
         self.assertEqual(mpv_options.resolve_osc_style(), "mpv")
 
     def test_the_legacy_opt_out_still_yields_the_users_own_osc(self):
+        """Still "default", which is why that value survives as an INTERNAL
+        resolution after CONFIG_VERSION 5 removed it from the settings
+        screen and from conf.json.
+
+        `custom` was tried here and is wrong. It sets `osc=False` and loads
+        nothing, which is right for someone genuinely running uosc and
+        leaves everyone else **with no OSC at all** -- and this flag is a
+        legacy default-off switch, not proof that a replacement exists.
+        "default" is the only value that leaves mpv's own OSC to load
+        itself, which is the safe reading of "don't replace my OSC"."""
         self.set(osc_style="mpvtk", enable_gui=True,
                  thumbnail_osc_builtin=False)
         self.assertEqual(mpv_options.resolve_osc_style(), "default")
+
+    def test_no_resolution_can_leave_a_user_with_no_osc_by_accident(self):
+        """The whole point of the paragraph above, as a property.
+
+        Every style that turns mpv's own OSC off must be one where either we
+        load one (`mpvtk`, `mpv`), the user asked for none (`none`), or the
+        user said they have their own (`custom`). A FALLBACK must never land
+        on the last two -- nobody chose them."""
+        chosen_none = {"none", "custom"}
+        for gui in (True, False):
+            for builtin in (True, False):
+                with self.subTest(enable_gui=gui,
+                                  thumbnail_osc_builtin=builtin):
+                    self.set(osc_style="mpvtk", enable_gui=gui,
+                             thumbnail_osc_builtin=builtin)
+                    got = mpv_options.resolve_osc_style()
+                    self.assertNotIn(got, chosen_none,
+                                     "a fallback from 'mpvtk' landed on a "
+                                     "style that draws no controls")
 
     def test_the_opt_out_does_not_apply_once_the_gui_fallback_has(self):
         # Order matters: enable_gui=False moves mpvtk -> mpv, and "mpv" is
@@ -98,10 +127,30 @@ class ResolveOscStyleTest(SettingsCase):
         self.assertEqual(mpv_options.resolve_osc_style(), "mpv")
 
     def test_explicit_styles_pass_through(self):
-        for style in ("mpv", "default", "none"):
-            self.set(osc_style=style, enable_gui=True,
-                     thumbnail_osc_builtin=True)
-            self.assertEqual(mpv_options.resolve_osc_style(), style)
+        for style in ("mpv", "custom", "none"):
+            with self.subTest(style=style):
+                self.set(osc_style=style, enable_gui=True,
+                         thumbnail_osc_builtin=True)
+                self.assertEqual(mpv_options.resolve_osc_style(), style)
+
+    def test_default_is_a_legacy_alias_for_mpv(self):
+        """"MPV built-in default" and "MPV UI with thumbnails" only differed
+        in who loaded the OSC, and once the shim started loading mpv's own
+        for both the difference showed up only as a bug -- nothing
+        suppressed the idle logo under "default". `_migrate` rewrites the
+        stored value at CONFIG_VERSION 5; this is what covers a hand-edited
+        conf.json, or one restored from a backup taken before it."""
+        self.set(osc_style="default", enable_gui=True,
+                 thumbnail_osc_builtin=True)
+        self.assertEqual(mpv_options.resolve_osc_style(), "mpv")
+
+    def test_the_alias_is_resolved_before_the_opt_out_can_see_it(self):
+        """Order: "default" becomes "mpv", and "mpv" is not subject to the
+        thumbnail_osc_builtin opt-out -- so an old config with both set does
+        not end up somewhere neither value asked for."""
+        self.set(osc_style="default", enable_gui=True,
+                 thumbnail_osc_builtin=False)
+        self.assertEqual(mpv_options.resolve_osc_style(), "mpv")
 
     def test_no_controls_is_not_talked_out_of_it(self):
         """Both fallbacks exist to find something to draw the HUD with.

--- a/tests/test_mpv_options.py
+++ b/tests/test_mpv_options.py
@@ -75,62 +75,37 @@ class SettingsCase(unittest.TestCase):
 
 class ResolveOscStyleTest(SettingsCase):
     def test_jellyfin_is_a_legacy_alias_for_the_hud(self):
-        self.set(osc_style="jellyfin", enable_gui=True,
-                 thumbnail_osc_builtin=True)
+        self.set(osc_style="jellyfin", enable_gui=True)
         self.assertEqual(mpv_options.resolve_osc_style(), "mpvtk")
 
     def test_without_a_gui_there_is_nothing_to_draw_the_hud(self):
         # The HUD is rendered by the library browser.
-        self.set(osc_style="mpvtk", enable_gui=False,
-                 thumbnail_osc_builtin=True)
+        self.set(osc_style="mpvtk", enable_gui=False)
         self.assertEqual(mpv_options.resolve_osc_style(), "mpv")
-
-    def test_the_legacy_opt_out_still_yields_the_users_own_osc(self):
-        """Still "default", which is why that value survives as an INTERNAL
-        resolution after CONFIG_VERSION 5 removed it from the settings
-        screen and from conf.json.
-
-        `custom` was tried here and is wrong. It sets `osc=False` and loads
-        nothing, which is right for someone genuinely running uosc and
-        leaves everyone else **with no OSC at all** -- and this flag is a
-        legacy default-off switch, not proof that a replacement exists.
-        "default" is the only value that leaves mpv's own OSC to load
-        itself, which is the safe reading of "don't replace my OSC"."""
-        self.set(osc_style="mpvtk", enable_gui=True,
-                 thumbnail_osc_builtin=False)
-        self.assertEqual(mpv_options.resolve_osc_style(), "default")
 
     def test_no_resolution_can_leave_a_user_with_no_osc_by_accident(self):
-        """The whole point of the paragraph above, as a property.
+        """Every style that turns mpv's own OSC off must be one where either
+        we load one (`mpvtk`, `mpv`), the user asked for none (`none`), or
+        the user said they have their own (`custom`). A FALLBACK must never
+        land on the last two -- nobody chose them.
 
-        Every style that turns mpv's own OSC off must be one where either we
-        load one (`mpvtk`, `mpv`), the user asked for none (`none`), or the
-        user said they have their own (`custom`). A FALLBACK must never land
-        on the last two -- nobody chose them."""
+        Kept as a property after `thumbnail_osc_builtin` (the fallback this
+        was written against) was deleted, because the rule outlives the
+        branch: it is what the next fallback added here has to satisfy."""
         chosen_none = {"none", "custom"}
         for gui in (True, False):
-            for builtin in (True, False):
-                with self.subTest(enable_gui=gui,
-                                  thumbnail_osc_builtin=builtin):
-                    self.set(osc_style="mpvtk", enable_gui=gui,
-                             thumbnail_osc_builtin=builtin)
+            for style in ("mpvtk", "jellyfin", "default"):
+                with self.subTest(enable_gui=gui, osc_style=style):
+                    self.set(osc_style=style, enable_gui=gui)
                     got = mpv_options.resolve_osc_style()
                     self.assertNotIn(got, chosen_none,
-                                     "a fallback from 'mpvtk' landed on a "
-                                     "style that draws no controls")
-
-    def test_the_opt_out_does_not_apply_once_the_gui_fallback_has(self):
-        # Order matters: enable_gui=False moves mpvtk -> mpv, and "mpv" is
-        # not subject to the thumbnail_osc_builtin opt-out.
-        self.set(osc_style="mpvtk", enable_gui=False,
-                 thumbnail_osc_builtin=False)
-        self.assertEqual(mpv_options.resolve_osc_style(), "mpv")
+                                     "a fallback from %r landed on a "
+                                     "style that draws no controls" % style)
 
     def test_explicit_styles_pass_through(self):
         for style in ("mpv", "custom", "none"):
             with self.subTest(style=style):
-                self.set(osc_style=style, enable_gui=True,
-                         thumbnail_osc_builtin=True)
+                self.set(osc_style=style, enable_gui=True)
                 self.assertEqual(mpv_options.resolve_osc_style(), style)
 
     def test_default_is_a_legacy_alias_for_mpv(self):
@@ -140,23 +115,34 @@ class ResolveOscStyleTest(SettingsCase):
         suppressed the idle logo under "default". `_migrate` rewrites the
         stored value at CONFIG_VERSION 5; this is what covers a hand-edited
         conf.json, or one restored from a backup taken before it."""
-        self.set(osc_style="default", enable_gui=True,
-                 thumbnail_osc_builtin=True)
+        self.set(osc_style="default", enable_gui=True)
         self.assertEqual(mpv_options.resolve_osc_style(), "mpv")
 
-    def test_the_alias_is_resolved_before_the_opt_out_can_see_it(self):
-        """Order: "default" becomes "mpv", and "mpv" is not subject to the
-        thumbnail_osc_builtin opt-out -- so an old config with both set does
-        not end up somewhere neither value asked for."""
-        self.set(osc_style="default", enable_gui=True,
-                 thumbnail_osc_builtin=False)
-        self.assertEqual(mpv_options.resolve_osc_style(), "mpv")
+    def test_nothing_resolves_to_default_any_more(self):
+        """"default" is an inbound legacy value only.
+
+        It survived as an internal resolution for exactly one caller -- the
+        `thumbnail_osc_builtin` opt-out -- and went when that did. This is
+        the half of the deletion that is invisible from the settings screen:
+        `build_mpv_options` still maps "default" (it is a pure style ->
+        options function), so a branch quietly re-appearing here would turn
+        mpv's own OSC back on for somebody and nothing else would say so.
+
+        Every value `osc_style` can hold and both sides of the one
+        surviving fallback, rather than a sample -- the claim is about the
+        whole function, not about the branch that was removed."""
+        for style in ("mpvtk", "jellyfin", "default", "mpv", "custom",
+                      "none"):
+            for gui in (True, False):
+                with self.subTest(osc_style=style, enable_gui=gui):
+                    self.set(osc_style=style, enable_gui=gui)
+                    self.assertNotEqual(mpv_options.resolve_osc_style(),
+                                        "default")
 
     def test_no_controls_is_not_talked_out_of_it(self):
-        """Both fallbacks exist to find something to draw the HUD with.
+        """The fallback exists to find something to draw the HUD with.
         Someone who asked for nothing has not got a problem to solve."""
-        self.set(osc_style="none", enable_gui=False,
-                 thumbnail_osc_builtin=False)
+        self.set(osc_style="none", enable_gui=False)
         self.assertEqual(mpv_options.resolve_osc_style(), "none")
 
 

--- a/tests/test_mpv_options.py
+++ b/tests/test_mpv_options.py
@@ -116,15 +116,26 @@ class ScriptListTest(SettingsCase):
         import os
         return [os.path.basename(p) for p in mpv_options.mpv_scripts(*a, **kw)]
 
-    def test_load_order_is_mouse_then_thumbfast_then_osc(self):
+    def test_load_order_is_mouse_then_thumbfast(self):
         self.set(menu_mouse=True)
         self.assertEqual(self.names("mpv", True),
-                         ["mouse.lua", "thumbfast.lua", "trickplay-osc.lua"])
+                         ["mouse.lua", "thumbfast.lua"])
 
-    def test_only_the_mpv_style_loads_an_osc_script(self):
+    def test_no_osc_script_is_chosen_here_any_more(self):
+        """Which classic OSC to load depends on the mpv about to be built --
+        the stock one on 0.41+, where its Preview API can drive our seek
+        previews, and the bundled fork below that. The version is not
+        knowable until the player exists (and the libmpv client API cannot
+        stand in: 0.40 and 0.41 both report 2.5), so the choice moved to
+        `PlayerManager._load_classic_osc`, right after construction.
+
+        Asserted for every style, including "mpv": a construction-time entry
+        would load the fork on top of whatever that method then chooses,
+        which is two OSCs at once."""
         self.set(menu_mouse=False)
-        for style in ("mpvtk", "default"):
-            self.assertNotIn("trickplay-osc.lua", self.names(style, True))
+        for style in ("mpv", "mpvtk", "default", "none"):
+            with self.subTest(style=style):
+                self.assertNotIn("trickplay-osc.lua", self.names(style, True))
 
     def test_thumbfast_follows_the_worker_not_the_setting(self):
         # A TrickPlay worker that failed to start must not advertise

--- a/tests/test_no_childcount_reads.py
+++ b/tests/test_no_childcount_reads.py
@@ -89,7 +89,8 @@ class NoChildCountReadsTest(unittest.TestCase):
         `"ChildCount": ...` key the filter above silently reclassifies it
         as a read, and this says so in one line instead of failing the
         real test with a confusing message."""
-        text = (PKG / "mpvtk_browser" / "repository.py").read_text()
+        text = (PKG / "mpvtk_browser" / "repository.py").read_text(
+            encoding="utf-8")
         self.assertIn('"ChildCount": len(members),', text)
 
 

--- a/tests/test_no_platform_text_reads.py
+++ b/tests/test_no_platform_text_reads.py
@@ -1,0 +1,135 @@
+"""A test that reads a repo file must say which encoding it is in.
+
+`Path.read_text()` and `open()` use `locale.getencoding()`, which is UTF-8
+on this project's Linux and macOS boxes and **cp1252 on Windows**. Five
+files under `jellyfin_mpv_shim/` hold bytes cp1252 cannot decode, so a
+source-walking test dies there with a `UnicodeDecodeError` that names a
+byte offset and nothing else -- it reads as a broken tree rather than as a
+test that forgot an argument.
+
+Found by running the unit suite on the Windows VM, where
+`test_hud_only_settings` was the one that happened to walk *all* of the
+package. It had seventeen siblings, every one of them passing only because
+the file it read was cp1252-decodable by luck: the failure is a property of
+the file being read, not of the test doing the reading, so which of them
+fails moves whenever somebody adds an em dash.
+
+Scoped to `tests/` and `tools/`, which is where the repo reads its own
+source. Application code that reads a *user's* file is a different
+question with a different answer -- `conf.py` states UTF-8 and forgives a
+BOM, and `docs/configuration.md` says so.
+"""
+
+# Run as a script, this is what puts the repo root on sys.path -- without
+# it `jellyfin_mpv_shim` resolves to whatever is pip-installed. A no-op
+# under `discover`; tests/test_module_paths.py is the guard.
+if __name__ == "__main__":
+    import os
+    import sys
+
+    sys.path.insert(0, os.path.dirname(
+        os.path.dirname(os.path.abspath(__file__))))
+
+import ast
+import pathlib
+import unittest
+
+ROOT = pathlib.Path(__file__).resolve().parent.parent
+SCANNED = ("tests", "tools")
+
+#: Sites that read BYTES, or that are themselves this guard. Nothing is
+#: listed here today; it exists so an exception is written down with a
+#: reason rather than by dropping the directory from SCANNED.
+ACCEPTED = {}
+
+
+def _offenders():
+    out = []
+    for where in SCANNED:
+        for path in sorted((ROOT / where).rglob("*.py")):
+            rel = path.relative_to(ROOT).as_posix()
+            try:
+                tree = ast.parse(path.read_text(encoding="utf-8"))
+            except SyntaxError:
+                continue
+            for node in ast.walk(tree):
+                if not isinstance(node, ast.Call):
+                    continue
+                func = node.func
+                # Builtin `open` ONLY as a bare name. `Image.open`,
+                # `tarfile.open` and `io.open`-alikes are not text reads,
+                # and matching them by attribute name filled the first
+                # draft's report with four calls that take no encoding at
+                # all -- an allowlist of false positives is how a guard
+                # teaches people to skim past it.
+                if isinstance(func, ast.Attribute):
+                    name = func.attr
+                    if name not in ("read_text", "write_text"):
+                        continue
+                elif isinstance(func, ast.Name):
+                    name = func.id
+                    if name != "open":
+                        continue
+                else:
+                    continue
+                # `open(f, "rb")` and friends take no encoding, and an
+                # `encoding=` anywhere in the call is the whole ask.
+                if any(k.arg == "encoding" for k in node.keywords):
+                    continue
+                mode = next((a.value for a in node.args
+                             if isinstance(a, ast.Constant)
+                             and isinstance(a.value, str)
+                             and set(a.value) <= set("rwxabt+")), "")
+                if "b" in mode:
+                    continue
+                if rel in ACCEPTED:
+                    continue
+                out.append("%s:%d  %s(" % (rel, node.lineno, name))
+    return out
+
+
+class NoPlatformTextReadsTest(unittest.TestCase):
+    def test_every_text_read_names_its_encoding(self):
+        found = _offenders()
+        self.assertEqual(
+            found, [],
+            "these read or write text in the platform's default encoding, "
+            "which is cp1252 on Windows:\n  " + "\n  ".join(found)
+            + "\n\nPass encoding=\"utf-8\". If the call really wants bytes, "
+              "open it in binary mode; if it really wants the platform's "
+              "encoding, add it to ACCEPTED with the reason.")
+
+    def test_the_guard_can_actually_see_a_violation(self):
+        """A lint that scans nothing passes for the wrong reason.
+
+        Parses a violation and a clean call through the same code path, so
+        "no offenders" is a measurement rather than an empty walk.
+        """
+        import tempfile
+
+        with tempfile.TemporaryDirectory() as tmp:
+            probe = pathlib.Path(tmp) / "tests"
+            probe.mkdir()
+            (probe / "sample.py").write_text(
+                "import pathlib\n"
+                "a = pathlib.Path('x').read_text()\n"
+                "b = pathlib.Path('y').read_text(encoding='utf-8')\n"
+                "c = open('z', 'rb').read()\n"
+                "d = Image.open('z.png')\n"
+                "e = tarfile.open('z.tar')\n",
+                encoding="utf-8")
+            global ROOT
+            was = ROOT
+            try:
+                ROOT = pathlib.Path(tmp)
+                found = _offenders()
+            finally:
+                ROOT = was
+        self.assertEqual(len(found), 1, found)
+        self.assertIn("sample.py:2", found[0],
+                      "the encoding-less read_text is what should be "
+                      "reported; anything else means the matcher moved")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_osc_style_migration.py
+++ b/tests/test_osc_style_migration.py
@@ -1,0 +1,119 @@
+""""MPV built-in default" folds into "MPV UI" (CONFIG_VERSION 5).
+
+The two only ever differed in who loaded the OSC: `default` let mpv load its
+own, `mpv` had the shim load a bundled fork. Once the shim started using
+mpv's OWN OSC for the `mpv` style -- driven through the 0.41 OSC Preview API
+-- the difference stopped being visible as anything but a bug: nothing
+suppressed mpv's "Drop files or URLs to play" logo under `default`, so it sat
+behind the library.
+
+[iw], on the fact that `default` was the only style that left mpv's OSC
+loading alone: *"default has the 'drag to start' issue present, so we need to
+do something about it, we already have a custom and no osc option for people
+who want that."* So the shim owns this one, `custom` stays for a user's own
+OSC and `none` for no controls, and whether previews appear is
+`thumbnail_enable` -- a question about trickplay, not about which controls
+you want.
+
+Two ways an old value can still arrive, and both are covered: the migration
+rewrites what is on disk, and `resolve_osc_style` keeps accepting it for a
+hand-edited conf.json or one restored from an older backup.
+"""
+
+# Run as a script, this is what puts the repo root on sys.path -- without
+# it `jellyfin_mpv_shim` resolves to whatever is pip-installed. A no-op
+# under `discover`; tests/test_module_paths.py is the guard.
+if __name__ == "__main__":
+    import os
+    import sys
+
+    sys.path.insert(0, os.path.dirname(
+        os.path.dirname(os.path.abspath(__file__))))
+
+import sys
+import unittest
+
+sys.argv = ["test"]
+
+from jellyfin_mpv_shim.conf import CONFIG_VERSION, Settings  # noqa: E402
+
+
+def _at(version, **kw):
+    """A Settings as an older config would have loaded it."""
+    s = Settings()
+    s.config_version = version
+    for key, value in kw.items():
+        setattr(s, key, value)
+    return s
+
+
+class MigrationTest(unittest.TestCase):
+    def test_default_becomes_mpv(self):
+        s = _at(4, osc_style="default")
+        self.assertTrue(s._migrate({}))
+        self.assertEqual(s.osc_style, "mpv")
+
+    def test_and_the_version_is_stamped(self):
+        s = _at(4, osc_style="default")
+        s._migrate({})
+        self.assertEqual(s.config_version, CONFIG_VERSION)
+
+    def test_every_other_style_is_left_alone(self):
+        """It is a rename, not a reset: `mpvtk`, `custom` and `none` are
+        real choices and must survive untouched."""
+        for style in ("mpvtk", "mpv", "custom", "none", "jellyfin"):
+            with self.subTest(style=style):
+                s = _at(4, osc_style=style)
+                s._migrate({})
+                self.assertEqual(s.osc_style, style)
+
+    def test_it_does_not_re_run(self):
+        """A config already at the current version is not migrated again --
+        which matters because somebody may have hand-set `default` back."""
+        s = _at(CONFIG_VERSION, osc_style="default")
+        s._migrate({})
+        self.assertEqual(s.osc_style, "default",
+                         "a current config was migrated a second time")
+
+    def test_the_default_style_is_not_the_one_being_removed(self):
+        """A fresh install must not land on a value the form no longer
+        offers. (`Settings()` itself is version 0 -- `load()` is what stamps
+        a new install as current, which is why this asserts the style and
+        not the version.)"""
+        s = Settings()
+        self.assertEqual(s.osc_style, "mpvtk")
+        self.assertLess(s.config_version, CONFIG_VERSION)
+
+
+class OfferedChoicesTest(unittest.TestCase):
+    def test_the_settings_screen_no_longer_offers_default(self):
+        from jellyfin_mpv_shim.mpvtk_browser import config as cfg
+
+        values = [v for _label, v in cfg.LABELED_ENUMS["osc_style"]]
+        self.assertNotIn("default", values)
+        self.assertEqual(values, ["mpvtk", "mpv", "custom", "none"])
+
+    def test_the_survivors_cover_what_default_was_for(self):
+        """Nothing is lost: `custom` is "my own OSC, leave it alone" and
+        `none` is "no controls". Those are the two reasons anyone chose
+        `default`, and both are still one click away."""
+        from jellyfin_mpv_shim.mpvtk_browser import config as cfg
+
+        values = [v for _label, v in cfg.LABELED_ENUMS["osc_style"]]
+        self.assertIn("custom", values)
+        self.assertIn("none", values)
+
+    def test_a_migrated_config_lands_on_an_offered_value(self):
+        """The migration must not strand anyone on a value the form cannot
+        display -- a dropdown with no matching entry is a setting the user
+        can see and cannot change back."""
+        from jellyfin_mpv_shim.mpvtk_browser import config as cfg
+
+        s = _at(4, osc_style="default")
+        s._migrate({})
+        values = [v for _label, v in cfg.LABELED_ENUMS["osc_style"]]
+        self.assertIn(s.osc_style, values)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_season_play.py
+++ b/tests/test_season_play.py
@@ -1,0 +1,224 @@
+"""The play chip on a SEASON tile plays the season (#720).
+
+It used to open it. `_resolve_play_ids` sent the season's id to
+`get_series_queue`, which asks `Shows/{id}/Episodes` -- and a season id
+there is not a series, so the server answered with nothing, and
+`_menu_play`'s "resolved to nothing" branch fell through to `_open_item`.
+The chip navigated, which is the one thing a Play button must not do.
+
+The behaviour it should have is jellyfin-web's, taken from
+`playbackmanager.js`'s `getSeriesOrSeasonPlaybackPromise` rather than from
+memory: a season queues **whole**, in order, and starts at the **first
+unplayed** episode. Web deliberately skips its Next Up lookup when a season
+is named (`!seasonId` guards it), because "play this season" and "carry on
+with this show" are different questions and only the second may leave the
+season.
+
+Two things here are about the *shape* of the fix rather than the behaviour,
+and both are regressions waiting to happen:
+
+* `_resolve_play_ids` is shared with `_menu_queue`, which passes its result
+  straight to `_queue_items`. Widening its return type to carry the start
+  index would hand a tuple to the queue path;
+* the season resolver must ask a season-scoped query. Reaching for the
+  series-wide one is the original bug, and it would look correct on a
+  one-season show.
+"""
+
+# Run as a script, this is what puts the repo root on sys.path -- without
+# it `jellyfin_mpv_shim` resolves to whatever is pip-installed. A no-op
+# under `discover`; tests/test_module_paths.py is the guard.
+if __name__ == "__main__":
+    import os
+    import sys
+
+    sys.path.insert(0, os.path.dirname(
+        os.path.dirname(os.path.abspath(__file__))))
+
+import sys
+import unittest
+
+sys.argv = ["test"]
+
+from jellyfin_mpv_shim.mpvtk_browser.app import MpvtkBrowser  # noqa: E402
+from jellyfin_mpv_shim.mpvtk_browser.tiles import TilesMixin  # noqa: E402
+
+from tests._shell_harness import (  # noqa: E402
+    FakeController, FakeSource, _SyncPool)
+
+
+SEASON = {"Id": "se1", "Name": "Season 1", "Type": "Season",
+          "SeriesId": "sh1", "SeriesName": "A Show"}
+
+
+class _RecordingSource(FakeSource):
+    """Records which queue query was asked, and with what."""
+
+    def __init__(self):
+        super().__init__()
+        self.asked = []
+
+    def get_season_queue(self, server_uuid, series_id, season_id):
+        self.asked.append(("season", series_id, season_id))
+        return super().get_season_queue(server_uuid, series_id, season_id)
+
+    #: The one id this stand-in will answer a SERIES query for.
+    SERIES_ID = "sh1"
+
+    def get_series_queue(self, server_uuid, series_id, start_item_id=None,
+                         limit=100):
+        """**Empty for anything that is not a series id**, which is the
+        whole point of this stand-in.
+
+        `Shows/{id}/Episodes` resolves `{id}` as a series; hand it a SEASON
+        id and the server answers with nothing. The shared `FakeSource`
+        returns three episodes for any id at all, so the original bug --
+        Play on a season falling through to navigation because the query
+        came back empty -- is invisible against it, and a test written on
+        that fixture passes with the defect in place. Verified: reverting
+        the fix leaves those tests green until this override exists.
+        """
+        self.asked.append(("series", series_id, start_item_id))
+        if series_id != self.SERIES_ID:
+            return []
+        return super().get_series_queue(server_uuid, series_id,
+                                        start_item_id, limit)
+
+
+def _browser(source=None):
+    b = MpvtkBrowser(app=None, source=source or _RecordingSource(),
+                     controller=FakeController())
+    b._pool = _SyncPool()
+    b.server = "srv1"
+    return b
+
+
+class SeasonPlayTest(unittest.TestCase):
+    def test_the_chip_plays_instead_of_navigating(self):
+        """The bug, stated as the user saw it."""
+        b = _browser()
+        before = list(b.route.items())
+        b._play_tile(dict(SEASON))
+        self.assertTrue(b.controller.played,
+                        "the season resolved to nothing and nothing played")
+        self.assertEqual(list(b.route.items()), before,
+                         "Play navigated -- that is the defect, not the fix")
+
+    def test_it_queues_the_whole_season_in_order(self):
+        b = _browser()
+        b._play_tile(dict(SEASON))
+        ids, server, _start = b.controller.played[-1]
+        self.assertEqual(ids, ["e0", "e1", "e2", "e3", "e4"])
+        self.assertEqual(server, "srv1")
+
+    def test_it_starts_at_the_first_unplayed_episode(self):
+        """Web's rule. The fixture marks e0 and e1 watched."""
+        b = _browser()
+        b._play_tile(dict(SEASON))
+        _ids, _server, start = b.controller.played[-1]
+        self.assertEqual(start, 2)
+
+    def test_a_fully_watched_season_starts_at_the_top(self):
+        """`|| 0` in web's own code, but reached honestly: with nothing
+        unplayed there is no better answer than the beginning."""
+        src = _RecordingSource()
+        src.season_watched = 5           # every episode played
+        b = _browser(src)
+        b._play_tile(dict(SEASON))
+        _ids, _server, start = b.controller.played[-1]
+        self.assertEqual(start, 0)
+
+    def test_an_untouched_season_starts_at_the_top(self):
+        src = _RecordingSource()
+        src.season_watched = 0
+        b = _browser(src)
+        b._play_tile(dict(SEASON))
+        _ids, _server, start = b.controller.played[-1]
+        self.assertEqual(start, 0)
+
+    def test_it_asks_a_season_scoped_query(self):
+        """The original bug in its pure form: the series-wide query, given a
+        season id. It would still look right on a one-season show, so this
+        asserts on the CALL rather than on the result."""
+        src = _RecordingSource()
+        b = _browser(src)
+        b._play_tile(dict(SEASON))
+        self.assertEqual(src.asked, [("season", "sh1", "se1")])
+
+    def test_a_season_with_no_series_id_plays_nothing_rather_than_the_show(
+            self):
+        """There is nothing to scope by, and falling back to the series
+        would put a whole show behind one season's button."""
+        src = _RecordingSource()
+        b = _browser(src)
+        b._play_tile({"Id": "se9", "Name": "Season 9", "Type": "Season"})
+        self.assertEqual([a for a in src.asked if a[0] == "series"], [],
+                         "fell back to the series-wide query")
+        self.assertEqual(b.controller.played, [])
+
+
+class SeasonQueueTest(unittest.TestCase):
+    """"Add to play queue" shares `_resolve_play_ids` with Play."""
+
+    def test_queueing_a_season_gets_ids_and_not_a_tuple(self):
+        """The shape regression the fix had to avoid: `_resolve_play_ids`
+        has two callers, and `_menu_queue` hands its result straight to
+        `_queue_items`. A `(ids, start, items)` tuple would arrive there as
+        though it were the id list."""
+        src = _RecordingSource()
+        b = _browser(src)
+        got = b._resolve_play_ids(dict(SEASON), "srv1")
+        self.assertEqual(got, ["e0", "e1", "e2", "e3", "e4"])
+        for entry in got:
+            self.assertIsInstance(entry, str)
+
+    def test_it_is_season_scoped_there_too(self):
+        src = _RecordingSource()
+        b = _browser(src)
+        b._resolve_play_ids(dict(SEASON), "srv1")
+        self.assertEqual(src.asked, [("season", "sh1", "se1")])
+
+    def test_a_series_still_uses_the_series_wide_query(self):
+        """The other half of the split -- a Series must keep crossing
+        season boundaries, which is what `get_series_queue` is for."""
+        src = _RecordingSource()
+        b = _browser(src)
+        b._resolve_play_ids({"Id": "sh1", "Type": "Series"}, "srv1")
+        self.assertEqual(src.asked, [("series", "sh1", None)])
+
+
+class FirstUnplayedTest(unittest.TestCase):
+    """The rule on its own, where the edge cases are cheap to state."""
+
+    def _at(self, *played):
+        return TilesMixin._first_unplayed(
+            [{"Id": str(i), "UserData": {"Played": p}}
+             for i, p in enumerate(played)])
+
+    def test_the_first_gap_wins(self):
+        self.assertEqual(self._at(True, True, False, True), 2)
+
+    def test_a_gap_after_an_unplayed_run_does_not(self):
+        self.assertEqual(self._at(False, True, False), 0)
+
+    def test_all_played_is_zero(self):
+        self.assertEqual(self._at(True, True, True), 0)
+
+    def test_zero_is_a_real_index_not_a_fallback(self):
+        """Web spells this `StartIndex || seasonStartIndex || 0`, which
+        only works because index 0 is falsy. Ours returns the index."""
+        self.assertEqual(self._at(False, False), 0)
+
+    def test_a_missing_userdata_reads_as_unplayed(self):
+        """An episode DTO without UserData is not evidence that it was
+        watched, and treating it as watched would skip past it."""
+        self.assertEqual(TilesMixin._first_unplayed(
+            [{"Id": "a", "UserData": {"Played": True}}, {"Id": "b"}]), 1)
+
+    def test_an_empty_queue_does_not_raise(self):
+        self.assertEqual(TilesMixin._first_unplayed([]), 0)
+        self.assertEqual(TilesMixin._first_unplayed(None), 0)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_shell_library.py
+++ b/tests/test_shell_library.py
@@ -1734,6 +1734,34 @@ class TestRemoteDisplayContent(unittest.TestCase):
         self.assertFalse(self.b.minimized)
         self.assertTrue(self.b._browsing)
         self.assertEqual(self.b.route["kind"], "detail")
+        self.assertEqual(self.ctl.raised, 1, "a summon must take the window")
+
+    def _summon(self, enabled):
+        from jellyfin_mpv_shim.conf import settings
+        saved = settings.display_mirror_summon
+        self.addCleanup(
+            lambda: setattr(settings, "display_mirror_summon", saved))
+        settings.display_mirror_summon = enabled
+
+    def test_does_not_take_the_foreground_while_already_browsing(self):
+        """#728. The window is already on screen, so there is nothing to
+        summon -- and raising it anyway is a real SetForegroundWindow on
+        Windows, which stole focus back from the web client the user was
+        casting FROM, once per page they opened."""
+        self._summon(False)
+        self.assertTrue(self.b._browsing, "premise: the window is up")
+        self.b.display_item("srv1", "m1")
+        self.assertEqual(self.b.route["kind"], "detail",
+                         "the page must still follow the remote")
+        self.assertEqual(self.ctl.raised, 0, "stole the foreground")
+
+    def test_summon_still_raises_a_visible_client(self):
+        """The setting is one answer to "may this app take the foreground",
+        not two: someone who opted in wants the cast target brought forward
+        whether it was closed to the tray or merely behind something."""
+        self._summon(True)
+        self.b.display_item("srv1", "m1")
+        self.assertEqual(self.ctl.raised, 1)
 
     def test_never_interrupts_playback(self):
         """jellyfin-web emits DisplayContent as you browse on the phone, so

--- a/tests/test_shell_playback.py
+++ b/tests/test_shell_playback.py
@@ -158,8 +158,42 @@ class TestPlaybackHudLayout(unittest.TestCase):
         self.assertIn("S1E2", [n.get("text") or "" for n in nodes])
 
     def test_narrow_viewport_drops_optional_controls(self):
+        """At 460px the bar keeps what a transport needs and gives up the
+        rest.
+
+        The list of survivors GREW when `hud_auto_scale` lowered the
+        floor: the seek buttons and the clock now shrink into the space
+        instead of being dropped, which is the whole point of the setting
+        [iw] -- "first scale the icons down then start sacrificing them".
+        Asserted with the setting pinned on, because that is what this
+        case is about; the legacy floor has its own case below."""
+        from unittest import mock
+        from jellyfin_mpv_shim.conf import settings
+
         b, _ctl = self._browser()
-        nodes, _h = build_scene(b, (460, 640))
+        with mock.patch.multiple(settings, hud_auto_scale=True):
+            nodes, _h = build_scene(b, (460, 640))
+        present = ids(nodes)
+        for nid in ("hud-pp", "hud-prev", "hud-next",
+                    "hud-audio", "hud-sub", "hud-mute", "hud-fs",
+                    "hud-seek-back", "hud-seek-fwd", "hud-clock"):
+            self.assertIn(nid, present)
+        for nid in ("hud-ch-prev", "hud-ch-next", "hud-chapters",
+                    "hud-quality", "hud-vol"):
+            self.assertNotIn(nid, present)
+        self.assertFalse(any("Ends at" in (n.get("text") or "")
+                             for n in nodes),
+                         "ends-at is first to go and must not be here")
+
+    def test_the_legacy_floor_still_drops_them(self):
+        """The other side of the setting, so "off is what the previous
+        release did" is a claim under test rather than a comment."""
+        from unittest import mock
+        from jellyfin_mpv_shim.conf import settings
+
+        b, _ctl = self._browser()
+        with mock.patch.multiple(settings, hud_auto_scale=False):
+            nodes, _h = build_scene(b, (460, 640))
         present = ids(nodes)
         for nid in ("hud-pp", "hud-prev", "hud-next",
                     "hud-audio", "hud-sub", "hud-mute", "hud-fs"):
@@ -168,9 +202,6 @@ class TestPlaybackHudLayout(unittest.TestCase):
                     "hud-ch-next", "hud-chapters", "hud-quality",
                     "hud-vol", "hud-clock"):
             self.assertNotIn(nid, present)
-        self.assertFalse(any("Ends at" in (n.get("text") or "")
-                             for n in nodes),
-                         "ends-at must drop below 1000px")
 
     # ------------------------------------------------ the measured fit
 
@@ -288,6 +319,44 @@ class TestPlaybackHudLayout(unittest.TestCase):
                     % sorted(shed))
             previous = shed
 
+    #: Widths, out of the 511 swept below, at which a control returns as
+    #: the window narrows. **Not zero, and the number is a ratchet rather
+    #: than a target** -- see `test_a_control_almost_never_comes_back`.
+    MAX_NON_MONOTONE = 3
+
+    def test_a_control_almost_never_comes_back(self):
+        """Dragging the edge inward should only ever take controls away.
+
+        It very nearly does. Every control sizes from one `sz(HUD_ICON)`,
+        so they round down together and the row's natural width falls in
+        ~16px cliffs while the room for it falls smoothly -- slack
+        sawtooths, and a control sitting near zero can return for a couple
+        of pixels either side of a cliff. `build_hud` snaps the decision
+        to the bottom of the glyph step, which halves it (6 widths -> 3,
+        measured on this sweep), but cannot remove it: the clock and the
+        "Ends at" label step on FONT metrics, whose period is different
+        again.
+
+        Removing the rest means measuring the row twice per repaint -- the
+        controls at the largest size in a width bucket against the room at
+        the smallest -- which is a build of every widget more than the bar
+        currently does, to close a 2px window in a drag gesture. Recorded
+        as a bound instead, so it cannot quietly get worse. The same class
+        of bug, and the same conclusion, as `music.py`'s NP_TITLE_W.
+        """
+        seen = []
+        previous = set()
+        for width in range(1400, 379, -2):
+            b, _ctl = self._browser()
+            build_scene(b, (width, 720))
+            if not previous <= b.hud.shed:
+                seen.append((width, sorted(previous - b.hud.shed)))
+            previous = b.hud.shed
+        self.assertLessEqual(
+            len(seen), self.MAX_NON_MONOTONE,
+            "controls come back at %d widths, was at most %d: %s"
+            % (len(seen), self.MAX_NON_MONOTONE, seen))
+
     def test_the_set_does_not_flicker_as_the_clock_ticks(self):
         """The clock is the one control whose width changes DURING an
         item -- "50:00 / 1:30:00" gains two characters at the hour mark --
@@ -330,6 +399,121 @@ class TestPlaybackHudLayout(unittest.TestCase):
                     "Video Quality is %s at %dpx"
                     % ("in both places" if offered else "in neither",
                        width))
+
+    # ------------------------------------------- the accessibility floor
+
+    def _floor(self, **opts):
+        from unittest import mock
+        from jellyfin_mpv_shim.conf import settings
+        from jellyfin_mpv_shim.mpvtk_browser import hud
+
+        with mock.patch.multiple(settings, **opts):
+            return hud.hud_scale_floor()
+
+    def test_off_is_exactly_the_old_behaviour(self):
+        """Off is the compatibility setting [iw], not a third behaviour
+        nobody has seen -- so it is the literal number the bar shipped
+        with, and this test is what stops it drifting into "1.0, no
+        scaling at all"."""
+        self.assertEqual(self._floor(hud_auto_scale=False), 0.72)
+
+    def test_on_lets_the_smallest_target_reach_the_wcag_minimum(self):
+        """The floor is the fraction at which the trigger box -- the
+        smallest interactive thing on the bar -- is exactly 24 logical
+        px. Asserted through `trigger_box` rather than against 0.51, so
+        changing HUD_ICON moves the floor instead of breaking this."""
+        from jellyfin_mpv_shim.mpvtk.widgets import trigger_box
+        from jellyfin_mpv_shim.mpvtk_browser.hud import HUD_ICON, MIN_TARGET_PX
+
+        floor = self._floor(hud_auto_scale=True)
+        self.assertAlmostEqual(trigger_box(HUD_ICON) * floor,
+                               MIN_TARGET_PX, places=6)
+        self.assertLess(floor, 0.72,
+                        "the point of the setting is to shrink FURTHER")
+
+    def test_the_floor_does_not_move_with_ui_scale(self):
+        """**The correction this setting's plan needed.** `ui_scale` is
+        either mpv's `display-hidpi-scale` or a number the user forced,
+        and dividing the floor by it is wrong both ways: on the first,
+        logical px are already density-independent, so dividing would
+        allow ~12 CSS px targets on exactly the HiDPI machines #721 came
+        from; on the second, someone who sets it to 2 to read the screen
+        across a room is asking for BIGGER, and shrinking back to a 24px
+        target undoes what they asked for.
+
+        So raising `ui_scale` may only ever make a target physically
+        larger. Asserted as a constant floor, which is what delivers
+        that."""
+        from jellyfin_mpv_shim.mpvtk import scaling
+
+        was = scaling.scale()
+        try:
+            floors = []
+            for factor in (1.0, 1.5, 2.0, 3.5):
+                scaling.set_scale(factor)
+                floors.append(round(self._floor(hud_auto_scale=True), 9))
+            self.assertEqual(floors, [floors[0]] * 4,
+                             "the floor moved with ui_scale")
+        finally:
+            scaling.set_scale(was)
+
+    def test_the_lower_floor_sheds_strictly_less(self):
+        """Shrink first, sacrifice second [iw]. Smaller controls fit in
+        less room, so at every width the accessibility floor must give up
+        no MORE than the legacy one -- if it ever gave up more, shrinking
+        would be costing controls rather than saving them."""
+        from unittest import mock
+        from jellyfin_mpv_shim.conf import settings
+
+        for width in self.WIDTHS:
+            sheds = {}
+            for on in (True, False):
+                b, _ctl = self._browser()
+                with mock.patch.multiple(settings, hud_auto_scale=on):
+                    build_scene(b, (width, 720))
+                sheds[on] = b.hud.shed
+            with self.subTest(width=width):
+                self.assertLessEqual(
+                    sheds[True], sheds[False],
+                    "auto-scale gave up %s that the legacy floor kept"
+                    % sorted(sheds[True] - sheds[False]))
+
+    def test_it_keeps_more_controls_somewhere_in_the_range(self):
+        """The premise of the test above: a subset relation is satisfied
+        by giving up exactly the same thing at every width, which would
+        make the setting do nothing at all."""
+        from unittest import mock
+        from jellyfin_mpv_shim.conf import settings
+
+        better = 0
+        for width in self.WIDTHS:
+            counts = {}
+            for on in (True, False):
+                b, _ctl = self._browser()
+                with mock.patch.multiple(settings, hud_auto_scale=on):
+                    build_scene(b, (width, 720))
+                counts[on] = len(b.hud.shed)
+            if counts[True] < counts[False]:
+                better += 1
+        self.assertGreater(better, 0,
+                           "auto-scale never kept a control the legacy "
+                           "floor dropped, so the setting is inert")
+
+    def test_the_bar_still_fits_with_the_floor_lowered(self):
+        """The fit is measured, so it should hold at any floor -- but
+        this is the pair of `test_the_bar_fits_at_every_width`, which
+        runs at the default. A floor change that broke the fit would
+        otherwise only show up once the setting shipped."""
+        from unittest import mock
+        from jellyfin_mpv_shim.conf import settings
+
+        for width in self.WIDTHS:
+            b, _ctl = self._browser()
+            with mock.patch.multiple(settings, hud_auto_scale=True):
+                nodes, _h = build_scene(b, (width, 720))
+            right, limit = self._bar_extent(nodes)
+            with self.subTest(width=width):
+                self.assertLessEqual(right, limit + 0.5)
 
     def test_volume_mute_fullscreen_and_clock_toggle(self):
         b, ctl = self._browser()

--- a/tests/test_shell_playback.py
+++ b/tests/test_shell_playback.py
@@ -63,6 +63,30 @@ class TestPlaybackHudLayout(unittest.TestCase):
         self.assertEqual(seek.get("marks"), [0.4, 0.8],
                          "chapter slits should be the interior chapters")
 
+    def test_the_clock_fits_its_own_text_with_no_duration(self):
+        """Live TV and unbounded streams report `duration` 0.
+
+        The clock's box is pinned to the widest reading the DURATION can
+        produce, which is right while there is one -- position can only
+        reach the duration, so that is the ceiling and the bar stops
+        shifting once a second. With `dur == 0` that ceiling is "0:00 /
+        -0:00" while the text keeps growing with the position, so past an
+        hour the position alone is wider than the whole box and the
+        non-wrapping Text ellipsizes inside it.
+
+        Asserted on the TEXT, not on box width against text width: the
+        renderer ellipsizes to fit, so those two always agree -- the
+        measured symptom was `"1:02:03 / 0\u2026"` in a box still sized for
+        `"0:00 / -0:00"`. Comparing the widths is a test that cannot fail.
+        """
+        b, _ctl = self._browser()
+        b.hud.state = dict(b.hud.state, duration=0.0, position=3723.0)
+        nodes, _handlers = build_scene(b, (1280, 720))
+        shown = [n.get("text") for n in nodes
+                 if (n.get("text") or "").startswith("1:02:03")]
+        self.assertEqual(shown, ["1:02:03 / 0:00"],
+                         "the clock ellipsized its own time")
+
     def test_play_pause_is_where_a_vertical_arrow_lands(self):
         """DOWN off the seek bar has to reach play/pause at every width.
 

--- a/tests/test_shell_playback.py
+++ b/tests/test_shell_playback.py
@@ -172,6 +172,165 @@ class TestPlaybackHudLayout(unittest.TestCase):
                              for n in nodes),
                          "ends-at must drop below 1000px")
 
+    # ------------------------------------------------ the measured fit
+
+    #: Every optional control, by the shed key that owns it. Two of them
+    #: own a PAIR, which is the point: half of a symmetric pair is worse
+    #: than neither half.
+    OPTIONAL = {
+        "ends_at": (),                  # a Text, matched by its words
+        "volbar": ("hud-vol",),
+        "ch_btns": ("hud-ch-prev", "hud-ch-next"),
+        "chapters": ("hud-chapters",),
+        "favorite": ("hud-fav",),
+        "quality": ("hud-quality",),
+        "clock": ("hud-clock",),
+        "seek_btns": ("hud-seek-back", "hud-seek-fwd"),
+    }
+
+    #: Never given up at any width: without these the bar is not a
+    #: transport, it is a decoration.
+    MANDATORY = ("hud-pp", "hud-prev", "hud-next", "hud-settings",
+                 "hud-fs", "hud-audio", "hud-sub", "hud-mute")
+
+    WIDTHS = (1920, 1400, 1280, 1100, 1000, 960, 900, 840, 800, 760,
+              720, 680, 640, 600, 560, 520, 480, 440, 400)
+
+    def _bar_extent(self, nodes):
+        """(rightmost edge, bar inner right edge) of the transport row."""
+        bar = next(n for n in nodes if n.get("id") == "hud-bar")
+        right = 0.0
+        for n in nodes:
+            if n.get("t") in ("icon", "dropdown", "slider", "text") \
+                    and n.get("x") is not None \
+                    and n.get("y", 0) > bar["y"]:
+                right = max(right, n["x"] + (n.get("w") or 0))
+        return right, bar["x"] + bar["w"]
+
+    def test_the_bar_fits_at_every_width(self):
+        """The invariant the pixel breakpoints were standing in for, and
+        did not deliver: measured across 400-1400px before this, the bar
+        overflowed its own window at every width between ~700 and ~1000,
+        by up to 113px. Nothing showed it because the four track pickers
+        absorbed the overflow -- they were the only children of the row
+        with no shrink floor -- collapsing to zero width while the
+        renderer drew their full-size glyphs across each other (#721)."""
+        for width in self.WIDTHS:
+            b, _ctl = self._browser()
+            nodes, _h = build_scene(b, (width, 720))
+            right, limit = self._bar_extent(nodes)
+            with self.subTest(width=width):
+                self.assertLessEqual(
+                    right, limit + 0.5,
+                    "the transport row runs %.0fpx past the bar"
+                    % (right - limit))
+
+    def test_nothing_is_given_up_that_did_not_need_to_be(self):
+        """Shedding is a last resort, so a bar with room keeps
+        everything. The half this guards is a `_shed` that drops the
+        whole order the moment one control does not fit."""
+        b, _ctl = self._browser()
+        nodes, _h = build_scene(b, (1920, 720))
+        present = ids(nodes)
+        for key, node_ids in self.OPTIONAL.items():
+            for nid in node_ids:
+                with self.subTest(key=key, id=nid):
+                    self.assertIn(nid, present)
+        self.assertEqual(b.hud.shed, set())
+
+    def test_the_mandatory_controls_survive_any_width(self):
+        for width in self.WIDTHS:
+            b, _ctl = self._browser()
+            nodes, _h = build_scene(b, (width, 720))
+            present = ids(nodes)
+            for nid in self.MANDATORY:
+                with self.subTest(width=width, id=nid):
+                    self.assertIn(nid, present)
+
+    def test_a_pair_is_never_half_present(self):
+        """`seek_btns` and `ch_btns` each tag TWO buttons. A bar with
+        Back-10 and no Forward-30 is worse than a bar with neither, and
+        the shared key is what makes that structural rather than
+        remembered [iw]."""
+        for width in self.WIDTHS:
+            b, _ctl = self._browser()
+            nodes, _h = build_scene(b, (width, 720))
+            present = ids(nodes)
+            for key in ("seek_btns", "ch_btns"):
+                got = [nid for nid in self.OPTIONAL[key]
+                       if nid in present]
+                with self.subTest(width=width, key=key):
+                    self.assertIn(len(got), (0, 2),
+                                  "%s is half there: %s" % (key, got))
+
+    def test_controls_go_in_the_documented_order(self):
+        """As the window narrows a control may leave and must not come
+        back, and what leaves is a prefix of `SHED_ORDER` -- the priority
+        the old breakpoints encoded [iw]. Asserted over the whole sweep
+        rather than at one width: the failure this is named for is an
+        order that is right at 900 and inverted at 600."""
+        from jellyfin_mpv_shim.mpvtk_browser.hud import SHED_ORDER
+
+        previous = set()
+        for width in self.WIDTHS:      # widest first
+            b, _ctl = self._browser()
+            build_scene(b, (width, 720))
+            shed = b.hud.shed
+            with self.subTest(width=width):
+                self.assertTrue(
+                    previous <= shed,
+                    "%s came back at %dpx"
+                    % (sorted(previous - shed), width))
+                order = [k for k in SHED_ORDER if k in shed]
+                self.assertEqual(
+                    order, list(SHED_ORDER)[:len(order)],
+                    "shed %s, which is not a prefix of the order"
+                    % sorted(shed))
+            previous = shed
+
+    def test_the_set_does_not_flicker_as_the_clock_ticks(self):
+        """The clock is the one control whose width changes DURING an
+        item -- "50:00 / 1:30:00" gains two characters at the hour mark --
+        and it is measured like everything else. If that ever decides a
+        shed, a control vanishes mid-film at no boundary the user can
+        see."""
+        for width in self.WIDTHS:
+            sheds = []
+            for pos in (0.0, 59.0, 3599.0, 3601.0, 7000.0):
+                b, _ctl = self._browser()
+                b.hud.state = dict(b.hud.state, position=pos,
+                                   duration=7200.0)
+                build_scene(b, (width, 720))
+                sheds.append(b.hud.shed)
+            with self.subTest(width=width):
+                self.assertEqual(
+                    [sorted(x) for x in sheds],
+                    [sorted(sheds[0])] * len(sheds),
+                    "the shed set moved as the position advanced")
+
+    def test_the_gear_offers_quality_exactly_when_the_bar_lost_it(self):
+        """The row used to appear below a pixel breakpoint. Width was
+        always the weaker question -- at 600px it said the button was on
+        screen while the bar it sat in overflowed by 36 -- and there is no
+        breakpoint left to ask."""
+        for width in self.WIDTHS:
+            b, _ctl = self._browser()
+            b.hud.menu = "root"
+            nodes, _h = build_scene(b, (width, 720))
+            # The gear menu is one renderer-drawn node carrying its rows
+            # in `items`; there are no Text nodes to search.
+            menu = next((n for n in nodes if n.get("t") == "menu"), None)
+            self.assertIsNotNone(menu, "the gear menu did not render")
+            offered = any("Change Video Quality" in row
+                          for row in menu.get("items") or [])
+            on_bar = "hud-quality" in ids(nodes)
+            with self.subTest(width=width):
+                self.assertNotEqual(
+                    offered, on_bar,
+                    "Video Quality is %s at %dpx"
+                    % ("in both places" if offered else "in neither",
+                       width))
+
     def test_volume_mute_fullscreen_and_clock_toggle(self):
         b, ctl = self._browser()
         nodes, handlers = build_scene(b, (1280, 720))

--- a/tests/test_shell_settings.py
+++ b/tests/test_shell_settings.py
@@ -79,14 +79,23 @@ class TestSettings(unittest.TestCase):
 
     def test_hud_key_settings_sit_under_the_keybind_note(self):
         """The real schema: the two HUD keyboard settings are curated
-        into Interface directly below the note explaining the default,
-        not buried in the auto-generated Advanced list."""
+        into Interface below the note explaining the default, not buried
+        in the auto-generated Advanced list.
+
+        Adjacent to each other and after `osc_style`, rather than pinned to
+        an exact slice of the group. The slice version broke when
+        `thumbnail_enable` was promoted between them and `osc_style` -- it
+        was over-specifying position for a claim that is about curation."""
         from jellyfin_mpv_shim.mpvtk_browser import config as real
 
         controls = dict(real.sections("playback"))["Player Controls"]
-        self.assertEqual(
-            controls[controls.index("osc_style"):][:3],
-            ["osc_style", "hud_grab_keys", "hud_wake_key"])
+        self.assertEqual(controls[0], "osc_style",
+                         "the group leads with the style picker; the rest "
+                         "of it may not apply at all until that is chosen")
+        self.assertEqual(controls.index("hud_wake_key"),
+                         controls.index("hud_grab_keys") + 1)
+        self.assertLess(controls.index("osc_style"),
+                        controls.index("hud_grab_keys"))
         self.assertIn("osc_style", real.NOTES)
         advanced = dict(real.sections()).get("Advanced", [])
         self.assertNotIn("hud_grab_keys", advanced)

--- a/tests/test_shell_settings.py
+++ b/tests/test_shell_settings.py
@@ -1095,6 +1095,43 @@ class TestGamepadSwapAppliesLive(unittest.TestCase):
         b.app.push_gamepad.assert_not_called()
 
 
+class TestSelectKeyAppliesLive(unittest.TestCase):
+    """Moving the select key re-pushes BOTH producers of it.
+
+    The keyboard's binding and the game controller's are two spellings of
+    one key (`conf.select_key`), and the pad's is a literal baked into the
+    table it was last pushed with. Re-push one without the other and the
+    pad is pressing a key nothing listens for -- which is #717 again, in
+    the code that closed it.
+    """
+
+    def _browser(self):
+        from unittest import mock
+
+        cfg = FakeConfig()
+        cfg.schema["ui_select_key"] = "str"
+        cfg.values["ui_select_key"] = "ENTER"
+        cfg.schema["player_name"] = "str"
+        cfg.values["player_name"] = "x"
+        b = MpvtkBrowser(app=mock.Mock(), source=FakeSource(),
+                         controller=mock.Mock(), config=cfg)
+        b._pool = _SyncPool()
+        b.app.push_select_key.reset_mock()
+        b.app.push_gamepad.reset_mock()
+        return b
+
+    def test_saving_it_re_pushes_both(self):
+        b = self._browser()
+        b._set_setting("ui_select_key", "KP_ENTER")
+        b.app.push_select_key.assert_called_once_with()
+        b.app.push_gamepad.assert_called_once_with()
+
+    def test_an_unrelated_setting_does_not(self):
+        b = self._browser()
+        b._set_setting("player_name", "Bud")
+        b.app.push_select_key.assert_not_called()
+
+
 class TestPinStartupSeeding(unittest.TestCase):
     """Changing a PIN silently cleared "require at startup": the dialog
     always opened with the box unticked and saved that back."""

--- a/tests/test_shell_settings.py
+++ b/tests/test_shell_settings.py
@@ -1095,6 +1095,50 @@ class TestGamepadSwapAppliesLive(unittest.TestCase):
         b.app.push_gamepad.assert_not_called()
 
 
+class TestBrowserFullscreenAppliesLive(unittest.TestCase):
+    """#729. It was read only on a browse TRANSITION, so it took effect
+    after the next thing you played -- and the reporter, sitting in
+    Settings watching nothing happen, read that as "needs a restart".
+
+    Not the restart banner: a restart is not what it needed, and
+    `RESTART_REQUIRED` means literally nothing happened. See
+    docs/settings-curation.md section 3.
+    """
+
+    def _browser(self):
+        from unittest import mock
+
+        cfg = FakeConfig()
+        cfg.schema["browser_fullscreen"] = "bool"
+        cfg.values["browser_fullscreen"] = False
+        cfg.schema["player_name"] = "str"
+        cfg.values["player_name"] = "x"
+        b = MpvtkBrowser(app=mock.Mock(), source=FakeSource(),
+                         controller=mock.Mock(), config=cfg)
+        b._pool = _SyncPool()
+        return b
+
+    def test_saving_it_moves_the_window(self):
+        b = self._browser()
+        b._set_setting("browser_fullscreen", True)
+        b.controller.apply_browser_fullscreen.assert_called_once_with()
+
+    def test_turning_it_off_does_too(self):
+        """Both directions, because the window has to come back."""
+        b = self._browser()
+        b._set_setting("browser_fullscreen", False)
+        b.controller.apply_browser_fullscreen.assert_called_once_with()
+
+    def test_an_unrelated_setting_does_not(self):
+        b = self._browser()
+        b._set_setting("player_name", "Bud")
+        b.controller.apply_browser_fullscreen.assert_not_called()
+
+    def test_it_is_not_marked_as_needing_a_restart(self):
+        from jellyfin_mpv_shim.mpvtk_browser import config as cfg
+        self.assertNotIn("browser_fullscreen", cfg.RESTART_REQUIRED)
+
+
 class TestSelectKeyAppliesLive(unittest.TestCase):
     """Moving the select key re-pushes BOTH producers of it.
 

--- a/tests/test_single_instance.py
+++ b/tests/test_single_instance.py
@@ -64,6 +64,60 @@ class SingleInstanceTest(unittest.TestCase):
         c = self._make()
         self.assertTrue(c.acquire())
 
+    def test_a_blocked_launch_releasing_leaves_the_endpoint_alone(self):
+        """Only the instance that WROTE the endpoint file may remove it.
+
+        It is how a later launch finds the running copy to ask it to show
+        its window. A non-primary `release()` used to unlink it anyway, and
+        the damage is invisible and permanent: the primary keeps running and
+        keeps listening, but nothing can find it, so every launch after the
+        first silently declines to start *and* fails to surface the window
+        somebody launched it to get at.
+
+        `main` returns without releasing on the blocked path, so nothing
+        shipped reaches this -- which is why it is a guard and not a
+        promise. Measured with the guard removed: the second of three
+        repeat launches stops activating the primary.
+        """
+        a = self._make()
+        self.assertTrue(a.acquire())
+        endpoint = a._lockpath
+        self.assertTrue(os.path.exists(endpoint))
+
+        b = self._make()
+        self.assertFalse(b.acquire())
+        b.release()
+        self.assertTrue(os.path.exists(endpoint),
+                        "a blocked launch deleted the primary's endpoint")
+
+    def test_a_later_launch_can_still_reach_the_primary_after_that(self):
+        """The consequence, stated as behaviour rather than as a file."""
+        a = self._make()
+        activated = threading.Event()
+        self.assertTrue(a.acquire())
+        a.on_activate = activated.set
+
+        first = self._make()
+        self.assertFalse(first.acquire())
+        first.release()
+        activated.clear()
+
+        second = self._make()
+        self.assertFalse(second.acquire())
+        self.assertTrue(activated.wait(5),
+                        "the primary became unreachable after one blocked "
+                        "launch released")
+
+    def test_the_owner_still_removes_it(self):
+        """The guard must not have turned the cleanup off entirely: a
+        stale endpoint naming a dead port is what `_request` then has to
+        time out against."""
+        a = self._make()
+        self.assertTrue(a.acquire())
+        endpoint = a._lockpath
+        a.release()
+        self.assertFalse(os.path.exists(endpoint))
+
     def test_unresponsive_primary_still_blocks_duplicates(self):
         # The election is the lock, not the handoff: even when the primary's
         # listener is gone (simulated by closing its socket), a second launch

--- a/tests/test_sync_manager.py
+++ b/tests/test_sync_manager.py
@@ -2420,7 +2420,8 @@ class TheRollbackNeverOverwritesTest(TmpTest):
         os.makedirs(old)
         os.makedirs(new)
         for name in ("a", "b"):
-            with open(os.path.join(old, name), "w") as fh:
+            with open(os.path.join(old, name), "w",
+                      encoding="utf-8") as fh:
                 fh.write("ORIGINAL-" + name)
 
         m = SyncManager()
@@ -2434,7 +2435,7 @@ class TheRollbackNeverOverwritesTest(TmpTest):
                 real_rename(src, dst)
                 moved_first["path"] = src
                 if recreate:
-                    with open(src, "w") as fh:
+                    with open(src, "w", encoding="utf-8") as fh:
                         fh.write("NEW USER DATA")
                 return
             raise OSError(18, "force the copy path")   # EXDEV
@@ -2453,7 +2454,7 @@ class TheRollbackNeverOverwritesTest(TmpTest):
 
     def test_a_source_recreated_during_the_move_is_not_replaced(self):
         old, new, first = self._raced_move(recreate=True)
-        with open(first) as fh:
+        with open(first, encoding="utf-8") as fh:
             self.assertEqual(fh.read(), "NEW USER DATA",
                              "the rollback destroyed a file written into the "
                              "store while the move was running")
@@ -2464,7 +2465,7 @@ class TheRollbackNeverOverwritesTest(TmpTest):
     def test_an_untouched_source_is_still_put_back(self):
         """The control, so the refusal cannot become "never roll back"."""
         old, new, first = self._raced_move(recreate=False)
-        with open(first) as fh:
+        with open(first, encoding="utf-8") as fh:
             self.assertEqual(fh.read(),
                              "ORIGINAL-" + os.path.basename(first))
         self.assertFalse(

--- a/tests/test_trickplay_setting.py
+++ b/tests/test_trickplay_setting.py
@@ -1,0 +1,172 @@
+"""`thumbnail_enable` is a curated setting, and `thumbnail_osc_builtin` is gone.
+
+Two changes with one subject: which of the trickplay settings a user can
+see, and which of them still exist.
+
+**The promotion.** `thumbnail_enable` was uncurated, so it fell through to
+Advanced -- behind a disclosure, under a name nobody types. It is the switch
+for the whole feature (the worker in `_init_mpv`, and thumbfast, which
+`mpv_scripts` loads only if the worker came up), it applies to every
+`osc_style`, and since CONFIG_VERSION 5 folded "MPV built-in default" into
+"MPV UI" it is the only thing that answers "do I want previews?". So it
+belongs directly under the style dropdown, which is where the question is
+asked.
+
+**The deletion.** `thumbnail_osc_builtin`'s one documented meaning was "use
+your own custom osc but leave trickplay enabled" (the README that introduced
+it, `acbc3e9d`). That is `osc_style: custom`, and `mpv_scripts` loads
+thumbfast under every style, so `custom` keeps the previews that sentence
+promises. Nothing it could express was lost. It is deleted with no
+migration -- a `false` in an old config is ignored, exactly as `enable_osc`
+is; docs/do-not-fix.md carries why. The half that is invisible from here --
+that its branch was the last thing which could resolve to "default", so
+nothing does now -- is pinned in `test_mpv_options`, beside the function it
+is about.
+"""
+
+# Run as a script, this is what puts the repo root on sys.path -- without
+# it `jellyfin_mpv_shim` resolves to whatever is pip-installed. A no-op
+# under `discover`; tests/test_module_paths.py is the guard.
+if __name__ == "__main__":
+    import os
+    import sys
+
+    sys.path.insert(0, os.path.dirname(
+        os.path.dirname(os.path.abspath(__file__))))
+
+import sys
+import unittest
+from unittest import mock
+
+sys.argv = ["test"]
+
+from jellyfin_mpv_shim.conf import Settings, settings  # noqa: E402
+from jellyfin_mpv_shim.mpvtk_browser import config as cfg  # noqa: E402
+
+
+def _groups(**overrides):
+    patches = {"osc_style": "mpvtk", "enable_gui": True,
+               "thumbnail_enable": True}
+    patches.update(overrides)
+    with mock.patch.multiple(settings, **patches):
+        return dict(cfg.sections())
+
+
+class PlacementTest(unittest.TestCase):
+    def test_it_sits_directly_under_the_style_dropdown(self):
+        """The placement asked for, as the assertion.
+
+        Directly under, not merely in the group: the dropdown is where a
+        user decides what their controls look like, and "do they show
+        previews" is the follow-up question to that one."""
+        controls = dict(cfg.sections("playback"))["Player Controls"]
+        self.assertEqual(
+            controls[controls.index("osc_style"):][:2],
+            ["osc_style", "thumbnail_enable"])
+
+    def test_it_is_no_longer_in_advanced(self):
+        """The half the promotion is FOR. A curated key is removed from
+        Advanced by `sections()` computing that list as the complement, so
+        this cannot fail while the row above passes -- which is why it
+        names Advanced explicitly rather than trusting that."""
+        self.assertNotIn("thumbnail_enable", _groups().get("Advanced", []))
+
+    def test_it_is_offered_under_every_style(self):
+        """NOT a HUD_ONLY setting, and the distinction is the whole point of
+        that mechanism. thumbfast is loaded whatever the style, so previews
+        reach the HUD, both classic OSCs and a thumbfast-aware script of the
+        user's -- and turning them off saves the download under all four,
+        including "none", where nothing draws them but the images are still
+        being fetched."""
+        for style in ("mpvtk", "mpv", "custom", "none"):
+            with self.subTest(style=style):
+                controls = _groups(osc_style=style)["Player Controls"]
+                self.assertIn("thumbnail_enable", controls)
+
+    def test_it_has_a_label_and_a_note(self):
+        self.assertEqual(cfg.label_for("thumbnail_enable"),
+                         "Enable Trickplay Thumbnails")
+        self.assertIn("thumbnail_enable", cfg.NOTES)
+
+    def test_it_needs_a_restart(self):
+        """`_init_mpv` reads it once per mpv, and mpv is not re-created
+        between queue items -- so without the banner, turning it on looks
+        like a switch that does nothing until the user happens to restart.
+
+        The direction that would be worst is ON: the worker starts and
+        fetches, and thumbfast was never loaded to draw any of it."""
+        self.assertIn("thumbnail_enable", cfg.RESTART_REQUIRED)
+
+
+class SearchTest(unittest.TestCase):
+    """Advanced is behind a disclosure, so search was how this setting was
+    reachable at all before the promotion. It stays reachable after it."""
+
+    def _finds(self, query):
+        return {k for _tab, _title, keys in cfg.search(query) for k in keys}
+
+    def test_the_words_people_type_find_it(self):
+        for query in ("thumbnail", "trickplay", "preview", "scrubbing",
+                      "seek preview", "chapter"):
+            with self.subTest(query=query):
+                self.assertIn("thumbnail_enable", self._finds(query))
+
+
+class DependentTest(unittest.TestCase):
+    """`trickplay_fast_mode` tunes how the previews are fetched, so with
+    previews off it does nothing at all. Hidden, not disabled
+    (docs/settings-curation.md section 2)."""
+
+    def test_it_is_offered_while_thumbnails_are_on(self):
+        self.assertIn("trickplay_fast_mode",
+                      _groups(thumbnail_enable=True)["Player Controls"])
+
+    def test_it_is_hidden_while_they_are_off(self):
+        """Every group, not just its own: this is also what proves the key
+        was seeded into `sections()`'s `curated` set.
+
+        `hidden` is computed as `curated - shown`, so a hideable key nobody
+        seeded is never in `hidden` and the filter simply does not reach it
+        -- the row goes on being drawn and nothing says why. The mirror
+        test, that a hidden key leaks into Advanced instead, is the one
+        that CANNOT fail here (c06e0351): `hidden` is a subset of `curated`
+        by construction, so the leak it looks for is impossible."""
+        drawn = {k for keys in _groups(thumbnail_enable=False).values()
+                 for k in keys}
+        self.assertNotIn("trickplay_fast_mode", drawn)
+
+
+class OptOutIsGoneTest(unittest.TestCase):
+    def test_the_setting_no_longer_exists(self):
+        self.assertNotIn("thumbnail_osc_builtin", settings.__fields__)
+
+    def test_an_old_config_is_ignored_rather_than_migrated(self):
+        """No migration, deliberately [iw]: the flag defaulted ON and was
+        turned off by hand, which says "don't replace my OSC" but is not
+        proof that a replacement exists. `custom` -- the faithful reading of
+        its own documentation -- sets `osc=False` and loads nothing, and a
+        silent upgrade must never leave somebody with no controls at all.
+
+        So the value is dropped and they land on the `mpvtk` default, and
+        anyone genuinely running uosc sets `osc_style: custom` once and can
+        see that they have.
+
+        Driven the way `load` drives it -- `parse_obj`, then the copy loop,
+        then `_migrate` with the raw dict -- because `_migrate` alone is the
+        only step that could read a removed key, and asserting on it alone
+        would pass for the trivial reason that there is no code there. The
+        three assertions are the three things a user experiences: the value
+        does not load, nothing translates it, and it leaves the file."""
+        s = Settings()
+        data = {"thumbnail_osc_builtin": False, "osc_style": "mpvtk"}
+        parsed = s.parse_obj(data)
+        self.assertNotIn("thumbnail_osc_builtin", parsed.__fields_set__)
+        for key in parsed.__fields_set__:
+            setattr(s, key, getattr(parsed, key))
+        s._migrate(data)
+        self.assertEqual(s.osc_style, "mpvtk")
+        self.assertNotIn("thumbnail_osc_builtin", s.dict())
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_ui_scale.py
+++ b/tests/test_ui_scale.py
@@ -64,8 +64,14 @@ def _tree():
         Dropdown("dd", ["a", "b"], selected=1, size=18, w=160),
         # An icon-trigger dropdown is what emits `pw` (the popup is sized
         # to its items rather than to the trigger).
+        #
+        # `icon_size` is what emits `isz`, and it is here because leaving it
+        # out is how `isz` escaped this test for two releases: the field the
+        # guard is about simply had nowhere to live, so the drift check
+        # passed while the playback HUD's track pickers drew a fixed 30px
+        # glyph inside a box that doubled with the interface scale (#721).
         Dropdown("dd2", ["alpha", "beta"], selected=0, size=18,
-                 trigger_icon="menu"),
+                 trigger_icon="menu", icon_size=30),
         TextBox("tb", text="typed", size=17, w=220, h=34),
         Icon("play", size=24),
         # A Menu is what emits `rh`, its row height. That field used to

--- a/tests/test_ui_select_key.py
+++ b/tests/test_ui_select_key.py
@@ -1,0 +1,204 @@
+"""One key means "activate what is focused", and three things send it.
+
+#717: `kb_menu_ok` was set to something else, ENTER kept working, and the
+new key did nothing. `kb_menu_ok` reaches only the legacy OSD menu
+(`player.py` binds it, and `_on_menu_ok` returns immediately unless that
+menu is showing); the ENTER the reporter was pressing belongs to the
+library and the playback HUD, where the renderer hardcoded it.
+
+**The trap, and why this file exists: ENTER is not only a keyboard key
+here -- it is the wire format two OTHER input sources use to mean
+Select.** `gamepad.py` maps Confirm to it, and `player.py`'s
+`_NAV_KEYPRESS` maps a Jellyfin remote's "ok" to it. Remap the keyboard
+alone and a user keeps keyboard selection while silently losing gamepad A
+and phone/web Select. From the plan's exit predicate:
+
+    A test that only presses the keyboard cannot fail for this.
+
+So the assertions below are about AGREEMENT between the three, not about
+any one of them.
+
+**Half-landed on purpose.** The two synthetic producers read
+`ui_select_key`; the renderer still force-binds ENTER, so the setting is
+not offered in the settings screen and the docs say so. It is a
+replacement, not an alias -- yielding ENTER back is the whole request
+[iw] -- and that cannot happen until `renderer.lua`'s `NAV_KEYS` binds the
+configured name and rebuilds `keyclaim.nav_names` with it. The last two
+cases here are the tripwires for that work.
+"""
+
+# Run as a script, this is what puts the repo root on sys.path -- without
+# it `jellyfin_mpv_shim` resolves to whatever is pip-installed. A no-op
+# under `discover`; tests/test_module_paths.py is the guard.
+if __name__ == "__main__":
+    import os
+    import sys
+
+    sys.path.insert(0, os.path.dirname(
+        os.path.dirname(os.path.abspath(__file__))))
+
+import pathlib
+import re
+import sys
+import unittest
+from unittest import mock
+
+sys.argv = ["test"]
+
+from jellyfin_mpv_shim import gamepad                       # noqa: E402
+from jellyfin_mpv_shim.conf import (                        # noqa: E402
+    Settings, select_key, settings)
+from jellyfin_mpv_shim.mpvtk_browser import config as cfg   # noqa: E402
+
+ROOT = pathlib.Path(__file__).resolve().parent.parent
+
+
+def confirm_key():
+    """What the gamepad's Confirm button sends.
+
+    Through `select_key()`, because that is what the real caller passes
+    (`mpvtk/app.py:push_gamepad`) -- calling `bindings()` with the raw
+    setting would be a stand-in that skips the fallback and would report
+    a pass for a cleared key that in production works.
+    """
+    binds = gamepad.bindings(select_key=select_key())
+    return next(b[2] for b in binds if b[0] == gamepad.CONFIRM_BUTTON)
+
+
+def remote_ok_key():
+    """What a Jellyfin remote's "ok" sends.
+
+    The same accessor, asserted at the source to be what `player.py`
+    actually calls -- importing that module builds its singleton and opens
+    a real mpv window (CLAUDE.md), so the press path cannot be executed
+    here. `test_the_remote_path_calls_it` is the half that keeps this
+    honest.
+    """
+    return select_key()
+
+
+def renderer_activate_key():
+    """The key `renderer.lua` binds to `nav_activate` in `NAV_KEYS`."""
+    src = ROOT.joinpath("jellyfin_mpv_shim", "mpvtk",
+                        "renderer.lua").read_text()
+    block = src[src.index("local NAV_KEYS = {"):]
+    block = block[:block.index("\n}")]
+    row = next(line for line in block.splitlines()
+               if "nav_activate()" in line)
+    return re.search(r"\{\s*'([^']+)'", row).group(1)
+
+
+class AgreementTest(unittest.TestCase):
+    def test_all_three_send_the_same_key_by_default(self):
+        """The property, at the shipped value. The two below are what stop
+        this one passing because everything is frozen at "ENTER"."""
+        self.assertEqual(confirm_key(), "ENTER")
+        self.assertEqual(remote_ok_key(), "ENTER")
+        self.assertEqual(renderer_activate_key(), "ENTER")
+
+    def test_the_two_synthetic_ones_follow_the_setting_together(self):
+        """Neither may keep a literal. This fails for a repair that moves
+        the keyboard and forgets the pad -- the exact failure the plan's
+        exit predicate names."""
+        for key in ("k", "SPACE", "KP_ENTER"):
+            with self.subTest(key=key), \
+                    mock.patch.object(settings, "ui_select_key", key):
+                self.assertEqual(confirm_key(), key,
+                                 "the gamepad's Confirm is still a literal")
+                self.assertEqual(remote_ok_key(), key,
+                                 "the remote's ok is still a literal")
+
+    def test_the_remote_path_calls_it(self):
+        """`remote_ok_key` above is `select_key()`, so on its own it would
+        prove nothing about the remote. This is what ties the two: read
+        from source, matching the CALL and the table it replaced -- never
+        a bare identifier, which the surrounding comment also contains."""
+        src = ROOT.joinpath("jellyfin_mpv_shim", "player.py").read_text()
+        body = src[src.index("elif ((action in self._NAV_KEYPRESS"):]
+        body = body[:body.index("elif action ==")]
+        self.assertIn("conf.select_key()", body)
+        self.assertNotIn('"ENTER"', body,
+                         "the remote path still spells the key itself")
+
+    def test_and_the_gamepad_table_no_longer_spells_it(self):
+        """`gamepad.py` is pure -- no settings import (its own header) --
+        so Confirm carries a placeholder that `bindings()` substitutes.
+        A literal creeping back would make the pad disagree silently."""
+        confirm = next(b for b in gamepad.DEFAULT_BINDS
+                       if b[0] == gamepad.CONFIRM_BUTTON)
+        self.assertIs(confirm[2], gamepad.SELECT)
+
+    def test_an_empty_value_falls_back_rather_than_unbinding(self):
+        """A cleared key is a config that cannot select anything, on a
+        screen whose only other way out is the mouse. Both readers fall
+        back for the same reason `hud_wake_key` does."""
+        for bad in ("", None):
+            with self.subTest(bad=repr(bad)), \
+                    mock.patch.object(settings, "ui_select_key", bad):
+                self.assertEqual(confirm_key(), "ENTER")
+                self.assertEqual(remote_ok_key(), "ENTER")
+
+
+class NotYetOfferedTest(unittest.TestCase):
+    """The tripwires for the renderer half. Both are meant to fail when
+    that work lands -- read this file's header, then delete them."""
+
+    def test_the_renderer_still_hardcodes_it(self):
+        """When `NAV_KEYS` stops naming ENTER literally, the setting has a
+        keyboard behind it and the two cases here are obsolete.
+
+        The rest of the repair is not visible from this line, and is the
+        reason it is called out rather than just deleted: the bound name
+        also has to reach `keyclaim.nav_names`, whose comment warns that a
+        claimed key OUTSIDE that set needs its own binding *and* its own
+        removal -- and the opts blob only reaches the renderer on
+        `mpvtk-hud` engage, while browse-mode nav is installed by
+        `mpvtk-active`, which carries no opts.
+        """
+        self.assertEqual(
+            renderer_activate_key(), "ENTER",
+            "the renderer now resolves the activation key -- if it reads "
+            "ui_select_key, delete this class and offer the setting")
+
+    def test_so_the_setting_is_not_offered_yet(self):
+        """Offering it while the renderer ignores it would let a user move
+        the gamepad and the remote onto a key nothing listens for, while
+        the keyboard kept ENTER. Worse than the bug being fixed."""
+        curated = {key for _title, keys in cfg.SECTIONS for key in keys}
+        self.assertNotIn("ui_select_key", curated,
+                         "ui_select_key is on the settings screen; the "
+                         "renderer must read it first")
+
+    def test_and_it_is_documented_as_such(self):
+        """Someone will find it in conf.json. The docs entry is what stops
+        them concluding the feature is broken."""
+        doc = ROOT.joinpath("docs", "configuration.md").read_text()
+        entry = doc[doc.index("- `ui_select_key`"):]
+        entry = entry[:entry.index("\n- `")]
+        self.assertIn("Not yet offered in the settings screen", entry)
+
+
+class DistinctFromTheMenuKeyTest(unittest.TestCase):
+    def test_kb_menu_ok_is_a_separate_setting(self):
+        """Kept independent [iw]: the smaller change, and it keeps
+        `kb_menu_ok` meaning what it always has."""
+        schema = cfg.settings_schema()
+        self.assertIn("kb_menu_ok", schema)
+        self.assertIn("ui_select_key", schema)
+        self.assertNotEqual(Settings().kb_menu_ok,
+                            Settings().ui_select_key,
+                            "if these ever hold the same spelling, the "
+                            "docs distinction below stops being visible")
+
+    def test_the_docs_say_which_one_reaches_the_hud(self):
+        """The whole of the bug report: the name promised the HUD. A user
+        reading the reference has to be able to tell them apart."""
+        doc = ROOT.joinpath("docs", "configuration.md").read_text()
+        entry = doc[doc.index("- `kb_menu_ok`"):]
+        entry = entry[:entry.index("\n- `")]
+        self.assertIn("legacy OSD menu only", entry)
+        self.assertIn("ui_select_key", entry)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_ui_select_key.py
+++ b/tests/test_ui_select_key.py
@@ -164,15 +164,43 @@ class OfferedTest(unittest.TestCase):
     presses the moved key and checks ENTER was handed back.
     """
 
-    def test_it_is_on_the_settings_screen(self):
-        """Under Input, not with the HUD keys: it governs the library too,
-        and the library exists under every `osc_style`. A key you can only
-        reach by editing conf.json is what #717 reported."""
+    def test_it_is_reachable_from_the_settings_screen(self):
+        """The requirement is that a setting EXISTS to point somebody at
+        [iw] -- an editable row, not a curated one.
+
+        `sections()` is the "reachable at all" question and Advanced is
+        one of its groups, so this passes for an uncurated key and fails
+        for one the form hides. `SECTIONS` would be the wrong ask: it is
+        the curated tabs only, and asserting membership there would pin
+        the placement decision rather than the requirement.
+        """
+        reachable = {key for _title, keys in cfg.sections() for key in keys}
+        self.assertIn("ui_select_key", reachable)
+
+    def test_but_it_is_not_advertised_in_a_curated_group(self):
+        """Key remapping is an answer to give somebody who asks, not a
+        control to put in front of everyone [iw]. It falls through to
+        Advanced, behind the disclosure.
+
+        Not a tripwire like the case this replaces: that one meant "the
+        renderer cannot honour this yet". This one is a placement the
+        settings screen is expected to keep.
+        """
         curated = {key for _title, keys in cfg.SECTIONS for key in keys}
-        self.assertIn("ui_select_key", curated)
-        self.assertNotIn("ui_select_key", cfg.HUD_ONLY,
-                         "hiding it under a non-mpvtk OSC would hide the "
-                         "library's own select key")
+        self.assertNotIn("ui_select_key", curated)
+
+    def test_and_the_words_someone_looking_for_it_types(self):
+        """Advanced is behind a disclosure, so search is how somebody sent
+        looking for "the Enter setting" arrives. Measured misses, not
+        guesses -- and asserted for `hud_wake_key` too, because it is the
+        OTHER Enter during playback and answering only for this one is how
+        the pair drifts."""
+        for query in ("enter", "remap", "rebind", "keyboard", "shortcut"):
+            with self.subTest(query=query):
+                found = {key for _tab, _title, keys in cfg.search(query)
+                         for key in keys}
+                self.assertIn("ui_select_key", found)
+                self.assertIn("hud_wake_key", found)
 
     def test_the_keyboard_is_pushed_the_value(self):
         """The keyboard's third of the agreement, at its one source.

--- a/tests/test_ui_select_key.py
+++ b/tests/test_ui_select_key.py
@@ -18,13 +18,12 @@ and phone/web Select. From the plan's exit predicate:
 So the assertions below are about AGREEMENT between the three, not about
 any one of them.
 
-**Half-landed on purpose.** The two synthetic producers read
-`ui_select_key`; the renderer still force-binds ENTER, so the setting is
-not offered in the settings screen and the docs say so. It is a
-replacement, not an alias -- yielding ENTER back is the whole request
-[iw] -- and that cannot happen until `renderer.lua`'s `NAV_KEYS` binds the
-configured name and rebuilds `keyclaim.nav_names` with it. The last two
-cases here are the tripwires for that work.
+It is a replacement, not an alias [iw]: pointing it elsewhere hands ENTER
+back to mpv, which is the whole request. `renderer.lua` resolves the name
+when it installs the bindings and rebuilds `keyclaim.nav_names` with it;
+the half of that no source-reading test can see -- the rebinding itself --
+is driven through the real script-message boundary in
+`tests/lua/test_renderer.lua`.
 """
 
 # Run as a script, this is what puts the repo root on sys.path -- without
@@ -78,14 +77,30 @@ def remote_ok_key():
 
 
 def renderer_activate_key():
-    """The key `renderer.lua` binds to `nav_activate` in `NAV_KEYS`."""
+    """The default `renderer.lua` activates on, from its `NAV_KEYS` row.
+
+    A DEFAULT and no longer a hardcode: the row carries a third field
+    marking it as following `state.select_key`, which `mpvtk-select-key`
+    moves. That the renderer really does resolve it -- and yields ENTER
+    when it does -- is driven through the real binding in
+    `tests/lua/test_renderer.lua`; what belongs here is only the fallback
+    the three producers have to agree on. The marker is asserted so a
+    row that quietly went back to a literal fails as a disagreement
+    rather than passing as one.
+    """
     src = ROOT.joinpath("jellyfin_mpv_shim", "mpvtk",
                         "renderer.lua").read_text()
     block = src[src.index("local NAV_KEYS = {"):]
     block = block[:block.index("\n}")]
-    row = next(line for line in block.splitlines()
-               if "nav_activate()" in line)
-    return re.search(r"\{\s*'([^']+)'", row).group(1)
+    marker = re.search(r"end,\s*true\s*\},", block)
+    assert marker is not None, (
+        "no NAV_KEYS row is marked as following state.select_key")
+    # Back to the start of that row, not forward from the block: every row
+    # opens the same way, so a forward match spans from the first one.
+    row = block[block.rindex("{ '", 0, marker.start()):marker.end()]
+    assert "nav_activate()" in row, (
+        "the row marked configurable is not the activation one")
+    return re.match(r"\{\s*'([^']+)'", row).group(1)
 
 
 class AgreementTest(unittest.TestCase):
@@ -139,43 +154,49 @@ class AgreementTest(unittest.TestCase):
                 self.assertEqual(remote_ok_key(), "ENTER")
 
 
-class NotYetOfferedTest(unittest.TestCase):
-    """The tripwires for the renderer half. Both are meant to fail when
-    that work lands -- read this file's header, then delete them."""
+class OfferedTest(unittest.TestCase):
+    """The renderer half landed, so the setting is reachable -- and the
+    keyboard is now the third thing that has to keep agreeing.
 
-    def test_the_renderer_still_hardcodes_it(self):
-        """When `NAV_KEYS` stops naming ENTER literally, the setting has a
-        keyboard behind it and the two cases here are obsolete.
+    These replace the tripwires this file shipped with. What they cannot
+    see is the renderer actually rebinding: that is driven through the
+    real script-message boundary in `tests/lua/test_renderer.lua`, which
+    presses the moved key and checks ENTER was handed back.
+    """
 
-        The rest of the repair is not visible from this line, and is the
-        reason it is called out rather than just deleted: the bound name
-        also has to reach `keyclaim.nav_names`, whose comment warns that a
-        claimed key OUTSIDE that set needs its own binding *and* its own
-        removal -- and the opts blob only reaches the renderer on
-        `mpvtk-hud` engage, while browse-mode nav is installed by
-        `mpvtk-active`, which carries no opts.
-        """
-        self.assertEqual(
-            renderer_activate_key(), "ENTER",
-            "the renderer now resolves the activation key -- if it reads "
-            "ui_select_key, delete this class and offer the setting")
-
-    def test_so_the_setting_is_not_offered_yet(self):
-        """Offering it while the renderer ignores it would let a user move
-        the gamepad and the remote onto a key nothing listens for, while
-        the keyboard kept ENTER. Worse than the bug being fixed."""
+    def test_it_is_on_the_settings_screen(self):
+        """Under Input, not with the HUD keys: it governs the library too,
+        and the library exists under every `osc_style`. A key you can only
+        reach by editing conf.json is what #717 reported."""
         curated = {key for _title, keys in cfg.SECTIONS for key in keys}
-        self.assertNotIn("ui_select_key", curated,
-                         "ui_select_key is on the settings screen; the "
-                         "renderer must read it first")
+        self.assertIn("ui_select_key", curated)
+        self.assertNotIn("ui_select_key", cfg.HUD_ONLY,
+                         "hiding it under a non-mpvtk OSC would hide the "
+                         "library's own select key")
 
-    def test_and_it_is_documented_as_such(self):
-        """Someone will find it in conf.json. The docs entry is what stops
-        them concluding the feature is broken."""
-        doc = ROOT.joinpath("docs", "configuration.md").read_text()
-        entry = doc[doc.index("- `ui_select_key`"):]
-        entry = entry[:entry.index("\n- `")]
-        self.assertIn("Not yet offered in the settings screen", entry)
+    def test_the_keyboard_is_pushed_the_value(self):
+        """The keyboard's third of the agreement, at its one source.
+
+        Read from source rather than executed, for the reason
+        `remote_ok_key` above gives: building an `MpvtkApp` opens a real
+        window. Scoped to the METHOD, so it says something -- `select_key`
+        already appears in `push_gamepad` a few lines up, and a whole-file
+        search for it would pass whatever this method did.
+
+        That the settings screen re-pushes it, and re-pushes the gamepad
+        table with it because a pad's Confirm carries the key as a
+        literal, is executed instead:
+        `tests/test_shell_settings.py:TestSelectKeyAppliesLive`.
+        """
+        src = ROOT.joinpath("jellyfin_mpv_shim", "mpvtk",
+                            "app.py").read_text()
+        body = src[src.index("    def push_select_key"):]
+        body = body[:body.index("\n    def ", 10)]
+        self.assertIn("mpvtk-select-key", body)
+        self.assertIn("select_key()", body,
+                      "push_select_key reads the setting itself instead "
+                      "of going through the one reader, so a cleared key "
+                      "unbinds the keyboard while the pad falls back")
 
 
 class DistinctFromTheMenuKeyTest(unittest.TestCase):

--- a/tests/test_ui_select_key.py
+++ b/tests/test_ui_select_key.py
@@ -89,7 +89,7 @@ def renderer_activate_key():
     rather than passing as one.
     """
     src = ROOT.joinpath("jellyfin_mpv_shim", "mpvtk",
-                        "renderer.lua").read_text()
+                        "renderer.lua").read_text(encoding="utf-8")
     block = src[src.index("local NAV_KEYS = {"):]
     block = block[:block.index("\n}")]
     marker = re.search(r"end,\s*true\s*\},", block)
@@ -128,7 +128,8 @@ class AgreementTest(unittest.TestCase):
         prove nothing about the remote. This is what ties the two: read
         from source, matching the CALL and the table it replaced -- never
         a bare identifier, which the surrounding comment also contains."""
-        src = ROOT.joinpath("jellyfin_mpv_shim", "player.py").read_text()
+        src = ROOT.joinpath("jellyfin_mpv_shim", "player.py").read_text(
+            encoding="utf-8")
         body = src[src.index("elif ((action in self._NAV_KEYPRESS"):]
         body = body[:body.index("elif action ==")]
         self.assertIn("conf.select_key()", body)
@@ -217,7 +218,7 @@ class OfferedTest(unittest.TestCase):
         `tests/test_shell_settings.py:TestSelectKeyAppliesLive`.
         """
         src = ROOT.joinpath("jellyfin_mpv_shim", "mpvtk",
-                            "app.py").read_text()
+                            "app.py").read_text(encoding="utf-8")
         body = src[src.index("    def push_select_key"):]
         body = body[:body.index("\n    def ", 10)]
         self.assertIn("mpvtk-select-key", body)
@@ -242,7 +243,8 @@ class DistinctFromTheMenuKeyTest(unittest.TestCase):
     def test_the_docs_say_which_one_reaches_the_hud(self):
         """The whole of the bug report: the name promised the HUD. A user
         reading the reference has to be able to tell them apart."""
-        doc = ROOT.joinpath("docs", "configuration.md").read_text()
+        doc = ROOT.joinpath("docs", "configuration.md").read_text(
+            encoding="utf-8")
         entry = doc[doc.index("- `kb_menu_ok`"):]
         entry = entry[:entry.index("\n- `")]
         self.assertIn("legacy OSD menu only", entry)

--- a/tests/test_userdata_refresh.py
+++ b/tests/test_userdata_refresh.py
@@ -1,0 +1,225 @@
+"""Watched state reaches every screen that shows it, not only Home (#722).
+
+A season fully watched in the web UI still read "3 episodes remaining" on
+the shim's series page, and opening the season showed every episode ticked.
+The badge is `UserData.UnplayedItemCount` on the PARENT -- computed by the
+server, so there is nothing to patch client-side -- and the only thing that
+refreshed on a `UserDataChanged` event was Home. A restart fixed it; the
+next episode brought it back.
+
+#560 built the right mechanism and wired it to the screen that was reported.
+This widens what it covers, and collapses the second copy of it that had
+grown alongside: `refresh_live_tv` was the same rules written again, and the
+two had drifted -- only the Live TV one took the `_refreshing` marker that
+stops a scroll paging in against a list about to be replaced. Widening the
+Home gate would have made that three copies and carried the missing marker
+onto a paged grid, which is where its absence stops being harmless.
+
+The server filter here is a pre-existing latent bug that this promotes:
+`_user_data_changed` discarded its client and refreshed whatever was on
+screen. Fair for Home, which is assembled from every logged-in server.
+Not fair for a Series page, which belongs to one.
+"""
+
+# Run as a script, this is what puts the repo root on sys.path -- without
+# it `jellyfin_mpv_shim` resolves to whatever is pip-installed. A no-op
+# under `discover`; tests/test_module_paths.py is the guard.
+if __name__ == "__main__":
+    import os
+    import sys
+
+    sys.path.insert(0, os.path.dirname(
+        os.path.dirname(os.path.abspath(__file__))))
+
+import sys
+import unittest
+
+sys.argv = ["test"]
+
+from jellyfin_mpv_shim.mpvtk_browser.app import (  # noqa: E402
+    LIVE_KINDS, USERDATA_KINDS, MpvtkBrowser)
+
+from tests._shell_harness import (  # noqa: E402
+    FakeController, FakeSource, _SyncPool)
+
+
+def _browser(kind="series", server="srv1"):
+    """A browser parked on ``kind`` with its loader replaced by a recorder.
+
+    The stub goes in BEFORE `navigate`, not after: navigating runs the real
+    loader for the destination, and several of these kinds need route keys
+    this test has no reason to invent (a grid wants `parent_id`). What is
+    under test is who ASKS for a load, so the loader is never wanted here.
+    """
+    b = MpvtkBrowser(app=None, source=FakeSource(),
+                     controller=FakeController())
+    b._pool = _SyncPool()
+    b.server = "srv1"
+    loads = []
+    b._load_route = lambda route, epoch=None: loads.append(route)
+    b.navigate({"kind": kind, "server": server, "item_id": "sh1"})
+    del loads[:]                 # the navigation itself is not a refresh
+    b._browsing = True
+    return b, loads
+
+
+class WidenedKindsTest(unittest.TestCase):
+    def test_a_series_page_re_reads(self):
+        """The reported screen: the per-season remaining count."""
+        b, loads = _browser("series")
+        b.refresh_userdata(now=True)
+        self.assertEqual(len(loads), 1)
+
+    def test_a_season_page_re_reads(self):
+        b, loads = _browser("season")
+        b.refresh_userdata(now=True)
+        self.assertEqual(len(loads), 1)
+
+    def test_home_still_does(self):
+        """#560 must not regress on the way past."""
+        b, loads = _browser("home")
+        b.refresh_userdata(now=True)
+        self.assertEqual(len(loads), 1)
+
+    def test_a_grid_still_does_not(self):
+        """Deliberately out until its refresh-versus-page-in interleaving
+        is checked -- a paged screen is where the `_refreshing` marker
+        starts mattering."""
+        b, loads = _browser("grid")
+        b.refresh_userdata(now=True)
+        self.assertEqual(loads, [])
+
+    def test_the_kinds_are_disjoint_from_live_tv(self):
+        """Two events, two sets. An overlap would mean a timer event and a
+        watched-state event both re-reading the same screen, at different
+        cadences, through one `_refreshing` marker."""
+        self.assertFalse(USERDATA_KINDS & LIVE_KINDS)
+
+
+class ServerFilterTest(unittest.TestCase):
+    def test_another_servers_event_leaves_a_series_page_alone(self):
+        b, loads = _browser("series", server="srv1")
+        b.refresh_userdata("srv2", now=True)
+        self.assertEqual(loads, [])
+
+    def test_its_own_servers_event_re_reads_it(self):
+        b, loads = _browser("series", server="srv1")
+        b.refresh_userdata("srv1", now=True)
+        self.assertEqual(len(loads), 1)
+
+    def test_home_answers_any_server(self):
+        """Home is assembled from every logged-in server, so an event from
+        any of them can change what it shows."""
+        b, loads = _browser("home", server="srv1")
+        b.refresh_userdata("srv2", now=True)
+        self.assertEqual(len(loads), 1)
+
+    def test_an_unresolved_client_still_refreshes(self):
+        """None means "could not tell which server". Refreshing is the old
+        behaviour and no worse than it; refusing would make an unresolvable
+        client silently stop updating anything."""
+        b, loads = _browser("series", server="srv1")
+        b.refresh_userdata(None, now=True)
+        self.assertEqual(len(loads), 1)
+
+
+class SharedRulesTest(unittest.TestCase):
+    """The rules Live TV had and Home did not, now that both go through one
+    implementation. Each of these used to hold for `refresh_live_tv` only."""
+
+    def test_it_marks_the_route_refreshing(self):
+        """`pagination` reads this to refuse a page-in against a list about
+        to be replaced. Home never set it."""
+        b, _loads = _browser("series")
+        b.refresh_userdata(now=True)
+        self.assertTrue(b.route.get("_refreshing"))
+
+    def test_a_refresh_already_in_flight_is_not_doubled(self):
+        b, loads = _browser("series")
+        b.route["_refreshing"] = True
+        b.refresh_userdata(now=True)
+        self.assertEqual(loads, [])
+
+    def test_a_load_in_flight_is_not_doubled(self):
+        b, loads = _browser("series")
+        b.route["_loading"] = True
+        b.refresh_userdata(now=True)
+        self.assertEqual(loads, [])
+
+    def test_an_open_menu_defers_it(self):
+        b, loads = _browser("series")
+        b._menu = {"kind": "history"}
+        b.refresh_userdata(now=True)
+        self.assertEqual(loads, [])
+
+    def test_an_open_dialog_defers_it(self):
+        b, loads = _browser("series")
+        b._dialog = lambda: None
+        b.refresh_userdata(now=True)
+        self.assertEqual(loads, [])
+
+    def test_playback_owning_the_window_defers_it(self):
+        b, loads = _browser("series")
+        b._browsing = False
+        b.refresh_userdata(now=True)
+        self.assertEqual(loads, [])
+
+    def test_live_tv_now_gets_the_browsing_guard_too(self):
+        """The one rule that moved the other way: `refresh_live_tv` had no
+        `_browsing` check, so a websocket event could fetch a guide nobody
+        was looking at. Its own poller already declined to, which is what
+        made the omission invisible."""
+        b, loads = _browser("livetv")
+        b._browsing = False
+        b.refresh_live_tv()
+        self.assertEqual(loads, [])
+
+    def test_live_tv_still_refreshes_when_it_is_up(self):
+        b, loads = _browser("livetv")
+        b.refresh_live_tv()
+        self.assertEqual(len(loads), 1)
+
+
+class RepeatedEventsTest(unittest.TestCase):
+    """The property over several steps, not the mechanics of one.
+
+    Watched state is exactly the shape that feeds back into its own input:
+    a refresh re-reads UserData, which the next event is about. A marker
+    left set, or an epoch bumped, shows up on the third pass and not the
+    first.
+    """
+
+    def test_three_rounds_each_re_read_once(self):
+        b, loads = _browser("series")
+        for round_no in range(1, 4):
+            with self.subTest(round=round_no):
+                b.refresh_userdata(now=True)
+                self.assertEqual(len(loads), round_no,
+                                 "round %d did not re-read" % round_no)
+                # what _route_async's `always` does when the load settles
+                b.route.pop("_refreshing", None)
+
+    def test_the_epoch_does_not_walk(self):
+        """A **load, not a reload**: bumping the epoch would cancel work in
+        flight and blink a spinner over what is being read."""
+        b, _loads = _browser("series")
+        before = b._epoch
+        for _ in range(3):
+            b.refresh_userdata(now=True)
+            b.route.pop("_refreshing", None)
+        self.assertEqual(b._epoch, before)
+
+    def test_a_stuck_marker_stops_everything_after_it(self):
+        """States the cost of the marker so nobody 'simplifies' the
+        `always` that clears it: one unreleased marker and the screen never
+        refreshes again for the rest of its life."""
+        b, loads = _browser("series")
+        b.refresh_userdata(now=True)
+        self.assertEqual(len(loads), 1)
+        for _ in range(3):           # marker deliberately not cleared
+            b.refresh_userdata(now=True)
+        self.assertEqual(len(loads), 1)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_userdata_refresh.py
+++ b/tests/test_userdata_refresh.py
@@ -123,6 +123,51 @@ class ServerFilterTest(unittest.TestCase):
         self.assertEqual(len(loads), 1)
 
 
+class CoalescedBurstTest(unittest.TestCase):
+    """A burst carries one server per event, and the debounce keeps one.
+
+    The refresh became server-FILTERED when #722 widened it past Home. The
+    debounce did not follow: the first arrival takes the single slot and
+    its server is captured in the closure, so in a two-server session an
+    event from B could take the slot, coalesce away A's event three hundred
+    milliseconds later, and then filter ITSELF out against the A page on
+    screen. The badge stayed stale until something else re-read the page.
+
+    Home never showed this, because Home is exempt from the filter -- which
+    is exactly why widening the kinds is what exposed it.
+    """
+
+    def _burst(self, page_server, event_servers, kind="series"):
+        b, loads = _browser(kind=kind, server=page_server)
+        b.USERDATA_DEBOUNCE = 0.01
+        for server in event_servers:
+            b.refresh_userdata(server)
+        thread = b._userdata_thread
+        if thread is not None:
+            thread.join(timeout=2)
+        return loads
+
+    def test_the_relevant_event_survives_an_earlier_irrelevant_one(self):
+        loads = self._burst("srv1", ["srv2", "srv1"])
+        self.assertEqual(len(loads), 1,
+                         "the event for the page on screen was coalesced "
+                         "away behind another server's")
+
+    def test_a_burst_for_another_server_alone_still_refreshes_nothing(self):
+        """The filter is the point of #722 and must survive the fix."""
+        self.assertEqual(self._burst("srv1", ["srv2", "srv2"]), [])
+
+    def test_home_still_refreshes_from_any_server(self):
+        """Home is assembled from every logged-in server, so it is exempt
+        from the filter and a burst from anywhere has to reach it."""
+        self.assertEqual(len(self._burst("srv1", ["srv2"], kind="home")), 1)
+
+    def test_an_unresolved_client_still_refreshes(self):
+        """`None` means the event could not be attributed to a server; it
+        refreshes unfiltered, as the pre-#722 path did."""
+        self.assertEqual(len(self._burst("srv1", ["srv2", None])), 1)
+
+
 class SharedRulesTest(unittest.TestCase):
     """The rules Live TV had and Home did not, now that both go through one
     implementation. Each of these used to hold for `refresh_live_tv` only."""

--- a/tests/test_window_chrome_settings.py
+++ b/tests/test_window_chrome_settings.py
@@ -1,0 +1,209 @@
+"""The two window-chrome settings from #727.
+
+The report had three parts. One was working as designed and now has an
+opt-out, one was a missing setting, and one was the classic OSC drawing its
+own buttons where we draw ours.
+
+* **"Only when the window has no title bar" shows nothing in full screen.**
+  Deliberate -- `window_controls_wanted` returns False on fullscreen before
+  it even reads the mode, because there is no title bar anywhere and nothing
+  to move or maximize. `window_controls_fullscreen` is the opt-in for the
+  other reading: with no title bar and no keyboard, full screen is a room
+  with no door.
+* **No way to hide the desktop title bar.** `hide_title_bar` is MPV's
+  `border`, and it is set only when ON -- writing `border=yes` otherwise
+  would override someone who put `border=no` in their own `mpv.conf` and
+  take the top-bar buttons away from exactly the person who wants them,
+  since `window_controls` "auto" reads that same property.
+* **A classic OSC drew its own window buttons.** Pushed off with
+  `osc-windowcontrols=no` beside the idlescreen opt, because the stock OSC
+  defaults it to "auto" -- which means "whenever the window has no border",
+  i.e. precisely when `hide_title_bar` is on and we are already drawing a
+  set.
+"""
+
+# Run as a script, this is what puts the repo root on sys.path -- without
+# it `jellyfin_mpv_shim` resolves to whatever is pip-installed. A no-op
+# under `discover`; tests/test_module_paths.py is the guard.
+if __name__ == "__main__":
+    import os
+    import sys
+
+    sys.path.insert(0, os.path.dirname(
+        os.path.dirname(os.path.abspath(__file__))))
+
+import pathlib
+import sys
+import unittest
+from unittest import mock
+
+sys.argv = ["test"]
+
+from jellyfin_mpv_shim import mpv_options  # noqa: E402
+from jellyfin_mpv_shim.conf import settings  # noqa: E402
+from jellyfin_mpv_shim.mpvtk_browser import config as cfg  # noqa: E402
+
+ROOT = pathlib.Path(__file__).resolve().parent.parent
+
+
+class _FakePlayer:
+    def __init__(self, fullscreen=False, border=True):
+        self.fullscreen = fullscreen
+        self.border = border
+        self.window_maximized = False
+
+
+class _Chrome:
+    """`WindowMixin.window_controls_wanted` on a stand-in.
+
+    The mixin is imported rather than a whole PlayerManager built: importing
+    `player` opens a real mpv window (CLAUDE.md), and this method only
+    touches `settings`, `_player` and `_mpv_alive`.
+    """
+
+    def __init__(self, player):
+        self._player = player
+        self._mpv_alive = True
+
+    @property
+    def _CSD_PROPS(self):
+        from jellyfin_mpv_shim.player_window import WindowMixin
+
+        return WindowMixin._CSD_PROPS
+
+    def __getattr__(self, name):
+        from jellyfin_mpv_shim.player_window import WindowMixin
+
+        attr = getattr(WindowMixin, name)
+        return attr.__get__(self, type(self))
+
+
+def _wanted(fullscreen=False, border=True, **overrides):
+    opts = {"window_controls": "always",
+            "window_controls_fullscreen": False}
+    opts.update(overrides)
+    with mock.patch.multiple(settings, **opts):
+        return _Chrome(_FakePlayer(fullscreen, border)).window_controls_wanted()
+
+
+class FullscreenTest(unittest.TestCase):
+    def test_full_screen_hides_them_by_default(self):
+        self.assertFalse(_wanted(fullscreen=True))
+
+    def test_windowed_still_shows_them(self):
+        """The premise: without this the test above passes for the wrong
+        reason on any change that turns the buttons off everywhere."""
+        self.assertTrue(_wanted(fullscreen=False))
+
+    def test_the_opt_in_keeps_them(self):
+        self.assertTrue(_wanted(fullscreen=True,
+                                window_controls_fullscreen=True))
+
+    def test_it_does_not_override_never(self):
+        """"Never" is the user saying they do not want these at all. A
+        full-screen opt-in must not talk them into it -- the same rule the
+        `none` OSC style gets."""
+        self.assertFalse(_wanted(fullscreen=True, window_controls="never",
+                                 window_controls_fullscreen=True))
+
+    def test_nor_does_it_override_auto_on_a_decorated_window(self):
+        """With a real title bar, "auto" says no -- and staying in full
+        screen does not change what the desktop draws when you leave it."""
+        self.assertFalse(_wanted(fullscreen=True, border=True,
+                                 window_controls="auto",
+                                 window_controls_fullscreen=True))
+
+    def test_but_auto_plus_no_border_says_yes_in_full_screen(self):
+        self.assertTrue(_wanted(fullscreen=True, border=False,
+                                window_controls="auto",
+                                window_controls_fullscreen=True))
+
+
+class HideTitleBarTest(unittest.TestCase):
+    def _border_option(self, **overrides):
+        opts = {"hide_title_bar": False, "enable_gui": True,
+                "osc_style": "mpvtk"}
+        opts.update(overrides)
+        with mock.patch.multiple(settings, **opts):
+            built = mpv_options.build_mpv_options(
+                "mpvtk", [], False, True)
+        return built.get("border", "unset")
+
+    def test_on_asks_for_no_border(self):
+        self.assertIs(self._border_option(hide_title_bar=True), False)
+
+    def test_off_says_nothing_at_all(self):
+        """Not `border=True`. `window_controls` "auto" reads the same
+        property to decide whether to draw its own buttons, so writing the
+        option unconditionally would override someone who put `border=no`
+        in their mpv.conf -- taking the title bar back AND the replacement
+        with it."""
+        self.assertEqual(self._border_option(hide_title_bar=False), "unset")
+
+    def test_it_needs_a_restart(self):
+        """A construction option. The marker is what stops the row claiming
+        something happened when nothing did."""
+        self.assertIn("hide_title_bar", cfg.RESTART_REQUIRED)
+
+    def test_the_fullscreen_one_does_not(self):
+        """It is read on every chrome snapshot, and editing it takes one --
+        see `_set_setting`. Marking it would be the lie the RESTART_REQUIRED
+        comment warns about."""
+        self.assertNotIn("window_controls_fullscreen", cfg.RESTART_REQUIRED)
+
+
+class LiveApplyTest(unittest.TestCase):
+    def test_editing_either_one_re_takes_the_chrome_snapshot(self):
+        """The snapshot is PUSHED, on decoration changes only, and editing a
+        setting is not one -- so without this the row waits for the next
+        fullscreen or maximize to take effect and looks broken. True of
+        `window_controls` before this, too."""
+        src = ROOT.joinpath("jellyfin_mpv_shim", "mpvtk_browser",
+                            "settings", "base.py").read_text()
+        self.assertIn('"window_controls", "window_controls_fullscreen"', src)
+        self.assertIn("refresh_window_controls", src)
+
+
+class ClassicOscTest(unittest.TestCase):
+    def _init_mpv_body(self):
+        src = ROOT.joinpath("jellyfin_mpv_shim", "player.py").read_text()
+        body = src[src.index("    def _init_mpv(self):"):]
+        return body[:body.index("\n    def ")]
+
+    def test_the_osc_is_told_not_to_draw_its_own(self):
+        """The stock OSC defaults `windowcontrols` to "auto", which means
+        "whenever the window has no border" -- exactly when
+        `hide_title_bar` is on and we are already drawing a set."""
+        self.assertIn("osc-windowcontrols=no", self._init_mpv_body())
+
+    def test_it_rides_the_same_append(self):
+        """One place that knows how to hand an option to a classic OSC, and
+        it appends rather than replacing `script-opts`."""
+        body = self._init_mpv_body()
+        self.assertIn('"change-list", "script-opts", "append"', body)
+        self.assertLess(body.index("osc-windowcontrols=no"),
+                        body.index("_load_classic_osc()"))
+
+    def test_exactly_two_options_are_pushed_and_no_more(self):
+        """It has no spelling there: the OSC's `window_controls_enabled`
+        reads `windowcontrols` and `border` and never asks about full
+        screen. Saying "yes" to carry the opt-in would show ITS buttons in
+        full screen even when ours are meant to be hidden.
+
+        Asserted as the SET of `osc-*` options actually pushed, not as
+        "`window_controls_fullscreen` does not appear" -- the comment right
+        above the call explains why it is absent, so a name search finds the
+        explanation and fails. That trap has caught three tests in this
+        branch: when reading source, match the code form (a quoted literal,
+        a call) and never a bare identifier that prose can also contain.
+        """
+        import re
+
+        pushed = set(re.findall(r'"(osc-[a-z-]+=[a-z]+)"',
+                                self._init_mpv_body()))
+        self.assertEqual(pushed, {"osc-idlescreen=no",
+                                  "osc-windowcontrols=no"})
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_window_chrome_settings.py
+++ b/tests/test_window_chrome_settings.py
@@ -171,39 +171,61 @@ class ClassicOscTest(unittest.TestCase):
         body = src[src.index("    def _init_mpv(self):"):]
         return body[:body.index("\n    def ")]
 
-    def test_the_osc_is_told_not_to_draw_its_own(self):
-        """The stock OSC defaults `windowcontrols` to "auto", which means
-        "whenever the window has no border" -- exactly when
-        `hide_title_bar` is on and we are already drawing a set."""
-        self.assertIn("osc-windowcontrols=no", self._init_mpv_body())
-
-    def test_it_rides_the_same_append(self):
+    def test_the_options_are_pushed_by_appending(self):
         """One place that knows how to hand an option to a classic OSC, and
-        it appends rather than replacing `script-opts`."""
+        it appends rather than replacing `script-opts` -- which is shared
+        with the user's own scripts."""
         body = self._init_mpv_body()
         self.assertIn('"change-list", "script-opts", "append"', body)
-        self.assertLess(body.index("osc-windowcontrols=no"),
+        self.assertIn("osc_script_opts(", body)
+        self.assertLess(body.index("osc_script_opts("),
                         body.index("_load_classic_osc()"))
 
-    def test_exactly_two_options_are_pushed_and_no_more(self):
-        """It has no spelling there: the OSC's `window_controls_enabled`
-        reads `windowcontrols` and `border` and never asks about full
-        screen. Saying "yes" to carry the opt-in would show ITS buttons in
-        full screen even when ours are meant to be hidden.
 
-        Asserted as the SET of `osc-*` options actually pushed, not as
-        "`window_controls_fullscreen` does not appear" -- the comment right
-        above the call explains why it is absent, so a name search finds the
-        explanation and fails. That trap has caught three tests in this
-        branch: when reading source, match the code form (a quoted literal,
-        a call) and never a bare identifier that prose can also contain.
+class OscScriptOptsTest(unittest.TestCase):
+    """WHICH `osc-*` options are pushed, by resolved style.
+
+    This was a flat pair of literals in `_init_mpv`, asserted by reading the
+    source -- which is why the question below was never put to it: the text
+    said `osc-windowcontrols=no` and every style got it.
+    """
+
+    def _opts(self, style):
+        return set(mpv_options.osc_script_opts(style))
+
+    def test_idlescreen_is_off_under_every_style(self):
+        """It has to cover the styles where mpv loads the OSC itself as well
+        as the one we load by hand, and is inert where there is no OSC."""
+        for style in ("mpv", "mpvtk", "default", "custom", "none"):
+            with self.subTest(style=style):
+                self.assertIn("osc-idlescreen=no", self._opts(style))
+
+    def test_only_mpvtk_suppresses_the_osc_s_window_buttons(self):
+        """We draw our own over PLAYBACK in exactly one style -- the mpvtk
+        HUD asks `window_chrome.window_controls` for a set. Everywhere else
+        the OSC on screen is the only thing that could offer any, and the
+        stock OSC, our own `trickplay-osc.lua` fork under "mpv", and a
+        custom one can all draw them. Telling them not to, with
+        `hide_title_bar` on, left a windowed video with no title bar and no
+        buttons anywhere.
         """
-        import re
+        self.assertIn("osc-windowcontrols=no", self._opts("mpvtk"))
+        for style in ("mpv", "default", "custom", "none"):
+            with self.subTest(style=style):
+                self.assertNotIn("osc-windowcontrols=no", self._opts(style),
+                                 "took the window buttons away from the "
+                                 "only thing drawing any")
 
-        pushed = set(re.findall(r'"(osc-[a-z-]+=[a-z]+)"',
-                                self._init_mpv_body()))
-        self.assertEqual(pushed, {"osc-idlescreen=no",
-                                  "osc-windowcontrols=no"})
+    def test_nothing_else_is_pushed(self):
+        """`window_controls_fullscreen` has no spelling here: the OSC's own
+        `window_controls_enabled` reads `windowcontrols` and `border` and
+        never asks about full screen, so saying "yes" to carry the opt-in
+        would show ITS buttons in full screen even when ours are hidden."""
+        for style in ("mpv", "mpvtk", "default", "custom", "none"):
+            with self.subTest(style=style):
+                self.assertTrue(
+                    self._opts(style) <= {"osc-idlescreen=no",
+                                          "osc-windowcontrols=no"})
 
 
 if __name__ == "__main__":

--- a/tests/test_window_chrome_settings.py
+++ b/tests/test_window_chrome_settings.py
@@ -159,14 +159,15 @@ class LiveApplyTest(unittest.TestCase):
         fullscreen or maximize to take effect and looks broken. True of
         `window_controls` before this, too."""
         src = ROOT.joinpath("jellyfin_mpv_shim", "mpvtk_browser",
-                            "settings", "base.py").read_text()
+                            "settings", "base.py").read_text(encoding="utf-8")
         self.assertIn('"window_controls", "window_controls_fullscreen"', src)
         self.assertIn("refresh_window_controls", src)
 
 
 class ClassicOscTest(unittest.TestCase):
     def _init_mpv_body(self):
-        src = ROOT.joinpath("jellyfin_mpv_shim", "player.py").read_text()
+        src = ROOT.joinpath("jellyfin_mpv_shim", "player.py").read_text(
+            encoding="utf-8")
         body = src[src.index("    def _init_mpv(self):"):]
         return body[:body.index("\n    def ")]
 

--- a/tests/test_window_geometry.py
+++ b/tests/test_window_geometry.py
@@ -198,6 +198,8 @@ class WindowMixinIsWiredInTest(unittest.TestCase):
         self.assertTrue(issubclass(PlayerManager, WindowMixin))
         for name in ("set_browse_window", "browse_yield", "force_window",
                      "raise_window", "set_fullscreen", "toggle_fullscreen",
+                     "apply_browser_fullscreen",
+                     "_apply_browse_fullscreen",
                      "_sync_window_geometry", "_rearm_window_geometry",
                      "_save_window_geometry", "_set_force_window",
                      "_reopen_window_size"):

--- a/tools/probe_classic_osc_mouse.py
+++ b/tools/probe_classic_osc_mouse.py
@@ -1,0 +1,174 @@
+#!/usr/bin/env python3
+"""Who owns the mouse buttons while a classic OSC is on screen? (#724)
+
+A manual probe against a REAL mpv, in the shape of `probe_hover_strand.py`:
+it reproduces a state and reports what mpv thinks, rather than asserting
+anything. Not a test -- it needs a display and an mpv binary, and what it
+answers is a question about mpv's input layer, not about our control flow.
+
+**The question.** With ``osc_style`` set to "mpv" or "default", the reporter
+says neither mouse button pauses. renderer.lua's ``mpvtk_mouse`` section
+claims ``mbtn_left``/``mbtn_right`` and sets no mouse area, so mpv treats it
+as covering the whole screen (input.c ``get_bind_section``:
+``{INT_MIN..INT_MAX}``) and prefers it over the builtin binding
+(``get_cmd_from_keys``). Both of the renderer's bare-video fall-throughs
+gate on ``state.phud.mode``, which classic-OSC modality never enters -- so
+while that section is enabled, both buttons are swallowed and do nothing.
+
+That is the mechanism. What was never established is whether the section is
+still enabled at the point the user is complaining about, and this probe
+splits that in half:
+
+  A. does telling the renderer ``mpvtk-active no`` actually release the
+     sections? (this file);
+  B. does the app send it, in classic-OSC modality? (a Python question,
+     answerable against the fake mpv -- see tests/test_classic_osc_mouse.py)
+
+If A says the renderer releases them, the renderer is not the bug and B is
+where to look. If A says it does not, stop: the fix is in renderer.lua.
+
+**Reading the output.** ``input-bindings`` reports a ``priority`` per
+binding, and ``-1`` means the owning section is not in ``active_sections``
+at all (input.c ``mp_input_get_bindings``) -- i.e. disabled. So a
+``mpvtk_mouse`` row at priority -1 is a released section, and one at >= 0 is
+a live claim that outranks mpv's own default.
+
+Usage:
+
+    xvfb-run -a python3 tools/probe_classic_osc_mouse.py
+    JMS_TEST_BACKEND=jsonipc xvfb-run -a python3 tools/probe_classic_osc_mouse.py
+"""
+
+import os
+import sys
+import threading
+import time
+
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+
+MOUSE_KEYS = ("MBTN_LEFT", "MBTN_RIGHT", "MBTN_LEFT_DBL", "MBTN_MID",
+              "MBTN_BACK", "MBTN_FORWARD", "WHEEL_UP", "WHEEL_DOWN")
+
+
+def _bindings(handle, keys=MOUSE_KEYS):
+    """``{key: [(section, priority, is_weak, cmd), ...]}`` for ``keys``."""
+    # The property ACCESSOR, not `command("get_property", ...)`: libmpv
+    # rejects the command form of a node-returning property with
+    # MPV_ERROR_PROPERTY_FORMAT. This read used to try the command first and
+    # fall through, which worked and hid the fact.
+    rows = handle.input_bindings
+    out = {}
+    for row in rows or ():
+        key = (row.get("key") or "").upper()
+        if key not in keys:
+            continue
+        out.setdefault(key, []).append((
+            row.get("section") or "", int(row.get("priority", -1)),
+            bool(row.get("is_weak")), (row.get("cmd") or "")[:40]))
+    for entries in out.values():
+        entries.sort(key=lambda e: -e[1])
+    return out
+
+
+def _report(label, handle):
+    print("\n=== %s ===" % label)
+    table = _bindings(handle)
+    for key in MOUSE_KEYS:
+        entries = table.get(key)
+        if not entries:
+            print("  %-16s (nothing bound)" % key)
+            continue
+        winner = entries[0]
+        for section, priority, weak, cmd in entries:
+            mark = "*" if (section, priority) == winner[:2] and priority >= 0 \
+                else " "
+            print("  %s %-16s %-18s prio=%-4d weak=%-5s %s"
+                  % (mark, key, section or "(default)", priority, weak, cmd))
+    # `input-builtin-dragging` is mpv 0.39+. The renderer turns it OFF while
+    # it owns the pointer (its own sections would refuse every VO drag
+    # otherwise) and hands it back in `ui_suspend`; that hand-back is the
+    # classic-OSC half of #726 -- dragging the video to move the window is
+    # what mpv does everywhere else, and it is only ours to take while our
+    # UI is up.
+    try:
+        drag = handle.input_builtin_dragging
+    except Exception:
+        try:
+            drag = handle.command("get_property", "input-builtin-dragging")
+        except Exception:
+            drag = "(unsupported by this mpv)"
+    print("  input-builtin-dragging: %s" % (drag,))
+
+
+def _spawn_handle():
+    """A raw mpv handle with the options the PLAYER uses, not the toolkit
+    demo's: builtin bindings ON (that is what puts `cycle pause` and friends
+    in the default section) and the stock OSC replaced, which is what
+    ``osc_style`` "mpv" does."""
+    opts = {
+        "idle": "yes",
+        "force_window": "yes",
+        "osc": "no",                    # REPLACES_OSC: the shim's own OSC
+        "input_default_bindings": "yes",
+        "config": "no",
+        "keepaspect_window": "no",
+        "title": "jms classic-osc mouse probe",
+    }
+    if os.environ.get("JMS_TEST_BACKEND") == "jsonipc":
+        import python_mpv_jsonipc
+        return python_mpv_jsonipc.MPV(start_mpv=True, **opts), True
+    import mpv as libmpv
+    return libmpv.MPV(**{k.replace("_", "-"): v for k, v in opts.items()}), False
+
+
+def main():
+    from jellyfin_mpv_shim.mpvtk.app import MpvtkApp
+
+    handle, ext = _spawn_handle()
+
+    # The OTHER claimant, and the one the probe originally forgot: in
+    # classic-OSC modality the shim also loads its patched stock OSC, whose
+    # `input` section binds mbtn_left/mbtn_right and is enabled at LOAD
+    # (trickplay-osc.lua: `mp.enable_key_bindings("input")` with
+    # `state.input_enabled = true`), before any layout has decided the OSC
+    # is invisible. Leaving it out measures a configuration nobody runs.
+    if "--no-osc" not in sys.argv:
+        osc = os.path.join(os.path.dirname(os.path.dirname(
+            os.path.abspath(__file__))), "jellyfin_mpv_shim",
+            "trickplay-osc.lua")
+        handle.command("load-script", osc)
+        time.sleep(0.5)
+        _report("stock OSC loaded, no renderer yet", handle)
+
+    app = MpvtkApp.attach(handle, ext=ext)
+    thread = threading.Thread(target=lambda: app.run(lambda b: []), daemon=True)
+    thread.start()
+    try:
+        app.ready.wait(10)
+        time.sleep(0.5)          # let the renderer install its sections
+        _report("renderer attached and ACTIVE (browse)", handle)
+
+        # What `_yield()` does in classic-OSC modality: the HUD is not
+        # available, so the renderer is detached outright rather than left
+        # attached-but-idle.
+        app.set_active(False)
+        time.sleep(0.5)
+        _report("after `mpvtk-active no` (classic-OSC playback)", handle)
+
+        app.set_active(True)
+        time.sleep(0.5)
+        _report("back to browse", handle)
+    finally:
+        try:
+            app.quit()
+            thread.join(timeout=5)
+        except Exception:
+            pass
+        try:
+            handle.terminate()
+        except Exception:
+            pass
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
This addresses a number of separate github issues:
- #721 - Fixes scaling of HUD icons on window resize
- #720 - Fixes play button on seasons.
- #719 - Added season view to context menu on tiles. (Updating to allow clicking series name deferred.)
- #718 - Make `--minimized` and other CLI options not get saved into the config.
- #722 - Update watched state on other pages not just home.
- #727 - Allow hiding the title bar and showing window controls on fullscreen.
- #717 - Add escape hatch config option (advanced) for remapping enter for people annoyed by it.
- #728 - Prevent display mirroring force raising the window when it is already open.
- #730 - Block MPV shortcuts in library browser.

It also includes a standalone fix:
- Use mpv preview API on 0.41 and newer, eliminating the forked OSC for "classic with trickplay" mode.
- Add more visible option to disable trickplay now that the fork/classic option is gone.