### PR TITLE
v3 release blocker fixes

### DIFF
--- a/docs/do-not-fix.md
+++ b/docs/do-not-fix.md
@@ -150,6 +150,7 @@ then dropped in the same commit).
 | F26 | `cast.py` | Cast parks the last composite. |
 | F29 | `player.py` load gate / `_on_cache_pause` | Field report, below. |
 | F35 | `renderer.lua` `phud_skip_bind` | Binds literal `'ENTER'` for the Skip button whatever `hud_wake_key` says, so a moved wake key leaves ENTER accepting a skip. Found while doing #717 and deliberately left: it is a `hud_wake_key` bug, and it wants a decision about whether the idle Skip offer follows the wake key or `ui_select_key`. |
+| F36 | `media.py` `get_playback_url` | Asking for a track pins `MediaSources[0]`, so a multi-version item loses the unplayable retry. Accepted for 3.0.0; below. |
 
 ### F29 — sleeping NAS, not reproduced
 
@@ -182,3 +183,53 @@ user has nothing on screen telling them the NAS is still spinning up.
 **Before acting, ask for** the shim's `log.txt` from the affected run — grabbed
 *before* relaunching, it is rewritten on every start — and mpv's own log, plus
 whether `direct_paths` is on (SMB and a NAS implies it).
+
+### F36 — the source pin collapses a multi-version item
+
+**Accepted for 3.0.0.** Pinned by `MultiVersionSourcePinTest` in
+`tests/test_track_negotiation.py`, which asserts the current behaviour
+*including where it fails* — so a fix cannot land silently, and the tests are
+expected to fail when one does.
+
+**What happens.** PlaybackInfo silently ignores `AudioStreamIndex` unless
+`MediaSourceId` is sent with it, so `get_playback_url` derives one whenever a
+real (non-negative) index is being asked for. `remember_audio_track` defaults
+on, so from the second item in a queue onward almost every play carries one.
+The derived id is `source_for_track_rules()`, i.e. `item["MediaSources"][0]`,
+and the server then answers with **that source alone** — measured on the QA
+server: `Pilot` has three versions, and PlaybackInfo returns three sources
+without an id and one with it.
+
+Two things downstream are then unreachable: `get_best_media_source`'s
+preference for the highest-bitrate source that will *direct play*, and the
+`if url is None and len(playback_info["MediaSources"]) > 1` retry — so an
+unplayable primary now fails outright instead of falling back.
+
+**Why it is accepted rather than fixed.** `MediaSources[0]` is not arbitrary.
+Jellyfin sorts the list (`SortMediaSources`, in
+`Emby.Server.Implementations/Library/MediaSourceManager.cs`) by: the queried
+item's own source first — the comment there says "so it stays the default that
+gets played" — then `VideoFile` over other video types, then non-3D, then
+**descending video width**. So [0] is the version the user clicked, else the
+highest-resolution one. The shim direct-plays most formats where bandwidth is
+not the constraint, and the alternative — dropping the pin — loses the
+remembered audio and subtitle track on *every* episode advance, which is the
+more visible regression by a wide margin.
+
+The residual risk is narrow and real: a library holding a 4K version the client
+cannot play alongside a 1080p one it can. The sort is by resolution, not by
+playability, so the pin picks exactly the version most likely to need
+transcoding, and the fallback that existed for that case is gone.
+
+**The fix, when it is time.** Derive the id only when the item has a single
+`MediaSource` — nothing to choose between and nothing to fall back to, so the
+pin costs nothing there. The multi-version case then needs the source resolved
+*before* the negotiation (from the item DTO, weighed the way
+`get_best_media_source` weighs it) and that source pinned, rather than [0].
+That is a real change to the negotiation order and wants its own round.
+
+**Note for whoever picks this up:** the review that found it framed this as
+"the pin takes the source choice away from the server", which is not quite
+right and points at a worse fix — restoring the server's choice would take the
+remembered tracks with it. The server sorts by width; the shim sorts by
+playability; they disagree exactly where this bites.

--- a/jellyfin_mpv_shim/conf.py
+++ b/jellyfin_mpv_shim/conf.py
@@ -947,6 +947,7 @@ class Settings(SettingsBase):
             # `READ_ENCODING` was introduced it was read with the locale
             # codec and worked. Measured, both directions.
             log.error("Could not read settings from json: %s" % e)
+            self.__dict__["_unreadable"] = True
             return False
         finally:
             fh.close()
@@ -993,6 +994,7 @@ class Settings(SettingsBase):
                     self.save()
             except Exception as e:
                 log.error("Error loading settings from json: %s" % e)
+                self.__dict__["_unreadable"] = True
                 return False
 
         return True
@@ -1000,6 +1002,25 @@ class Settings(SettingsBase):
     def save(self):
         if config_path is None:
             raise FileNotFoundError("Config path not set.")
+
+        # **Never write over a config we could not READ.** Returning False
+        # from `load` leaves the app running on defaults, and the very next
+        # save -- window geometry on a clean exit, `remember_window_size`
+        # defaults True -- would `os.replace` those defaults over the user's
+        # file. Measured: a 70-byte hand-edited conf.json became 5,858 bytes
+        # of defaults, with their `sync_path` gone and only a `log.error` in
+        # a log.txt that the next launch truncates.
+        #
+        # That is a worse failure than the crash this guard's sibling was
+        # added to prevent: an unlaunchable app keeps your settings, and
+        # there is no `conf.json.bak` here the way there is for `cred.json`
+        # and `catalog.db`. So a failed load makes this session read-only,
+        # and the user's file waits intact for them to fix the encoding.
+        if self.__dict__.get("_unreadable"):
+            log.error("Refusing to save: the config file could not be read, "
+                      "and writing defaults over it would discard settings "
+                      "this session never saw.")
+            return
 
         # Write-temp-then-rename under a lock: concurrent savers can't
         # interleave, and a crash mid-write leaves the old file intact

--- a/jellyfin_mpv_shim/conf.py
+++ b/jellyfin_mpv_shim/conf.py
@@ -931,6 +931,23 @@ class Settings(SettingsBase):
         # POSIX renames over an open file happily, which is why this stood.
         try:
             raw = None if created else fh.read()
+        except (UnicodeDecodeError, OSError) as e:
+            # **A config we cannot DECODE is a corrupt config, not a crash.**
+            # This read is the first thing `main` does (`mpv_shim.py:133`)
+            # and logging is not configured until :160, so an exception here
+            # escapes before there is a `log.txt` to put it in -- and the
+            # Windows build is PyInstaller `-w`, with no console either. The
+            # user double-clicks and nothing happens, with nothing to send.
+            #
+            # Reachable only by UPGRADERS who hand-edited: we write with
+            # `json.dump`'s default `ensure_ascii=True`, so a file this app
+            # produced is pure ASCII and decodes under any codec. A file
+            # Notepad saved as ANSI or Unicode with a non-ASCII value in it
+            # (a `sync_path` under `D:/Filme/Übersicht`) does not, and before
+            # `READ_ENCODING` was introduced it was read with the locale
+            # codec and worked. Measured, both directions.
+            log.error("Could not read settings from json: %s" % e)
+            return False
         finally:
             fh.close()
         if created:

--- a/jellyfin_mpv_shim/media.py
+++ b/jellyfin_mpv_shim/media.py
@@ -963,8 +963,13 @@ class Video(object):
         # ordinary play, where srcid is None.
         #
         # Only when we are actually asking for a track. With no aid/sid there
-        # is nothing to pin and the server should keep choosing the source
-        # itself, which is what multi-version items rely on.
+        # is nothing to pin and the server keeps choosing the source itself.
+        #
+        # But `remember_audio_track` defaults on, so from the second item in a
+        # queue onward there usually IS one -- and the pin then collapses a
+        # multi-version item to MediaSources[0], costing the unplayable retry
+        # below. Accepted, with the reasoning and the fix: docs/do-not-fix.md
+        # F36. Pinned by MultiVersionSourcePinTest.
         srcid = self.srcid
         # Only for an index that actually INDEXES INTO a source. `sid = -1` is
         # "no subtitles", which is source-independent -- and the remembered

--- a/jellyfin_mpv_shim/mpvtk_browser/app.py
+++ b/jellyfin_mpv_shim/mpvtk_browser/app.py
@@ -2883,6 +2883,15 @@ class MpvtkBrowser(DialogsMixin, LiveTvDialogsMixin, AuthMixin, SettingsMixin,
         # what shows before the first scene lands -- so this paints over it
         # rather than replacing it. Bottom of the Stack, so every bit of
         # chrome still draws on top.
+        # **Nothing while a page is on the VO.** A comic is rendered by mpv
+        # itself, and everything below is a BITMAP -- which composites above
+        # the video output, not behind it -- so a backdrop here paints over
+        # the page instead of behind it. Neither feature that wants one knows
+        # about the reader: a theme's gradient (jf-wmc draws one) and Custom
+        # OSC's opaque box, whose whole job is hiding an idle screen that
+        # cannot be on display while the VO is showing something.
+        if self.route.get("_showing"):
+            return page
         stops = theme.window_gradient()
         if stops:
             back = Gradient(stops=stops, axis="y", w=w, h=h)

--- a/jellyfin_mpv_shim/player_window.py
+++ b/jellyfin_mpv_shim/player_window.py
@@ -395,7 +395,12 @@ class WindowMixin:
         self.fullscreen_disable = not enabled
         if not persist:
             return
-        key = "fullscreen" if self._video is not None else "browser_fullscreen"
+        # `_library_showing()`, not `_video is not None`: music keeps
+        # `_video` set and keeps the library up, so a toggle made while a
+        # track played was persisted as the VIDEO preference -- which also
+        # arms auto-fullscreen for the next film, or turns it off, without
+        # the user touching a video setting.
+        key = "browser_fullscreen" if self._library_showing() else "fullscreen"
         if getattr(settings, key) == enabled:
             return
         setattr(settings, key, enabled)

--- a/tests/test_conf_file_encoding.py
+++ b/tests/test_conf_file_encoding.py
@@ -109,6 +109,46 @@ class ConfigFileEncodingTest(unittest.TestCase):
                         "caller can tell the user rather than silently "
                         "running on defaults")
 
+    def test_a_config_we_could_not_read_is_never_written_over(self):
+        """**A failed load makes the session read-only.**
+
+        Refusing to crash is only half the repair. The app then runs on
+        defaults, and the very next `save()` -- window geometry on a clean
+        exit, `remember_window_size` defaults True -- would `os.replace`
+        those defaults over the file. Measured before this guard: a 70-byte
+        hand-edited conf.json became 5,858 bytes of defaults, the user's
+        `sync_path` gone, with only a `log.error` in a log.txt the next
+        launch truncates.
+
+        That is worse than the crash: an unlaunchable app keeps your
+        settings, and there is no `conf.json.bak` here the way there is for
+        `cred.json` and `catalog.db`.
+
+        Both failure modes, because the rule is about the LOAD failing and
+        not about encoding -- the corrupt-JSON half predates the decode half
+        and had the same consequence.
+        """
+        cases = (("undecodable", "cp1252",
+                  json.dumps({"sync_path": NON_ASCII_PATH},
+                             ensure_ascii=False)),
+                 ("corrupt json", "utf-8", '{"sync_path": "D:/x", '))
+        for label, encoding, body in cases:
+            with self.subTest(config=label):
+                path = os.path.join(self.tmp, "c-%s.json" % encoding)
+                with open(path, "w", encoding=encoding) as fh:
+                    fh.write(body)
+                original = open(path, "rb").read()
+
+                settings = Settings()
+                self.assertFalse(settings.load(path))
+                settings.window_width = 1280       # as a clean exit does
+                settings.save()
+
+                self.assertEqual(
+                    open(path, "rb").read(), original,
+                    "%s: the config was overwritten with defaults, so every "
+                    "setting the user had is gone" % label)
+
     def test_a_utf8_value_survives_a_non_utf8_locale(self):
         """In a subprocess, because the locale's codec is fixed at startup and
         this machine's is UTF-8 -- in process the bug is unreachable and the

--- a/tests/test_conf_file_encoding.py
+++ b/tests/test_conf_file_encoding.py
@@ -70,6 +70,45 @@ class ConfigFileEncodingTest(unittest.TestCase):
             "every setting in it was silently ignored")
         self.assertEqual(s.sync_path, NON_ASCII_PATH)
 
+    def test_a_file_we_cannot_decode_is_refused_not_raised(self):
+        """**The direction this file was missing.** Every case above asks
+        whether a readable config is read correctly. None asked what happens
+        to one that is not valid UTF-8 at all.
+
+        It matters more than the others because of WHERE it lands. The read
+        is the first thing `main` does (`mpv_shim.py:133`) and logging is not
+        configured until `:160`, so an exception escapes before there is a
+        `log.txt` to record it -- and the Windows build is PyInstaller `-w`,
+        with no console. The user double-clicks and nothing happens, with
+        nothing to send anybody.
+
+        Only upgraders who hand-edited can reach it: `json.dump` defaults to
+        `ensure_ascii=True`, so a file this app wrote is pure ASCII and
+        decodes under any codec. Notepad's "ANSI" and "Unicode" do not, and
+        before `READ_ENCODING` existed they were read with the locale codec
+        and worked -- so this is a regression, not a new limitation.
+        """
+        body = json.dumps({"sync_path": "D:/Filme/\u00dcbersicht"},
+                          ensure_ascii=False)
+        for label, encoding in (("Notepad ANSI", "cp1252"),
+                                ("Notepad Unicode", "utf-16")):
+            with self.subTest(saved_as=label):
+                path = os.path.join(self.tmp, "conf-%s.json" % encoding)
+                with open(path, "w", encoding=encoding) as fh:
+                    fh.write(body)
+                try:
+                    ok = Settings().load(path)
+                except Exception as exc:      # noqa: BLE001 - the point
+                    self.fail(
+                        "a config saved as %s raised %s out of load(), which "
+                        "happens before logging is configured -- no log.txt, "
+                        "and on Windows no console either: %s"
+                        % (label, type(exc).__name__, exc))
+                self.assertFalse(
+                    ok, "an undecodable config must report failure, so the "
+                        "caller can tell the user rather than silently "
+                        "running on defaults")
+
     def test_a_utf8_value_survives_a_non_utf8_locale(self):
         """In a subprocess, because the locale's codec is fixed at startup and
         this machine's is UTF-8 -- in process the bug is unreachable and the

--- a/tests/test_library_showing.py
+++ b/tests/test_library_showing.py
@@ -192,3 +192,84 @@ class LibraryHasInputTest(unittest.TestCase):
                     self._has_input(video, False),
                     "%s: the renderer does not hold input, so the library "
                     "does not either" % label)
+
+
+class _FakeWindow:
+    """Enough mpv for `show_picture`, recording what it was told."""
+
+    def __init__(self):
+        self.loaded = []
+        self.keepaspect = False
+        self.osd_width, self.osd_height = 1280, 720
+        self.window_maximized = False
+        self.fullscreen = False
+        self.image_display_duration = 1
+        self.keep_open = False
+        self.fs = False
+
+    def command(self, *args):
+        if args and args[0] == "loadfile":
+            self.loaded.append(args[1])
+
+
+def _window_pm(video):
+    import threading
+
+    pm = _pm(video)
+    # `__new__` skips `__init__`, so the RLock the @synchronous methods take
+    # does not exist yet. A real one, not a stub: re-entrancy across these
+    # methods is load-bearing (show_picture calls stop, which is synchronous).
+    pm._lock = threading.RLock()
+    pm._player = _FakeWindow()
+    pm._mpv_alive = True
+    pm._loading = False
+    pm._geometry_armed = "1280x720"
+    pm._showing_browse_bg = True
+    pm._suspend_shaders_for_still = lambda: None
+    pm.stopped = []
+    pm.stop = lambda *a, **k: pm.stopped.append(1)
+    return pm
+
+
+class FullscreenPersistTest(unittest.TestCase):
+    """Which settings key a persisted fullscreen toggle lands in.
+
+    `set_fullscreen`'s docstring states the rule -- "browsing writes
+    browser_fullscreen, playback writes fullscreen. They're separate settings
+    precisely because people want different answers for the two" -- and the
+    line below it asked `_video is not None`. So a toggle made while music
+    played was stored as the VIDEO preference, which silently armed or
+    disarmed auto-fullscreen for the next film.
+    """
+
+    def _persist(self, video, enabled):
+        from jellyfin_mpv_shim.conf import settings
+
+        pm = _window_pm(video)
+        before = (settings.fullscreen, settings.browser_fullscreen,
+                  settings.save)
+        settings.save = lambda *a, **k: None
+        settings.fullscreen = settings.browser_fullscreen = not enabled
+
+        def restore():
+            (settings.fullscreen, settings.browser_fullscreen,
+             settings.save) = before
+        self.addCleanup(restore)
+        pm.set_fullscreen(enabled, persist=True)
+        return settings.fullscreen, settings.browser_fullscreen
+
+    def test_the_key_follows_what_is_on_screen(self):
+        for label, video, showing in STATES:
+            with self.subTest(state=label):
+                video_key, browser_key = self._persist(video, True)
+                if showing:
+                    self.assertTrue(browser_key,
+                                    "%s: the library's own preference was "
+                                    "not recorded" % label)
+                    self.assertFalse(
+                        video_key,
+                        "%s: this wrote the VIDEO setting, so the next film "
+                        "goes fullscreen unasked (or stops doing so)" % label)
+                else:
+                    self.assertTrue(video_key, "%s" % label)
+                    self.assertFalse(browser_key, "%s" % label)

--- a/tests/test_library_showing.py
+++ b/tests/test_library_showing.py
@@ -1,0 +1,194 @@
+"""``_library_showing()`` — the predicate that decides whether the user is
+looking at the library, and the three call sites that ride it.
+
+It had **no test at all** and six callers. That is the gap this file closes,
+and the reason it matters is that the obvious spelling is wrong in a way that
+looks right:
+
+    ``_video is None``          # what everything used to ask
+    ``_library_showing()``      # what it means to ask
+
+A video PICTURE is what takes the library away; **music does not**. Audio
+keeps ``_video`` set *and* keeps the browser on screen — that is what the
+now-playing bar is for — so ``_video is None`` answers "is the library up?"
+with a no while the user is looking straight at it.
+
+``_nav_back`` asked it the wrong way and refused BACK for the whole of music
+and audiobook playback. The mouse's back button rides the same path (the
+renderer routes it as a synthetic ESC), so it died the moment anything
+played; and with no way back, FORWARD had nothing to return to and looked
+broken with it. `CLAUDE.md` lists this as one of two "ambushes that fire far
+from the feature that owns them".
+
+So the table below is not about a boolean. Each row is a state a user can be
+in, and each call site is asked what it does there — because the defect was
+never in the predicate, it was in who did not call it.
+"""
+
+# Run as a script, this is what puts the repo root on sys.path -- without
+# it `jellyfin_mpv_shim` resolves to whatever is pip-installed. A no-op
+# under `discover`; tests/test_module_paths.py is the guard.
+if __name__ == "__main__":
+    import os
+    import sys
+
+    sys.path.insert(0, os.path.dirname(
+        os.path.dirname(os.path.abspath(__file__))))
+
+import sys
+import types
+import unittest
+
+sys.argv = [sys.argv[0]]      # importing the shim reaches args.get_args()
+
+
+def _video(**item):
+    """A stand-in for the queue's current item.
+
+    `_item_is_audio` reads metadata off `video.item` and nothing else, so
+    this models exactly the field it consults -- and deliberately carries
+    BOTH spellings the server uses, because the predicate accepts either.
+    """
+    return types.SimpleNamespace(item=dict(item))
+
+
+#: The states a user can actually be in, and whether the library is on screen.
+#: `None` is browse; the rest are things playing.
+STATES = (
+    ("browse, nothing playing", None, True),
+    ("a film playing", _video(MediaType="Video", Type="Movie"), False),
+    ("an episode playing", _video(MediaType="Video", Type="Episode"), False),
+    ("music playing", _video(MediaType="Audio", Type="Audio"), True),
+    ("an audiobook playing", _video(MediaType="Audio", Type="AudioBook"),
+     True),
+    # The server is not consistent about which field carries it, and the
+    # predicate accepts either. A stand-in that modelled only one would make
+    # the other branch unreachable while reporting a pass.
+    ("an item typed Audio with no MediaType", _video(Type="Audio"), True),
+    ("an item whose MediaType is Audio only", _video(MediaType="Audio"),
+     True),
+    # A photo is a picture, so it takes the library away like a film does.
+    ("a photo on screen", _video(MediaType="Photo", Type="Photo"), False),
+)
+
+
+def _pm(video):
+    """A PlayerManager with no mpv behind it.
+
+    `__new__`, not `__init__`: the constructor ends in `_init_mpv()` and
+    would open a window. Same idiom as `test_auth_header_truth_table`.
+    """
+    from jellyfin_mpv_shim.player import PlayerManager
+
+    pm = PlayerManager.__new__(PlayerManager)
+    pm._video = video
+    return pm
+
+
+class LibraryShowingTest(unittest.TestCase):
+    def test_the_table(self):
+        for label, video, expected in STATES:
+            with self.subTest(state=label):
+                self.assertIs(
+                    _pm(video)._library_showing(), expected,
+                    "%s: _library_showing() should be %s" % (label, expected))
+
+    def test_it_is_not_the_same_question_as_video_is_none(self):
+        """The premise of every row below, stated once.
+
+        If these two ever agree everywhere, this file is testing nothing:
+        the whole point is that the cheap spelling differs from the correct
+        one on the audio rows, and a fixture that lost its audio states
+        would make every assertion here pass against `_video is None`.
+        """
+        differ = [label for label, video, expected in STATES
+                  if (video is None) != expected]
+        self.assertTrue(
+            differ,
+            "no state distinguishes _library_showing() from `_video is "
+            "None`, so these tests would pass against the bug they exist "
+            "for")
+
+
+class NavBackTest(unittest.TestCase):
+    """The shipped defect, at the call site that shipped it."""
+
+    def _back(self, video):
+        calls = []
+        pm = _pm(video)
+        pm.mpvtk_active = True
+        pm.on_nav_back = lambda: calls.append(1) or True
+        return pm._nav_back(), calls
+
+    def test_back_works_while_music_plays(self):
+        for label, video, showing in STATES:
+            if not showing:
+                continue
+            with self.subTest(state=label):
+                ok, calls = self._back(video)
+                self.assertTrue(
+                    ok and calls,
+                    "%s: BACK was refused while the library was on screen "
+                    "-- this is the bug that killed the mouse's back button "
+                    "for the whole of music playback" % label)
+
+    def test_back_is_refused_over_a_picture(self):
+        """The other direction, and it is not symmetric politeness: over a
+        video BACK belongs to the player, and handing it to the browser
+        would navigate the library nobody can see."""
+        for label, video, showing in STATES:
+            if showing:
+                continue
+            with self.subTest(state=label):
+                ok, calls = self._back(video)
+                self.assertFalse(
+                    ok or calls,
+                    "%s: BACK reached the browser over a picture" % label)
+
+
+class NavCommandTest(unittest.TestCase):
+    def _command(self, video, action):
+        calls = []
+        pm = _pm(video)
+        pm.mpvtk_active = True
+        pm.on_nav_command = lambda a: calls.append(a) or True
+        return pm._nav_command(action), calls
+
+    def test_a_nav_command_follows_the_same_rule(self):
+        for label, video, showing in STATES:
+            with self.subTest(state=label):
+                ok, calls = self._command(video, "back")
+                self.assertIs(bool(ok and calls), showing,
+                              "%s: a nav command did not follow the library"
+                              % label)
+
+    def test_home_is_the_exception_and_gets_through_anyway(self):
+        """`_NAV_COMMANDS_WHILE_PLAYING`. Home means "leave this and show me
+        the library", so refusing it during playback would make it the one
+        button with no way to undo the state it is trying to leave."""
+        for label, video, _showing in STATES:
+            with self.subTest(state=label):
+                ok, calls = self._command(video, "home")
+                self.assertTrue(ok and calls,
+                                "%s: home was refused" % label)
+
+
+class LibraryHasInputTest(unittest.TestCase):
+    """`_library_has_input` is `_library_showing()` AND the renderer owning
+    input -- a summoned HUD owns input too, so the second half cannot be
+    dropped and the first half cannot be skipped."""
+
+    def _has_input(self, video, mpvtk_input):
+        pm = _pm(video)
+        pm._mpvtk_input_active = lambda: mpvtk_input
+        return pm._library_has_input()
+
+    def test_it_needs_both_halves(self):
+        for label, video, showing in STATES:
+            with self.subTest(state=label):
+                self.assertIs(self._has_input(video, True), showing,
+                              "%s: with the renderer holding input" % label)
+                self.assertFalse(
+                    self._has_input(video, False),
+                    "%s: the renderer does not hold input, so the library "
+                    "does not either" % label)

--- a/tests/test_shell_comic.py
+++ b/tests/test_shell_comic.py
@@ -138,6 +138,102 @@ class ComicHarness(unittest.TestCase):
         return browser._page_for(browser.route)
 
 
+class TestTheVoIsNotPaintedOver(ComicHarness):
+    """A comic page is rendered by **mpv's VO**, and the browser's own page
+    background is a **bitmap** -- which composites ABOVE the VO. So anything
+    that forces a full-window backdrop paints over the comic.
+
+    Two features force one, for unrelated reasons, and neither knew about the
+    reader:
+
+    * a theme with `window_gradient` (the Windows Media Centre theme draws
+      one, `jf-wmc.json`);
+    * "Custom OSC" mode, where `_wants_opaque_backdrop()` paints an opaque
+      box to hide the idle screen that OSC draws over the VO background --
+      "no colour we give mpv can hide it. Ours is a bitmap, which composites
+      above OSD, and is the only thing that can."
+
+    Both have to stand down while a page is on the VO, and the observable is
+    the shape of the tree: `build()` returns the bare page when it wants no
+    backdrop and wraps it in a `Stack` when it does.
+    """
+
+    SIZE = (1280, 720)
+
+    def _backdrop(self, browser):
+        """The backdrop widget `build()` put behind the page, or None."""
+        from jellyfin_mpv_shim.mpvtk.widgets import Box, Gradient, Stack
+
+        tree = browser.build(self.SIZE)
+        if isinstance(tree, Stack) and tree.children:
+            first = tree.children[0]
+            if isinstance(first, (Gradient, Box)):
+                return type(first).__name__
+        return None
+
+    def _with_gradient(self):
+        """The real Windows Media Centre theme, by name, rather than a
+        hand-built gradient: it is the one that reported this, and a theme
+        that stopped carrying a gradient should retire this test rather than
+        have it keep passing against a fixture."""
+        from jellyfin_mpv_shim.mpvtk_browser import theme
+
+        applied = theme.apply("jf-wmc")
+        self.addCleanup(theme.apply, "default")
+        self.assertTrue(applied.get("window_gradient"),
+                        "jf-wmc no longer carries a window gradient")
+
+    def _with_custom_osc(self):
+        from unittest import mock
+
+        patcher = mock.patch(
+            "jellyfin_mpv_shim.mpv_options.resolve_osc_style",
+            return_value="custom")
+        patcher.start()
+        self.addCleanup(patcher.stop)
+
+    def test_the_backdrop_is_drawn_when_nothing_is_on_the_vo(self):
+        """The premise, once per feature. Without it either assertion below
+        would pass on a build that never drew a backdrop at all -- which is
+        not hypothetical: written with the Custom OSC mock returning "mpv"
+        instead of "custom", this file reported a pass for a backdrop that
+        was never staged."""
+        for label, arm, want in (("gradient theme", self._with_gradient,
+                                  "Gradient"),
+                                 ("custom osc", self._with_custom_osc, "Box")):
+            with self.subTest(feature=label):
+                browser = self.open_comic()
+                # A route with nothing on the VO -- NOT the comic route with
+                # `_showing` popped, which the page sets again on its next
+                # build, so the premise would stage the very state it is
+                # supposed to be the control for.
+                browser.navigate({"kind": "home", "server": "srv1"})
+                arm()
+                self.assertEqual(
+                    self._backdrop(browser), want,
+                    "%s drew no backdrop, so its absence over a comic would "
+                    "prove nothing" % label)
+
+    def test_a_gradient_theme_stands_down_for_a_comic_page(self):
+        browser = self.open_comic()
+        browser.route["_showing"] = True
+        self._with_gradient()
+        self.assertIsNone(
+            self._backdrop(browser),
+            "the theme's window gradient is painted over the comic: the page "
+            "is on mpv's VO and this is a bitmap, which composites above it")
+
+    def test_custom_osc_stands_down_for_a_comic_page(self):
+        browser = self.open_comic()
+        browser.route["_showing"] = True
+        self._with_custom_osc()
+        self.assertIsNone(
+            self._backdrop(browser),
+            "Custom OSC's opaque backdrop is painted over the comic. It is "
+            "there to hide the OSC's idle screen, which cannot appear while "
+            "the VO is showing a page")
+
+
 class TestOpening(ComicHarness):
     def test_a_downloaded_comic_opens_on_its_first_page(self):
         browser = self.open_comic()

--- a/tests/test_track_negotiation.py
+++ b/tests/test_track_negotiation.py
@@ -354,5 +354,161 @@ class TheSourcePinIsOnlyForARealIndexTest(unittest.TestCase):
         self.assertEqual(asked["srcid"], "src1")
 
 
+#: A second version of the same episode: same streams, lower resolution, and
+#: -- the part that matters -- it can only be transcoded.
+VERSION_2 = {"Id": "src2", "MediaStreams": [dict(s) for s in STREAMS],
+             "SupportsDirectPlay": False, "SupportsDirectStream": False,
+             "SupportsTranscoding": True,
+             "TranscodingUrl": "/videos/1/v2.m3u8?AudioStreamIndex=1",
+             "DefaultAudioStreamIndex": 1, "RunTimeTicks": 1}
+
+
+class _MultiVersionRecorder(_Recorder):
+    """PlaybackInfo the way the server answers an item with several versions.
+
+    Measured on the QA server (`Pilot`, three versions): asking with no
+    MediaSourceId returns **all three**; asking with one returns **that one**.
+    The single-source `_Recorder` above cannot express that difference, and
+    that is precisely why the pin below went unnoticed for a release -- with
+    one version in the fixture, pinning it and leaving the choice open answer
+    identically, so every test here passed either way.
+    """
+
+    def __init__(self, sources):
+        self.sources = sources
+        self.asked = []
+
+    def get_play_info(self, item_id, profile, aid, sid, media_source_id=None):
+        self.asked.append({"aid": aid, "sid": sid, "srcid": media_source_id})
+        if media_source_id is None:
+            return {"MediaSources": [dict(s) for s in self.sources]}
+        return {"MediaSources": [dict(s) for s in self.sources
+                                 if s["Id"] == media_source_id]}
+
+
+def _multi_version_video(sources):
+    from jellyfin_mpv_shim.media import Video
+
+    item = {"Type": "Episode", "Name": "Ep",
+            "MediaSources": [dict(s) for s in sources], "RunTimeTicks": 1}
+    api = _MultiVersionRecorder(sources)
+    api.item = item
+    client = NS(
+        config=NS(data={"auth.server": SERVER, "auth.token": "t",
+                        "auth.server-id": "sid"}),
+        http=NS(_get_authenication_header=lambda: 'MediaBrowser Token="t"'),
+        jellyfin=api,
+    )
+    parent = NS(client=client, is_local=True, item=item)
+    v = Video("ep1", parent)
+    v.item = item
+    v.explicit_tracks = False
+    v.aid = v.sid = None
+    v.track_memory = None
+    return v, api
+
+
+class MultiVersionSourcePinTest(unittest.TestCase):
+    """What the source pin costs an item that has several versions.
+
+    **Accepted for 3.0.0, not a fix waiting to happen** -- see
+    `docs/do-not-fix.md` F36. Asking for a track pins `MediaSources[0]`, and
+    the server then answers with that source alone. Jellyfin's own
+    `SortMediaSources` puts the queried item's source first and otherwise
+    sorts by **descending video width**
+    (`Emby.Server.Implementations/Library/MediaSourceManager.cs`), so [0] is
+    the version you clicked, else the highest-resolution one. That is a
+    reasonable default and the shim direct-plays most formats, which is why
+    this is accepted rather than fixed before the release.
+
+    What it costs is the two fallbacks below, and both only bite when the
+    highest-resolution version is the one this client cannot play -- which is
+    the exact setup people keep dual versions for. Weighed against losing the
+    remembered audio/subtitle track on every episode advance, which is what
+    dropping the pin would cost, and the pin wins.
+
+    So these tests assert the **current** behaviour, including where it fails.
+    If a fix lands they are expected to fail: read F36, then update them.
+    """
+
+    #: The previous episode, shaped so _rank_stream matches on language.
+    PREV = {"MediaStreams": [dict(s) for s in STREAMS]}
+
+    def _play(self, video):
+        from jellyfin_mpv_shim.conf import settings
+        with mock.patch.object(settings, "always_transcode", False):
+            return video.get_playback_url()
+
+    def test_a_remembered_track_pins_the_first_version(self):
+        """The accepted cost, stated plainly."""
+        from jellyfin_mpv_shim.conf import settings
+
+        v, api = _multi_version_video([_source(), VERSION_2])
+        pm = _pm(memory=(self.PREV, 2, None))
+        with mock.patch.object(settings, "language_config", None), \
+                mock.patch.object(settings, "remember_audio_track", True), \
+                mock.patch.object(settings, "remember_subtitle_track", False), \
+                mock.patch.object(settings, "always_transcode", False):
+            pm.play(v)
+        self.assertEqual(api.asked[0]["srcid"], "src1")
+        self.assertEqual(
+            len(v.playback_info["MediaSources"]), 1,
+            "the server was asked for one version and answered with one, so "
+            "get_best_media_source has nothing left to choose between")
+
+    def test_the_remembered_track_is_what_the_pin_buys(self):
+        """And the reason it is kept: the server ignores AudioStreamIndex
+        without a MediaSourceId, so without the pin the advance plays the
+        server's default while the HUD claims the remembered track."""
+        from jellyfin_mpv_shim.conf import settings
+
+        v, api = _multi_version_video([_source(), VERSION_2])
+        pm = _pm(memory=(self.PREV, 2, None))
+        with mock.patch.object(settings, "language_config", None), \
+                mock.patch.object(settings, "remember_audio_track", True), \
+                mock.patch.object(settings, "remember_subtitle_track", False), \
+                mock.patch.object(settings, "always_transcode", False):
+            pm.play(v)
+        self.assertEqual(api.asked[0]["aid"], 2)
+        self.assertIsNotNone(api.asked[0]["srcid"],
+                             "an index with no source to index into is one "
+                             "the server drops")
+
+    def test_the_unplayable_retry_still_covers_an_unpinned_play(self):
+        """The control, and the thing being traded away. With no track asked
+        for, every version is on offer and the `len(MediaSources) > 1` retry
+        in get_playback_url can walk to a playable one."""
+        from jellyfin_mpv_shim.conf import settings
+
+        dead = _source(SupportsTranscoding=False, TranscodingUrl=None)
+        v, api = _multi_version_video([dead, VERSION_2])
+        with mock.patch.object(settings, "language_config", None):
+            url = self._play(v)
+        self.assertIsNone(api.asked[0]["srcid"])
+        self.assertIsNotNone(
+            url, "the retry did not reach the second version")
+        self.assertEqual(v.media_source["Id"], "src2")
+
+    def test_a_pinned_play_has_no_retry_left(self):
+        """The same item, the same dead first version, one remembered track --
+        and the retry is now unreachable, because the list it walks has one
+        entry. This is the failure F36 describes; it is asserted so that a fix
+        cannot land silently.
+        """
+        from jellyfin_mpv_shim.conf import settings
+
+        dead = _source(SupportsTranscoding=False, TranscodingUrl=None)
+        v, api = _multi_version_video([dead, VERSION_2])
+        v.aid = 2                       # what the memory would have set
+        with mock.patch.object(settings, "language_config", None):
+            url = self._play(v)
+        self.assertEqual(api.asked[0]["srcid"], "src1")
+        self.assertIsNone(
+            url,
+            "the retry reached a playable version -- which is the wanted "
+            "behaviour, so F36 has been fixed and this test should now "
+            "assert it rather than the failure")
+
+
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
Working branch for final fixes before v3 lands.

Changes so far:
- Stop custom OSC or WMC theme breaking comics
- Fix set full screen contaminating settings during music play
- Catch invalid settings file not loading and don't silently replace invalid file with defaults
- Test improvements




