### PR TITLE
Fixes for 3.0.0

### DIFF
--- a/Jellyfin MPV Shim.iss
+++ b/Jellyfin MPV Shim.iss
@@ -2,7 +2,7 @@
 ; SEE THE DOCUMENTATION FOR DETAILS ON CREATING INNO SETUP SCRIPT FILES!
 
 #define MyAppName "Jellyfin MPV Shim"
-#define MyAppVersion "3.0.0pre14"
+#define MyAppVersion "3.0.0"
 #define MyAppPublisher "Izzie Walton"
 #define MyAppURL "https://github.com/jellyfin/jellyfin-mpv-shim"
 #define MyAppExeName "run.exe"

--- a/docs/archive/REGRESSION_CHECKLIST_2026-09-07.md
+++ b/docs/archive/REGRESSION_CHECKLIST_2026-09-07.md
@@ -1,0 +1,376 @@
+# v3.0.0 hand regression checklist
+
+Tested on: 2026-09-07, against `fixes-for-3.0.0`.
+
+The hand pass that preceded the v3.0.0 release. Kept for the same reason as
+`REGRESSION_CHECKLIST_2026-07-13.md`: a point-in-time record of what was
+actually exercised, with the results inline, so the next release can see what
+was covered rather than guessing.
+
+**Aimed at seams rather than smoke**, because the automated suites already
+cover the parts they can reach: ~5.7k unit tests, an 8-leg integration matrix
+across both mpv backends, and 49 e2e legs against a live server. What they
+could not see is *composition* — two features sharing one mpv window — and
+that is where every defect in this pass lived.
+
+## What it found
+
+Fourteen defects, all of them in seams:
+
+* the four sites that disagreed about "is this item audio" — the last of
+  which blanked the library when a music playlist played;
+* three feedback loops, all with the same signature (a guard comparing
+  against a value the guarded action itself produces): the epub reader
+  measuring the node it had just sized, the HUD auto-hide suspending the
+  library that hosted it, and the Logs tab redrawing for its own render
+  line;
+* a HUD engage that spanned a re-entry (`_yield` overtaken by
+  `enter_browse`), found only because the refusal logged its caller;
+* two half-rules — the Move button's `or` fallback, and "Seek to Skip"
+  offered for a gesture that was switched off.
+
+Findings that were left open are in `docs/do-not-fix.md` as F37-F42, each
+with what was ruled out and what evidence would close it.
+
+## Legend
+
+[X] Tested fine
+[*] Tested, has problems
+[ ] Not tested
+
+# Main regression sweep
+
+## 1. The five composite states
+
+Two features sharing one window. One screenshot each; these are the states the
+suite structurally cannot judge.
+
+- [X] 🟢 Comic, default theme — page fills correctly, nothing painted over it
+- [X] 🟢 Comic under **jf-wmc** — the gradient must *release*, not cover the page
+- [X] 🟢 Comic with **osc_style: custom** — the forced background must release too
+   - Verified working under uosc and modernz
+   - Only oddity is how photos interact with custom OSCs, but it works enough that I am not going to gate v3 on it.
+- [*] 🟢 Comic opened **while music is playing** (R6 — this used to refuse outright)
+   - *Mostly* works now, killing the music playback takes out the VO but it recovers on scroll. Likely not worth fixing for v3.0.
+- [X] 🔴 **Video started straight after a comic** (R7/F15) — watch for stretched
+      video. This is the `keepaspect` handoff that made *every* film play
+      stretched with no comic anywhere in the session
+- [X] Same five again after a quit/relaunch, in case anything is order-dependent
+
+## 2. Comics
+
+- [X] Open a CBZ from the library, page forward and back to the end
+- [X] Fit mode: width vs page (default is still `width` on this branch; the
+      change to `page` was held back on `enrich-e2e-tests`)
+   - We should keep that default change on this branch, fit width is a little odd the more I think about it.
+- [X] Pan a zoomed page in all four directions, then page-turn while panned
+   - Works fine, panning is preserved between pages.
+- [*] Resize the window **by dragging**, then open a comic — the reported bug
+      was a jump on open when live size ≠ armed geometry 🔴
+   - Geometry jump now only happens on leaving a comic, not opening one.
+- [X] Leave a comic → back to library → open a different comic
+- [X] Leave a comic → start a video (see §1) → back to library
+- [X] Comic while music plays, then stop the music with the comic still open
+   - Music stops, next page turn displays page correctly.
+
+## 3. Music × library
+
+The `_video is not None` trap: audio keeps `_video` set **and** keeps the
+browser up, so anything asking that question answers wrong during music.
+
+- [X] Play an album; confirm the library stays navigable and the now-playing bar
+      is present
+- [X] 🟢 Toggle fullscreen during music, stop the music, return to the library —
+      the *browser's* preference must be what persisted, not the video's (R5)
+   - There is no way to toggle fullscreen in the library browser now apart from settings or WM bindings because we block default MPV keyboard shortcuts. Might be a good idea to re-bind F11 at a minimum.
+   - Checking fullscreen library browser correctly fullscreens the app during music playback, but unchecking it does not. The checkbox does work when not playing music.
+- [X] Mouse thumb buttons (Back/Forward) during music — these died for the whole
+      of music and audiobook playback once
+- [X] 🔴 Press the menu key during music with the library on screen — does the
+      HUD gear menu open over a track? (R11: verified as written, needs your
+      product read, not a fix)
+   - Nothing happens, as expected. (We block keybinds in the library browser.)
+- [X] Navigate to a different library while music continues
+- [X] Start a video while music is playing
+   - The UI flashes a little oddly, but nothing actually breaks.
+- [X] Play a playlist containing mixed types
+
+## 4. Video ↔ picture ↔ reader handoffs
+
+- [X] Photo → video → photo
+   - Works, note as designed if you click a video in a mixed content library, next and back don't do anything. Next and back do work for photos, but only photo sibblings are played, videos are ignored. The Play All button on the entire folder works as designed.
+- [X] Photo viewed while music plays
+   - Photo wins, music stops as expected.
+- [X] EPUB reader open, then start playback, then return
+- [X] Audiobook: resume position across a stop/start (resume is in **minutes**
+      for audiobooks — a wrong unit looks like "resume is broken")
+   - Yes it works, provided the audio is >5mins (upstream jellyfin behaviour).
+- [X] Book → comic → video, in one session, without relaunching
+
+## 5. Window geometry & fullscreen
+
+- [X] Resize the window in the library; the layout reflows and tiles stay square
+- [X] Fullscreen in the library, leave, re-enter — preference sticks
+- [X] Fullscreen during playback, stop, return to library
+   - Setting is remembered for playback only, as expected.
+- [ ] 🔴 Be fullscreen when an **update notice** arrives (R8) —
+      `fullscreen_disable` is written above its own `persist` gate, so an
+      app-initiated un-fullscreen can latch a flag meant to record *user* intent
+   - This one is a pain to test due to update notifier requiring manual mutation testing.
+- [X] Start minimized (tray), then restore
+- [X] Maximize / unmaximize with a video playing
+- [X] Multi-monitor: move the window between screens mid-playback, if you have one
+
+## 6. Keyboard & input across transitions
+
+The surface with the worst record — three regressions in 48 hours, all "a key
+section never re-enabled after a transition".
+
+- [X] Arrows/ENTER/TAB/MENU work in the library **from launch**, before anything
+      has played
+- [X] Same keys after: library → play a video → back to library
+- [X] Same keys after: summoning the HUD and clicking Back on a visible bar
+      (the common way to leave a film)
+- [X] Arrows during plain playback **seek** — the UI must not be holding them
+- [X] `q` and other printable mpv shortcuts in the library — **known dead** under
+      `browse_block_keys` (deliberate #730 fix). Decide whether `q` passes through
+   - Known dead, we should probably re-allow `q`, `f`, and `F11`. And `p` while playing music.
+   - Need to make sure these don't break text entry. (`m` and `space` don't break during music and work.)
+   - ESC should dismiss keynav and NOT act as a back button until key nav is dismissed. (Keynav drops the space keyboard shortcut for music control, that is how I found out.)
+- [X] Mouse: hover highlights follow the pointer after a window resize (a WM grab
+      spanning a resize used to strand the hover flag)
+- [X] Wheel over an open HUD gear menu — **known** to seek (accepted for #711)
+   - It doesn't seek though, it updates volume control on my MPV. Accepted as-is for v3.
+- [X] Gamepad, if you test it: confirm nav and Back in library and playback
+
+## 7. Themes × OSC styles
+
+Themes: `jf-appletv`, `jf-blueradiance`, `jf-light`, `jf-purplehaze`, `jf-wmc`,
+`nebula`, `superdark`. OSC styles: `mpvtk` (default), `mpv`, `none`, `custom`.
+
+- [X] Each theme: library home renders, text is legible, no black-on-black
+- [X] 🟢 jf-wmc specifically over a comic and over a video (§1)
+- [X] Switch theme **mid-session** and confirm the library repaints. Note: mpv's
+      own window background does *not* move on a live theme change — that is
+      expected, not a defect
+- [X] `osc_style: mpv` — mpv's built-in OSC appears and the mpvtk HUD does not
+- [X] `osc_style: none` — nothing appears
+- [X] 🟢 `osc_style: custom` with a third-party OSC (uosc) — no doubled bar
+- [X] HUD on **duration-less content** (Live TV, or a >1h item in a narrow
+      window) — **known** to shed a control
+   - It actually doesn't, seek works it just lets you seek back in livestream history and the duration is just the history length. This is standard MPV behaviour, no desire to break it.
+
+## 8. Less-used surfaces
+
+Under-covered and easy to skip; a year-later bug lives here.
+
+- [X] Live TV: channel list, guide, tune a channel, timers
+- [X] Live TV → back to library → a normal video
+- [X] Search, including a query with non-ASCII characters
+- [X] Filter panel: apply, clear, and confirm the grid actually changed
+   - Category filter is KNOWN BROKEN this is an upstream issue not us.
+- [X] Collections / playlists / Next Up / Continue Watching tiles all play
+- [X] Cast: send to another client, and cast-and-play. **Known**: casting no
+      longer raises the window by default
+   - Works, but "seek to skip" shows when casting even though HUD is supposed to suppress it.
+- [X] SyncPlay, if you have a second client
+- [X] Trickplay/seek-preview bubble on a long item; then seek repeatedly
+
+## 9. Downloads & offline
+
+- [X] Download an item, watch it complete, play it offline
+- [X] 🔴 Quit the app **while an auto-download is running** (R4 —
+      `auto.tick()` is called without `stopping=` while the line below it passes
+      one). Confirm a clean exit and an intact catalog
+- [X] Watched state written offline surfaces on the server after reconnect
+- [X] Delete a downloaded item and confirm the store and the catalog agree
+- [X] Startup cost: note whether launch feels slower — **known**, ~4 extra
+      catalog scans plus a sqlite backup run synchronously
+
+## 10. Track selection & F36
+
+- [X] Pick a non-default audio track, then let the episode advance — the
+      remembered track carries over and the HUD agrees with what you hear
+- [X] Same for subtitles, including turning them **off** and advancing
+- [ ] **Known**: subtitles can now turn themselves on mid-season
+- [ ] 🔴 If you have a **multi-version** item (4K + 1080p of the same title):
+      play with a remembered track and confirm the version that plays is the one
+      you expect. F36 — the pin selects `MediaSources[0]`, which Jellyfin sorts
+      as the *highest resolution*, not the most playable
+   - TODO for later: Add this to stdjflib
+## 11. Settings
+
+- [X] Every settings tab opens and renders
+- [X] Change a setting that applies live (theme, HUD options) — takes effect
+- [X] Change a setting that needs a restart — the restart banner appears
+- [X] Settings search finds a key by name
+- [X] 🔴 Settings → Downloads → **Move** the store: confirm the field afterwards
+      shows the path it actually moved to (`_sync_path` is Tier 1 and
+      destructive — the visible field was showing the wrong path)
+- [X] Quality/bitrate override, then play — the stream honours it
+   - Works, but this test uncovered that changing subtitle/audio tracks during a transcode sometimes causes the HUD to die from the loading page coming up and then not dismissing correctly. -- Can't reproduce, should be fixed now.
+## 12. Startup, shutdown, tray
+
+- [X] Cold start with no config → first-run flow → log in
+- [X] Restart with saved credentials → straight to the library
+- [X] Second launch while the first is running (single-instance)
+- [X] Tray: show/hide, quit from the tray
+- [X] Quit **during playback**, and quit **during a comic**
+   - Comic "quit" is really minimize to tray, video is a proper quit to tray
+- [X] Confirm no orphaned mpv process after each exit
+- [X] Startup PIN gate, if you use it
+
+# Fix regression tests
+
+## 🔴 Not reproduced — this pass IS the test
+
+### 1. Playlist: video → song, library UI auto-hides
+`4c8a385c`. **I could not reproduce your symptom**, so I fixed the class it
+belongs to rather than the instance. Two real defects found on the way:
+
+- `ItemActions.play` tested `Type == "Audio"` only, so an **audiobook**
+  (`Type="AudioBook"`, `MediaType="Audio"`) launched down the *video* branch,
+  which clears `_browsing` and hands the window over
+- a film's `hud.state` outlived it across a queue advance, and
+  `reassert_window_state` reads that as "a video is in flight, re-enter HUD mode"
+
+- [X] The original: playlist with a video **then** a song. Leave the mouse
+      still through the song. Library must stay up. **(confirmed fixed)**
+- [X] **Song → video, back in the same playlist: the HUD comes back.** This
+      is the regression `4c8a385c` caused and `a3d8bd96` repairs — a late
+      audio push (the ticker sends one a second) wiped the HUD state off the
+      video that had just started and pulled the renderer out of HUD mode.
+      Move the mouse / press the wake key; controls must appear.
+- [X] Video → song → video → song, twice round, in case it needs a repeat
+- [X] Let the HUD auto-hide during the second video, then summon it again
+- [X] Reverse order: song **then** video, then back to a song
+- [X] Audiobook launched from a tile — does the window flash/hand over before
+      coming back? That is the half-rule, and it should be gone
+- [X] A song playing when mpv is re-created (change a setting needing a
+      restart of the player, if you have one) — the HUD must not appear
+
+---
+
+## 🟡 Diagnosed from your screenshot and fixed
+
+### 2. EPUB reader + music
+`00ee2c3d`. The reader is meant to measure the hole its bars left and
+rasterize to it. **That measurement had never once succeeded**: a plain Row
+emits no scene node whatever id it carries, so `node_rect("rd-area")` was
+always None and the fallback (`window − 44 − 48`) was the only path that ever
+ran. Right whenever the reader owns the whole window; too tall by exactly the
+now-playing bar otherwise, and centred, so it spilled over both of the
+reader's own bars. AREA_ID now sits on a transparent Box, which draws nothing
+and measures.
+
+- [X] Reader open, then start music — the top bar and the page controls stay
+      visible, page reflows to the smaller area
+   - Not actually possible to do this, so successful by default.
+- [X] Music first, then open the reader
+- [X] Stop the music with the reader open — the page grows back
+- [X] Resize the window while reading with music playing
+- [X] **Control**: reading with nothing playing still uses the whole window
+      (this is the case the old fallback got right, and a bad fix would
+      shrink it)
+- [X] Page turns, the reader menu, and text selection/copy still work
+   - Doesn't actually support text selection, but copy works.
+
+---
+
+## 🟡 Fixed, mechanism confirmed, but the surface is twitchy
+
+### 3. Focus ring no longer eats non-nav claims
+`1ad8d4ea`. `keyclaim.take` refused **every** claim while a focus ring was up;
+under `browse_block_keys` a refused claim is *swallowed*, so keynav killed
+SPACE for music with no keyboard way back. Now scoped to the keys the ring
+actually uses.
+
+- [X] Music playing, arrow around the library to raise the ring, press SPACE —
+      pauses
+- [X] Same with `m` (mute)
+- [X] **The control**: with the ring up, arrows still move focus and do not
+      leak to the player
+- [X] In the comic reader: DOWN into the bottom bar, then LEFT/RIGHT steps
+      between buttons rather than turning the page (this is the behaviour the
+      old blanket refusal existed to protect)
+   - Works, but no keyboard only way to kill the focus ring without ESC which also exits the reader.
+- [X] In the epub reader, same
+   - Works, but no keyboard only way to kill the focus ring without ESC which also exits the reader.
+- [X] Text entry (search box, login form) still types normally
+- [X] ESC still backs out where it used to
+
+### 4. Comic + music, geometry, fit-page
+`d3ef8ef1` + `607442f9`, cherry-picked from `enrich-e2e-tests` — the three
+changes you independently confirmed were right to have made.
+
+- [X] Comic opened **while music plays**: music stops, page displays
+- [X] Drag-resize the window, then open a comic — **no jump**
+- [X] A comic opens at **fit page**, not fit width
+- [X] Video started straight after a comic — not stretched
+- [X] A comic while a *video* plays is still refused (the control)
+   - Not actually possible to do this, so successful by default.
+
+### 5. Fullscreen during music, and the theme background
+`572a9b5a`. Three sites of the `_video`-vs-`_library_showing` rule.
+
+- [X] Music playing: **untick** "fullscreen library browser" — it leaves
+      fullscreen now (this was the reported half)
+- [X] Music playing: tick it — still goes fullscreen (the half that worked)
+- [X] With a **video** playing, the browse preference does not yank it
+   - Not possible to change the setting while playing video.
+   - Generally behaves except one edge case, fullscreen library browser does not exit fullscreen when regular fullscreen setting is not set.
+- [X] Change theme **while music plays** — the background behind the library
+      updates immediately, no longer only after stopping
+- [X] Press the menu key / use a **remote's cog** during music — the OSD menu
+      must not open over the library
+
+---
+
+## 🟢 Small and self-contained
+
+### 6. Next Up vs Continue Watching
+`eeb299af`. Now sends `EnableResumable=false`, matching jellyfin-web.
+
+- [X] A part-watched episode appears in Continue Watching **only**
+- [X] Next Up still lists the genuinely-next episodes
+- [X] Next Up tiles still have artwork (the query moved off the apiclient
+      helper, so the image params moved with it)
+- [X] Autoplay-next at the end of an episode still finds the next one
+      (different call, deliberately unchanged)
+
+### 7. Adding a server
+`eeb299af`.
+
+- [X] Add a second server from the server manager — you land on **its** home
+- [X] Quick Connect login — same
+- [*] Re-authenticate a server already in the list — you stay where you were
+   - I don't think there is a way to do this without delete/re-create.
+- [X] Restart: still opens on the last server you browsed
+
+### 8. Casting
+`eeb299af`.
+
+- [X] Cast something with an intro — no "Seek to Skip" on the OSD
+- [X] Locally with the mpvtk HUD, the Skip button still appears in "ask" mode
+- [X] With `osc_style` set to `mpv` or `none`, the OSD prompt still appears
+      (that is the only surface left there)
+
+
+---
+
+## Regression sweep
+
+Cheap, and these are the seams the six commits touched.
+
+- [X] Library → video → library: keys, focus, window size all normal
+- [X] Library → music → comic → video, in one session
+- [X] Photo → video → photo
+- [X] Quit during playback and during a comic; no orphaned mpv
+- [X] Downloads still list and play (untouched, but `is_audio` moved)
+   - Download smoke test went well.
+
+## Notes / defects found
+
+1. Background color does not update when changing theme while playing music. Background change does apply after stopping music. -- Confirmed fixed.
+2. When you log onto a new server added via the server manager page, it goes to the homepage of the previous server not the newly added one. -- Confirmed fixed.
+3. We should see if enableResumable=false and enableRewatching=false should be added to the NextUp request. Right now partially watched episodes show in both Continue Watching and Next Up, they should only show in Continue Watching. -- Confirmed fixed.

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -491,7 +491,7 @@ You can use the config file to enable and disable features.
   - Dark to match the rest of the app, not because it is better to read: the other two are there for that. The button at the bottom right of the reader cycles them.
 - `reader_justify` - Justify the text, as a printed book does. Default: `true`
   - Off gives a ragged right edge. Worth trying in a narrow window, where justification has fewer places to put the extra space and can open up rivers.
-- `comic_fit` - How a comic page is fitted when you open one. One of `width` (the page as wide as the window, scrolled down) or `page` (a whole page at once). Default: `width`
+- `comic_fit` - How a comic page is fitted when you open one. One of `width` (the page as wide as the window, scrolled down) or `page` (a whole page at once). Default: `page`
   - The **Fit Width** / **Fit Page** buttons on the comic reader's own bar write this setting, so the next comic opens the way you were reading the last one.
 - `ui_scale` - Scale factor for the in-player UI (tiles, text, chrome). Default: `null`
   - `null` follows the display: mpv's `display-hidpi-scale`, which is `1.0` on

--- a/docs/do-not-fix.md
+++ b/docs/do-not-fix.md
@@ -151,6 +151,7 @@ then dropped in the same commit).
 | F29 | `player.py` load gate / `_on_cache_pause` | Field report, below. |
 | F35 | `renderer.lua` `phud_skip_bind` | Binds literal `'ENTER'` for the Skip button whatever `hud_wake_key` says, so a moved wake key leaves ENTER accepting a skip. Found while doing #717 and deliberately left: it is a `hud_wake_key` bug, and it wants a decision about whether the idle Skip offer follows the wake key or `ui_select_key`. |
 | F36 | `media.py` `get_playback_url` | Asking for a track pins `MediaSources[0]`, so a multi-version item loses the unplayable retry. Accepted for 3.0.0; below. |
+| F37 | `renderer.lua` `keyclaim.block_take` | `browse_block_keys` swallows `q`/`f`/`p` in the library, defeating the player's STANDING fullscreen claim. Two claim mechanisms; below. |
 
 ### F29 — sleeping NAS, not reproduced
 
@@ -233,3 +234,43 @@ That is a real change to the negotiation order and wants its own round.
 right and points at a worse fix — restoring the server's choice would take the
 remembered tracks with it. The server sorts by width; the shim sorts by
 playability; they disagree exactly where this bites.
+
+### F37 — the key block defeats the player's own claims
+
+**Deferred past 3.0.0 by decision** [iw]: "ALT+F4 or settings can escape
+fullscreen." It is a change to the input arbiter — the surface with the worst
+regression record here (three in 48 hours, `tests/e2e/test_input_routing.py`)
+— and the ask is a convenience, not a repair of something that used to work
+for a user.
+
+**What happens.** `browse_block_keys` (default on, #730) installs a forced
+`any_unicode` binding that swallows every printable key while the library is
+up, so `q`, `f` and `p` do nothing there. A forced binding that returns does
+not hand the key back, so "not handled" means "gone".
+
+**Why `f` is the interesting one.** `_bind_mpv_handlers` sets a **standing**
+claim — `self._key_claims["fullscreen"] = {keysweep.FULLSCREEN}` — with a
+comment explaining that recording "the user asked for fullscreen" is always
+wanted. That claim is installed as an mpv input section, and the block's
+`any_unicode` binding shadows it. `block_take` does consult a claim set, but
+it is `state.keys`, the **renderer's** set (what a page claimed through
+`claim_keys`), not the player's.
+
+So this is not a missing entry in a list. It is two claim mechanisms that do
+not know about each other, and the block honours one of them.
+
+**What a fix has to answer.** How a blocked key reaches the player's claim
+section, given that the forced binding cannot pass a key through. The
+existing machinery is on the Python side: `_swept_keys()` already maps key →
+(semantic, arg), and `_on_claimed_key` already carries out fullscreen, pause
+and seek through the operations that know about SyncPlay and about
+remembering the choice. So the plausible shape is the renderer routing a
+blocked-but-claimed key to that dispatcher rather than swallowing it — but
+that is a new channel through the arbiter, and it wants a real-mpv matrix
+run, not a unit test.
+
+**Also wanted in the same pass** [iw]: `p` while music is playing, and a
+check that none of it breaks text entry. `m` and SPACE already work during
+music (they are claimed and routed), which is the behaviour the rest should
+match. The focus-ring half of the same report is fixed — see
+`keyclaim.nav_names` in `keyclaim.take`.

--- a/docs/do-not-fix.md
+++ b/docs/do-not-fix.md
@@ -301,7 +301,37 @@ renderer's own lifecycle is correct across the equivalent message sequence in
 `tests/lua/`, including from an auto-hidden HUD. `_release_page_grabs` drops a
 key claim and the pan model and touches neither.
 
-**The remaining suspect is the picture path and its deferral.** `show_picture`
+**Reproduced, in part** (`tests/lua/`, 2026-09-07). Izzie's ordering was
+photo x3 -> video -> video, and repetition is the point rather than the
+photo/video mix. The `mpvtk-hud` handler early-returns when the mode already
+matches:
+
+    if want == state.phud.mode then return end
+
+Summoning the HUD unbinds the wake key -- correct, it is already up. The next
+item's `set_hud(True)` then hits that early return, so `state.phud.shown` stays
+true for an item that is gone and **nothing re-binds summon**. Measured: after
+the second video the wake binding does not exist and mouse moves produce no HUD
+event at all, because the renderer believes it is already showing.
+
+**What is NOT explained**: in the harness this self-heals as soon as the
+auto-hide timer fires (wake comes back, the HUD hides normally), so the
+reproduction is "no controls for the length of the auto-hide delay", not the
+permanent death reported. Either something stops that timer firing in the real
+app (`hud_autohide`, `hud_hide_secs`, or `phud_busy` re-arming forever -- it
+holds the bar up while the pointer rests on it, and unconditionally in the
+`paused` mode) or there is a further step. `phud_bind_summon` also declines to
+bind at all while `state.kb_saved` is set (mpv's console holding the keys),
+which would be permanent -- unverified.
+
+**A fix needs a decision, not just a patch**: the renderer cannot tell "a new
+item started" from "a setting changed", because `hud.engage()` is both -- its
+docstring says re-engaging is the ONLY thing that carries a changed setting
+through. Returning to idle on every engage would hide the HUD when someone
+changes a setting mid-film. So the item change has to come from the Python
+side, which knows it.
+
+**The other suspect, still open, is the picture path and its deferral.** `show_picture`
 / `clear_picture` reach the player through `run_action`, which defers whenever
 the player lock is busy -- and it is busy for the whole of a playback start.
 `clear_picture` guards on `self._video is not None` **with no `_loading`

--- a/docs/do-not-fix.md
+++ b/docs/do-not-fix.md
@@ -155,7 +155,7 @@ then dropped in the same commit).
 | F38 | `player_window.py` picture path | **Unverified.** The playback HUD stops appearing after several photo/video handoffs. Needs evidence; below. |
 | F39 | `player_window.py` `clear_picture` / `set_browse_window` | The window jump moved from opening a comic to LEAVING one. Cosmetic, and the open half is fixed. |
 | F40 | `player_window.py` `_apply_browse_fullscreen` | Reported edge case: the browse preference does not leave fullscreen when `fullscreen` is unset. Not yet reproduced. |
-| F41 | `mpvtk_browser/app.py` HUD engage | Something engages the HUD while `_browsing`, reliably, on a video->music playlist advance. The invariant is enforced; the caller is unidentified. Below. |
+| F41 | `mpvtk_browser/app.py` `_yield` | **Diagnosed and closed.** A yield overtaken by `enter_browse` engaged the HUD over the library. Below, kept for the shape. |
 
 ### F29 — sleeping NAS, not reproduced
 
@@ -381,25 +381,32 @@ drawn, so the cursor hid, the library vanished after `hud_hide_secs`
 (`phud_hide` calls `ui_suspend`) and came back on motion (`mouse-pos` is
 observed and needs no input section).
 
-**But the refusal fires**, and Izzie's log has it landing right after the
-transition to music:
+**The caller, named by the log on its first use:**
 
-    [DEBUG] mpvtk_browser.hud_control: refusing a HUD engage while browsing
+    Player is busy; deferring UI action to the action thread
+    window: browse=on <- gateway.playback.on_browse_enter:23
+    refusing a HUD engage while browsing <- app._yield:2294
 
-So this is not a rare interleaving -- it is reliable on that path. Every
-known call site (`_yield`, the playstate handler, `reassert_window_state`,
-the SyncPlay config re-send) tests `not self._browsing` **before** calling,
-and `_yield` sets the flag False first, so none of them should be able to
-reach it with the flag True. Either one races the flag from another thread,
-or there is a fifth caller.
+`_yield` clears `_browsing` **first** and engages **last**, and the work in
+between is not atomic. `_tell_controller("on_browse_leave")` reaches the
+gateway, `run_action` defers because the player lock is held for the whole
+of a playback start, and the next queue item -- the song -- runs
+`enter_browse()` inside that window. The engage that follows is **stale by
+the time it runs**: one call spanning a re-entry, not a fifth caller and not
+a flag read early, which is why every call-site guard looked correct and why
+neither harness reproduced it from a message sequence.
 
-Not reproducible in either harness: the browser sends `set_active(True)` on
-the advance in every ordering driven, and the renderer clears HUD mode on
-receipt in all three states (HUD idle, shown, auto-hidden first).
+Pinned by `TheCursorNeverHidesOverTheLibraryTest`, which re-enters browse
+from the leave callback -- exactly where the log shows it happening -- and
+fails without the guard.
 
-**The refusal now logs its caller** (`module.function:line`), so the next
-occurrence names it. That is the whole of the follow-up: reproduce with
-debug logging on, read the arrow, and fix the site rather than the symptom.
-Enforcing the invariant was chosen over diagnosing because
-transition-by-transition reasoning missed this three times; the guard can
-only ever refuse an engage, never cause one.
+**Why the repair stays in `engage()`** rather than becoming a second check
+inside `_yield`: the stale-engage shape belongs to any caller whose work can
+span a re-entry, and `_yield` is simply the one that does. One authority, at
+the point that can see the current answer. It can only ever refuse an
+engage, never cause one.
+
+The lesson worth keeping is about the instrument, not the bug: three
+reproduction attempts from message sequences failed, and a one-line
+`_caller()` on the refusal named it the first time it fired. Same reasoning
+as `player_window._caller` -- "which caller it was IS the finding".

--- a/docs/do-not-fix.md
+++ b/docs/do-not-fix.md
@@ -156,6 +156,7 @@ then dropped in the same commit).
 | F39 | `player_window.py` `clear_picture` / `set_browse_window` | The window jump moved from opening a comic to LEAVING one. Cosmetic, and the open half is fixed. |
 | F40 | `player_window.py` `_apply_browse_fullscreen` | Reported edge case: the browse preference does not leave fullscreen when `fullscreen` is unset. Not yet reproduced. |
 | F41 | `mpvtk_browser/app.py` `_yield` | **Diagnosed and closed.** A yield overtaken by `enter_browse` engaged the HUD over the library. Below, kept for the shape. |
+| F42 | `settings/general.py` `_sync_path` | The dict holding the typed download folder is created once and never cleared, so a value can outlive the field that produced it. Below. |
 
 ### F29 — sleeping NAS, not reproduced
 
@@ -410,3 +411,28 @@ The lesson worth keeping is about the instrument, not the bug: three
 reproduction attempts from message sequences failed, and a one-line
 `_caller()` on the refusal named it the first time it fired. Same reasoning
 as `player_window._caller` -- "which caller it was IS the finding".
+
+### F42 — the download-folder field remembers across pages
+
+`_sync_path` is created once (`app.py`, `self._sync_path = {}`) and written
+by the folder TextBox's `on_change`. **Nothing ever clears it.** So a path
+typed once, on any visit to Settings, stays in that dict for the life of the
+browser -- and the Move button reads it in preference to the value the field
+is showing.
+
+Found while fixing the reported "moving to an empty folder is a no-op",
+which was the sibling bug in the same expression (`get("path") or val`
+could not tell "not edited" from "cleared"). That half is fixed and tested;
+this half is not, and it is the risk map's
+"`_sync_path` is Tier 1 and destructive -- Move relocates the store to a
+path the visible field is not showing".
+
+**Why it is not fixed here**: the obvious repair -- seed the dict from the
+current setting when the row is built -- runs on every repaint and would
+clobber an edit in progress, which is the standing footgun of this shell
+(docs/browser-shell.md: a screen is rebuilt from scratch on every repaint).
+The right fix is to clear it when the settings route is entered or retired,
+and that wants a look at `_retire_page` rather than a line in a builder.
+
+Reachable, but it needs a typed-then-abandoned edit followed by a Move on a
+later visit, and the destination is still confirmed for the empty case.

--- a/docs/do-not-fix.md
+++ b/docs/do-not-fix.md
@@ -316,22 +316,22 @@ true for an item that is gone and **nothing re-binds summon**. Measured: after
 the second video the wake binding does not exist and mouse moves produce no HUD
 event at all, because the renderer believes it is already showing.
 
-**What is NOT explained**: in the harness this self-heals as soon as the
-auto-hide timer fires (wake comes back, the HUD hides normally), so the
-reproduction is "no controls for the length of the auto-hide delay", not the
-permanent death reported. Either something stops that timer firing in the real
-app (`hud_autohide`, `hud_hide_secs`, or `phud_busy` re-arming forever -- it
-holds the bar up while the pointer rests on it, and unconditionally in the
-`paused` mode) or there is a further step. `phud_bind_summon` also declines to
-bind at all while `state.kb_saved` is set (mpv's console holding the keys),
-which would be permanent -- unverified.
+**FIXED**, once a second report gave the trigger: changing an audio or
+subtitle track during a transcode deletes and re-creates it, so the loading
+screen comes up and `LoadFeedback.clear()` hands off through `_yield()` --
+which engages while the renderer is ALREADY in HUD mode, hits the early
+return, and re-establishes nothing. The bar the user changed the track in was
+still up, so `phud.shown` stayed true for a stream that had ended.
+Intermittent because it depends on the bar still being up when the handoff
+lands; the auto-hide firing first re-binds summon and it recovers on its own,
+which is why the first reproduction looked self-healing.
 
-**A fix needs a decision, not just a patch**: the renderer cannot tell "a new
-item started" from "a setting changed", because `hud.engage()` is both -- its
-docstring says re-engaging is the ONLY thing that carries a changed setting
-through. Returning to idle on every engage would hide the HUD when someone
-changes a setting mid-film. So the item change has to come from the Python
-side, which knows it.
+The decision the fix needed: the renderer cannot tell "a new stream started"
+from "a setting changed" -- `hud.engage()` is both -- but the PYTHON side can.
+`_yield()` is a handoff by definition, so it now engages with `reset=True`,
+which cycles `set_hud(False)`/`set_hud(True)` and returns the HUD to a clean
+idle. Every other caller is a re-send (settings, SyncPlay, a fresh renderer)
+and must NOT hide a bar somebody is using; that is the control test.
 
 **The other suspect, still open, is the picture path and its deferral.** `show_picture`
 / `clear_picture` reach the player through `run_action`, which defers whenever

--- a/docs/do-not-fix.md
+++ b/docs/do-not-fix.md
@@ -155,6 +155,7 @@ then dropped in the same commit).
 | F38 | `player_window.py` picture path | **Unverified.** The playback HUD stops appearing after several photo/video handoffs. Needs evidence; below. |
 | F39 | `player_window.py` `clear_picture` / `set_browse_window` | The window jump moved from opening a comic to LEAVING one. Cosmetic, and the open half is fixed. |
 | F40 | `player_window.py` `_apply_browse_fullscreen` | Reported edge case: the browse preference does not leave fullscreen when `fullscreen` is unset. Not yet reproduced. |
+| F41 | `mpvtk_browser/app.py` HUD engage | Something engages the HUD while `_browsing`, reliably, on a video->music playlist advance. The invariant is enforced; the caller is unidentified. Below. |
 
 ### F29 — sleeping NAS, not reproduced
 
@@ -370,3 +371,35 @@ reads `browser_fullscreen or headless` for the ON direction and
 either. So either the path is a different one (`set_fullscreen`, or the
 live-apply in `apply_browser_fullscreen`) or the report is about a state
 neither of us has pinned down. Wants a reproduction before a fix.
+
+### F41 — a HUD engage while the library is on screen, caller unknown
+
+**The symptom is fixed and the cause is not found.** `HudController.engage`
+refuses while `_browsing` (659bb8c7), which closes the reported bug: a video
+-> music playlist advance left the renderer in HUD mode with the library
+drawn, so the cursor hid, the library vanished after `hud_hide_secs`
+(`phud_hide` calls `ui_suspend`) and came back on motion (`mouse-pos` is
+observed and needs no input section).
+
+**But the refusal fires**, and Izzie's log has it landing right after the
+transition to music:
+
+    [DEBUG] mpvtk_browser.hud_control: refusing a HUD engage while browsing
+
+So this is not a rare interleaving -- it is reliable on that path. Every
+known call site (`_yield`, the playstate handler, `reassert_window_state`,
+the SyncPlay config re-send) tests `not self._browsing` **before** calling,
+and `_yield` sets the flag False first, so none of them should be able to
+reach it with the flag True. Either one races the flag from another thread,
+or there is a fifth caller.
+
+Not reproducible in either harness: the browser sends `set_active(True)` on
+the advance in every ordering driven, and the renderer clears HUD mode on
+receipt in all three states (HUD idle, shown, auto-hidden first).
+
+**The refusal now logs its caller** (`module.function:line`), so the next
+occurrence names it. That is the whole of the follow-up: reproduce with
+debug logging on, read the arrow, and fix the site rather than the symptom.
+Enforcing the invariant was chosen over diagnosing because
+transition-by-transition reasoning missed this three times; the guard can
+only ever refuse an engage, never cause one.

--- a/docs/do-not-fix.md
+++ b/docs/do-not-fix.md
@@ -152,6 +152,9 @@ then dropped in the same commit).
 | F35 | `renderer.lua` `phud_skip_bind` | Binds literal `'ENTER'` for the Skip button whatever `hud_wake_key` says, so a moved wake key leaves ENTER accepting a skip. Found while doing #717 and deliberately left: it is a `hud_wake_key` bug, and it wants a decision about whether the idle Skip offer follows the wake key or `ui_select_key`. |
 | F36 | `media.py` `get_playback_url` | Asking for a track pins `MediaSources[0]`, so a multi-version item loses the unplayable retry. Accepted for 3.0.0; below. |
 | F37 | `renderer.lua` `keyclaim.block_take` | `browse_block_keys` swallows `q`/`f`/`p` in the library, defeating the player's STANDING fullscreen claim. Two claim mechanisms; below. |
+| F38 | `player_window.py` picture path | **Unverified.** The playback HUD stops appearing after several photo/video handoffs. Needs evidence; below. |
+| F39 | `player_window.py` `clear_picture` / `set_browse_window` | The window jump moved from opening a comic to LEAVING one. Cosmetic, and the open half is fixed. |
+| F40 | `player_window.py` `_apply_browse_fullscreen` | Reported edge case: the browse preference does not leave fullscreen when `fullscreen` is unset. Not yet reproduced. |
 
 ### F29 — sleeping NAS, not reproduced
 
@@ -269,8 +272,71 @@ blocked-but-claimed key to that dispatcher rather than swallowing it — but
 that is a new channel through the arbiter, and it wants a real-mpv matrix
 run, not a unit test.
 
+**And the ESC half, now confirmed twice** [iw]: in the comic reader and the
+epub reader there is "no keyboard only way to kill the focus ring without ESC
+which also exits the reader". ESC should drop the ring first and only page back
+on a second press. It belongs here rather than in its own entry because it is
+the same decision -- what the library's keyboard policy is -- and splitting it
+would produce two guards where the repair is one rule. The claim-swallowing
+half of that report IS fixed (`keyclaim.nav_names` in `keyclaim.take`); this is
+what is left.
+
 **Also wanted in the same pass** [iw]: `p` while music is playing, and a
 check that none of it breaks text entry. `m` and SPACE already work during
 music (they are claimed and routed), which is the behaviour the rest should
 match. The focus-ring half of the same report is fixed — see
 `keyclaim.nav_names` in `keyclaim.take`.
+
+### F38 — the HUD stops appearing after photo/video handoffs
+
+**Reported, not reproduced.** "Photo -> video -> photo ... this kills the HUD
+after a few video skips, not sure why." Several handoffs in, the playback HUD
+no longer summons.
+
+**Ruled out, by driving them:** the browser's `on_playstate` is correct across
+every photo/video alternation tried (photo, photo->video, photo->video->photo,
+four alternations, five video advances, and each with a `stopped` push in the
+middle) -- `hud.state` stays set and `set_hud(True)` keeps being sent. The
+renderer's own lifecycle is correct across the equivalent message sequence in
+`tests/lua/`, including from an auto-hidden HUD. `_release_page_grabs` drops a
+key claim and the pan model and touches neither.
+
+**The remaining suspect is the picture path and its deferral.** `show_picture`
+/ `clear_picture` reach the player through `run_action`, which defers whenever
+the player lock is busy -- and it is busy for the whole of a playback start.
+`clear_picture` guards on `self._video is not None` **with no `_loading`
+half**, where its sibling `reset_picture_view` guards on `self._video is None
+and not self._loading`. `_video` is not assigned until the duration wait
+succeeds, so a deferred `clear_picture` landing mid-start passes its guard and
+calls `set_browse_window(True)`. That is F15's asymmetry with a symptom
+attached, and it is the first evidence for it -- but it is a hypothesis, and
+the last two fixes made from a hypothesis in this area both had to be redone.
+
+**Before acting, ask for** `log.txt` from the affected run, grabbed *before*
+relaunching (it is rewritten on every start). `wlog` logs every
+`set_browse_window` with its caller, which is exactly the line that would
+settle this.
+
+### F39 — the comic window jump moved rather than went away
+
+`f583dc7f` gave `show_picture` the `_sync_window_geometry` call that every
+other load already had, and the reported jump on **opening** a comic is gone.
+The hand pass then found it on **leaving** one instead.
+
+Not diagnosed. The shape to check first: the reader borrows `keepaspect`, so
+the window can change size while a page is up; `set_browse_window(True)` on
+the way out turns it off and re-arms nothing, so the geometry armed before the
+comic is what the VO reconfig re-applies. Whether that is a jump or a restore
+is a product question as much as a bug.
+
+Cosmetic, one window resize, and the half that draws over the page is fixed.
+
+### F40 — browse fullscreen and the playback setting
+
+Reported: "fullscreen library browser does not exit fullscreen when regular
+fullscreen setting is not set." Not reproduced -- `_apply_browse_fullscreen`
+reads `browser_fullscreen or headless` for the ON direction and
+`_library_showing()` for the OFF one, and `settings.fullscreen` is not in
+either. So either the path is a different one (`set_fullscreen`, or the
+live-apply in `apply_browser_fullscreen`) or the report is about a state
+neither of us has pinned down. Wants a reproduction before a fix.

--- a/jellyfin_mpv_shim/conf.py
+++ b/jellyfin_mpv_shim/conf.py
@@ -665,7 +665,7 @@ class Settings(SettingsBase):
     # because it is a preference about how somebody reads comics, not
     # about one comic -- a reader who wants whole pages wants them for
     # every book, and picking it again per volume is the annoyance.
-    comic_fit: str = "width"
+    comic_fit: str = "page"
     # While a video plays with the HUD hidden, grab UP/DOWN/LEFT/RIGHT
     # (and ENTER) to summon/drive the HUD. Off by default: mpv's own
     # seek keys keep working and only hud_wake_key is taken over.

--- a/jellyfin_mpv_shim/constants.py
+++ b/jellyfin_mpv_shim/constants.py
@@ -5,7 +5,7 @@ USER_APP_NAME = "Jellyfin MPV Shim"
 # how a Linux desktop finds the window's icon — see player.py's x11_name /
 # wayland_app_id. Changing one without the others loses the icon silently.
 DESKTOP_ID = "com.github.iwalton3.jellyfin-mpv-shim"
-CLIENT_VERSION = "3.0.0pre14"
+CLIENT_VERSION = "3.0.0"
 USER_AGENT = "Jellyfin-MPV-Shim/%s" % CLIENT_VERSION
 CAPABILITIES = {
     "PlayableMediaTypes": ["Video"],

--- a/jellyfin_mpv_shim/integration/com.github.iwalton3.jellyfin-mpv-shim.appdata.xml
+++ b/jellyfin_mpv_shim/integration/com.github.iwalton3.jellyfin-mpv-shim.appdata.xml
@@ -5,22 +5,17 @@
   <metadata_license>FSFAP</metadata_license>
   <project_license>GPL-3.0</project_license>
   <name>Jellyfin MPV Shim</name>
-  <summary>Cast-only client for Jellyfin Media Server</summary>
+  <summary>MPV-Based Jellyfin Client with Offline Sync</summary>
   <developer id="com.github.iwalton3">
     <name>Izzie Walton</name>
   </developer>
 
   <description>
     <p>
-        Jellyfin MPV Shim is a client for the Jellyfin media server which plays media in the
-        MPV media player. The application runs in the background and opens MPV only
-        when media is cast to the player. The player supports most file formats, allowing you
-        to prevent needless transcoding of your media files on the server. The player also has
-        advanced features, such as bulk subtitle updates and launching commands on events.
-    </p>
-    <p>
-        Please read the detailed instructions on GitHub for more details, including usage
-        instructions and configuration details.
+        Jellyfin MPV Shim is a fully featured Jellyfin client built on top of MPV with support
+        for offline sync, media browsing, background casting, syncplay, music, live TV, books, and photos.
+        It does not depend on or use a webview and doesn't mess with MPV's video output pipeline, allowing
+        for HDR and tone mapping support.
     </p>
   </description>
 
@@ -38,39 +33,39 @@
 
   <screenshots>
     <screenshot type="default">
-      <caption>The library browser, running inside MPV</caption>
+      <caption>The MPV-based library browser</caption>
       <image type="source" width="1134" height="810">https://raw.githubusercontent.com/iwalton3/mpv-shim-misc-docs/refs/heads/master/mpv-shim-v3/mpv-ui-home.png</image>
     </screenshot>
     <screenshot>
-      <caption>The playback controls</caption>
+      <caption>Media playback</caption>
       <image type="source" width="1134" height="807">https://raw.githubusercontent.com/iwalton3/mpv-shim-misc-docs/refs/heads/master/mpv-shim-v3/mpv-ui-player.png</image>
     </screenshot>
     <screenshot>
-      <caption>Music, with the now-playing bar over the library</caption>
+      <caption>Music playback</caption>
       <image type="source" width="1137" height="810">https://raw.githubusercontent.com/iwalton3/mpv-shim-misc-docs/refs/heads/master/mpv-shim-v3/mpv-ui-music.png</image>
     </screenshot>
     <screenshot>
-      <caption>A movie detail page</caption>
+      <caption>Movie details</caption>
       <image type="source" width="1133" height="809">https://raw.githubusercontent.com/iwalton3/mpv-shim-misc-docs/refs/heads/master/mpv-shim-v3/mpv-ui-movie.png</image>
     </screenshot>
     <screenshot>
-      <caption>Browsing a TV library</caption>
+      <caption>TV library</caption>
       <image type="source" width="1137" height="806">https://raw.githubusercontent.com/iwalton3/mpv-shim-misc-docs/refs/heads/master/mpv-shim-v3/mpv-ui-shows.png</image>
     </screenshot>
     <screenshot>
-      <caption>The Live TV guide</caption>
+      <caption>Live TV guide</caption>
       <image type="source" width="1135" height="807">https://raw.githubusercontent.com/iwalton3/mpv-shim-misc-docs/refs/heads/master/mpv-shim-v3/mpv-ui-guide.png</image>
     </screenshot>
     <screenshot>
-      <caption>The built-in comic book reader</caption>
+      <caption>Comic book support</caption>
       <image type="source" width="1137" height="811">https://raw.githubusercontent.com/iwalton3/mpv-shim-misc-docs/refs/heads/master/mpv-shim-v3/mpv-ui-comics.png</image>
     </screenshot>
     <screenshot>
-      <caption>Audiobook playback, with chapters</caption>
+      <caption>Audiobook playback</caption>
       <image type="source" width="1135" height="807">https://raw.githubusercontent.com/iwalton3/mpv-shim-misc-docs/refs/heads/master/mpv-shim-v3/mpv-ui-audiobook.png</image>
     </screenshot>
     <screenshot>
-      <caption>The built-in epub reader</caption>
+      <caption>Epub reader</caption>
       <image type="source" width="1135" height="810">https://raw.githubusercontent.com/iwalton3/mpv-shim-misc-docs/refs/heads/master/mpv-shim-v3/mpv-ui-epub.png</image>
     </screenshot>
   </screenshots>
@@ -87,25 +82,22 @@
     <release version="3.0.0" date="2026-09-07">
       <description>
         <p>
-          A full library browser inside MPV, offline sync, and Jellyfin v12 support.
-          Jellyfin v12 requires MPV Shim v3 unless legacy authentication is enabled
-          on the server. Tested against Jellyfin 10.11 and 12.
+          Adds a Jellyfin library browser and improved video controls built on top of MPV
+          without any webviews, including offline sync and easy user switching.
         </p>
         <p>Changes:</p>
         <ul>
-          <li>Browse and search the whole library inside MPV: playlists, collections, detail pages, favorites, genres and Live TV, with per-library views, sorting, filtering and themes</li>
-          <li>Offline sync for movies, shows, playlists, music and books, with automatic downloads of new episodes, progress sync, skip intro, trickplay and artwork</li>
-          <li>Improved player UI: audio and subtitle switching (including external subtitles and transcodes), a standalone skip intro button, chapters, next/previous episode, volume, trickplay and media info</li>
-          <li>Classic MPV OSC and custom OSCs (uosc, modernz) are still supported, and keyboard shortcuts are only claimed when needed</li>
-          <li>Music, browsable by song, album, artist, album artist and genre, with playlist creation and editing</li>
-          <li>Books: audiobooks with chapters and resume, plus built-in epub and comic (CBZ/CBT) readers</li>
-          <li>Live TV with channels, guide and recording</li>
-          <li>Quick Connect support, and fast switching between servers and users with an optional PIN</li>
-          <li>Full keyboard, Jellyfin cast navigation and gamepad support</li>
-          <li>Video: Dolby Vision, per-library and per-series shader packs, audio passthrough and exclusive mode, night-mode normalization, optional hardware decoding, secondary subtitles</li>
-          <li>A new searchable settings screen covering most of the client</li>
+          <li>Browse and search the whole library inside MPV, including music, comics, and books.</li>
+          <li>Offline sync with automatic downloads</li>
+          <li>Full Jellyfin player controls built on top of MPV</li>
+          <li>Classic MPV controls can be used if desired, customization remains a priority</li>
+          <li>Live TV including channels, guide, and recording</li>
+          <li>Quick connect and easy server/user switching</li>
+          <li>Navigate using keyboard, gamepad, or cast controls</li>
+          <li>Includes presets for shaders, audio passthrough, and volume normalization</li>
+          <li>Most settings are now managable without editing files</li>
           <li>HiDPI support, client-side decorations, and proper Wayland support</li>
-          <li>SyncPlay no longer stalls on seek, and groups can be joined from the home screen</li>
+          <li>Syncplay can be joined from homescreen and doesn't stall unexpectedly</li>
         </ul>
       </description>
     </release>

--- a/jellyfin_mpv_shim/integration/com.github.iwalton3.jellyfin-mpv-shim.appdata.xml
+++ b/jellyfin_mpv_shim/integration/com.github.iwalton3.jellyfin-mpv-shim.appdata.xml
@@ -38,16 +38,40 @@
 
   <screenshots>
     <screenshot type="default">
-      <caption>The web app casting to MPV Shim</caption>
-      <image type="source" width="802" height="602">https://user-images.githubusercontent.com/8078788/78717835-392d2c00-78ef-11ea-9731-7fd4a1d8ebbe.png</image>
+      <caption>The library browser, running inside MPV</caption>
+      <image type="source" width="1134" height="810">https://raw.githubusercontent.com/iwalton3/mpv-shim-misc-docs/refs/heads/master/mpv-shim-v3/mpv-ui-home.png</image>
     </screenshot>
     <screenshot>
-      <caption>The application playing the MKV Test Suite</caption>
-      <image type="source" width="1024" height="576">https://jellyfin.org/assets/images/blender-c74e98002e3842e5c5ffa8770e17905d.png</image>
+      <caption>The playback controls</caption>
+      <image type="source" width="1134" height="807">https://raw.githubusercontent.com/iwalton3/mpv-shim-misc-docs/refs/heads/master/mpv-shim-v3/mpv-ui-player.png</image>
     </screenshot>
     <screenshot>
-      <caption>The built-in menu inside MPV</caption>
-      <image type="source" width="1024" height="576">https://jellyfin.org/assets/images/menu-d7fdb971f324d02abe0c36ad3cef17e8.png</image>
+      <caption>Music, with the now-playing bar over the library</caption>
+      <image type="source" width="1137" height="810">https://raw.githubusercontent.com/iwalton3/mpv-shim-misc-docs/refs/heads/master/mpv-shim-v3/mpv-ui-music.png</image>
+    </screenshot>
+    <screenshot>
+      <caption>A movie detail page</caption>
+      <image type="source" width="1133" height="809">https://raw.githubusercontent.com/iwalton3/mpv-shim-misc-docs/refs/heads/master/mpv-shim-v3/mpv-ui-movie.png</image>
+    </screenshot>
+    <screenshot>
+      <caption>Browsing a TV library</caption>
+      <image type="source" width="1137" height="806">https://raw.githubusercontent.com/iwalton3/mpv-shim-misc-docs/refs/heads/master/mpv-shim-v3/mpv-ui-shows.png</image>
+    </screenshot>
+    <screenshot>
+      <caption>The Live TV guide</caption>
+      <image type="source" width="1135" height="807">https://raw.githubusercontent.com/iwalton3/mpv-shim-misc-docs/refs/heads/master/mpv-shim-v3/mpv-ui-guide.png</image>
+    </screenshot>
+    <screenshot>
+      <caption>The built-in comic book reader</caption>
+      <image type="source" width="1137" height="811">https://raw.githubusercontent.com/iwalton3/mpv-shim-misc-docs/refs/heads/master/mpv-shim-v3/mpv-ui-comics.png</image>
+    </screenshot>
+    <screenshot>
+      <caption>Audiobook playback, with chapters</caption>
+      <image type="source" width="1135" height="807">https://raw.githubusercontent.com/iwalton3/mpv-shim-misc-docs/refs/heads/master/mpv-shim-v3/mpv-ui-audiobook.png</image>
+    </screenshot>
+    <screenshot>
+      <caption>The built-in epub reader</caption>
+      <image type="source" width="1135" height="810">https://raw.githubusercontent.com/iwalton3/mpv-shim-misc-docs/refs/heads/master/mpv-shim-v3/mpv-ui-epub.png</image>
     </screenshot>
   </screenshots>
 
@@ -60,6 +84,31 @@
 
   <content_rating type="oars-1.1" />
   <releases>
+    <release version="3.0.0" date="2026-09-07">
+      <description>
+        <p>
+          A full library browser inside MPV, offline sync, and Jellyfin v12 support.
+          Jellyfin v12 requires MPV Shim v3 unless legacy authentication is enabled
+          on the server. Tested against Jellyfin 10.11 and 12.
+        </p>
+        <p>Changes:</p>
+        <ul>
+          <li>Browse and search the whole library inside MPV: playlists, collections, detail pages, favorites, genres and Live TV, with per-library views, sorting, filtering and themes</li>
+          <li>Offline sync for movies, shows, playlists, music and books, with automatic downloads of new episodes, progress sync, skip intro, trickplay and artwork</li>
+          <li>Improved player UI: audio and subtitle switching (including external subtitles and transcodes), a standalone skip intro button, chapters, next/previous episode, volume, trickplay and media info</li>
+          <li>Classic MPV OSC and custom OSCs (uosc, modernz) are still supported, and keyboard shortcuts are only claimed when needed</li>
+          <li>Music, browsable by song, album, artist, album artist and genre, with playlist creation and editing</li>
+          <li>Books: audiobooks with chapters and resume, plus built-in epub and comic (CBZ/CBT) readers</li>
+          <li>Live TV with channels, guide and recording</li>
+          <li>Quick Connect support, and fast switching between servers and users with an optional PIN</li>
+          <li>Full keyboard, Jellyfin cast navigation and gamepad support</li>
+          <li>Video: Dolby Vision, per-library and per-series shader packs, audio passthrough and exclusive mode, night-mode normalization, optional hardware decoding, secondary subtitles</li>
+          <li>A new searchable settings screen covering most of the client</li>
+          <li>HiDPI support, client-side decorations, and proper Wayland support</li>
+          <li>SyncPlay no longer stalls on seek, and groups can be joined from the home screen</li>
+        </ul>
+      </description>
+    </release>
     <release version="2.10.0" date="2026-05-03">
       <description>
         <p>Changes:</p>

--- a/jellyfin_mpv_shim/log_utils.py
+++ b/jellyfin_mpv_shim/log_utils.py
@@ -140,11 +140,29 @@ def configure_log_file(destination: str, level: str = "info"):
     root_logger.addHandler(handler)
 
 
+#: Loggers the in-app viewer must not see, because DRAWING the viewer is
+#: what produces them.
+#:
+#: `mpvtk.render` is the per-frame timing line. The Logs tab polls the ring
+#: and re-renders when the content changed -- so a render line lands in the
+#: ring, the next poll sees a change, re-renders, and logs another one. The
+#: "only when something changed" guard cannot help: the render IS the
+#: change. With debug logging on (i.e. exactly when someone is reading the
+#: log) that never goes idle, one render and one line per poll, forever.
+#:
+#: Excluded from the RING only. The file handler still records them, so
+#: `log.txt` is unchanged and the timings stay available to whoever asked
+#: for debug logging in the first place.
+RING_EXCLUDED = ("mpvtk.render",)
+
+
 class RingLogHandler(logging.Handler):
     """Keeps the last N formatted log lines in memory for in-app log views.
 
     The browser runs in *this* process and reads the ring directly, so the
-    log viewer needs no IPC and no separate copy of the buffer."""
+    log viewer needs no IPC and no separate copy of the buffer -- which is
+    also why it needs `RING_EXCLUDED`: a viewer reading its own output is a
+    feedback loop, and nothing else in the process has that problem."""
 
     def __init__(self, capacity=2000):
         super().__init__()
@@ -152,6 +170,8 @@ class RingLogHandler(logging.Handler):
 
     def emit(self, record):
         try:
+            if record.name in RING_EXCLUDED:
+                return
             self.lines.append(self.format(record))
         except Exception:
             pass

--- a/jellyfin_mpv_shim/messages/af/LC_MESSAGES/base.po
+++ b/jellyfin_mpv_shim/messages/af/LC_MESSAGES/base.po
@@ -6,7 +6,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2026-08-30 22:19-0400\n"
+"POT-Creation-Date: 2026-09-07 17:35-0400\n"
 "PO-Revision-Date: 2026-03-04 23:20+0000\n"
 "Last-Translator: Eugene <eugclass@gmail.com>\n"
 "Language-Team: Afrikaans <https://translate.jellyfin.org/projects/jellyfin/"
@@ -546,6 +546,11 @@ msgid "Night Mode (Auto Volume Adj)"
 msgstr ""
 
 #: jellyfin_mpv_shim/mpvtk_browser/app.py
+#: jellyfin_mpv_shim/mpvtk_browser/auth.py
+msgid "Locked"
+msgstr ""
+
+#: jellyfin_mpv_shim/mpvtk_browser/app.py
 msgid "Failed to load. Check the connection."
 msgstr ""
 
@@ -823,10 +828,6 @@ msgstr ""
 "Gaan u na verbindingsinligting toe."
 
 #: jellyfin_mpv_shim/mpvtk_browser/auth.py
-msgid "Locked"
-msgstr ""
-
-#: jellyfin_mpv_shim/mpvtk_browser/auth.py
 #: jellyfin_mpv_shim/mpvtk_browser/pages/home.py
 msgid "Connecting to your server…"
 msgstr ""
@@ -907,6 +908,10 @@ msgstr "Verlaat en Merk as Ongekyk"
 #: jellyfin_mpv_shim/mpvtk_browser/pages/books.py
 msgid "Favorite"
 msgstr "Gunstelling"
+
+#: jellyfin_mpv_shim/mpvtk_browser/components/detail.py
+msgid "Web"
+msgstr ""
 
 # seeded from jellyfin-web: HeaderVideos
 #: jellyfin_mpv_shim/mpvtk_browser/components/media_info.py
@@ -1460,11 +1465,7 @@ msgid "Jellyfin UI"
 msgstr ""
 
 #: jellyfin_mpv_shim/mpvtk_browser/config.py
-msgid "MPV UI with thumbnails"
-msgstr ""
-
-#: jellyfin_mpv_shim/mpvtk_browser/config.py
-msgid "MPV built-in default"
+msgid "MPV UI"
 msgstr ""
 
 #: jellyfin_mpv_shim/mpvtk_browser/config.py
@@ -1811,8 +1812,22 @@ msgid "Window Buttons in the Top Bar"
 msgstr ""
 
 #: jellyfin_mpv_shim/mpvtk_browser/config.py
+msgid "Keep Window Buttons in Full Screen"
+msgstr ""
+
+#: jellyfin_mpv_shim/mpvtk_browser/config.py
+msgid "Hide the Desktop Title Bar"
+msgstr ""
+
+#: jellyfin_mpv_shim/mpvtk_browser/config.py
 msgid "Player Controls Style"
 msgstr ""
+
+#: jellyfin_mpv_shim/mpvtk_browser/config.py
+#, fuzzy
+#| msgid "Enable thumbnail previews"
+msgid "Enable Trickplay Thumbnails"
+msgstr "Aktiveer duimnaalvoorskoue"
 
 #: jellyfin_mpv_shim/mpvtk_browser/config.py
 msgid "Load All Seek Previews at Once"
@@ -1841,6 +1856,10 @@ msgstr ""
 
 #: jellyfin_mpv_shim/mpvtk_browser/config.py
 msgid "Full-Width Backdrops"
+msgstr ""
+
+#: jellyfin_mpv_shim/mpvtk_browser/config.py
+msgid "12-Hour Clock"
 msgstr ""
 
 #: jellyfin_mpv_shim/mpvtk_browser/config.py
@@ -1884,11 +1903,19 @@ msgid "Fullscreen Library Browser"
 msgstr ""
 
 #: jellyfin_mpv_shim/mpvtk_browser/config.py
+msgid "Block Player Keybinds While Browsing"
+msgstr ""
+
+#: jellyfin_mpv_shim/mpvtk_browser/config.py
 msgid "Always Bind Arrow Keys to Player Controls"
 msgstr ""
 
 #: jellyfin_mpv_shim/mpvtk_browser/config.py
 msgid "Player Controls Activation Key"
+msgstr ""
+
+#: jellyfin_mpv_shim/mpvtk_browser/config.py
+msgid "Select Key"
 msgstr ""
 
 #: jellyfin_mpv_shim/mpvtk_browser/config.py
@@ -1901,6 +1928,10 @@ msgstr ""
 
 #: jellyfin_mpv_shim/mpvtk_browser/config.py
 msgid "Hide the Player Controls After (seconds)"
+msgstr ""
+
+#: jellyfin_mpv_shim/mpvtk_browser/config.py
+msgid "Shrink the Player Controls on a Narrow Window"
 msgstr ""
 
 #: jellyfin_mpv_shim/mpvtk_browser/config.py
@@ -1987,6 +2018,21 @@ msgstr ""
 
 #: jellyfin_mpv_shim/mpvtk_browser/config.py
 msgid ""
+"Stops MPV's own shortcuts -- picture adjustment, screenshots, subtitle and "
+"audio switching -- from acting while you are in the library, where there is "
+"no video for them to act on. Turn it off to use your own MPV key bindings "
+"there."
+msgstr ""
+
+#: jellyfin_mpv_shim/mpvtk_browser/config.py
+msgid ""
+"Activates whatever is highlighted, in the library and on the player "
+"controls. An mpv key name; changing it hands Enter back to MPV. The game "
+"controller's Confirm button and a phone's Select follow it."
+msgstr ""
+
+#: jellyfin_mpv_shim/mpvtk_browser/config.py
+msgid ""
 "Leave these blank unless downloads are waking your disks too often. Set both "
 "of the first two together: episodes are then fetched in one batch when a "
 "series runs low, instead of one at a time."
@@ -2000,7 +2046,8 @@ msgstr ""
 #: jellyfin_mpv_shim/mpvtk_browser/config.py
 msgid ""
 "Off gives MPV's own mouse behaviour instead: drag the video to move the "
-"window, and right click to pause. Double click is full screen either way."
+"window, and the right button does whatever your MPV config gives it. Double "
+"click is full screen either way."
 msgstr ""
 
 #: jellyfin_mpv_shim/mpvtk_browser/config.py
@@ -2090,6 +2137,30 @@ msgid ""
 "maximize and close in the top bar instead, and lets you drag the window by "
 "it. On \"Only when the window has no title bar\", MPV is asked whether this "
 "window got one, so desktops that draw a title bar are left alone."
+msgstr ""
+
+#: jellyfin_mpv_shim/mpvtk_browser/config.py
+msgid ""
+"Full screen has no title bar anywhere and nothing to move or maximize, so "
+"the buttons are normally hidden there. Turn this on to keep a way out of "
+"full screen that is not a keyboard shortcut."
+msgstr ""
+
+#: jellyfin_mpv_shim/mpvtk_browser/config.py
+msgid ""
+"Asks the desktop for no title bar on the player window, so the top bar above "
+"is the only one. Pairs with the setting above: on \"Only when the window has "
+"no title bar\" the buttons appear as soon as this is on. Leave both off "
+"unless you want them, since a window with neither can be awkward to move on "
+"some desktops."
+msgstr ""
+
+#: jellyfin_mpv_shim/mpvtk_browser/config.py
+msgid ""
+"Shows a preview frame while you drag the seek bar. Works with every player "
+"control style, including your own OSC script if it supports thumbfast. The "
+"images are fetched from the server per video, which costs disk space and "
+"memory -- tens of MB for an episode, a few hundred for a long film."
 msgstr ""
 
 #: jellyfin_mpv_shim/mpvtk_browser/config.py
@@ -2199,6 +2270,13 @@ msgstr ""
 
 #: jellyfin_mpv_shim/mpvtk_browser/config.py
 msgid ""
+"Show times of day as \"8:30 PM\" rather than \"20:30\" — the Live TV guide "
+"and its air times, and the \"Ends at\" labels on a detail page and the "
+"player controls."
+msgstr ""
+
+#: jellyfin_mpv_shim/mpvtk_browser/config.py
+msgid ""
 "The controls have to stay legible over any frame. \"None\" gives the text a "
 "drop shadow instead of shading the picture behind it."
 msgstr ""
@@ -2213,6 +2291,13 @@ msgstr ""
 msgid ""
 "0 hides them as soon as the pointer is not on them, and forces \"Hide unless "
 "hovered\"."
+msgstr ""
+
+#: jellyfin_mpv_shim/mpvtk_browser/config.py
+msgid ""
+"Narrowing the window shrinks the controls until the smallest button reaches "
+"the accessibility minimum, instead of dropping buttons sooner. Off keeps the "
+"older, larger floor."
 msgstr ""
 
 #: jellyfin_mpv_shim/mpvtk_browser/config.py
@@ -3766,6 +3851,7 @@ msgid "More Like This"
 msgstr "Meer Soos Hierdie"
 
 #: jellyfin_mpv_shim/mpvtk_browser/pages/detail.py
+#: jellyfin_mpv_shim/mpvtk_browser/tiles.py
 msgid "Go to Series"
 msgstr ""
 
@@ -4931,6 +5017,22 @@ msgstr "Verwyder Server"
 msgid "There is nothing here to queue."
 msgstr ""
 
+#: jellyfin_mpv_shim/mpvtk_browser/timefmt.py
+#, python-brace-format
+msgctxt "12-hour clock"
+msgid "{time} {period}"
+msgstr ""
+
+#: jellyfin_mpv_shim/mpvtk_browser/timefmt.py
+msgctxt "12-hour clock"
+msgid "AM"
+msgstr ""
+
+#: jellyfin_mpv_shim/mpvtk_browser/timefmt.py
+msgctxt "12-hour clock"
+msgid "PM"
+msgstr ""
+
 #: jellyfin_mpv_shim/mpvtk_browser/views.py
 #: jellyfin_mpv_shim/mpvtk_browser/window_chrome.py
 msgid "Search"
@@ -5094,13 +5196,32 @@ msgid "Enable SVP"
 msgstr "Aktiveer SVP"
 
 #: jellyfin_mpv_shim/sync/manager.py
+msgid "The downloads are already in that folder."
+msgstr ""
+
+#: jellyfin_mpv_shim/sync/manager.py
 msgid ""
 "Can't change the download folder while a download is in progress. Wait for "
 "it to finish, then try again."
 msgstr ""
 
 #: jellyfin_mpv_shim/sync/manager.py
+msgid ""
+"That folder is inside the current download folder. Choose one outside it."
+msgstr ""
+
+#: jellyfin_mpv_shim/sync/manager.py
+msgid "Can't read that folder. Check the path and its permissions."
+msgstr ""
+
+#: jellyfin_mpv_shim/sync/manager.py
 msgid "That folder already contains downloads. Choose an empty folder."
+msgstr ""
+
+#: jellyfin_mpv_shim/sync/manager.py
+msgid ""
+"That folder isn't empty. Choose an empty folder — the download folder is "
+"managed by this app and anything else in it can be moved or removed."
 msgstr ""
 
 #: jellyfin_mpv_shim/sync/manager.py
@@ -5109,6 +5230,12 @@ msgstr ""
 
 #: jellyfin_mpv_shim/sync/manager.py
 msgid "A download is still finishing. Wait for it to stop, then try again."
+msgstr ""
+
+#: jellyfin_mpv_shim/sync/manager.py
+msgid ""
+"There isn't enough space on that drive to move the downloads. Free some "
+"space and try again — nothing was moved."
 msgstr ""
 
 #: jellyfin_mpv_shim/sync/manager.py

--- a/jellyfin_mpv_shim/messages/am/LC_MESSAGES/base.po
+++ b/jellyfin_mpv_shim/messages/am/LC_MESSAGES/base.po
@@ -6,7 +6,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2026-08-30 22:19-0400\n"
+"POT-Creation-Date: 2026-09-07 17:35-0400\n"
 "PO-Revision-Date: 2026-03-08 09:12+0000\n"
 "Last-Translator: Jack Ward <jack200114@hotmail.com>\n"
 "Language-Team: Amharic <https://translate.jellyfin.org/projects/jellyfin/"
@@ -508,6 +508,11 @@ msgid "Night Mode (Auto Volume Adj)"
 msgstr ""
 
 #: jellyfin_mpv_shim/mpvtk_browser/app.py
+#: jellyfin_mpv_shim/mpvtk_browser/auth.py
+msgid "Locked"
+msgstr ""
+
+#: jellyfin_mpv_shim/mpvtk_browser/app.py
 msgid "Failed to load. Check the connection."
 msgstr ""
 
@@ -748,10 +753,6 @@ msgid "Could not connect. Please check your details."
 msgstr ""
 
 #: jellyfin_mpv_shim/mpvtk_browser/auth.py
-msgid "Locked"
-msgstr ""
-
-#: jellyfin_mpv_shim/mpvtk_browser/auth.py
 #: jellyfin_mpv_shim/mpvtk_browser/pages/home.py
 msgid "Connecting to your server…"
 msgstr ""
@@ -821,6 +822,10 @@ msgstr ""
 #: jellyfin_mpv_shim/mpvtk_browser/hud.py
 #: jellyfin_mpv_shim/mpvtk_browser/pages/books.py
 msgid "Favorite"
+msgstr ""
+
+#: jellyfin_mpv_shim/mpvtk_browser/components/detail.py
+msgid "Web"
 msgstr ""
 
 #: jellyfin_mpv_shim/mpvtk_browser/components/media_info.py
@@ -1330,11 +1335,7 @@ msgid "Jellyfin UI"
 msgstr ""
 
 #: jellyfin_mpv_shim/mpvtk_browser/config.py
-msgid "MPV UI with thumbnails"
-msgstr ""
-
-#: jellyfin_mpv_shim/mpvtk_browser/config.py
-msgid "MPV built-in default"
+msgid "MPV UI"
 msgstr ""
 
 #: jellyfin_mpv_shim/mpvtk_browser/config.py
@@ -1667,7 +1668,19 @@ msgid "Window Buttons in the Top Bar"
 msgstr ""
 
 #: jellyfin_mpv_shim/mpvtk_browser/config.py
+msgid "Keep Window Buttons in Full Screen"
+msgstr ""
+
+#: jellyfin_mpv_shim/mpvtk_browser/config.py
+msgid "Hide the Desktop Title Bar"
+msgstr ""
+
+#: jellyfin_mpv_shim/mpvtk_browser/config.py
 msgid "Player Controls Style"
+msgstr ""
+
+#: jellyfin_mpv_shim/mpvtk_browser/config.py
+msgid "Enable Trickplay Thumbnails"
 msgstr ""
 
 #: jellyfin_mpv_shim/mpvtk_browser/config.py
@@ -1697,6 +1710,10 @@ msgstr ""
 
 #: jellyfin_mpv_shim/mpvtk_browser/config.py
 msgid "Full-Width Backdrops"
+msgstr ""
+
+#: jellyfin_mpv_shim/mpvtk_browser/config.py
+msgid "12-Hour Clock"
 msgstr ""
 
 #: jellyfin_mpv_shim/mpvtk_browser/config.py
@@ -1740,11 +1757,19 @@ msgid "Fullscreen Library Browser"
 msgstr ""
 
 #: jellyfin_mpv_shim/mpvtk_browser/config.py
+msgid "Block Player Keybinds While Browsing"
+msgstr ""
+
+#: jellyfin_mpv_shim/mpvtk_browser/config.py
 msgid "Always Bind Arrow Keys to Player Controls"
 msgstr ""
 
 #: jellyfin_mpv_shim/mpvtk_browser/config.py
 msgid "Player Controls Activation Key"
+msgstr ""
+
+#: jellyfin_mpv_shim/mpvtk_browser/config.py
+msgid "Select Key"
 msgstr ""
 
 #: jellyfin_mpv_shim/mpvtk_browser/config.py
@@ -1757,6 +1782,10 @@ msgstr ""
 
 #: jellyfin_mpv_shim/mpvtk_browser/config.py
 msgid "Hide the Player Controls After (seconds)"
+msgstr ""
+
+#: jellyfin_mpv_shim/mpvtk_browser/config.py
+msgid "Shrink the Player Controls on a Narrow Window"
 msgstr ""
 
 #: jellyfin_mpv_shim/mpvtk_browser/config.py
@@ -1839,6 +1868,21 @@ msgstr ""
 
 #: jellyfin_mpv_shim/mpvtk_browser/config.py
 msgid ""
+"Stops MPV's own shortcuts -- picture adjustment, screenshots, subtitle and "
+"audio switching -- from acting while you are in the library, where there is "
+"no video for them to act on. Turn it off to use your own MPV key bindings "
+"there."
+msgstr ""
+
+#: jellyfin_mpv_shim/mpvtk_browser/config.py
+msgid ""
+"Activates whatever is highlighted, in the library and on the player "
+"controls. An mpv key name; changing it hands Enter back to MPV. The game "
+"controller's Confirm button and a phone's Select follow it."
+msgstr ""
+
+#: jellyfin_mpv_shim/mpvtk_browser/config.py
+msgid ""
 "Leave these blank unless downloads are waking your disks too often. Set both "
 "of the first two together: episodes are then fetched in one batch when a "
 "series runs low, instead of one at a time."
@@ -1852,7 +1896,8 @@ msgstr ""
 #: jellyfin_mpv_shim/mpvtk_browser/config.py
 msgid ""
 "Off gives MPV's own mouse behaviour instead: drag the video to move the "
-"window, and right click to pause. Double click is full screen either way."
+"window, and the right button does whatever your MPV config gives it. Double "
+"click is full screen either way."
 msgstr ""
 
 #: jellyfin_mpv_shim/mpvtk_browser/config.py
@@ -1942,6 +1987,30 @@ msgid ""
 "maximize and close in the top bar instead, and lets you drag the window by "
 "it. On \"Only when the window has no title bar\", MPV is asked whether this "
 "window got one, so desktops that draw a title bar are left alone."
+msgstr ""
+
+#: jellyfin_mpv_shim/mpvtk_browser/config.py
+msgid ""
+"Full screen has no title bar anywhere and nothing to move or maximize, so "
+"the buttons are normally hidden there. Turn this on to keep a way out of "
+"full screen that is not a keyboard shortcut."
+msgstr ""
+
+#: jellyfin_mpv_shim/mpvtk_browser/config.py
+msgid ""
+"Asks the desktop for no title bar on the player window, so the top bar above "
+"is the only one. Pairs with the setting above: on \"Only when the window has "
+"no title bar\" the buttons appear as soon as this is on. Leave both off "
+"unless you want them, since a window with neither can be awkward to move on "
+"some desktops."
+msgstr ""
+
+#: jellyfin_mpv_shim/mpvtk_browser/config.py
+msgid ""
+"Shows a preview frame while you drag the seek bar. Works with every player "
+"control style, including your own OSC script if it supports thumbfast. The "
+"images are fetched from the server per video, which costs disk space and "
+"memory -- tens of MB for an episode, a few hundred for a long film."
 msgstr ""
 
 #: jellyfin_mpv_shim/mpvtk_browser/config.py
@@ -2049,6 +2118,13 @@ msgstr ""
 
 #: jellyfin_mpv_shim/mpvtk_browser/config.py
 msgid ""
+"Show times of day as \"8:30 PM\" rather than \"20:30\" — the Live TV guide "
+"and its air times, and the \"Ends at\" labels on a detail page and the "
+"player controls."
+msgstr ""
+
+#: jellyfin_mpv_shim/mpvtk_browser/config.py
+msgid ""
 "The controls have to stay legible over any frame. \"None\" gives the text a "
 "drop shadow instead of shading the picture behind it."
 msgstr ""
@@ -2063,6 +2139,13 @@ msgstr ""
 msgid ""
 "0 hides them as soon as the pointer is not on them, and forces \"Hide unless "
 "hovered\"."
+msgstr ""
+
+#: jellyfin_mpv_shim/mpvtk_browser/config.py
+msgid ""
+"Narrowing the window shrinks the controls until the smallest button reaches "
+"the accessibility minimum, instead of dropping buttons sooner. Off keeps the "
+"older, larger floor."
 msgstr ""
 
 #: jellyfin_mpv_shim/mpvtk_browser/config.py
@@ -3403,6 +3486,7 @@ msgid "More Like This"
 msgstr ""
 
 #: jellyfin_mpv_shim/mpvtk_browser/pages/detail.py
+#: jellyfin_mpv_shim/mpvtk_browser/tiles.py
 msgid "Go to Series"
 msgstr ""
 
@@ -4397,6 +4481,22 @@ msgstr ""
 msgid "There is nothing here to queue."
 msgstr ""
 
+#: jellyfin_mpv_shim/mpvtk_browser/timefmt.py
+#, python-brace-format
+msgctxt "12-hour clock"
+msgid "{time} {period}"
+msgstr ""
+
+#: jellyfin_mpv_shim/mpvtk_browser/timefmt.py
+msgctxt "12-hour clock"
+msgid "AM"
+msgstr ""
+
+#: jellyfin_mpv_shim/mpvtk_browser/timefmt.py
+msgctxt "12-hour clock"
+msgid "PM"
+msgstr ""
+
 #: jellyfin_mpv_shim/mpvtk_browser/views.py
 #: jellyfin_mpv_shim/mpvtk_browser/window_chrome.py
 msgid "Search"
@@ -4547,13 +4647,32 @@ msgid "Enable SVP"
 msgstr ""
 
 #: jellyfin_mpv_shim/sync/manager.py
+msgid "The downloads are already in that folder."
+msgstr ""
+
+#: jellyfin_mpv_shim/sync/manager.py
 msgid ""
 "Can't change the download folder while a download is in progress. Wait for "
 "it to finish, then try again."
 msgstr ""
 
 #: jellyfin_mpv_shim/sync/manager.py
+msgid ""
+"That folder is inside the current download folder. Choose one outside it."
+msgstr ""
+
+#: jellyfin_mpv_shim/sync/manager.py
+msgid "Can't read that folder. Check the path and its permissions."
+msgstr ""
+
+#: jellyfin_mpv_shim/sync/manager.py
 msgid "That folder already contains downloads. Choose an empty folder."
+msgstr ""
+
+#: jellyfin_mpv_shim/sync/manager.py
+msgid ""
+"That folder isn't empty. Choose an empty folder — the download folder is "
+"managed by this app and anything else in it can be moved or removed."
 msgstr ""
 
 #: jellyfin_mpv_shim/sync/manager.py
@@ -4562,6 +4681,12 @@ msgstr ""
 
 #: jellyfin_mpv_shim/sync/manager.py
 msgid "A download is still finishing. Wait for it to stop, then try again."
+msgstr ""
+
+#: jellyfin_mpv_shim/sync/manager.py
+msgid ""
+"There isn't enough space on that drive to move the downloads. Free some "
+"space and try again — nothing was moved."
 msgstr ""
 
 #: jellyfin_mpv_shim/sync/manager.py

--- a/jellyfin_mpv_shim/messages/ar/LC_MESSAGES/base.po
+++ b/jellyfin_mpv_shim/messages/ar/LC_MESSAGES/base.po
@@ -6,7 +6,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2026-08-30 22:19-0400\n"
+"POT-Creation-Date: 2026-09-07 17:35-0400\n"
 "PO-Revision-Date: 2026-09-02 16:00+0000\n"
 "Last-Translator: Translation expert <eleceng4ever@hotmail.com>\n"
 "Language-Team: Arabic <https://translate.jellyfin.org/projects/jellyfin/"
@@ -508,6 +508,11 @@ msgid "Night Mode (Auto Volume Adj)"
 msgstr "النمط الليلي (ضبط صوت تلقائي)"
 
 #: jellyfin_mpv_shim/mpvtk_browser/app.py
+#: jellyfin_mpv_shim/mpvtk_browser/auth.py
+msgid "Locked"
+msgstr "مقفل"
+
+#: jellyfin_mpv_shim/mpvtk_browser/app.py
 msgid "Failed to load. Check the connection."
 msgstr "فشل التحميل. تأكد من التوصيل."
 
@@ -750,10 +755,6 @@ msgid "Could not connect. Please check your details."
 msgstr "تعذر التواصل مع الخادم. يرجى مراجعة تفاصيلك."
 
 #: jellyfin_mpv_shim/mpvtk_browser/auth.py
-msgid "Locked"
-msgstr "مقفل"
-
-#: jellyfin_mpv_shim/mpvtk_browser/auth.py
 #: jellyfin_mpv_shim/mpvtk_browser/pages/home.py
 msgid "Connecting to your server…"
 msgstr "التوصيل لخادمك…"
@@ -827,6 +828,10 @@ msgstr "مُشاهد"
 #: jellyfin_mpv_shim/mpvtk_browser/pages/books.py
 msgid "Favorite"
 msgstr "مفضل"
+
+#: jellyfin_mpv_shim/mpvtk_browser/components/detail.py
+msgid "Web"
+msgstr ""
 
 # seeded from jellyfin-web: Video
 #: jellyfin_mpv_shim/mpvtk_browser/components/media_info.py
@@ -1397,12 +1402,8 @@ msgid "Jellyfin UI"
 msgstr "واجهة Jellyfin"
 
 #: jellyfin_mpv_shim/mpvtk_browser/config.py
-msgid "MPV UI with thumbnails"
-msgstr "واجهة MPV مع صور مصغرة"
-
-#: jellyfin_mpv_shim/mpvtk_browser/config.py
-msgid "MPV built-in default"
-msgstr "MPV المضمن تلقائيا"
+msgid "MPV UI"
+msgstr ""
 
 #: jellyfin_mpv_shim/mpvtk_browser/config.py
 msgid "Custom OSC"
@@ -1741,8 +1742,24 @@ msgid "Window Buttons in the Top Bar"
 msgstr "أظرار النافذة في الشريط الأعلى"
 
 #: jellyfin_mpv_shim/mpvtk_browser/config.py
+#, fuzzy
+#| msgid "Window Buttons in the Top Bar"
+msgid "Keep Window Buttons in Full Screen"
+msgstr "أظرار النافذة في الشريط الأعلى"
+
+#: jellyfin_mpv_shim/mpvtk_browser/config.py
+msgid "Hide the Desktop Title Bar"
+msgstr ""
+
+#: jellyfin_mpv_shim/mpvtk_browser/config.py
 msgid "Player Controls Style"
 msgstr "نمط متحكمات المشغل"
+
+#: jellyfin_mpv_shim/mpvtk_browser/config.py
+#, fuzzy
+#| msgid "Enable thumbnail previews"
+msgid "Enable Trickplay Thumbnails"
+msgstr "تمكين الصور المصغرة للمعاينة"
 
 #: jellyfin_mpv_shim/mpvtk_browser/config.py
 msgid "Load All Seek Previews at Once"
@@ -1773,6 +1790,10 @@ msgstr "حجم الغلاف"
 
 #: jellyfin_mpv_shim/mpvtk_browser/config.py
 msgid "Full-Width Backdrops"
+msgstr ""
+
+#: jellyfin_mpv_shim/mpvtk_browser/config.py
+msgid "12-Hour Clock"
 msgstr ""
 
 #: jellyfin_mpv_shim/mpvtk_browser/config.py
@@ -1819,12 +1840,23 @@ msgid "Fullscreen Library Browser"
 msgstr ""
 
 #: jellyfin_mpv_shim/mpvtk_browser/config.py
+msgid "Block Player Keybinds While Browsing"
+msgstr ""
+
+#: jellyfin_mpv_shim/mpvtk_browser/config.py
 msgid "Always Bind Arrow Keys to Player Controls"
 msgstr ""
 
 #: jellyfin_mpv_shim/mpvtk_browser/config.py
 msgid "Player Controls Activation Key"
 msgstr ""
+
+# seeded from jellyfin-web: SelectAll
+#: jellyfin_mpv_shim/mpvtk_browser/config.py
+#, fuzzy
+#| msgid "Select All"
+msgid "Select Key"
+msgstr "اختيار الكل"
 
 #: jellyfin_mpv_shim/mpvtk_browser/config.py
 msgid "Shading Behind the Player Controls"
@@ -1836,6 +1868,10 @@ msgstr ""
 
 #: jellyfin_mpv_shim/mpvtk_browser/config.py
 msgid "Hide the Player Controls After (seconds)"
+msgstr ""
+
+#: jellyfin_mpv_shim/mpvtk_browser/config.py
+msgid "Shrink the Player Controls on a Narrow Window"
 msgstr ""
 
 #: jellyfin_mpv_shim/mpvtk_browser/config.py
@@ -1922,6 +1958,21 @@ msgstr ""
 
 #: jellyfin_mpv_shim/mpvtk_browser/config.py
 msgid ""
+"Stops MPV's own shortcuts -- picture adjustment, screenshots, subtitle and "
+"audio switching -- from acting while you are in the library, where there is "
+"no video for them to act on. Turn it off to use your own MPV key bindings "
+"there."
+msgstr ""
+
+#: jellyfin_mpv_shim/mpvtk_browser/config.py
+msgid ""
+"Activates whatever is highlighted, in the library and on the player "
+"controls. An mpv key name; changing it hands Enter back to MPV. The game "
+"controller's Confirm button and a phone's Select follow it."
+msgstr ""
+
+#: jellyfin_mpv_shim/mpvtk_browser/config.py
+msgid ""
 "Leave these blank unless downloads are waking your disks too often. Set both "
 "of the first two together: episodes are then fetched in one batch when a "
 "series runs low, instead of one at a time."
@@ -1935,7 +1986,8 @@ msgstr ""
 #: jellyfin_mpv_shim/mpvtk_browser/config.py
 msgid ""
 "Off gives MPV's own mouse behaviour instead: drag the video to move the "
-"window, and right click to pause. Double click is full screen either way."
+"window, and the right button does whatever your MPV config gives it. Double "
+"click is full screen either way."
 msgstr ""
 
 #: jellyfin_mpv_shim/mpvtk_browser/config.py
@@ -2025,6 +2077,30 @@ msgid ""
 "maximize and close in the top bar instead, and lets you drag the window by "
 "it. On \"Only when the window has no title bar\", MPV is asked whether this "
 "window got one, so desktops that draw a title bar are left alone."
+msgstr ""
+
+#: jellyfin_mpv_shim/mpvtk_browser/config.py
+msgid ""
+"Full screen has no title bar anywhere and nothing to move or maximize, so "
+"the buttons are normally hidden there. Turn this on to keep a way out of "
+"full screen that is not a keyboard shortcut."
+msgstr ""
+
+#: jellyfin_mpv_shim/mpvtk_browser/config.py
+msgid ""
+"Asks the desktop for no title bar on the player window, so the top bar above "
+"is the only one. Pairs with the setting above: on \"Only when the window has "
+"no title bar\" the buttons appear as soon as this is on. Leave both off "
+"unless you want them, since a window with neither can be awkward to move on "
+"some desktops."
+msgstr ""
+
+#: jellyfin_mpv_shim/mpvtk_browser/config.py
+msgid ""
+"Shows a preview frame while you drag the seek bar. Works with every player "
+"control style, including your own OSC script if it supports thumbfast. The "
+"images are fetched from the server per video, which costs disk space and "
+"memory -- tens of MB for an episode, a few hundred for a long film."
 msgstr ""
 
 #: jellyfin_mpv_shim/mpvtk_browser/config.py
@@ -2132,6 +2208,13 @@ msgstr ""
 
 #: jellyfin_mpv_shim/mpvtk_browser/config.py
 msgid ""
+"Show times of day as \"8:30 PM\" rather than \"20:30\" — the Live TV guide "
+"and its air times, and the \"Ends at\" labels on a detail page and the "
+"player controls."
+msgstr ""
+
+#: jellyfin_mpv_shim/mpvtk_browser/config.py
+msgid ""
 "The controls have to stay legible over any frame. \"None\" gives the text a "
 "drop shadow instead of shading the picture behind it."
 msgstr ""
@@ -2146,6 +2229,13 @@ msgstr ""
 msgid ""
 "0 hides them as soon as the pointer is not on them, and forces \"Hide unless "
 "hovered\"."
+msgstr ""
+
+#: jellyfin_mpv_shim/mpvtk_browser/config.py
+msgid ""
+"Narrowing the window shrinks the controls until the smallest button reaches "
+"the accessibility minimum, instead of dropping buttons sooner. Off keeps the "
+"older, larger floor."
 msgstr ""
 
 #: jellyfin_mpv_shim/mpvtk_browser/config.py
@@ -3712,6 +3802,7 @@ msgid "More Like This"
 msgstr "المزيد من المثيل لهذا"
 
 #: jellyfin_mpv_shim/mpvtk_browser/pages/detail.py
+#: jellyfin_mpv_shim/mpvtk_browser/tiles.py
 msgid "Go to Series"
 msgstr ""
 
@@ -4850,6 +4941,22 @@ msgstr "حذف %s من هذه التجميعة؟"
 msgid "There is nothing here to queue."
 msgstr "لا يوجد شيء هنا للترصيف."
 
+#: jellyfin_mpv_shim/mpvtk_browser/timefmt.py
+#, python-brace-format
+msgctxt "12-hour clock"
+msgid "{time} {period}"
+msgstr ""
+
+#: jellyfin_mpv_shim/mpvtk_browser/timefmt.py
+msgctxt "12-hour clock"
+msgid "AM"
+msgstr ""
+
+#: jellyfin_mpv_shim/mpvtk_browser/timefmt.py
+msgctxt "12-hour clock"
+msgid "PM"
+msgstr ""
+
 # seeded from jellyfin-web: Search
 #: jellyfin_mpv_shim/mpvtk_browser/views.py
 #: jellyfin_mpv_shim/mpvtk_browser/window_chrome.py
@@ -5006,6 +5113,10 @@ msgid "Enable SVP"
 msgstr "تفعيل SVP"
 
 #: jellyfin_mpv_shim/sync/manager.py
+msgid "The downloads are already in that folder."
+msgstr ""
+
+#: jellyfin_mpv_shim/sync/manager.py
 msgid ""
 "Can't change the download folder while a download is in progress. Wait for "
 "it to finish, then try again."
@@ -5014,8 +5125,27 @@ msgstr ""
 "اخرى."
 
 #: jellyfin_mpv_shim/sync/manager.py
+#, fuzzy
+#| msgid "That folder already contains downloads. Choose an empty folder."
+msgid ""
+"That folder is inside the current download folder. Choose one outside it."
+msgstr "هذا المجلد يحتوي على ملفات منزلة. اختر ملجد فارغ."
+
+#: jellyfin_mpv_shim/sync/manager.py
+#, fuzzy
+#| msgid "Can't create that folder. Check the path and its permissions."
+msgid "Can't read that folder. Check the path and its permissions."
+msgstr "تعذر تكون هذا المجلد. افحص المسار و تصاريحه."
+
+#: jellyfin_mpv_shim/sync/manager.py
 msgid "That folder already contains downloads. Choose an empty folder."
 msgstr "هذا المجلد يحتوي على ملفات منزلة. اختر ملجد فارغ."
+
+#: jellyfin_mpv_shim/sync/manager.py
+msgid ""
+"That folder isn't empty. Choose an empty folder — the download folder is "
+"managed by this app and anything else in it can be moved or removed."
+msgstr ""
 
 #: jellyfin_mpv_shim/sync/manager.py
 msgid "Can't create that folder. Check the path and its permissions."
@@ -5024,6 +5154,12 @@ msgstr "تعذر تكون هذا المجلد. افحص المسار و تصار
 #: jellyfin_mpv_shim/sync/manager.py
 msgid "A download is still finishing. Wait for it to stop, then try again."
 msgstr "عملية تنزيل تنتهي اللآن. انتظر حتى تنتهي, ثم جرب مرة اخرى."
+
+#: jellyfin_mpv_shim/sync/manager.py
+msgid ""
+"There isn't enough space on that drive to move the downloads. Free some "
+"space and try again — nothing was moved."
+msgstr ""
 
 #: jellyfin_mpv_shim/sync/manager.py
 msgid ""
@@ -5222,6 +5358,12 @@ msgstr "ملف تشغيل الفيديو"
 #: jellyfin_mpv_shim/video_profile.py
 msgid "Select Shader Profile"
 msgstr "تحديد وضع التظليل"
+
+#~ msgid "MPV UI with thumbnails"
+#~ msgstr "واجهة MPV مع صور مصغرة"
+
+#~ msgid "MPV built-in default"
+#~ msgstr "MPV المضمن تلقائيا"
 
 #, fuzzy
 #~| msgid "Could not copy the log."

--- a/jellyfin_mpv_shim/messages/az/LC_MESSAGES/base.po
+++ b/jellyfin_mpv_shim/messages/az/LC_MESSAGES/base.po
@@ -6,7 +6,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2026-08-30 22:19-0400\n"
+"POT-Creation-Date: 2026-09-07 17:35-0400\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: Automatically generated\n"
 "Language-Team: none\n"
@@ -504,6 +504,11 @@ msgid "Night Mode (Auto Volume Adj)"
 msgstr ""
 
 #: jellyfin_mpv_shim/mpvtk_browser/app.py
+#: jellyfin_mpv_shim/mpvtk_browser/auth.py
+msgid "Locked"
+msgstr ""
+
+#: jellyfin_mpv_shim/mpvtk_browser/app.py
 msgid "Failed to load. Check the connection."
 msgstr ""
 
@@ -744,10 +749,6 @@ msgid "Could not connect. Please check your details."
 msgstr ""
 
 #: jellyfin_mpv_shim/mpvtk_browser/auth.py
-msgid "Locked"
-msgstr ""
-
-#: jellyfin_mpv_shim/mpvtk_browser/auth.py
 #: jellyfin_mpv_shim/mpvtk_browser/pages/home.py
 msgid "Connecting to your server…"
 msgstr ""
@@ -817,6 +818,10 @@ msgstr ""
 #: jellyfin_mpv_shim/mpvtk_browser/hud.py
 #: jellyfin_mpv_shim/mpvtk_browser/pages/books.py
 msgid "Favorite"
+msgstr ""
+
+#: jellyfin_mpv_shim/mpvtk_browser/components/detail.py
+msgid "Web"
 msgstr ""
 
 #: jellyfin_mpv_shim/mpvtk_browser/components/media_info.py
@@ -1322,11 +1327,7 @@ msgid "Jellyfin UI"
 msgstr ""
 
 #: jellyfin_mpv_shim/mpvtk_browser/config.py
-msgid "MPV UI with thumbnails"
-msgstr ""
-
-#: jellyfin_mpv_shim/mpvtk_browser/config.py
-msgid "MPV built-in default"
+msgid "MPV UI"
 msgstr ""
 
 #: jellyfin_mpv_shim/mpvtk_browser/config.py
@@ -1659,7 +1660,19 @@ msgid "Window Buttons in the Top Bar"
 msgstr ""
 
 #: jellyfin_mpv_shim/mpvtk_browser/config.py
+msgid "Keep Window Buttons in Full Screen"
+msgstr ""
+
+#: jellyfin_mpv_shim/mpvtk_browser/config.py
+msgid "Hide the Desktop Title Bar"
+msgstr ""
+
+#: jellyfin_mpv_shim/mpvtk_browser/config.py
 msgid "Player Controls Style"
+msgstr ""
+
+#: jellyfin_mpv_shim/mpvtk_browser/config.py
+msgid "Enable Trickplay Thumbnails"
 msgstr ""
 
 #: jellyfin_mpv_shim/mpvtk_browser/config.py
@@ -1689,6 +1702,10 @@ msgstr ""
 
 #: jellyfin_mpv_shim/mpvtk_browser/config.py
 msgid "Full-Width Backdrops"
+msgstr ""
+
+#: jellyfin_mpv_shim/mpvtk_browser/config.py
+msgid "12-Hour Clock"
 msgstr ""
 
 #: jellyfin_mpv_shim/mpvtk_browser/config.py
@@ -1732,11 +1749,19 @@ msgid "Fullscreen Library Browser"
 msgstr ""
 
 #: jellyfin_mpv_shim/mpvtk_browser/config.py
+msgid "Block Player Keybinds While Browsing"
+msgstr ""
+
+#: jellyfin_mpv_shim/mpvtk_browser/config.py
 msgid "Always Bind Arrow Keys to Player Controls"
 msgstr ""
 
 #: jellyfin_mpv_shim/mpvtk_browser/config.py
 msgid "Player Controls Activation Key"
+msgstr ""
+
+#: jellyfin_mpv_shim/mpvtk_browser/config.py
+msgid "Select Key"
 msgstr ""
 
 #: jellyfin_mpv_shim/mpvtk_browser/config.py
@@ -1749,6 +1774,10 @@ msgstr ""
 
 #: jellyfin_mpv_shim/mpvtk_browser/config.py
 msgid "Hide the Player Controls After (seconds)"
+msgstr ""
+
+#: jellyfin_mpv_shim/mpvtk_browser/config.py
+msgid "Shrink the Player Controls on a Narrow Window"
 msgstr ""
 
 #: jellyfin_mpv_shim/mpvtk_browser/config.py
@@ -1831,6 +1860,21 @@ msgstr ""
 
 #: jellyfin_mpv_shim/mpvtk_browser/config.py
 msgid ""
+"Stops MPV's own shortcuts -- picture adjustment, screenshots, subtitle and "
+"audio switching -- from acting while you are in the library, where there is "
+"no video for them to act on. Turn it off to use your own MPV key bindings "
+"there."
+msgstr ""
+
+#: jellyfin_mpv_shim/mpvtk_browser/config.py
+msgid ""
+"Activates whatever is highlighted, in the library and on the player "
+"controls. An mpv key name; changing it hands Enter back to MPV. The game "
+"controller's Confirm button and a phone's Select follow it."
+msgstr ""
+
+#: jellyfin_mpv_shim/mpvtk_browser/config.py
+msgid ""
 "Leave these blank unless downloads are waking your disks too often. Set both "
 "of the first two together: episodes are then fetched in one batch when a "
 "series runs low, instead of one at a time."
@@ -1844,7 +1888,8 @@ msgstr ""
 #: jellyfin_mpv_shim/mpvtk_browser/config.py
 msgid ""
 "Off gives MPV's own mouse behaviour instead: drag the video to move the "
-"window, and right click to pause. Double click is full screen either way."
+"window, and the right button does whatever your MPV config gives it. Double "
+"click is full screen either way."
 msgstr ""
 
 #: jellyfin_mpv_shim/mpvtk_browser/config.py
@@ -1934,6 +1979,30 @@ msgid ""
 "maximize and close in the top bar instead, and lets you drag the window by "
 "it. On \"Only when the window has no title bar\", MPV is asked whether this "
 "window got one, so desktops that draw a title bar are left alone."
+msgstr ""
+
+#: jellyfin_mpv_shim/mpvtk_browser/config.py
+msgid ""
+"Full screen has no title bar anywhere and nothing to move or maximize, so "
+"the buttons are normally hidden there. Turn this on to keep a way out of "
+"full screen that is not a keyboard shortcut."
+msgstr ""
+
+#: jellyfin_mpv_shim/mpvtk_browser/config.py
+msgid ""
+"Asks the desktop for no title bar on the player window, so the top bar above "
+"is the only one. Pairs with the setting above: on \"Only when the window has "
+"no title bar\" the buttons appear as soon as this is on. Leave both off "
+"unless you want them, since a window with neither can be awkward to move on "
+"some desktops."
+msgstr ""
+
+#: jellyfin_mpv_shim/mpvtk_browser/config.py
+msgid ""
+"Shows a preview frame while you drag the seek bar. Works with every player "
+"control style, including your own OSC script if it supports thumbfast. The "
+"images are fetched from the server per video, which costs disk space and "
+"memory -- tens of MB for an episode, a few hundred for a long film."
 msgstr ""
 
 #: jellyfin_mpv_shim/mpvtk_browser/config.py
@@ -2041,6 +2110,13 @@ msgstr ""
 
 #: jellyfin_mpv_shim/mpvtk_browser/config.py
 msgid ""
+"Show times of day as \"8:30 PM\" rather than \"20:30\" — the Live TV guide "
+"and its air times, and the \"Ends at\" labels on a detail page and the "
+"player controls."
+msgstr ""
+
+#: jellyfin_mpv_shim/mpvtk_browser/config.py
+msgid ""
 "The controls have to stay legible over any frame. \"None\" gives the text a "
 "drop shadow instead of shading the picture behind it."
 msgstr ""
@@ -2055,6 +2131,13 @@ msgstr ""
 msgid ""
 "0 hides them as soon as the pointer is not on them, and forces \"Hide unless "
 "hovered\"."
+msgstr ""
+
+#: jellyfin_mpv_shim/mpvtk_browser/config.py
+msgid ""
+"Narrowing the window shrinks the controls until the smallest button reaches "
+"the accessibility minimum, instead of dropping buttons sooner. Off keeps the "
+"older, larger floor."
 msgstr ""
 
 #: jellyfin_mpv_shim/mpvtk_browser/config.py
@@ -3383,6 +3466,7 @@ msgid "More Like This"
 msgstr ""
 
 #: jellyfin_mpv_shim/mpvtk_browser/pages/detail.py
+#: jellyfin_mpv_shim/mpvtk_browser/tiles.py
 msgid "Go to Series"
 msgstr ""
 
@@ -4377,6 +4461,22 @@ msgstr ""
 msgid "There is nothing here to queue."
 msgstr ""
 
+#: jellyfin_mpv_shim/mpvtk_browser/timefmt.py
+#, python-brace-format
+msgctxt "12-hour clock"
+msgid "{time} {period}"
+msgstr ""
+
+#: jellyfin_mpv_shim/mpvtk_browser/timefmt.py
+msgctxt "12-hour clock"
+msgid "AM"
+msgstr ""
+
+#: jellyfin_mpv_shim/mpvtk_browser/timefmt.py
+msgctxt "12-hour clock"
+msgid "PM"
+msgstr ""
+
 #: jellyfin_mpv_shim/mpvtk_browser/views.py
 #: jellyfin_mpv_shim/mpvtk_browser/window_chrome.py
 msgid "Search"
@@ -4527,13 +4627,32 @@ msgid "Enable SVP"
 msgstr ""
 
 #: jellyfin_mpv_shim/sync/manager.py
+msgid "The downloads are already in that folder."
+msgstr ""
+
+#: jellyfin_mpv_shim/sync/manager.py
 msgid ""
 "Can't change the download folder while a download is in progress. Wait for "
 "it to finish, then try again."
 msgstr ""
 
 #: jellyfin_mpv_shim/sync/manager.py
+msgid ""
+"That folder is inside the current download folder. Choose one outside it."
+msgstr ""
+
+#: jellyfin_mpv_shim/sync/manager.py
+msgid "Can't read that folder. Check the path and its permissions."
+msgstr ""
+
+#: jellyfin_mpv_shim/sync/manager.py
 msgid "That folder already contains downloads. Choose an empty folder."
+msgstr ""
+
+#: jellyfin_mpv_shim/sync/manager.py
+msgid ""
+"That folder isn't empty. Choose an empty folder — the download folder is "
+"managed by this app and anything else in it can be moved or removed."
 msgstr ""
 
 #: jellyfin_mpv_shim/sync/manager.py
@@ -4542,6 +4661,12 @@ msgstr ""
 
 #: jellyfin_mpv_shim/sync/manager.py
 msgid "A download is still finishing. Wait for it to stop, then try again."
+msgstr ""
+
+#: jellyfin_mpv_shim/sync/manager.py
+msgid ""
+"There isn't enough space on that drive to move the downloads. Free some "
+"space and try again — nothing was moved."
 msgstr ""
 
 #: jellyfin_mpv_shim/sync/manager.py

--- a/jellyfin_mpv_shim/messages/base.pot
+++ b/jellyfin_mpv_shim/messages/base.pot
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: jellyfin-mpv-shim\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2026-09-06 16:28-0400\n"
+"POT-Creation-Date: 2026-09-07 17:35-0400\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -4621,6 +4621,10 @@ msgstr ""
 
 #: jellyfin_mpv_shim/svp_integration.py
 msgid "Enable SVP"
+msgstr ""
+
+#: jellyfin_mpv_shim/sync/manager.py
+msgid "The downloads are already in that folder."
 msgstr ""
 
 #: jellyfin_mpv_shim/sync/manager.py

--- a/jellyfin_mpv_shim/messages/be/LC_MESSAGES/base.po
+++ b/jellyfin_mpv_shim/messages/be/LC_MESSAGES/base.po
@@ -6,7 +6,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2026-08-30 22:19-0400\n"
+"POT-Creation-Date: 2026-09-07 17:35-0400\n"
 "PO-Revision-Date: 2026-06-29 09:08+0000\n"
 "Last-Translator: Pavel Miniutka <pavel.miniutka@gmail.com>\n"
 "Language-Team: Belarusian <https://translate.jellyfin.org/projects/jellyfin/"
@@ -542,6 +542,11 @@ msgid "Night Mode (Auto Volume Adj)"
 msgstr ""
 
 #: jellyfin_mpv_shim/mpvtk_browser/app.py
+#: jellyfin_mpv_shim/mpvtk_browser/auth.py
+msgid "Locked"
+msgstr ""
+
+#: jellyfin_mpv_shim/mpvtk_browser/app.py
 msgid "Failed to load. Check the connection."
 msgstr ""
 
@@ -801,10 +806,6 @@ msgstr ""
 "Праверце інфармацыю аб падлучэнні."
 
 #: jellyfin_mpv_shim/mpvtk_browser/auth.py
-msgid "Locked"
-msgstr ""
-
-#: jellyfin_mpv_shim/mpvtk_browser/auth.py
 #: jellyfin_mpv_shim/mpvtk_browser/pages/home.py
 msgid "Connecting to your server…"
 msgstr ""
@@ -880,6 +881,10 @@ msgstr "Выйсці і пазначыць неназіраным"
 #: jellyfin_mpv_shim/mpvtk_browser/hud.py
 #: jellyfin_mpv_shim/mpvtk_browser/pages/books.py
 msgid "Favorite"
+msgstr ""
+
+#: jellyfin_mpv_shim/mpvtk_browser/components/detail.py
+msgid "Web"
 msgstr ""
 
 #: jellyfin_mpv_shim/mpvtk_browser/components/media_info.py
@@ -1417,11 +1422,7 @@ msgid "Jellyfin UI"
 msgstr ""
 
 #: jellyfin_mpv_shim/mpvtk_browser/config.py
-msgid "MPV UI with thumbnails"
-msgstr ""
-
-#: jellyfin_mpv_shim/mpvtk_browser/config.py
-msgid "MPV built-in default"
+msgid "MPV UI"
 msgstr ""
 
 #: jellyfin_mpv_shim/mpvtk_browser/config.py
@@ -1766,8 +1767,22 @@ msgid "Window Buttons in the Top Bar"
 msgstr ""
 
 #: jellyfin_mpv_shim/mpvtk_browser/config.py
+msgid "Keep Window Buttons in Full Screen"
+msgstr ""
+
+#: jellyfin_mpv_shim/mpvtk_browser/config.py
+msgid "Hide the Desktop Title Bar"
+msgstr ""
+
+#: jellyfin_mpv_shim/mpvtk_browser/config.py
 msgid "Player Controls Style"
 msgstr ""
+
+#: jellyfin_mpv_shim/mpvtk_browser/config.py
+#, fuzzy
+#| msgid "Enable thumbnail previews"
+msgid "Enable Trickplay Thumbnails"
+msgstr "Уключыць папярэдні прагляд мініяцюр"
 
 #: jellyfin_mpv_shim/mpvtk_browser/config.py
 msgid "Load All Seek Previews at Once"
@@ -1796,6 +1811,10 @@ msgstr ""
 
 #: jellyfin_mpv_shim/mpvtk_browser/config.py
 msgid "Full-Width Backdrops"
+msgstr ""
+
+#: jellyfin_mpv_shim/mpvtk_browser/config.py
+msgid "12-Hour Clock"
 msgstr ""
 
 #: jellyfin_mpv_shim/mpvtk_browser/config.py
@@ -1839,11 +1858,19 @@ msgid "Fullscreen Library Browser"
 msgstr ""
 
 #: jellyfin_mpv_shim/mpvtk_browser/config.py
+msgid "Block Player Keybinds While Browsing"
+msgstr ""
+
+#: jellyfin_mpv_shim/mpvtk_browser/config.py
 msgid "Always Bind Arrow Keys to Player Controls"
 msgstr ""
 
 #: jellyfin_mpv_shim/mpvtk_browser/config.py
 msgid "Player Controls Activation Key"
+msgstr ""
+
+#: jellyfin_mpv_shim/mpvtk_browser/config.py
+msgid "Select Key"
 msgstr ""
 
 #: jellyfin_mpv_shim/mpvtk_browser/config.py
@@ -1856,6 +1883,10 @@ msgstr ""
 
 #: jellyfin_mpv_shim/mpvtk_browser/config.py
 msgid "Hide the Player Controls After (seconds)"
+msgstr ""
+
+#: jellyfin_mpv_shim/mpvtk_browser/config.py
+msgid "Shrink the Player Controls on a Narrow Window"
 msgstr ""
 
 #: jellyfin_mpv_shim/mpvtk_browser/config.py
@@ -1942,6 +1973,21 @@ msgstr ""
 
 #: jellyfin_mpv_shim/mpvtk_browser/config.py
 msgid ""
+"Stops MPV's own shortcuts -- picture adjustment, screenshots, subtitle and "
+"audio switching -- from acting while you are in the library, where there is "
+"no video for them to act on. Turn it off to use your own MPV key bindings "
+"there."
+msgstr ""
+
+#: jellyfin_mpv_shim/mpvtk_browser/config.py
+msgid ""
+"Activates whatever is highlighted, in the library and on the player "
+"controls. An mpv key name; changing it hands Enter back to MPV. The game "
+"controller's Confirm button and a phone's Select follow it."
+msgstr ""
+
+#: jellyfin_mpv_shim/mpvtk_browser/config.py
+msgid ""
 "Leave these blank unless downloads are waking your disks too often. Set both "
 "of the first two together: episodes are then fetched in one batch when a "
 "series runs low, instead of one at a time."
@@ -1955,7 +2001,8 @@ msgstr ""
 #: jellyfin_mpv_shim/mpvtk_browser/config.py
 msgid ""
 "Off gives MPV's own mouse behaviour instead: drag the video to move the "
-"window, and right click to pause. Double click is full screen either way."
+"window, and the right button does whatever your MPV config gives it. Double "
+"click is full screen either way."
 msgstr ""
 
 #: jellyfin_mpv_shim/mpvtk_browser/config.py
@@ -2045,6 +2092,30 @@ msgid ""
 "maximize and close in the top bar instead, and lets you drag the window by "
 "it. On \"Only when the window has no title bar\", MPV is asked whether this "
 "window got one, so desktops that draw a title bar are left alone."
+msgstr ""
+
+#: jellyfin_mpv_shim/mpvtk_browser/config.py
+msgid ""
+"Full screen has no title bar anywhere and nothing to move or maximize, so "
+"the buttons are normally hidden there. Turn this on to keep a way out of "
+"full screen that is not a keyboard shortcut."
+msgstr ""
+
+#: jellyfin_mpv_shim/mpvtk_browser/config.py
+msgid ""
+"Asks the desktop for no title bar on the player window, so the top bar above "
+"is the only one. Pairs with the setting above: on \"Only when the window has "
+"no title bar\" the buttons appear as soon as this is on. Leave both off "
+"unless you want them, since a window with neither can be awkward to move on "
+"some desktops."
+msgstr ""
+
+#: jellyfin_mpv_shim/mpvtk_browser/config.py
+msgid ""
+"Shows a preview frame while you drag the seek bar. Works with every player "
+"control style, including your own OSC script if it supports thumbfast. The "
+"images are fetched from the server per video, which costs disk space and "
+"memory -- tens of MB for an episode, a few hundred for a long film."
 msgstr ""
 
 #: jellyfin_mpv_shim/mpvtk_browser/config.py
@@ -2154,6 +2225,13 @@ msgstr ""
 
 #: jellyfin_mpv_shim/mpvtk_browser/config.py
 msgid ""
+"Show times of day as \"8:30 PM\" rather than \"20:30\" — the Live TV guide "
+"and its air times, and the \"Ends at\" labels on a detail page and the "
+"player controls."
+msgstr ""
+
+#: jellyfin_mpv_shim/mpvtk_browser/config.py
+msgid ""
 "The controls have to stay legible over any frame. \"None\" gives the text a "
 "drop shadow instead of shading the picture behind it."
 msgstr ""
@@ -2168,6 +2246,13 @@ msgstr ""
 msgid ""
 "0 hides them as soon as the pointer is not on them, and forces \"Hide unless "
 "hovered\"."
+msgstr ""
+
+#: jellyfin_mpv_shim/mpvtk_browser/config.py
+msgid ""
+"Narrowing the window shrinks the controls until the smallest button reaches "
+"the accessibility minimum, instead of dropping buttons sooner. Off keeps the "
+"older, larger floor."
 msgstr ""
 
 #: jellyfin_mpv_shim/mpvtk_browser/config.py
@@ -3611,6 +3696,7 @@ msgid "More Like This"
 msgstr ""
 
 #: jellyfin_mpv_shim/mpvtk_browser/pages/detail.py
+#: jellyfin_mpv_shim/mpvtk_browser/tiles.py
 msgid "Go to Series"
 msgstr ""
 
@@ -4684,6 +4770,22 @@ msgstr ""
 msgid "There is nothing here to queue."
 msgstr ""
 
+#: jellyfin_mpv_shim/mpvtk_browser/timefmt.py
+#, python-brace-format
+msgctxt "12-hour clock"
+msgid "{time} {period}"
+msgstr ""
+
+#: jellyfin_mpv_shim/mpvtk_browser/timefmt.py
+msgctxt "12-hour clock"
+msgid "AM"
+msgstr ""
+
+#: jellyfin_mpv_shim/mpvtk_browser/timefmt.py
+msgctxt "12-hour clock"
+msgid "PM"
+msgstr ""
+
 #: jellyfin_mpv_shim/mpvtk_browser/views.py
 #: jellyfin_mpv_shim/mpvtk_browser/window_chrome.py
 msgid "Search"
@@ -4847,13 +4949,32 @@ msgid "Enable SVP"
 msgstr "Уключыць SVP"
 
 #: jellyfin_mpv_shim/sync/manager.py
+msgid "The downloads are already in that folder."
+msgstr ""
+
+#: jellyfin_mpv_shim/sync/manager.py
 msgid ""
 "Can't change the download folder while a download is in progress. Wait for "
 "it to finish, then try again."
 msgstr ""
 
 #: jellyfin_mpv_shim/sync/manager.py
+msgid ""
+"That folder is inside the current download folder. Choose one outside it."
+msgstr ""
+
+#: jellyfin_mpv_shim/sync/manager.py
+msgid "Can't read that folder. Check the path and its permissions."
+msgstr ""
+
+#: jellyfin_mpv_shim/sync/manager.py
 msgid "That folder already contains downloads. Choose an empty folder."
+msgstr ""
+
+#: jellyfin_mpv_shim/sync/manager.py
+msgid ""
+"That folder isn't empty. Choose an empty folder — the download folder is "
+"managed by this app and anything else in it can be moved or removed."
 msgstr ""
 
 #: jellyfin_mpv_shim/sync/manager.py
@@ -4862,6 +4983,12 @@ msgstr ""
 
 #: jellyfin_mpv_shim/sync/manager.py
 msgid "A download is still finishing. Wait for it to stop, then try again."
+msgstr ""
+
+#: jellyfin_mpv_shim/sync/manager.py
+msgid ""
+"There isn't enough space on that drive to move the downloads. Free some "
+"space and try again — nothing was moved."
 msgstr ""
 
 #: jellyfin_mpv_shim/sync/manager.py

--- a/jellyfin_mpv_shim/messages/bg/LC_MESSAGES/base.po
+++ b/jellyfin_mpv_shim/messages/bg/LC_MESSAGES/base.po
@@ -6,7 +6,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2026-08-30 22:19-0400\n"
+"POT-Creation-Date: 2026-09-07 17:35-0400\n"
 "PO-Revision-Date: 2026-08-23 07:26+0000\n"
 "Last-Translator: Koralski <bkoralski@gmail.com>\n"
 "Language-Team: Bulgarian <https://translate.jellyfin.org/projects/jellyfin/"
@@ -534,6 +534,11 @@ msgid "Night Mode (Auto Volume Adj)"
 msgstr ""
 
 #: jellyfin_mpv_shim/mpvtk_browser/app.py
+#: jellyfin_mpv_shim/mpvtk_browser/auth.py
+msgid "Locked"
+msgstr ""
+
+#: jellyfin_mpv_shim/mpvtk_browser/app.py
 msgid "Failed to load. Check the connection."
 msgstr ""
 
@@ -807,10 +812,6 @@ msgstr ""
 "Моля,проверете информацията за връзката."
 
 #: jellyfin_mpv_shim/mpvtk_browser/auth.py
-msgid "Locked"
-msgstr ""
-
-#: jellyfin_mpv_shim/mpvtk_browser/auth.py
 #: jellyfin_mpv_shim/mpvtk_browser/pages/home.py
 msgid "Connecting to your server…"
 msgstr ""
@@ -886,6 +887,10 @@ msgstr "Излез и маркирай ,като негледано"
 #: jellyfin_mpv_shim/mpvtk_browser/hud.py
 #: jellyfin_mpv_shim/mpvtk_browser/pages/books.py
 msgid "Favorite"
+msgstr ""
+
+#: jellyfin_mpv_shim/mpvtk_browser/components/detail.py
+msgid "Web"
 msgstr ""
 
 #: jellyfin_mpv_shim/mpvtk_browser/components/media_info.py
@@ -1423,11 +1428,7 @@ msgid "Jellyfin UI"
 msgstr ""
 
 #: jellyfin_mpv_shim/mpvtk_browser/config.py
-msgid "MPV UI with thumbnails"
-msgstr ""
-
-#: jellyfin_mpv_shim/mpvtk_browser/config.py
-msgid "MPV built-in default"
+msgid "MPV UI"
 msgstr ""
 
 #: jellyfin_mpv_shim/mpvtk_browser/config.py
@@ -1772,8 +1773,22 @@ msgid "Window Buttons in the Top Bar"
 msgstr ""
 
 #: jellyfin_mpv_shim/mpvtk_browser/config.py
+msgid "Keep Window Buttons in Full Screen"
+msgstr ""
+
+#: jellyfin_mpv_shim/mpvtk_browser/config.py
+msgid "Hide the Desktop Title Bar"
+msgstr ""
+
+#: jellyfin_mpv_shim/mpvtk_browser/config.py
 msgid "Player Controls Style"
 msgstr ""
+
+#: jellyfin_mpv_shim/mpvtk_browser/config.py
+#, fuzzy
+#| msgid "Enable thumbnail previews"
+msgid "Enable Trickplay Thumbnails"
+msgstr "Активиране преглед на миниатюрни визуализации"
 
 #: jellyfin_mpv_shim/mpvtk_browser/config.py
 msgid "Load All Seek Previews at Once"
@@ -1802,6 +1817,10 @@ msgstr ""
 
 #: jellyfin_mpv_shim/mpvtk_browser/config.py
 msgid "Full-Width Backdrops"
+msgstr ""
+
+#: jellyfin_mpv_shim/mpvtk_browser/config.py
+msgid "12-Hour Clock"
 msgstr ""
 
 #: jellyfin_mpv_shim/mpvtk_browser/config.py
@@ -1845,11 +1864,19 @@ msgid "Fullscreen Library Browser"
 msgstr ""
 
 #: jellyfin_mpv_shim/mpvtk_browser/config.py
+msgid "Block Player Keybinds While Browsing"
+msgstr ""
+
+#: jellyfin_mpv_shim/mpvtk_browser/config.py
 msgid "Always Bind Arrow Keys to Player Controls"
 msgstr ""
 
 #: jellyfin_mpv_shim/mpvtk_browser/config.py
 msgid "Player Controls Activation Key"
+msgstr ""
+
+#: jellyfin_mpv_shim/mpvtk_browser/config.py
+msgid "Select Key"
 msgstr ""
 
 #: jellyfin_mpv_shim/mpvtk_browser/config.py
@@ -1862,6 +1889,10 @@ msgstr ""
 
 #: jellyfin_mpv_shim/mpvtk_browser/config.py
 msgid "Hide the Player Controls After (seconds)"
+msgstr ""
+
+#: jellyfin_mpv_shim/mpvtk_browser/config.py
+msgid "Shrink the Player Controls on a Narrow Window"
 msgstr ""
 
 #: jellyfin_mpv_shim/mpvtk_browser/config.py
@@ -1948,6 +1979,21 @@ msgstr ""
 
 #: jellyfin_mpv_shim/mpvtk_browser/config.py
 msgid ""
+"Stops MPV's own shortcuts -- picture adjustment, screenshots, subtitle and "
+"audio switching -- from acting while you are in the library, where there is "
+"no video for them to act on. Turn it off to use your own MPV key bindings "
+"there."
+msgstr ""
+
+#: jellyfin_mpv_shim/mpvtk_browser/config.py
+msgid ""
+"Activates whatever is highlighted, in the library and on the player "
+"controls. An mpv key name; changing it hands Enter back to MPV. The game "
+"controller's Confirm button and a phone's Select follow it."
+msgstr ""
+
+#: jellyfin_mpv_shim/mpvtk_browser/config.py
+msgid ""
 "Leave these blank unless downloads are waking your disks too often. Set both "
 "of the first two together: episodes are then fetched in one batch when a "
 "series runs low, instead of one at a time."
@@ -1961,7 +2007,8 @@ msgstr ""
 #: jellyfin_mpv_shim/mpvtk_browser/config.py
 msgid ""
 "Off gives MPV's own mouse behaviour instead: drag the video to move the "
-"window, and right click to pause. Double click is full screen either way."
+"window, and the right button does whatever your MPV config gives it. Double "
+"click is full screen either way."
 msgstr ""
 
 #: jellyfin_mpv_shim/mpvtk_browser/config.py
@@ -2051,6 +2098,30 @@ msgid ""
 "maximize and close in the top bar instead, and lets you drag the window by "
 "it. On \"Only when the window has no title bar\", MPV is asked whether this "
 "window got one, so desktops that draw a title bar are left alone."
+msgstr ""
+
+#: jellyfin_mpv_shim/mpvtk_browser/config.py
+msgid ""
+"Full screen has no title bar anywhere and nothing to move or maximize, so "
+"the buttons are normally hidden there. Turn this on to keep a way out of "
+"full screen that is not a keyboard shortcut."
+msgstr ""
+
+#: jellyfin_mpv_shim/mpvtk_browser/config.py
+msgid ""
+"Asks the desktop for no title bar on the player window, so the top bar above "
+"is the only one. Pairs with the setting above: on \"Only when the window has "
+"no title bar\" the buttons appear as soon as this is on. Leave both off "
+"unless you want them, since a window with neither can be awkward to move on "
+"some desktops."
+msgstr ""
+
+#: jellyfin_mpv_shim/mpvtk_browser/config.py
+msgid ""
+"Shows a preview frame while you drag the seek bar. Works with every player "
+"control style, including your own OSC script if it supports thumbfast. The "
+"images are fetched from the server per video, which costs disk space and "
+"memory -- tens of MB for an episode, a few hundred for a long film."
 msgstr ""
 
 #: jellyfin_mpv_shim/mpvtk_browser/config.py
@@ -2160,6 +2231,13 @@ msgstr ""
 
 #: jellyfin_mpv_shim/mpvtk_browser/config.py
 msgid ""
+"Show times of day as \"8:30 PM\" rather than \"20:30\" — the Live TV guide "
+"and its air times, and the \"Ends at\" labels on a detail page and the "
+"player controls."
+msgstr ""
+
+#: jellyfin_mpv_shim/mpvtk_browser/config.py
+msgid ""
 "The controls have to stay legible over any frame. \"None\" gives the text a "
 "drop shadow instead of shading the picture behind it."
 msgstr ""
@@ -2174,6 +2252,13 @@ msgstr ""
 msgid ""
 "0 hides them as soon as the pointer is not on them, and forces \"Hide unless "
 "hovered\"."
+msgstr ""
+
+#: jellyfin_mpv_shim/mpvtk_browser/config.py
+msgid ""
+"Narrowing the window shrinks the controls until the smallest button reaches "
+"the accessibility minimum, instead of dropping buttons sooner. Off keeps the "
+"older, larger floor."
 msgstr ""
 
 #: jellyfin_mpv_shim/mpvtk_browser/config.py
@@ -3668,6 +3753,7 @@ msgid "More Like This"
 msgstr ""
 
 #: jellyfin_mpv_shim/mpvtk_browser/pages/detail.py
+#: jellyfin_mpv_shim/mpvtk_browser/tiles.py
 msgid "Go to Series"
 msgstr ""
 
@@ -4798,6 +4884,22 @@ msgstr "Отдалечен сървър"
 msgid "There is nothing here to queue."
 msgstr ""
 
+#: jellyfin_mpv_shim/mpvtk_browser/timefmt.py
+#, python-brace-format
+msgctxt "12-hour clock"
+msgid "{time} {period}"
+msgstr ""
+
+#: jellyfin_mpv_shim/mpvtk_browser/timefmt.py
+msgctxt "12-hour clock"
+msgid "AM"
+msgstr ""
+
+#: jellyfin_mpv_shim/mpvtk_browser/timefmt.py
+msgctxt "12-hour clock"
+msgid "PM"
+msgstr ""
+
 #: jellyfin_mpv_shim/mpvtk_browser/views.py
 #: jellyfin_mpv_shim/mpvtk_browser/window_chrome.py
 msgid "Search"
@@ -4961,13 +5063,32 @@ msgid "Enable SVP"
 msgstr "Включи SVP"
 
 #: jellyfin_mpv_shim/sync/manager.py
+msgid "The downloads are already in that folder."
+msgstr ""
+
+#: jellyfin_mpv_shim/sync/manager.py
 msgid ""
 "Can't change the download folder while a download is in progress. Wait for "
 "it to finish, then try again."
 msgstr ""
 
 #: jellyfin_mpv_shim/sync/manager.py
+msgid ""
+"That folder is inside the current download folder. Choose one outside it."
+msgstr ""
+
+#: jellyfin_mpv_shim/sync/manager.py
+msgid "Can't read that folder. Check the path and its permissions."
+msgstr ""
+
+#: jellyfin_mpv_shim/sync/manager.py
 msgid "That folder already contains downloads. Choose an empty folder."
+msgstr ""
+
+#: jellyfin_mpv_shim/sync/manager.py
+msgid ""
+"That folder isn't empty. Choose an empty folder — the download folder is "
+"managed by this app and anything else in it can be moved or removed."
 msgstr ""
 
 #: jellyfin_mpv_shim/sync/manager.py
@@ -4976,6 +5097,12 @@ msgstr ""
 
 #: jellyfin_mpv_shim/sync/manager.py
 msgid "A download is still finishing. Wait for it to stop, then try again."
+msgstr ""
+
+#: jellyfin_mpv_shim/sync/manager.py
+msgid ""
+"There isn't enough space on that drive to move the downloads. Free some "
+"space and try again — nothing was moved."
 msgstr ""
 
 #: jellyfin_mpv_shim/sync/manager.py

--- a/jellyfin_mpv_shim/messages/bn/LC_MESSAGES/base.po
+++ b/jellyfin_mpv_shim/messages/bn/LC_MESSAGES/base.po
@@ -6,7 +6,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2026-08-30 22:19-0400\n"
+"POT-Creation-Date: 2026-09-07 17:35-0400\n"
 "PO-Revision-Date: 2026-05-20 10:59+0000\n"
 "Last-Translator: Sarker Siam <siamsarker36@gmail.com>\n"
 "Language-Team: Bengali <https://translate.jellyfin.org/projects/jellyfin/"
@@ -546,6 +546,11 @@ msgid "Night Mode (Auto Volume Adj)"
 msgstr ""
 
 #: jellyfin_mpv_shim/mpvtk_browser/app.py
+#: jellyfin_mpv_shim/mpvtk_browser/auth.py
+msgid "Locked"
+msgstr ""
+
+#: jellyfin_mpv_shim/mpvtk_browser/app.py
 msgid "Failed to load. Check the connection."
 msgstr ""
 
@@ -819,10 +824,6 @@ msgstr ""
 "দয়া করে আপনার কানেকশনের তথ্য পর্যালোচনা করুন।"
 
 #: jellyfin_mpv_shim/mpvtk_browser/auth.py
-msgid "Locked"
-msgstr ""
-
-#: jellyfin_mpv_shim/mpvtk_browser/auth.py
 #: jellyfin_mpv_shim/mpvtk_browser/pages/home.py
 msgid "Connecting to your server…"
 msgstr ""
@@ -898,6 +899,10 @@ msgstr "প্রস্থান করুন ও 'অদেখা' প্রত
 #: jellyfin_mpv_shim/mpvtk_browser/hud.py
 #: jellyfin_mpv_shim/mpvtk_browser/pages/books.py
 msgid "Favorite"
+msgstr ""
+
+#: jellyfin_mpv_shim/mpvtk_browser/components/detail.py
+msgid "Web"
 msgstr ""
 
 #: jellyfin_mpv_shim/mpvtk_browser/components/media_info.py
@@ -1437,11 +1442,7 @@ msgid "Jellyfin UI"
 msgstr ""
 
 #: jellyfin_mpv_shim/mpvtk_browser/config.py
-msgid "MPV UI with thumbnails"
-msgstr ""
-
-#: jellyfin_mpv_shim/mpvtk_browser/config.py
-msgid "MPV built-in default"
+msgid "MPV UI"
 msgstr ""
 
 #: jellyfin_mpv_shim/mpvtk_browser/config.py
@@ -1786,8 +1787,22 @@ msgid "Window Buttons in the Top Bar"
 msgstr ""
 
 #: jellyfin_mpv_shim/mpvtk_browser/config.py
+msgid "Keep Window Buttons in Full Screen"
+msgstr ""
+
+#: jellyfin_mpv_shim/mpvtk_browser/config.py
+msgid "Hide the Desktop Title Bar"
+msgstr ""
+
+#: jellyfin_mpv_shim/mpvtk_browser/config.py
 msgid "Player Controls Style"
 msgstr ""
+
+#: jellyfin_mpv_shim/mpvtk_browser/config.py
+#, fuzzy
+#| msgid "Enable thumbnail previews"
+msgid "Enable Trickplay Thumbnails"
+msgstr "থাম্বনেইল প্রিভিউ সক্ষম করুন"
 
 #: jellyfin_mpv_shim/mpvtk_browser/config.py
 msgid "Load All Seek Previews at Once"
@@ -1816,6 +1831,10 @@ msgstr ""
 
 #: jellyfin_mpv_shim/mpvtk_browser/config.py
 msgid "Full-Width Backdrops"
+msgstr ""
+
+#: jellyfin_mpv_shim/mpvtk_browser/config.py
+msgid "12-Hour Clock"
 msgstr ""
 
 #: jellyfin_mpv_shim/mpvtk_browser/config.py
@@ -1859,11 +1878,19 @@ msgid "Fullscreen Library Browser"
 msgstr ""
 
 #: jellyfin_mpv_shim/mpvtk_browser/config.py
+msgid "Block Player Keybinds While Browsing"
+msgstr ""
+
+#: jellyfin_mpv_shim/mpvtk_browser/config.py
 msgid "Always Bind Arrow Keys to Player Controls"
 msgstr ""
 
 #: jellyfin_mpv_shim/mpvtk_browser/config.py
 msgid "Player Controls Activation Key"
+msgstr ""
+
+#: jellyfin_mpv_shim/mpvtk_browser/config.py
+msgid "Select Key"
 msgstr ""
 
 #: jellyfin_mpv_shim/mpvtk_browser/config.py
@@ -1876,6 +1903,10 @@ msgstr ""
 
 #: jellyfin_mpv_shim/mpvtk_browser/config.py
 msgid "Hide the Player Controls After (seconds)"
+msgstr ""
+
+#: jellyfin_mpv_shim/mpvtk_browser/config.py
+msgid "Shrink the Player Controls on a Narrow Window"
 msgstr ""
 
 #: jellyfin_mpv_shim/mpvtk_browser/config.py
@@ -1962,6 +1993,21 @@ msgstr ""
 
 #: jellyfin_mpv_shim/mpvtk_browser/config.py
 msgid ""
+"Stops MPV's own shortcuts -- picture adjustment, screenshots, subtitle and "
+"audio switching -- from acting while you are in the library, where there is "
+"no video for them to act on. Turn it off to use your own MPV key bindings "
+"there."
+msgstr ""
+
+#: jellyfin_mpv_shim/mpvtk_browser/config.py
+msgid ""
+"Activates whatever is highlighted, in the library and on the player "
+"controls. An mpv key name; changing it hands Enter back to MPV. The game "
+"controller's Confirm button and a phone's Select follow it."
+msgstr ""
+
+#: jellyfin_mpv_shim/mpvtk_browser/config.py
+msgid ""
 "Leave these blank unless downloads are waking your disks too often. Set both "
 "of the first two together: episodes are then fetched in one batch when a "
 "series runs low, instead of one at a time."
@@ -1975,7 +2021,8 @@ msgstr ""
 #: jellyfin_mpv_shim/mpvtk_browser/config.py
 msgid ""
 "Off gives MPV's own mouse behaviour instead: drag the video to move the "
-"window, and right click to pause. Double click is full screen either way."
+"window, and the right button does whatever your MPV config gives it. Double "
+"click is full screen either way."
 msgstr ""
 
 #: jellyfin_mpv_shim/mpvtk_browser/config.py
@@ -2065,6 +2112,30 @@ msgid ""
 "maximize and close in the top bar instead, and lets you drag the window by "
 "it. On \"Only when the window has no title bar\", MPV is asked whether this "
 "window got one, so desktops that draw a title bar are left alone."
+msgstr ""
+
+#: jellyfin_mpv_shim/mpvtk_browser/config.py
+msgid ""
+"Full screen has no title bar anywhere and nothing to move or maximize, so "
+"the buttons are normally hidden there. Turn this on to keep a way out of "
+"full screen that is not a keyboard shortcut."
+msgstr ""
+
+#: jellyfin_mpv_shim/mpvtk_browser/config.py
+msgid ""
+"Asks the desktop for no title bar on the player window, so the top bar above "
+"is the only one. Pairs with the setting above: on \"Only when the window has "
+"no title bar\" the buttons appear as soon as this is on. Leave both off "
+"unless you want them, since a window with neither can be awkward to move on "
+"some desktops."
+msgstr ""
+
+#: jellyfin_mpv_shim/mpvtk_browser/config.py
+msgid ""
+"Shows a preview frame while you drag the seek bar. Works with every player "
+"control style, including your own OSC script if it supports thumbfast. The "
+"images are fetched from the server per video, which costs disk space and "
+"memory -- tens of MB for an episode, a few hundred for a long film."
 msgstr ""
 
 #: jellyfin_mpv_shim/mpvtk_browser/config.py
@@ -2174,6 +2245,13 @@ msgstr ""
 
 #: jellyfin_mpv_shim/mpvtk_browser/config.py
 msgid ""
+"Show times of day as \"8:30 PM\" rather than \"20:30\" — the Live TV guide "
+"and its air times, and the \"Ends at\" labels on a detail page and the "
+"player controls."
+msgstr ""
+
+#: jellyfin_mpv_shim/mpvtk_browser/config.py
+msgid ""
 "The controls have to stay legible over any frame. \"None\" gives the text a "
 "drop shadow instead of shading the picture behind it."
 msgstr ""
@@ -2188,6 +2266,13 @@ msgstr ""
 msgid ""
 "0 hides them as soon as the pointer is not on them, and forces \"Hide unless "
 "hovered\"."
+msgstr ""
+
+#: jellyfin_mpv_shim/mpvtk_browser/config.py
+msgid ""
+"Narrowing the window shrinks the controls until the smallest button reaches "
+"the accessibility minimum, instead of dropping buttons sooner. Off keeps the "
+"older, larger floor."
 msgstr ""
 
 #: jellyfin_mpv_shim/mpvtk_browser/config.py
@@ -3695,6 +3780,7 @@ msgid "More Like This"
 msgstr ""
 
 #: jellyfin_mpv_shim/mpvtk_browser/pages/detail.py
+#: jellyfin_mpv_shim/mpvtk_browser/tiles.py
 msgid "Go to Series"
 msgstr ""
 
@@ -4834,6 +4920,22 @@ msgstr "সার্ভার মুছে ফেলুন"
 msgid "There is nothing here to queue."
 msgstr ""
 
+#: jellyfin_mpv_shim/mpvtk_browser/timefmt.py
+#, python-brace-format
+msgctxt "12-hour clock"
+msgid "{time} {period}"
+msgstr ""
+
+#: jellyfin_mpv_shim/mpvtk_browser/timefmt.py
+msgctxt "12-hour clock"
+msgid "AM"
+msgstr ""
+
+#: jellyfin_mpv_shim/mpvtk_browser/timefmt.py
+msgctxt "12-hour clock"
+msgid "PM"
+msgstr ""
+
 #: jellyfin_mpv_shim/mpvtk_browser/views.py
 #: jellyfin_mpv_shim/mpvtk_browser/window_chrome.py
 msgid "Search"
@@ -4996,13 +5098,32 @@ msgid "Enable SVP"
 msgstr "এসভিপি সক্ষম করুন"
 
 #: jellyfin_mpv_shim/sync/manager.py
+msgid "The downloads are already in that folder."
+msgstr ""
+
+#: jellyfin_mpv_shim/sync/manager.py
 msgid ""
 "Can't change the download folder while a download is in progress. Wait for "
 "it to finish, then try again."
 msgstr ""
 
 #: jellyfin_mpv_shim/sync/manager.py
+msgid ""
+"That folder is inside the current download folder. Choose one outside it."
+msgstr ""
+
+#: jellyfin_mpv_shim/sync/manager.py
+msgid "Can't read that folder. Check the path and its permissions."
+msgstr ""
+
+#: jellyfin_mpv_shim/sync/manager.py
 msgid "That folder already contains downloads. Choose an empty folder."
+msgstr ""
+
+#: jellyfin_mpv_shim/sync/manager.py
+msgid ""
+"That folder isn't empty. Choose an empty folder — the download folder is "
+"managed by this app and anything else in it can be moved or removed."
 msgstr ""
 
 #: jellyfin_mpv_shim/sync/manager.py
@@ -5011,6 +5132,12 @@ msgstr ""
 
 #: jellyfin_mpv_shim/sync/manager.py
 msgid "A download is still finishing. Wait for it to stop, then try again."
+msgstr ""
+
+#: jellyfin_mpv_shim/sync/manager.py
+msgid ""
+"There isn't enough space on that drive to move the downloads. Free some "
+"space and try again — nothing was moved."
 msgstr ""
 
 #: jellyfin_mpv_shim/sync/manager.py

--- a/jellyfin_mpv_shim/messages/br/LC_MESSAGES/base.po
+++ b/jellyfin_mpv_shim/messages/br/LC_MESSAGES/base.po
@@ -6,7 +6,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2026-08-30 22:19-0400\n"
+"POT-Creation-Date: 2026-09-07 17:35-0400\n"
 "PO-Revision-Date: 2026-05-23 07:46+0000\n"
 "Last-Translator: Klomer <florent.grouin+jellyfin@gmail.com>\n"
 "Language-Team: Breton <https://translate.jellyfin.org/projects/jellyfin/"
@@ -536,6 +536,11 @@ msgid "Night Mode (Auto Volume Adj)"
 msgstr ""
 
 #: jellyfin_mpv_shim/mpvtk_browser/app.py
+#: jellyfin_mpv_shim/mpvtk_browser/auth.py
+msgid "Locked"
+msgstr ""
+
+#: jellyfin_mpv_shim/mpvtk_browser/app.py
 msgid "Failed to load. Check the connection."
 msgstr ""
 
@@ -811,10 +816,6 @@ msgstr ""
 "Trugarez da wiriañ titouroù ar c'hennask."
 
 #: jellyfin_mpv_shim/mpvtk_browser/auth.py
-msgid "Locked"
-msgstr ""
-
-#: jellyfin_mpv_shim/mpvtk_browser/auth.py
 #: jellyfin_mpv_shim/mpvtk_browser/pages/home.py
 msgid "Connecting to your server…"
 msgstr ""
@@ -893,6 +894,10 @@ msgstr "Sellet"
 #: jellyfin_mpv_shim/mpvtk_browser/pages/books.py
 msgid "Favorite"
 msgstr "Sined"
+
+#: jellyfin_mpv_shim/mpvtk_browser/components/detail.py
+msgid "Web"
+msgstr ""
 
 # seeded from jellyfin-web: HeaderVideos
 #: jellyfin_mpv_shim/mpvtk_browser/components/media_info.py
@@ -1448,11 +1453,7 @@ msgid "Jellyfin UI"
 msgstr ""
 
 #: jellyfin_mpv_shim/mpvtk_browser/config.py
-msgid "MPV UI with thumbnails"
-msgstr ""
-
-#: jellyfin_mpv_shim/mpvtk_browser/config.py
-msgid "MPV built-in default"
+msgid "MPV UI"
 msgstr ""
 
 #: jellyfin_mpv_shim/mpvtk_browser/config.py
@@ -1789,7 +1790,19 @@ msgid "Window Buttons in the Top Bar"
 msgstr ""
 
 #: jellyfin_mpv_shim/mpvtk_browser/config.py
+msgid "Keep Window Buttons in Full Screen"
+msgstr ""
+
+#: jellyfin_mpv_shim/mpvtk_browser/config.py
+msgid "Hide the Desktop Title Bar"
+msgstr ""
+
+#: jellyfin_mpv_shim/mpvtk_browser/config.py
 msgid "Player Controls Style"
+msgstr ""
+
+#: jellyfin_mpv_shim/mpvtk_browser/config.py
+msgid "Enable Trickplay Thumbnails"
 msgstr ""
 
 #: jellyfin_mpv_shim/mpvtk_browser/config.py
@@ -1820,6 +1833,10 @@ msgstr ""
 
 #: jellyfin_mpv_shim/mpvtk_browser/config.py
 msgid "Full-Width Backdrops"
+msgstr ""
+
+#: jellyfin_mpv_shim/mpvtk_browser/config.py
+msgid "12-Hour Clock"
 msgstr ""
 
 #: jellyfin_mpv_shim/mpvtk_browser/config.py
@@ -1865,12 +1882,23 @@ msgid "Fullscreen Library Browser"
 msgstr ""
 
 #: jellyfin_mpv_shim/mpvtk_browser/config.py
+msgid "Block Player Keybinds While Browsing"
+msgstr ""
+
+#: jellyfin_mpv_shim/mpvtk_browser/config.py
 msgid "Always Bind Arrow Keys to Player Controls"
 msgstr ""
 
 #: jellyfin_mpv_shim/mpvtk_browser/config.py
 msgid "Player Controls Activation Key"
 msgstr ""
+
+# seeded from jellyfin-web: SelectAll
+#: jellyfin_mpv_shim/mpvtk_browser/config.py
+#, fuzzy
+#| msgid "Select All"
+msgid "Select Key"
+msgstr "Diuzañ an holl"
 
 #: jellyfin_mpv_shim/mpvtk_browser/config.py
 msgid "Shading Behind the Player Controls"
@@ -1882,6 +1910,10 @@ msgstr ""
 
 #: jellyfin_mpv_shim/mpvtk_browser/config.py
 msgid "Hide the Player Controls After (seconds)"
+msgstr ""
+
+#: jellyfin_mpv_shim/mpvtk_browser/config.py
+msgid "Shrink the Player Controls on a Narrow Window"
 msgstr ""
 
 #: jellyfin_mpv_shim/mpvtk_browser/config.py
@@ -1964,6 +1996,21 @@ msgstr ""
 
 #: jellyfin_mpv_shim/mpvtk_browser/config.py
 msgid ""
+"Stops MPV's own shortcuts -- picture adjustment, screenshots, subtitle and "
+"audio switching -- from acting while you are in the library, where there is "
+"no video for them to act on. Turn it off to use your own MPV key bindings "
+"there."
+msgstr ""
+
+#: jellyfin_mpv_shim/mpvtk_browser/config.py
+msgid ""
+"Activates whatever is highlighted, in the library and on the player "
+"controls. An mpv key name; changing it hands Enter back to MPV. The game "
+"controller's Confirm button and a phone's Select follow it."
+msgstr ""
+
+#: jellyfin_mpv_shim/mpvtk_browser/config.py
+msgid ""
 "Leave these blank unless downloads are waking your disks too often. Set both "
 "of the first two together: episodes are then fetched in one batch when a "
 "series runs low, instead of one at a time."
@@ -1977,7 +2024,8 @@ msgstr ""
 #: jellyfin_mpv_shim/mpvtk_browser/config.py
 msgid ""
 "Off gives MPV's own mouse behaviour instead: drag the video to move the "
-"window, and right click to pause. Double click is full screen either way."
+"window, and the right button does whatever your MPV config gives it. Double "
+"click is full screen either way."
 msgstr ""
 
 #: jellyfin_mpv_shim/mpvtk_browser/config.py
@@ -2067,6 +2115,30 @@ msgid ""
 "maximize and close in the top bar instead, and lets you drag the window by "
 "it. On \"Only when the window has no title bar\", MPV is asked whether this "
 "window got one, so desktops that draw a title bar are left alone."
+msgstr ""
+
+#: jellyfin_mpv_shim/mpvtk_browser/config.py
+msgid ""
+"Full screen has no title bar anywhere and nothing to move or maximize, so "
+"the buttons are normally hidden there. Turn this on to keep a way out of "
+"full screen that is not a keyboard shortcut."
+msgstr ""
+
+#: jellyfin_mpv_shim/mpvtk_browser/config.py
+msgid ""
+"Asks the desktop for no title bar on the player window, so the top bar above "
+"is the only one. Pairs with the setting above: on \"Only when the window has "
+"no title bar\" the buttons appear as soon as this is on. Leave both off "
+"unless you want them, since a window with neither can be awkward to move on "
+"some desktops."
+msgstr ""
+
+#: jellyfin_mpv_shim/mpvtk_browser/config.py
+msgid ""
+"Shows a preview frame while you drag the seek bar. Works with every player "
+"control style, including your own OSC script if it supports thumbfast. The "
+"images are fetched from the server per video, which costs disk space and "
+"memory -- tens of MB for an episode, a few hundred for a long film."
 msgstr ""
 
 #: jellyfin_mpv_shim/mpvtk_browser/config.py
@@ -2174,6 +2246,13 @@ msgstr ""
 
 #: jellyfin_mpv_shim/mpvtk_browser/config.py
 msgid ""
+"Show times of day as \"8:30 PM\" rather than \"20:30\" — the Live TV guide "
+"and its air times, and the \"Ends at\" labels on a detail page and the "
+"player controls."
+msgstr ""
+
+#: jellyfin_mpv_shim/mpvtk_browser/config.py
+msgid ""
 "The controls have to stay legible over any frame. \"None\" gives the text a "
 "drop shadow instead of shading the picture behind it."
 msgstr ""
@@ -2188,6 +2267,13 @@ msgstr ""
 msgid ""
 "0 hides them as soon as the pointer is not on them, and forces \"Hide unless "
 "hovered\"."
+msgstr ""
+
+#: jellyfin_mpv_shim/mpvtk_browser/config.py
+msgid ""
+"Narrowing the window shrinks the controls until the smallest button reaches "
+"the accessibility minimum, instead of dropping buttons sooner. Off keeps the "
+"older, larger floor."
 msgstr ""
 
 #: jellyfin_mpv_shim/mpvtk_browser/config.py
@@ -3718,6 +3804,7 @@ msgid "More Like This"
 msgstr ""
 
 #: jellyfin_mpv_shim/mpvtk_browser/pages/detail.py
+#: jellyfin_mpv_shim/mpvtk_browser/tiles.py
 msgid "Go to Series"
 msgstr ""
 
@@ -4878,6 +4965,22 @@ msgstr "Dilemel ar Servijer"
 msgid "There is nothing here to queue."
 msgstr ""
 
+#: jellyfin_mpv_shim/mpvtk_browser/timefmt.py
+#, python-brace-format
+msgctxt "12-hour clock"
+msgid "{time} {period}"
+msgstr ""
+
+#: jellyfin_mpv_shim/mpvtk_browser/timefmt.py
+msgctxt "12-hour clock"
+msgid "AM"
+msgstr ""
+
+#: jellyfin_mpv_shim/mpvtk_browser/timefmt.py
+msgctxt "12-hour clock"
+msgid "PM"
+msgstr ""
+
 # seeded from jellyfin-web: Search
 #: jellyfin_mpv_shim/mpvtk_browser/views.py
 #: jellyfin_mpv_shim/mpvtk_browser/window_chrome.py
@@ -5040,13 +5143,32 @@ msgid "Enable SVP"
 msgstr ""
 
 #: jellyfin_mpv_shim/sync/manager.py
+msgid "The downloads are already in that folder."
+msgstr ""
+
+#: jellyfin_mpv_shim/sync/manager.py
 msgid ""
 "Can't change the download folder while a download is in progress. Wait for "
 "it to finish, then try again."
 msgstr ""
 
 #: jellyfin_mpv_shim/sync/manager.py
+msgid ""
+"That folder is inside the current download folder. Choose one outside it."
+msgstr ""
+
+#: jellyfin_mpv_shim/sync/manager.py
+msgid "Can't read that folder. Check the path and its permissions."
+msgstr ""
+
+#: jellyfin_mpv_shim/sync/manager.py
 msgid "That folder already contains downloads. Choose an empty folder."
+msgstr ""
+
+#: jellyfin_mpv_shim/sync/manager.py
+msgid ""
+"That folder isn't empty. Choose an empty folder — the download folder is "
+"managed by this app and anything else in it can be moved or removed."
 msgstr ""
 
 #: jellyfin_mpv_shim/sync/manager.py
@@ -5055,6 +5177,12 @@ msgstr ""
 
 #: jellyfin_mpv_shim/sync/manager.py
 msgid "A download is still finishing. Wait for it to stop, then try again."
+msgstr ""
+
+#: jellyfin_mpv_shim/sync/manager.py
+msgid ""
+"There isn't enough space on that drive to move the downloads. Free some "
+"space and try again — nothing was moved."
 msgstr ""
 
 #: jellyfin_mpv_shim/sync/manager.py

--- a/jellyfin_mpv_shim/messages/bs/LC_MESSAGES/base.po
+++ b/jellyfin_mpv_shim/messages/bs/LC_MESSAGES/base.po
@@ -6,7 +6,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2026-08-30 22:19-0400\n"
+"POT-Creation-Date: 2026-09-07 17:35-0400\n"
 "PO-Revision-Date: 2026-04-17 12:45+0000\n"
 "Last-Translator: SecularSteve <fairfull.playing@gmail.com>\n"
 "Language-Team: Bosnian <https://translate.jellyfin.org/projects/jellyfin/"
@@ -548,6 +548,11 @@ msgid "Night Mode (Auto Volume Adj)"
 msgstr ""
 
 #: jellyfin_mpv_shim/mpvtk_browser/app.py
+#: jellyfin_mpv_shim/mpvtk_browser/auth.py
+msgid "Locked"
+msgstr ""
+
+#: jellyfin_mpv_shim/mpvtk_browser/app.py
 msgid "Failed to load. Check the connection."
 msgstr ""
 
@@ -827,10 +832,6 @@ msgstr ""
 "Provjerite podatke o vezi."
 
 #: jellyfin_mpv_shim/mpvtk_browser/auth.py
-msgid "Locked"
-msgstr ""
-
-#: jellyfin_mpv_shim/mpvtk_browser/auth.py
 #: jellyfin_mpv_shim/mpvtk_browser/pages/home.py
 msgid "Connecting to your server…"
 msgstr ""
@@ -911,6 +912,10 @@ msgstr "Prestani pratiti i označi kao nepratimo"
 #: jellyfin_mpv_shim/mpvtk_browser/pages/books.py
 msgid "Favorite"
 msgstr "Omiljeni"
+
+#: jellyfin_mpv_shim/mpvtk_browser/components/detail.py
+msgid "Web"
+msgstr ""
 
 # seeded from jellyfin-web: HeaderVideos
 #: jellyfin_mpv_shim/mpvtk_browser/components/media_info.py
@@ -1530,11 +1535,7 @@ msgid "Jellyfin UI"
 msgstr ""
 
 #: jellyfin_mpv_shim/mpvtk_browser/config.py
-msgid "MPV UI with thumbnails"
-msgstr ""
-
-#: jellyfin_mpv_shim/mpvtk_browser/config.py
-msgid "MPV built-in default"
+msgid "MPV UI"
 msgstr ""
 
 #: jellyfin_mpv_shim/mpvtk_browser/config.py
@@ -1883,8 +1884,22 @@ msgid "Window Buttons in the Top Bar"
 msgstr ""
 
 #: jellyfin_mpv_shim/mpvtk_browser/config.py
+msgid "Keep Window Buttons in Full Screen"
+msgstr ""
+
+#: jellyfin_mpv_shim/mpvtk_browser/config.py
+msgid "Hide the Desktop Title Bar"
+msgstr ""
+
+#: jellyfin_mpv_shim/mpvtk_browser/config.py
 msgid "Player Controls Style"
 msgstr ""
+
+#: jellyfin_mpv_shim/mpvtk_browser/config.py
+#, fuzzy
+#| msgid "Enable thumbnail previews"
+msgid "Enable Trickplay Thumbnails"
+msgstr "Omogući pregled minijatura"
 
 #: jellyfin_mpv_shim/mpvtk_browser/config.py
 msgid "Load All Seek Previews at Once"
@@ -1914,6 +1929,10 @@ msgstr ""
 
 #: jellyfin_mpv_shim/mpvtk_browser/config.py
 msgid "Full-Width Backdrops"
+msgstr ""
+
+#: jellyfin_mpv_shim/mpvtk_browser/config.py
+msgid "12-Hour Clock"
 msgstr ""
 
 #: jellyfin_mpv_shim/mpvtk_browser/config.py
@@ -1959,12 +1978,23 @@ msgid "Fullscreen Library Browser"
 msgstr ""
 
 #: jellyfin_mpv_shim/mpvtk_browser/config.py
+msgid "Block Player Keybinds While Browsing"
+msgstr ""
+
+#: jellyfin_mpv_shim/mpvtk_browser/config.py
 msgid "Always Bind Arrow Keys to Player Controls"
 msgstr ""
 
 #: jellyfin_mpv_shim/mpvtk_browser/config.py
 msgid "Player Controls Activation Key"
 msgstr ""
+
+# seeded from jellyfin-web: SelectAll
+#: jellyfin_mpv_shim/mpvtk_browser/config.py
+#, fuzzy
+#| msgid "Select All"
+msgid "Select Key"
+msgstr "Odaberi sve"
 
 #: jellyfin_mpv_shim/mpvtk_browser/config.py
 msgid "Shading Behind the Player Controls"
@@ -1976,6 +2006,10 @@ msgstr ""
 
 #: jellyfin_mpv_shim/mpvtk_browser/config.py
 msgid "Hide the Player Controls After (seconds)"
+msgstr ""
+
+#: jellyfin_mpv_shim/mpvtk_browser/config.py
+msgid "Shrink the Player Controls on a Narrow Window"
 msgstr ""
 
 #: jellyfin_mpv_shim/mpvtk_browser/config.py
@@ -2062,6 +2096,21 @@ msgstr ""
 
 #: jellyfin_mpv_shim/mpvtk_browser/config.py
 msgid ""
+"Stops MPV's own shortcuts -- picture adjustment, screenshots, subtitle and "
+"audio switching -- from acting while you are in the library, where there is "
+"no video for them to act on. Turn it off to use your own MPV key bindings "
+"there."
+msgstr ""
+
+#: jellyfin_mpv_shim/mpvtk_browser/config.py
+msgid ""
+"Activates whatever is highlighted, in the library and on the player "
+"controls. An mpv key name; changing it hands Enter back to MPV. The game "
+"controller's Confirm button and a phone's Select follow it."
+msgstr ""
+
+#: jellyfin_mpv_shim/mpvtk_browser/config.py
+msgid ""
 "Leave these blank unless downloads are waking your disks too often. Set both "
 "of the first two together: episodes are then fetched in one batch when a "
 "series runs low, instead of one at a time."
@@ -2075,7 +2124,8 @@ msgstr ""
 #: jellyfin_mpv_shim/mpvtk_browser/config.py
 msgid ""
 "Off gives MPV's own mouse behaviour instead: drag the video to move the "
-"window, and right click to pause. Double click is full screen either way."
+"window, and the right button does whatever your MPV config gives it. Double "
+"click is full screen either way."
 msgstr ""
 
 #: jellyfin_mpv_shim/mpvtk_browser/config.py
@@ -2165,6 +2215,30 @@ msgid ""
 "maximize and close in the top bar instead, and lets you drag the window by "
 "it. On \"Only when the window has no title bar\", MPV is asked whether this "
 "window got one, so desktops that draw a title bar are left alone."
+msgstr ""
+
+#: jellyfin_mpv_shim/mpvtk_browser/config.py
+msgid ""
+"Full screen has no title bar anywhere and nothing to move or maximize, so "
+"the buttons are normally hidden there. Turn this on to keep a way out of "
+"full screen that is not a keyboard shortcut."
+msgstr ""
+
+#: jellyfin_mpv_shim/mpvtk_browser/config.py
+msgid ""
+"Asks the desktop for no title bar on the player window, so the top bar above "
+"is the only one. Pairs with the setting above: on \"Only when the window has "
+"no title bar\" the buttons appear as soon as this is on. Leave both off "
+"unless you want them, since a window with neither can be awkward to move on "
+"some desktops."
+msgstr ""
+
+#: jellyfin_mpv_shim/mpvtk_browser/config.py
+msgid ""
+"Shows a preview frame while you drag the seek bar. Works with every player "
+"control style, including your own OSC script if it supports thumbfast. The "
+"images are fetched from the server per video, which costs disk space and "
+"memory -- tens of MB for an episode, a few hundred for a long film."
 msgstr ""
 
 #: jellyfin_mpv_shim/mpvtk_browser/config.py
@@ -2274,6 +2348,13 @@ msgstr ""
 
 #: jellyfin_mpv_shim/mpvtk_browser/config.py
 msgid ""
+"Show times of day as \"8:30 PM\" rather than \"20:30\" — the Live TV guide "
+"and its air times, and the \"Ends at\" labels on a detail page and the "
+"player controls."
+msgstr ""
+
+#: jellyfin_mpv_shim/mpvtk_browser/config.py
+msgid ""
 "The controls have to stay legible over any frame. \"None\" gives the text a "
 "drop shadow instead of shading the picture behind it."
 msgstr ""
@@ -2288,6 +2369,13 @@ msgstr ""
 msgid ""
 "0 hides them as soon as the pointer is not on them, and forces \"Hide unless "
 "hovered\"."
+msgstr ""
+
+#: jellyfin_mpv_shim/mpvtk_browser/config.py
+msgid ""
+"Narrowing the window shrinks the controls until the smallest button reaches "
+"the accessibility minimum, instead of dropping buttons sooner. Off keeps the "
+"older, larger floor."
 msgstr ""
 
 #: jellyfin_mpv_shim/mpvtk_browser/config.py
@@ -3895,6 +3983,7 @@ msgid "More Like This"
 msgstr "Više ovakvih"
 
 #: jellyfin_mpv_shim/mpvtk_browser/pages/detail.py
+#: jellyfin_mpv_shim/mpvtk_browser/tiles.py
 msgid "Go to Series"
 msgstr ""
 
@@ -5089,6 +5178,22 @@ msgstr "Ukloni server"
 msgid "There is nothing here to queue."
 msgstr ""
 
+#: jellyfin_mpv_shim/mpvtk_browser/timefmt.py
+#, python-brace-format
+msgctxt "12-hour clock"
+msgid "{time} {period}"
+msgstr ""
+
+#: jellyfin_mpv_shim/mpvtk_browser/timefmt.py
+msgctxt "12-hour clock"
+msgid "AM"
+msgstr ""
+
+#: jellyfin_mpv_shim/mpvtk_browser/timefmt.py
+msgctxt "12-hour clock"
+msgid "PM"
+msgstr ""
+
 # seeded from jellyfin-web: Search
 #: jellyfin_mpv_shim/mpvtk_browser/views.py
 #: jellyfin_mpv_shim/mpvtk_browser/window_chrome.py
@@ -5256,13 +5361,32 @@ msgid "Enable SVP"
 msgstr "Omogući SVP"
 
 #: jellyfin_mpv_shim/sync/manager.py
+msgid "The downloads are already in that folder."
+msgstr ""
+
+#: jellyfin_mpv_shim/sync/manager.py
 msgid ""
 "Can't change the download folder while a download is in progress. Wait for "
 "it to finish, then try again."
 msgstr ""
 
 #: jellyfin_mpv_shim/sync/manager.py
+msgid ""
+"That folder is inside the current download folder. Choose one outside it."
+msgstr ""
+
+#: jellyfin_mpv_shim/sync/manager.py
+msgid "Can't read that folder. Check the path and its permissions."
+msgstr ""
+
+#: jellyfin_mpv_shim/sync/manager.py
 msgid "That folder already contains downloads. Choose an empty folder."
+msgstr ""
+
+#: jellyfin_mpv_shim/sync/manager.py
+msgid ""
+"That folder isn't empty. Choose an empty folder — the download folder is "
+"managed by this app and anything else in it can be moved or removed."
 msgstr ""
 
 #: jellyfin_mpv_shim/sync/manager.py
@@ -5271,6 +5395,12 @@ msgstr ""
 
 #: jellyfin_mpv_shim/sync/manager.py
 msgid "A download is still finishing. Wait for it to stop, then try again."
+msgstr ""
+
+#: jellyfin_mpv_shim/sync/manager.py
+msgid ""
+"There isn't enough space on that drive to move the downloads. Free some "
+"space and try again — nothing was moved."
 msgstr ""
 
 #: jellyfin_mpv_shim/sync/manager.py

--- a/jellyfin_mpv_shim/messages/ca/LC_MESSAGES/base.po
+++ b/jellyfin_mpv_shim/messages/ca/LC_MESSAGES/base.po
@@ -6,7 +6,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2026-08-30 22:19-0400\n"
+"POT-Creation-Date: 2026-09-07 17:35-0400\n"
 "PO-Revision-Date: 2026-08-31 09:07+0000\n"
 "Last-Translator: Andreu Punsola Soler <andreu4ps@gmail.com>\n"
 "Language-Team: Catalan <https://translate.jellyfin.org/projects/jellyfin/"
@@ -509,6 +509,11 @@ msgid "Night Mode (Auto Volume Adj)"
 msgstr "Mode nocturn (ajust automàtic de volum)"
 
 #: jellyfin_mpv_shim/mpvtk_browser/app.py
+#: jellyfin_mpv_shim/mpvtk_browser/auth.py
+msgid "Locked"
+msgstr "Blocat"
+
+#: jellyfin_mpv_shim/mpvtk_browser/app.py
 msgid "Failed to load. Check the connection."
 msgstr "No s'ha pogut carregar. Reviseu la connexió."
 
@@ -751,10 +756,6 @@ msgid "Could not connect. Please check your details."
 msgstr "No s'ha pogut establir una connexió. Comproveu les dades."
 
 #: jellyfin_mpv_shim/mpvtk_browser/auth.py
-msgid "Locked"
-msgstr "Blocat"
-
-#: jellyfin_mpv_shim/mpvtk_browser/auth.py
 #: jellyfin_mpv_shim/mpvtk_browser/pages/home.py
 msgid "Connecting to your server…"
 msgstr "S'està connectant al vostre servidor…"
@@ -826,6 +827,10 @@ msgstr "Vist"
 #: jellyfin_mpv_shim/mpvtk_browser/pages/books.py
 msgid "Favorite"
 msgstr "Preferit"
+
+#: jellyfin_mpv_shim/mpvtk_browser/components/detail.py
+msgid "Web"
+msgstr ""
 
 # seeded from jellyfin-web: HeaderVideos
 #: jellyfin_mpv_shim/mpvtk_browser/components/media_info.py
@@ -1389,12 +1394,8 @@ msgid "Jellyfin UI"
 msgstr "Interfície de Jellyfin"
 
 #: jellyfin_mpv_shim/mpvtk_browser/config.py
-msgid "MPV UI with thumbnails"
-msgstr "Interfície MPV amb miniatures"
-
-#: jellyfin_mpv_shim/mpvtk_browser/config.py
-msgid "MPV built-in default"
-msgstr "Configuració per defecte de MPV"
+msgid "MPV UI"
+msgstr ""
 
 #: jellyfin_mpv_shim/mpvtk_browser/config.py
 msgid "Custom OSC"
@@ -1727,8 +1728,24 @@ msgid "Window Buttons in the Top Bar"
 msgstr "Botons de la finestra a la barra superior"
 
 #: jellyfin_mpv_shim/mpvtk_browser/config.py
+#, fuzzy
+#| msgid "Window Buttons in the Top Bar"
+msgid "Keep Window Buttons in Full Screen"
+msgstr "Botons de la finestra a la barra superior"
+
+#: jellyfin_mpv_shim/mpvtk_browser/config.py
+msgid "Hide the Desktop Title Bar"
+msgstr ""
+
+#: jellyfin_mpv_shim/mpvtk_browser/config.py
 msgid "Player Controls Style"
 msgstr "Estil dels controls del reproductor"
+
+#: jellyfin_mpv_shim/mpvtk_browser/config.py
+#, fuzzy
+#| msgid "Enable thumbnail previews"
+msgid "Enable Trickplay Thumbnails"
+msgstr "Activa la vista prèvia de les miniatures"
 
 #: jellyfin_mpv_shim/mpvtk_browser/config.py
 msgid "Load All Seek Previews at Once"
@@ -1758,6 +1775,10 @@ msgstr "Mida de la coberta"
 #: jellyfin_mpv_shim/mpvtk_browser/config.py
 msgid "Full-Width Backdrops"
 msgstr "Fons d'amplada completa"
+
+#: jellyfin_mpv_shim/mpvtk_browser/config.py
+msgid "12-Hour Clock"
+msgstr ""
 
 #: jellyfin_mpv_shim/mpvtk_browser/config.py
 msgid "Grid Spacing"
@@ -1801,12 +1822,23 @@ msgid "Fullscreen Library Browser"
 msgstr "Navegador a pantalla completa de la biblioteca"
 
 #: jellyfin_mpv_shim/mpvtk_browser/config.py
+msgid "Block Player Keybinds While Browsing"
+msgstr ""
+
+#: jellyfin_mpv_shim/mpvtk_browser/config.py
 msgid "Always Bind Arrow Keys to Player Controls"
 msgstr "Vincula sempre les tecles de fletxes al controlador de reproducció"
 
 #: jellyfin_mpv_shim/mpvtk_browser/config.py
 msgid "Player Controls Activation Key"
 msgstr "Tecla d'activació dels controladors de reproducció"
+
+# seeded from jellyfin-web: SelectAll
+#: jellyfin_mpv_shim/mpvtk_browser/config.py
+#, fuzzy
+#| msgid "Select All"
+msgid "Select Key"
+msgstr "Selecciona-ho tot"
 
 #: jellyfin_mpv_shim/mpvtk_browser/config.py
 msgid "Shading Behind the Player Controls"
@@ -1819,6 +1851,12 @@ msgstr "Quan s'amaguen els controladors de reproducció"
 #: jellyfin_mpv_shim/mpvtk_browser/config.py
 msgid "Hide the Player Controls After (seconds)"
 msgstr "Amaga els controls de reproducció després de (segons)"
+
+#: jellyfin_mpv_shim/mpvtk_browser/config.py
+#, fuzzy
+#| msgid "When the Player Controls Hide"
+msgid "Shrink the Player Controls on a Narrow Window"
+msgstr "Quan s'amaguen els controladors de reproducció"
 
 #: jellyfin_mpv_shim/mpvtk_browser/config.py
 msgid "Mouse Back/Forward Buttons Skip Chapters"
@@ -1914,6 +1952,21 @@ msgstr ""
 
 #: jellyfin_mpv_shim/mpvtk_browser/config.py
 msgid ""
+"Stops MPV's own shortcuts -- picture adjustment, screenshots, subtitle and "
+"audio switching -- from acting while you are in the library, where there is "
+"no video for them to act on. Turn it off to use your own MPV key bindings "
+"there."
+msgstr ""
+
+#: jellyfin_mpv_shim/mpvtk_browser/config.py
+msgid ""
+"Activates whatever is highlighted, in the library and on the player "
+"controls. An mpv key name; changing it hands Enter back to MPV. The game "
+"controller's Confirm button and a phone's Select follow it."
+msgstr ""
+
+#: jellyfin_mpv_shim/mpvtk_browser/config.py
+msgid ""
 "Leave these blank unless downloads are waking your disks too often. Set both "
 "of the first two together: episodes are then fetched in one batch when a "
 "series runs low, instead of one at a time."
@@ -1930,9 +1983,14 @@ msgstr ""
 "hàgiu vist."
 
 #: jellyfin_mpv_shim/mpvtk_browser/config.py
+#, fuzzy
+#| msgid ""
+#| "Off gives MPV's own mouse behaviour instead: drag the video to move the "
+#| "window, and right click to pause. Double click is full screen either way."
 msgid ""
 "Off gives MPV's own mouse behaviour instead: drag the video to move the "
-"window, and right click to pause. Double click is full screen either way."
+"window, and the right button does whatever your MPV config gives it. Double "
+"click is full screen either way."
 msgstr ""
 "Quan està desactivat es comporta com el ratolí de MPV: arrossega el vídeo "
 "per a moure la finestra, clic dret per a pausar. Doble clic amb qualsevol "
@@ -2089,6 +2147,30 @@ msgstr ""
 
 #: jellyfin_mpv_shim/mpvtk_browser/config.py
 msgid ""
+"Full screen has no title bar anywhere and nothing to move or maximize, so "
+"the buttons are normally hidden there. Turn this on to keep a way out of "
+"full screen that is not a keyboard shortcut."
+msgstr ""
+
+#: jellyfin_mpv_shim/mpvtk_browser/config.py
+msgid ""
+"Asks the desktop for no title bar on the player window, so the top bar above "
+"is the only one. Pairs with the setting above: on \"Only when the window has "
+"no title bar\" the buttons appear as soon as this is on. Leave both off "
+"unless you want them, since a window with neither can be awkward to move on "
+"some desktops."
+msgstr ""
+
+#: jellyfin_mpv_shim/mpvtk_browser/config.py
+msgid ""
+"Shows a preview frame while you drag the seek bar. Works with every player "
+"control style, including your own OSC script if it supports thumbfast. The "
+"images are fetched from the server per video, which costs disk space and "
+"memory -- tens of MB for an episode, a few hundred for a long film."
+msgstr ""
+
+#: jellyfin_mpv_shim/mpvtk_browser/config.py
+msgid ""
 "Seek previews are normally fetched a few minutes at a time around where you "
 "are seeking, so scrubbing somewhere new waits briefly. Turn this on to load "
 "them all up front instead: nothing ever waits, but a long film can cost "
@@ -2241,6 +2323,13 @@ msgstr ""
 
 #: jellyfin_mpv_shim/mpvtk_browser/config.py
 msgid ""
+"Show times of day as \"8:30 PM\" rather than \"20:30\" — the Live TV guide "
+"and its air times, and the \"Ends at\" labels on a detail page and the "
+"player controls."
+msgstr ""
+
+#: jellyfin_mpv_shim/mpvtk_browser/config.py
+msgid ""
 "The controls have to stay legible over any frame. \"None\" gives the text a "
 "drop shadow instead of shading the picture behind it."
 msgstr ""
@@ -2263,6 +2352,13 @@ msgid ""
 msgstr ""
 "0 els amaga tan bon punt el punter no hi és a sobre i força \"Amaga tret que "
 "es mogui el cursor per sobre\"."
+
+#: jellyfin_mpv_shim/mpvtk_browser/config.py
+msgid ""
+"Narrowing the window shrinks the controls until the smallest button reaches "
+"the accessibility minimum, instead of dropping buttons sooner. Off keeps the "
+"older, larger floor."
+msgstr ""
 
 #: jellyfin_mpv_shim/mpvtk_browser/config.py
 msgid ""
@@ -3712,6 +3808,7 @@ msgid "More Like This"
 msgstr "Similars"
 
 #: jellyfin_mpv_shim/mpvtk_browser/pages/detail.py
+#: jellyfin_mpv_shim/mpvtk_browser/tiles.py
 msgid "Go to Series"
 msgstr "Ves a les sèries"
 
@@ -4789,6 +4886,22 @@ msgstr "Desitgeu eliminar %s d'aquesta col·lecció?"
 msgid "There is nothing here to queue."
 msgstr "No hi ha res aquí a la cua."
 
+#: jellyfin_mpv_shim/mpvtk_browser/timefmt.py
+#, python-brace-format
+msgctxt "12-hour clock"
+msgid "{time} {period}"
+msgstr ""
+
+#: jellyfin_mpv_shim/mpvtk_browser/timefmt.py
+msgctxt "12-hour clock"
+msgid "AM"
+msgstr ""
+
+#: jellyfin_mpv_shim/mpvtk_browser/timefmt.py
+msgctxt "12-hour clock"
+msgid "PM"
+msgstr ""
+
 # seeded from jellyfin-web: Search
 #: jellyfin_mpv_shim/mpvtk_browser/views.py
 #: jellyfin_mpv_shim/mpvtk_browser/window_chrome.py
@@ -4946,6 +5059,12 @@ msgid "Enable SVP"
 msgstr "Activa SVP"
 
 #: jellyfin_mpv_shim/sync/manager.py
+#, fuzzy
+#| msgid "Move the downloads back to the default folder?"
+msgid "The downloads are already in that folder."
+msgstr "Desitgeu traslladar les descàrregues al directori per defecte?"
+
+#: jellyfin_mpv_shim/sync/manager.py
 msgid ""
 "Can't change the download folder while a download is in progress. Wait for "
 "it to finish, then try again."
@@ -4954,8 +5073,29 @@ msgstr ""
 "curs. Espereu que s'acabi i torneu-ho a provar."
 
 #: jellyfin_mpv_shim/sync/manager.py
+#, fuzzy
+#| msgid "That folder already contains downloads. Choose an empty folder."
+msgid ""
+"That folder is inside the current download folder. Choose one outside it."
+msgstr "Aquest directori ja conté descàrregues. Trieu un directori buit."
+
+#: jellyfin_mpv_shim/sync/manager.py
+#, fuzzy
+#| msgid "Can't create that folder. Check the path and its permissions."
+msgid "Can't read that folder. Check the path and its permissions."
+msgstr ""
+"No s'ha pogut crear aquest directori. Reviseu el camí i els permisos "
+"associats."
+
+#: jellyfin_mpv_shim/sync/manager.py
 msgid "That folder already contains downloads. Choose an empty folder."
 msgstr "Aquest directori ja conté descàrregues. Trieu un directori buit."
+
+#: jellyfin_mpv_shim/sync/manager.py
+msgid ""
+"That folder isn't empty. Choose an empty folder — the download folder is "
+"managed by this app and anything else in it can be moved or removed."
+msgstr ""
 
 #: jellyfin_mpv_shim/sync/manager.py
 msgid "Can't create that folder. Check the path and its permissions."
@@ -4968,6 +5108,12 @@ msgid "A download is still finishing. Wait for it to stop, then try again."
 msgstr ""
 "Hi ha una descàrrega que encara no ha acabat. Espereu que s'aturi i llavors "
 "torneu-ho a provar."
+
+#: jellyfin_mpv_shim/sync/manager.py
+msgid ""
+"There isn't enough space on that drive to move the downloads. Free some "
+"space and try again — nothing was moved."
+msgstr ""
 
 #: jellyfin_mpv_shim/sync/manager.py
 msgid ""
@@ -5172,6 +5318,12 @@ msgstr "Perfil de reproducció de vídeo"
 #: jellyfin_mpv_shim/video_profile.py
 msgid "Select Shader Profile"
 msgstr "Seleccioneu el perfil d'ombres"
+
+#~ msgid "MPV UI with thumbnails"
+#~ msgstr "Interfície MPV amb miniatures"
+
+#~ msgid "MPV built-in default"
+#~ msgstr "Configuració per defecte de MPV"
 
 #~ msgid "Discord Rich Presence. Takes effect after a restart."
 #~ msgstr "Discord Rich Presence. Té efecte després de reiniciar."

--- a/jellyfin_mpv_shim/messages/ckb/LC_MESSAGES/base.po
+++ b/jellyfin_mpv_shim/messages/ckb/LC_MESSAGES/base.po
@@ -6,7 +6,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2026-08-30 22:19-0400\n"
+"POT-Creation-Date: 2026-09-07 17:35-0400\n"
 "PO-Revision-Date: 2026-08-22 14:26+0000\n"
 "Last-Translator: ahmadjamel89 <ahmadjamel89@gmail.com>\n"
 "Language-Team: Kurdish (Central) <https://translate.jellyfin.org/projects/"
@@ -546,6 +546,11 @@ msgid "Night Mode (Auto Volume Adj)"
 msgstr ""
 
 #: jellyfin_mpv_shim/mpvtk_browser/app.py
+#: jellyfin_mpv_shim/mpvtk_browser/auth.py
+msgid "Locked"
+msgstr ""
+
+#: jellyfin_mpv_shim/mpvtk_browser/app.py
 msgid "Failed to load. Check the connection."
 msgstr ""
 
@@ -792,10 +797,6 @@ msgid "Could not connect. Please check your details."
 msgstr "ناتوانرێت پەیوەندی بكرێت. تکایە وردەکارییەکانت بپشکنە."
 
 #: jellyfin_mpv_shim/mpvtk_browser/auth.py
-msgid "Locked"
-msgstr ""
-
-#: jellyfin_mpv_shim/mpvtk_browser/auth.py
 #: jellyfin_mpv_shim/mpvtk_browser/pages/home.py
 msgid "Connecting to your server…"
 msgstr ""
@@ -874,6 +875,10 @@ msgstr "چوونەدەرەوە و دەستنیشانکردنی سەیرنەکر�
 #: jellyfin_mpv_shim/mpvtk_browser/pages/books.py
 msgid "Favorite"
 msgstr "دڵخواز"
+
+#: jellyfin_mpv_shim/mpvtk_browser/components/detail.py
+msgid "Web"
+msgstr ""
 
 #: jellyfin_mpv_shim/mpvtk_browser/components/media_info.py
 msgid "Video"
@@ -1427,11 +1432,7 @@ msgid "Jellyfin UI"
 msgstr ""
 
 #: jellyfin_mpv_shim/mpvtk_browser/config.py
-msgid "MPV UI with thumbnails"
-msgstr ""
-
-#: jellyfin_mpv_shim/mpvtk_browser/config.py
-msgid "MPV built-in default"
+msgid "MPV UI"
 msgstr ""
 
 #: jellyfin_mpv_shim/mpvtk_browser/config.py
@@ -1774,8 +1775,22 @@ msgid "Window Buttons in the Top Bar"
 msgstr ""
 
 #: jellyfin_mpv_shim/mpvtk_browser/config.py
+msgid "Keep Window Buttons in Full Screen"
+msgstr ""
+
+#: jellyfin_mpv_shim/mpvtk_browser/config.py
+msgid "Hide the Desktop Title Bar"
+msgstr ""
+
+#: jellyfin_mpv_shim/mpvtk_browser/config.py
 msgid "Player Controls Style"
 msgstr ""
+
+#: jellyfin_mpv_shim/mpvtk_browser/config.py
+#, fuzzy
+#| msgid "Enable thumbnail previews"
+msgid "Enable Trickplay Thumbnails"
+msgstr "لابردنی وێنەی بچووكی پێشبینین"
 
 #: jellyfin_mpv_shim/mpvtk_browser/config.py
 msgid "Load All Seek Previews at Once"
@@ -1805,6 +1820,10 @@ msgstr ""
 
 #: jellyfin_mpv_shim/mpvtk_browser/config.py
 msgid "Full-Width Backdrops"
+msgstr ""
+
+#: jellyfin_mpv_shim/mpvtk_browser/config.py
+msgid "12-Hour Clock"
 msgstr ""
 
 #: jellyfin_mpv_shim/mpvtk_browser/config.py
@@ -1850,11 +1869,19 @@ msgid "Fullscreen Library Browser"
 msgstr ""
 
 #: jellyfin_mpv_shim/mpvtk_browser/config.py
+msgid "Block Player Keybinds While Browsing"
+msgstr ""
+
+#: jellyfin_mpv_shim/mpvtk_browser/config.py
 msgid "Always Bind Arrow Keys to Player Controls"
 msgstr ""
 
 #: jellyfin_mpv_shim/mpvtk_browser/config.py
 msgid "Player Controls Activation Key"
+msgstr ""
+
+#: jellyfin_mpv_shim/mpvtk_browser/config.py
+msgid "Select Key"
 msgstr ""
 
 #: jellyfin_mpv_shim/mpvtk_browser/config.py
@@ -1867,6 +1894,10 @@ msgstr ""
 
 #: jellyfin_mpv_shim/mpvtk_browser/config.py
 msgid "Hide the Player Controls After (seconds)"
+msgstr ""
+
+#: jellyfin_mpv_shim/mpvtk_browser/config.py
+msgid "Shrink the Player Controls on a Narrow Window"
 msgstr ""
 
 #: jellyfin_mpv_shim/mpvtk_browser/config.py
@@ -1951,6 +1982,21 @@ msgstr ""
 
 #: jellyfin_mpv_shim/mpvtk_browser/config.py
 msgid ""
+"Stops MPV's own shortcuts -- picture adjustment, screenshots, subtitle and "
+"audio switching -- from acting while you are in the library, where there is "
+"no video for them to act on. Turn it off to use your own MPV key bindings "
+"there."
+msgstr ""
+
+#: jellyfin_mpv_shim/mpvtk_browser/config.py
+msgid ""
+"Activates whatever is highlighted, in the library and on the player "
+"controls. An mpv key name; changing it hands Enter back to MPV. The game "
+"controller's Confirm button and a phone's Select follow it."
+msgstr ""
+
+#: jellyfin_mpv_shim/mpvtk_browser/config.py
+msgid ""
 "Leave these blank unless downloads are waking your disks too often. Set both "
 "of the first two together: episodes are then fetched in one batch when a "
 "series runs low, instead of one at a time."
@@ -1964,7 +2010,8 @@ msgstr ""
 #: jellyfin_mpv_shim/mpvtk_browser/config.py
 msgid ""
 "Off gives MPV's own mouse behaviour instead: drag the video to move the "
-"window, and right click to pause. Double click is full screen either way."
+"window, and the right button does whatever your MPV config gives it. Double "
+"click is full screen either way."
 msgstr ""
 
 #: jellyfin_mpv_shim/mpvtk_browser/config.py
@@ -2054,6 +2101,30 @@ msgid ""
 "maximize and close in the top bar instead, and lets you drag the window by "
 "it. On \"Only when the window has no title bar\", MPV is asked whether this "
 "window got one, so desktops that draw a title bar are left alone."
+msgstr ""
+
+#: jellyfin_mpv_shim/mpvtk_browser/config.py
+msgid ""
+"Full screen has no title bar anywhere and nothing to move or maximize, so "
+"the buttons are normally hidden there. Turn this on to keep a way out of "
+"full screen that is not a keyboard shortcut."
+msgstr ""
+
+#: jellyfin_mpv_shim/mpvtk_browser/config.py
+msgid ""
+"Asks the desktop for no title bar on the player window, so the top bar above "
+"is the only one. Pairs with the setting above: on \"Only when the window has "
+"no title bar\" the buttons appear as soon as this is on. Leave both off "
+"unless you want them, since a window with neither can be awkward to move on "
+"some desktops."
+msgstr ""
+
+#: jellyfin_mpv_shim/mpvtk_browser/config.py
+msgid ""
+"Shows a preview frame while you drag the seek bar. Works with every player "
+"control style, including your own OSC script if it supports thumbfast. The "
+"images are fetched from the server per video, which costs disk space and "
+"memory -- tens of MB for an episode, a few hundred for a long film."
 msgstr ""
 
 #: jellyfin_mpv_shim/mpvtk_browser/config.py
@@ -2163,6 +2234,13 @@ msgstr ""
 
 #: jellyfin_mpv_shim/mpvtk_browser/config.py
 msgid ""
+"Show times of day as \"8:30 PM\" rather than \"20:30\" — the Live TV guide "
+"and its air times, and the \"Ends at\" labels on a detail page and the "
+"player controls."
+msgstr ""
+
+#: jellyfin_mpv_shim/mpvtk_browser/config.py
+msgid ""
 "The controls have to stay legible over any frame. \"None\" gives the text a "
 "drop shadow instead of shading the picture behind it."
 msgstr ""
@@ -2177,6 +2255,13 @@ msgstr ""
 msgid ""
 "0 hides them as soon as the pointer is not on them, and forces \"Hide unless "
 "hovered\"."
+msgstr ""
+
+#: jellyfin_mpv_shim/mpvtk_browser/config.py
+msgid ""
+"Narrowing the window shrinks the controls until the smallest button reaches "
+"the accessibility minimum, instead of dropping buttons sooner. Off keeps the "
+"older, larger floor."
 msgstr ""
 
 #: jellyfin_mpv_shim/mpvtk_browser/config.py
@@ -3655,6 +3740,7 @@ msgid "More Like This"
 msgstr "هاوشێوەی ئەمە"
 
 #: jellyfin_mpv_shim/mpvtk_browser/pages/detail.py
+#: jellyfin_mpv_shim/mpvtk_browser/tiles.py
 msgid "Go to Series"
 msgstr ""
 
@@ -4733,6 +4819,22 @@ msgstr "ئایا %s لەم کۆمەڵەیە بسڕدرێتەوە؟"
 msgid "There is nothing here to queue."
 msgstr ""
 
+#: jellyfin_mpv_shim/mpvtk_browser/timefmt.py
+#, python-brace-format
+msgctxt "12-hour clock"
+msgid "{time} {period}"
+msgstr ""
+
+#: jellyfin_mpv_shim/mpvtk_browser/timefmt.py
+msgctxt "12-hour clock"
+msgid "AM"
+msgstr ""
+
+#: jellyfin_mpv_shim/mpvtk_browser/timefmt.py
+msgctxt "12-hour clock"
+msgid "PM"
+msgstr ""
+
 #: jellyfin_mpv_shim/mpvtk_browser/views.py
 #: jellyfin_mpv_shim/mpvtk_browser/window_chrome.py
 msgid "Search"
@@ -4889,6 +4991,10 @@ msgid "Enable SVP"
 msgstr "بەکارخستنی SVP"
 
 #: jellyfin_mpv_shim/sync/manager.py
+msgid "The downloads are already in that folder."
+msgstr ""
+
+#: jellyfin_mpv_shim/sync/manager.py
 msgid ""
 "Can't change the download folder while a download is in progress. Wait for "
 "it to finish, then try again."
@@ -4897,7 +5003,22 @@ msgstr ""
 "هەوڵ بدەرەوە."
 
 #: jellyfin_mpv_shim/sync/manager.py
+msgid ""
+"That folder is inside the current download folder. Choose one outside it."
+msgstr ""
+
+#: jellyfin_mpv_shim/sync/manager.py
+msgid "Can't read that folder. Check the path and its permissions."
+msgstr ""
+
+#: jellyfin_mpv_shim/sync/manager.py
 msgid "That folder already contains downloads. Choose an empty folder."
+msgstr ""
+
+#: jellyfin_mpv_shim/sync/manager.py
+msgid ""
+"That folder isn't empty. Choose an empty folder — the download folder is "
+"managed by this app and anything else in it can be moved or removed."
 msgstr ""
 
 #: jellyfin_mpv_shim/sync/manager.py
@@ -4906,6 +5027,12 @@ msgstr ""
 
 #: jellyfin_mpv_shim/sync/manager.py
 msgid "A download is still finishing. Wait for it to stop, then try again."
+msgstr ""
+
+#: jellyfin_mpv_shim/sync/manager.py
+msgid ""
+"There isn't enough space on that drive to move the downloads. Free some "
+"space and try again — nothing was moved."
 msgstr ""
 
 #: jellyfin_mpv_shim/sync/manager.py

--- a/jellyfin_mpv_shim/messages/cs/LC_MESSAGES/base.po
+++ b/jellyfin_mpv_shim/messages/cs/LC_MESSAGES/base.po
@@ -6,7 +6,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2026-08-30 22:19-0400\n"
+"POT-Creation-Date: 2026-09-07 17:35-0400\n"
 "PO-Revision-Date: 2026-09-02 10:02+0000\n"
 "Last-Translator: Helak <adamhavra@seznam.cz>\n"
 "Language-Team: Czech <https://translate.jellyfin.org/projects/jellyfin/"
@@ -509,6 +509,11 @@ msgid "Night Mode (Auto Volume Adj)"
 msgstr "Noční režim (automatické nastavení hlasitosti)"
 
 #: jellyfin_mpv_shim/mpvtk_browser/app.py
+#: jellyfin_mpv_shim/mpvtk_browser/auth.py
+msgid "Locked"
+msgstr "Zamčeno"
+
+#: jellyfin_mpv_shim/mpvtk_browser/app.py
 msgid "Failed to load. Check the connection."
 msgstr "Načtení se nezdařilo. Zkontrolujte připojení."
 
@@ -756,10 +761,6 @@ msgid "Could not connect. Please check your details."
 msgstr "Nepodařilo se navázat spojení. Zkontrolujte prosím zadané údaje."
 
 #: jellyfin_mpv_shim/mpvtk_browser/auth.py
-msgid "Locked"
-msgstr "Zamčeno"
-
-#: jellyfin_mpv_shim/mpvtk_browser/auth.py
 #: jellyfin_mpv_shim/mpvtk_browser/pages/home.py
 msgid "Connecting to your server…"
 msgstr "Připojování k tvému serveru…"
@@ -834,6 +835,10 @@ msgstr "Zhlédnuto"
 #: jellyfin_mpv_shim/mpvtk_browser/pages/books.py
 msgid "Favorite"
 msgstr "Oblíbené"
+
+#: jellyfin_mpv_shim/mpvtk_browser/components/detail.py
+msgid "Web"
+msgstr ""
 
 # seeded from jellyfin-web: HeaderVideos
 #: jellyfin_mpv_shim/mpvtk_browser/components/media_info.py
@@ -1416,11 +1421,7 @@ msgid "Jellyfin UI"
 msgstr ""
 
 #: jellyfin_mpv_shim/mpvtk_browser/config.py
-msgid "MPV UI with thumbnails"
-msgstr ""
-
-#: jellyfin_mpv_shim/mpvtk_browser/config.py
-msgid "MPV built-in default"
+msgid "MPV UI"
 msgstr ""
 
 #: jellyfin_mpv_shim/mpvtk_browser/config.py
@@ -1771,8 +1772,22 @@ msgid "Window Buttons in the Top Bar"
 msgstr ""
 
 #: jellyfin_mpv_shim/mpvtk_browser/config.py
+msgid "Keep Window Buttons in Full Screen"
+msgstr ""
+
+#: jellyfin_mpv_shim/mpvtk_browser/config.py
+msgid "Hide the Desktop Title Bar"
+msgstr ""
+
+#: jellyfin_mpv_shim/mpvtk_browser/config.py
 msgid "Player Controls Style"
 msgstr ""
+
+#: jellyfin_mpv_shim/mpvtk_browser/config.py
+#, fuzzy
+#| msgid "Enable thumbnail previews"
+msgid "Enable Trickplay Thumbnails"
+msgstr "Zobrazit náhledy na časové ose"
 
 #: jellyfin_mpv_shim/mpvtk_browser/config.py
 msgid "Load All Seek Previews at Once"
@@ -1802,6 +1817,10 @@ msgstr ""
 
 #: jellyfin_mpv_shim/mpvtk_browser/config.py
 msgid "Full-Width Backdrops"
+msgstr ""
+
+#: jellyfin_mpv_shim/mpvtk_browser/config.py
+msgid "12-Hour Clock"
 msgstr ""
 
 #: jellyfin_mpv_shim/mpvtk_browser/config.py
@@ -1847,12 +1866,23 @@ msgid "Fullscreen Library Browser"
 msgstr ""
 
 #: jellyfin_mpv_shim/mpvtk_browser/config.py
+msgid "Block Player Keybinds While Browsing"
+msgstr ""
+
+#: jellyfin_mpv_shim/mpvtk_browser/config.py
 msgid "Always Bind Arrow Keys to Player Controls"
 msgstr ""
 
 #: jellyfin_mpv_shim/mpvtk_browser/config.py
 msgid "Player Controls Activation Key"
 msgstr ""
+
+# seeded from jellyfin-web: SelectAll
+#: jellyfin_mpv_shim/mpvtk_browser/config.py
+#, fuzzy
+#| msgid "Select All"
+msgid "Select Key"
+msgstr "Vybrat vše"
 
 #: jellyfin_mpv_shim/mpvtk_browser/config.py
 msgid "Shading Behind the Player Controls"
@@ -1864,6 +1894,10 @@ msgstr ""
 
 #: jellyfin_mpv_shim/mpvtk_browser/config.py
 msgid "Hide the Player Controls After (seconds)"
+msgstr ""
+
+#: jellyfin_mpv_shim/mpvtk_browser/config.py
+msgid "Shrink the Player Controls on a Narrow Window"
 msgstr ""
 
 #: jellyfin_mpv_shim/mpvtk_browser/config.py
@@ -1950,6 +1984,21 @@ msgstr ""
 
 #: jellyfin_mpv_shim/mpvtk_browser/config.py
 msgid ""
+"Stops MPV's own shortcuts -- picture adjustment, screenshots, subtitle and "
+"audio switching -- from acting while you are in the library, where there is "
+"no video for them to act on. Turn it off to use your own MPV key bindings "
+"there."
+msgstr ""
+
+#: jellyfin_mpv_shim/mpvtk_browser/config.py
+msgid ""
+"Activates whatever is highlighted, in the library and on the player "
+"controls. An mpv key name; changing it hands Enter back to MPV. The game "
+"controller's Confirm button and a phone's Select follow it."
+msgstr ""
+
+#: jellyfin_mpv_shim/mpvtk_browser/config.py
+msgid ""
 "Leave these blank unless downloads are waking your disks too often. Set both "
 "of the first two together: episodes are then fetched in one batch when a "
 "series runs low, instead of one at a time."
@@ -1963,7 +2012,8 @@ msgstr ""
 #: jellyfin_mpv_shim/mpvtk_browser/config.py
 msgid ""
 "Off gives MPV's own mouse behaviour instead: drag the video to move the "
-"window, and right click to pause. Double click is full screen either way."
+"window, and the right button does whatever your MPV config gives it. Double "
+"click is full screen either way."
 msgstr ""
 
 #: jellyfin_mpv_shim/mpvtk_browser/config.py
@@ -2053,6 +2103,30 @@ msgid ""
 "maximize and close in the top bar instead, and lets you drag the window by "
 "it. On \"Only when the window has no title bar\", MPV is asked whether this "
 "window got one, so desktops that draw a title bar are left alone."
+msgstr ""
+
+#: jellyfin_mpv_shim/mpvtk_browser/config.py
+msgid ""
+"Full screen has no title bar anywhere and nothing to move or maximize, so "
+"the buttons are normally hidden there. Turn this on to keep a way out of "
+"full screen that is not a keyboard shortcut."
+msgstr ""
+
+#: jellyfin_mpv_shim/mpvtk_browser/config.py
+msgid ""
+"Asks the desktop for no title bar on the player window, so the top bar above "
+"is the only one. Pairs with the setting above: on \"Only when the window has "
+"no title bar\" the buttons appear as soon as this is on. Leave both off "
+"unless you want them, since a window with neither can be awkward to move on "
+"some desktops."
+msgstr ""
+
+#: jellyfin_mpv_shim/mpvtk_browser/config.py
+msgid ""
+"Shows a preview frame while you drag the seek bar. Works with every player "
+"control style, including your own OSC script if it supports thumbfast. The "
+"images are fetched from the server per video, which costs disk space and "
+"memory -- tens of MB for an episode, a few hundred for a long film."
 msgstr ""
 
 #: jellyfin_mpv_shim/mpvtk_browser/config.py
@@ -2162,6 +2236,13 @@ msgstr ""
 
 #: jellyfin_mpv_shim/mpvtk_browser/config.py
 msgid ""
+"Show times of day as \"8:30 PM\" rather than \"20:30\" — the Live TV guide "
+"and its air times, and the \"Ends at\" labels on a detail page and the "
+"player controls."
+msgstr ""
+
+#: jellyfin_mpv_shim/mpvtk_browser/config.py
+msgid ""
 "The controls have to stay legible over any frame. \"None\" gives the text a "
 "drop shadow instead of shading the picture behind it."
 msgstr ""
@@ -2176,6 +2257,13 @@ msgstr ""
 msgid ""
 "0 hides them as soon as the pointer is not on them, and forces \"Hide unless "
 "hovered\"."
+msgstr ""
+
+#: jellyfin_mpv_shim/mpvtk_browser/config.py
+msgid ""
+"Narrowing the window shrinks the controls until the smallest button reaches "
+"the accessibility minimum, instead of dropping buttons sooner. Off keeps the "
+"older, larger floor."
 msgstr ""
 
 #: jellyfin_mpv_shim/mpvtk_browser/config.py
@@ -3791,6 +3879,7 @@ msgid "More Like This"
 msgstr "Podobné položky"
 
 #: jellyfin_mpv_shim/mpvtk_browser/pages/detail.py
+#: jellyfin_mpv_shim/mpvtk_browser/tiles.py
 msgid "Go to Series"
 msgstr ""
 
@@ -4984,6 +5073,22 @@ msgstr "Vzdálený server"
 msgid "There is nothing here to queue."
 msgstr ""
 
+#: jellyfin_mpv_shim/mpvtk_browser/timefmt.py
+#, python-brace-format
+msgctxt "12-hour clock"
+msgid "{time} {period}"
+msgstr ""
+
+#: jellyfin_mpv_shim/mpvtk_browser/timefmt.py
+msgctxt "12-hour clock"
+msgid "AM"
+msgstr ""
+
+#: jellyfin_mpv_shim/mpvtk_browser/timefmt.py
+msgctxt "12-hour clock"
+msgid "PM"
+msgstr ""
+
 # seeded from jellyfin-web: Search
 #: jellyfin_mpv_shim/mpvtk_browser/views.py
 #: jellyfin_mpv_shim/mpvtk_browser/window_chrome.py
@@ -5152,13 +5257,32 @@ msgid "Enable SVP"
 msgstr "Zapnout SVP"
 
 #: jellyfin_mpv_shim/sync/manager.py
+msgid "The downloads are already in that folder."
+msgstr ""
+
+#: jellyfin_mpv_shim/sync/manager.py
 msgid ""
 "Can't change the download folder while a download is in progress. Wait for "
 "it to finish, then try again."
 msgstr ""
 
 #: jellyfin_mpv_shim/sync/manager.py
+msgid ""
+"That folder is inside the current download folder. Choose one outside it."
+msgstr ""
+
+#: jellyfin_mpv_shim/sync/manager.py
+msgid "Can't read that folder. Check the path and its permissions."
+msgstr ""
+
+#: jellyfin_mpv_shim/sync/manager.py
 msgid "That folder already contains downloads. Choose an empty folder."
+msgstr ""
+
+#: jellyfin_mpv_shim/sync/manager.py
+msgid ""
+"That folder isn't empty. Choose an empty folder — the download folder is "
+"managed by this app and anything else in it can be moved or removed."
 msgstr ""
 
 #: jellyfin_mpv_shim/sync/manager.py
@@ -5167,6 +5291,12 @@ msgstr ""
 
 #: jellyfin_mpv_shim/sync/manager.py
 msgid "A download is still finishing. Wait for it to stop, then try again."
+msgstr ""
+
+#: jellyfin_mpv_shim/sync/manager.py
+msgid ""
+"There isn't enough space on that drive to move the downloads. Free some "
+"space and try again — nothing was moved."
 msgstr ""
 
 #: jellyfin_mpv_shim/sync/manager.py

--- a/jellyfin_mpv_shim/messages/cy/LC_MESSAGES/base.po
+++ b/jellyfin_mpv_shim/messages/cy/LC_MESSAGES/base.po
@@ -6,7 +6,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2026-08-30 22:19-0400\n"
+"POT-Creation-Date: 2026-09-07 17:35-0400\n"
 "PO-Revision-Date: 2026-01-09 22:16+0000\n"
 "Last-Translator: SilentSkies <toby.taylor400@outlook.com>\n"
 "Language-Team: Welsh <https://translate.jellyfin.org/projects/jellyfin/"
@@ -552,6 +552,11 @@ msgid "Night Mode (Auto Volume Adj)"
 msgstr ""
 
 #: jellyfin_mpv_shim/mpvtk_browser/app.py
+#: jellyfin_mpv_shim/mpvtk_browser/auth.py
+msgid "Locked"
+msgstr ""
+
+#: jellyfin_mpv_shim/mpvtk_browser/app.py
 msgid "Failed to load. Check the connection."
 msgstr ""
 
@@ -831,10 +836,6 @@ msgstr ""
 "Gwiriwch eich gwybodaeth cyswllt."
 
 #: jellyfin_mpv_shim/mpvtk_browser/auth.py
-msgid "Locked"
-msgstr ""
-
-#: jellyfin_mpv_shim/mpvtk_browser/auth.py
 #: jellyfin_mpv_shim/mpvtk_browser/pages/home.py
 msgid "Connecting to your server…"
 msgstr ""
@@ -915,6 +916,10 @@ msgstr "Gadael a Marcio fel Heb ei wylio"
 #: jellyfin_mpv_shim/mpvtk_browser/pages/books.py
 msgid "Favorite"
 msgstr "Ffefryn"
+
+#: jellyfin_mpv_shim/mpvtk_browser/components/detail.py
+msgid "Web"
+msgstr ""
 
 # seeded from jellyfin-web: HeaderVideos
 #: jellyfin_mpv_shim/mpvtk_browser/components/media_info.py
@@ -1493,11 +1498,7 @@ msgid "Jellyfin UI"
 msgstr ""
 
 #: jellyfin_mpv_shim/mpvtk_browser/config.py
-msgid "MPV UI with thumbnails"
-msgstr ""
-
-#: jellyfin_mpv_shim/mpvtk_browser/config.py
-msgid "MPV built-in default"
+msgid "MPV UI"
 msgstr ""
 
 #: jellyfin_mpv_shim/mpvtk_browser/config.py
@@ -1844,8 +1845,22 @@ msgid "Window Buttons in the Top Bar"
 msgstr ""
 
 #: jellyfin_mpv_shim/mpvtk_browser/config.py
+msgid "Keep Window Buttons in Full Screen"
+msgstr ""
+
+#: jellyfin_mpv_shim/mpvtk_browser/config.py
+msgid "Hide the Desktop Title Bar"
+msgstr ""
+
+#: jellyfin_mpv_shim/mpvtk_browser/config.py
 msgid "Player Controls Style"
 msgstr ""
+
+#: jellyfin_mpv_shim/mpvtk_browser/config.py
+#, fuzzy
+#| msgid "Enable thumbnail previews"
+msgid "Enable Trickplay Thumbnails"
+msgstr "Galluogi rhagolwg mân-luniau"
 
 #: jellyfin_mpv_shim/mpvtk_browser/config.py
 msgid "Load All Seek Previews at Once"
@@ -1874,6 +1889,10 @@ msgstr ""
 
 #: jellyfin_mpv_shim/mpvtk_browser/config.py
 msgid "Full-Width Backdrops"
+msgstr ""
+
+#: jellyfin_mpv_shim/mpvtk_browser/config.py
+msgid "12-Hour Clock"
 msgstr ""
 
 #: jellyfin_mpv_shim/mpvtk_browser/config.py
@@ -1919,12 +1938,23 @@ msgid "Fullscreen Library Browser"
 msgstr ""
 
 #: jellyfin_mpv_shim/mpvtk_browser/config.py
+msgid "Block Player Keybinds While Browsing"
+msgstr ""
+
+#: jellyfin_mpv_shim/mpvtk_browser/config.py
 msgid "Always Bind Arrow Keys to Player Controls"
 msgstr ""
 
 #: jellyfin_mpv_shim/mpvtk_browser/config.py
 msgid "Player Controls Activation Key"
 msgstr ""
+
+# seeded from jellyfin-web: SelectAll
+#: jellyfin_mpv_shim/mpvtk_browser/config.py
+#, fuzzy
+#| msgid "Select All"
+msgid "Select Key"
+msgstr "Dewiswch Pawb"
 
 #: jellyfin_mpv_shim/mpvtk_browser/config.py
 msgid "Shading Behind the Player Controls"
@@ -1936,6 +1966,10 @@ msgstr ""
 
 #: jellyfin_mpv_shim/mpvtk_browser/config.py
 msgid "Hide the Player Controls After (seconds)"
+msgstr ""
+
+#: jellyfin_mpv_shim/mpvtk_browser/config.py
+msgid "Shrink the Player Controls on a Narrow Window"
 msgstr ""
 
 #: jellyfin_mpv_shim/mpvtk_browser/config.py
@@ -2022,6 +2056,21 @@ msgstr ""
 
 #: jellyfin_mpv_shim/mpvtk_browser/config.py
 msgid ""
+"Stops MPV's own shortcuts -- picture adjustment, screenshots, subtitle and "
+"audio switching -- from acting while you are in the library, where there is "
+"no video for them to act on. Turn it off to use your own MPV key bindings "
+"there."
+msgstr ""
+
+#: jellyfin_mpv_shim/mpvtk_browser/config.py
+msgid ""
+"Activates whatever is highlighted, in the library and on the player "
+"controls. An mpv key name; changing it hands Enter back to MPV. The game "
+"controller's Confirm button and a phone's Select follow it."
+msgstr ""
+
+#: jellyfin_mpv_shim/mpvtk_browser/config.py
+msgid ""
 "Leave these blank unless downloads are waking your disks too often. Set both "
 "of the first two together: episodes are then fetched in one batch when a "
 "series runs low, instead of one at a time."
@@ -2035,7 +2084,8 @@ msgstr ""
 #: jellyfin_mpv_shim/mpvtk_browser/config.py
 msgid ""
 "Off gives MPV's own mouse behaviour instead: drag the video to move the "
-"window, and right click to pause. Double click is full screen either way."
+"window, and the right button does whatever your MPV config gives it. Double "
+"click is full screen either way."
 msgstr ""
 
 #: jellyfin_mpv_shim/mpvtk_browser/config.py
@@ -2125,6 +2175,30 @@ msgid ""
 "maximize and close in the top bar instead, and lets you drag the window by "
 "it. On \"Only when the window has no title bar\", MPV is asked whether this "
 "window got one, so desktops that draw a title bar are left alone."
+msgstr ""
+
+#: jellyfin_mpv_shim/mpvtk_browser/config.py
+msgid ""
+"Full screen has no title bar anywhere and nothing to move or maximize, so "
+"the buttons are normally hidden there. Turn this on to keep a way out of "
+"full screen that is not a keyboard shortcut."
+msgstr ""
+
+#: jellyfin_mpv_shim/mpvtk_browser/config.py
+msgid ""
+"Asks the desktop for no title bar on the player window, so the top bar above "
+"is the only one. Pairs with the setting above: on \"Only when the window has "
+"no title bar\" the buttons appear as soon as this is on. Leave both off "
+"unless you want them, since a window with neither can be awkward to move on "
+"some desktops."
+msgstr ""
+
+#: jellyfin_mpv_shim/mpvtk_browser/config.py
+msgid ""
+"Shows a preview frame while you drag the seek bar. Works with every player "
+"control style, including your own OSC script if it supports thumbfast. The "
+"images are fetched from the server per video, which costs disk space and "
+"memory -- tens of MB for an episode, a few hundred for a long film."
 msgstr ""
 
 #: jellyfin_mpv_shim/mpvtk_browser/config.py
@@ -2234,6 +2308,13 @@ msgstr ""
 
 #: jellyfin_mpv_shim/mpvtk_browser/config.py
 msgid ""
+"Show times of day as \"8:30 PM\" rather than \"20:30\" — the Live TV guide "
+"and its air times, and the \"Ends at\" labels on a detail page and the "
+"player controls."
+msgstr ""
+
+#: jellyfin_mpv_shim/mpvtk_browser/config.py
+msgid ""
 "The controls have to stay legible over any frame. \"None\" gives the text a "
 "drop shadow instead of shading the picture behind it."
 msgstr ""
@@ -2248,6 +2329,13 @@ msgstr ""
 msgid ""
 "0 hides them as soon as the pointer is not on them, and forces \"Hide unless "
 "hovered\"."
+msgstr ""
+
+#: jellyfin_mpv_shim/mpvtk_browser/config.py
+msgid ""
+"Narrowing the window shrinks the controls until the smallest button reaches "
+"the accessibility minimum, instead of dropping buttons sooner. Off keeps the "
+"older, larger floor."
 msgstr ""
 
 #: jellyfin_mpv_shim/mpvtk_browser/config.py
@@ -3830,6 +3918,7 @@ msgid "More Like This"
 msgstr "Mwy fel hwn"
 
 #: jellyfin_mpv_shim/mpvtk_browser/pages/detail.py
+#: jellyfin_mpv_shim/mpvtk_browser/tiles.py
 msgid "Go to Series"
 msgstr ""
 
@@ -5007,6 +5096,22 @@ msgstr "Dileu Gweinydd"
 msgid "There is nothing here to queue."
 msgstr ""
 
+#: jellyfin_mpv_shim/mpvtk_browser/timefmt.py
+#, python-brace-format
+msgctxt "12-hour clock"
+msgid "{time} {period}"
+msgstr ""
+
+#: jellyfin_mpv_shim/mpvtk_browser/timefmt.py
+msgctxt "12-hour clock"
+msgid "AM"
+msgstr ""
+
+#: jellyfin_mpv_shim/mpvtk_browser/timefmt.py
+msgctxt "12-hour clock"
+msgid "PM"
+msgstr ""
+
 # seeded from jellyfin-web: Search
 #: jellyfin_mpv_shim/mpvtk_browser/views.py
 #: jellyfin_mpv_shim/mpvtk_browser/window_chrome.py
@@ -5173,13 +5278,32 @@ msgid "Enable SVP"
 msgstr "Dechrau SVP"
 
 #: jellyfin_mpv_shim/sync/manager.py
+msgid "The downloads are already in that folder."
+msgstr ""
+
+#: jellyfin_mpv_shim/sync/manager.py
 msgid ""
 "Can't change the download folder while a download is in progress. Wait for "
 "it to finish, then try again."
 msgstr ""
 
 #: jellyfin_mpv_shim/sync/manager.py
+msgid ""
+"That folder is inside the current download folder. Choose one outside it."
+msgstr ""
+
+#: jellyfin_mpv_shim/sync/manager.py
+msgid "Can't read that folder. Check the path and its permissions."
+msgstr ""
+
+#: jellyfin_mpv_shim/sync/manager.py
 msgid "That folder already contains downloads. Choose an empty folder."
+msgstr ""
+
+#: jellyfin_mpv_shim/sync/manager.py
+msgid ""
+"That folder isn't empty. Choose an empty folder — the download folder is "
+"managed by this app and anything else in it can be moved or removed."
 msgstr ""
 
 #: jellyfin_mpv_shim/sync/manager.py
@@ -5188,6 +5312,12 @@ msgstr ""
 
 #: jellyfin_mpv_shim/sync/manager.py
 msgid "A download is still finishing. Wait for it to stop, then try again."
+msgstr ""
+
+#: jellyfin_mpv_shim/sync/manager.py
+msgid ""
+"There isn't enough space on that drive to move the downloads. Free some "
+"space and try again — nothing was moved."
 msgstr ""
 
 #: jellyfin_mpv_shim/sync/manager.py

--- a/jellyfin_mpv_shim/messages/da/LC_MESSAGES/base.po
+++ b/jellyfin_mpv_shim/messages/da/LC_MESSAGES/base.po
@@ -6,7 +6,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2026-08-30 22:19-0400\n"
+"POT-Creation-Date: 2026-09-07 17:35-0400\n"
 "PO-Revision-Date: 2026-08-29 13:34+0000\n"
 "Last-Translator: Lau <waulau@pm.me>\n"
 "Language-Team: Danish <https://translate.jellyfin.org/projects/jellyfin/"
@@ -508,6 +508,11 @@ msgid "Night Mode (Auto Volume Adj)"
 msgstr "Nat tilstand (Automatisk lydstyrke justering)"
 
 #: jellyfin_mpv_shim/mpvtk_browser/app.py
+#: jellyfin_mpv_shim/mpvtk_browser/auth.py
+msgid "Locked"
+msgstr "Låst"
+
+#: jellyfin_mpv_shim/mpvtk_browser/app.py
 msgid "Failed to load. Check the connection."
 msgstr "Indlæsning fejlede. Tjek tilslutningen."
 
@@ -756,10 +761,6 @@ msgid "Could not connect. Please check your details."
 msgstr "Det var ikke muligt at tilslutte. Kontroller venligst dine detaljer."
 
 #: jellyfin_mpv_shim/mpvtk_browser/auth.py
-msgid "Locked"
-msgstr "Låst"
-
-#: jellyfin_mpv_shim/mpvtk_browser/auth.py
 #: jellyfin_mpv_shim/mpvtk_browser/pages/home.py
 msgid "Connecting to your server…"
 msgstr "Tilslutter sig til din server…"
@@ -834,6 +835,10 @@ msgstr "Set"
 #: jellyfin_mpv_shim/mpvtk_browser/pages/books.py
 msgid "Favorite"
 msgstr "Favorit"
+
+#: jellyfin_mpv_shim/mpvtk_browser/components/detail.py
+msgid "Web"
+msgstr ""
 
 # seeded from jellyfin-web: HeaderVideos
 #: jellyfin_mpv_shim/mpvtk_browser/components/media_info.py
@@ -1411,12 +1416,8 @@ msgid "Jellyfin UI"
 msgstr "Jellyfin brugerflade"
 
 #: jellyfin_mpv_shim/mpvtk_browser/config.py
-msgid "MPV UI with thumbnails"
-msgstr "MPV brugerflade med miniaturebilleder"
-
-#: jellyfin_mpv_shim/mpvtk_browser/config.py
-msgid "MPV built-in default"
-msgstr "Indbygget standard fra MPV"
+msgid "MPV UI"
+msgstr ""
 
 #: jellyfin_mpv_shim/mpvtk_browser/config.py
 msgid "Custom OSC"
@@ -1751,8 +1752,24 @@ msgid "Window Buttons in the Top Bar"
 msgstr "Vindue knapper i top-baren"
 
 #: jellyfin_mpv_shim/mpvtk_browser/config.py
+#, fuzzy
+#| msgid "Window Buttons in the Top Bar"
+msgid "Keep Window Buttons in Full Screen"
+msgstr "Vindue knapper i top-baren"
+
+#: jellyfin_mpv_shim/mpvtk_browser/config.py
+msgid "Hide the Desktop Title Bar"
+msgstr ""
+
+#: jellyfin_mpv_shim/mpvtk_browser/config.py
 msgid "Player Controls Style"
 msgstr "Størrelse for afspiller betjening"
+
+#: jellyfin_mpv_shim/mpvtk_browser/config.py
+#, fuzzy
+#| msgid "Enable thumbnail previews"
+msgid "Enable Trickplay Thumbnails"
+msgstr "Aktivér forhåndsvisning af miniaturer"
 
 #: jellyfin_mpv_shim/mpvtk_browser/config.py
 msgid "Load All Seek Previews at Once"
@@ -1783,6 +1800,10 @@ msgstr "Coverstørrelse"
 #: jellyfin_mpv_shim/mpvtk_browser/config.py
 msgid "Full-Width Backdrops"
 msgstr "Fuldbredde baggrunde"
+
+#: jellyfin_mpv_shim/mpvtk_browser/config.py
+msgid "12-Hour Clock"
+msgstr ""
 
 #: jellyfin_mpv_shim/mpvtk_browser/config.py
 msgid "Grid Spacing"
@@ -1826,12 +1847,23 @@ msgid "Fullscreen Library Browser"
 msgstr "Maksimeret biblioteksbrowser"
 
 #: jellyfin_mpv_shim/mpvtk_browser/config.py
+msgid "Block Player Keybinds While Browsing"
+msgstr ""
+
+#: jellyfin_mpv_shim/mpvtk_browser/config.py
 msgid "Always Bind Arrow Keys to Player Controls"
 msgstr "Brug altid piletasterne til afspiller betjeningen"
 
 #: jellyfin_mpv_shim/mpvtk_browser/config.py
 msgid "Player Controls Activation Key"
 msgstr "Tast som aktiverer afspiller betjeningen"
+
+# seeded from jellyfin-web: SelectAll
+#: jellyfin_mpv_shim/mpvtk_browser/config.py
+#, fuzzy
+#| msgid "Select All"
+msgid "Select Key"
+msgstr "Vælg alle"
 
 #: jellyfin_mpv_shim/mpvtk_browser/config.py
 msgid "Shading Behind the Player Controls"
@@ -1844,6 +1876,12 @@ msgstr "Når afspiller betjeningen gemmes"
 #: jellyfin_mpv_shim/mpvtk_browser/config.py
 msgid "Hide the Player Controls After (seconds)"
 msgstr "Gem afspiller betjeningen efter (sekunder)"
+
+#: jellyfin_mpv_shim/mpvtk_browser/config.py
+#, fuzzy
+#| msgid "When the Player Controls Hide"
+msgid "Shrink the Player Controls on a Narrow Window"
+msgstr "Når afspiller betjeningen gemmes"
 
 #: jellyfin_mpv_shim/mpvtk_browser/config.py
 msgid "Mouse Back/Forward Buttons Skip Chapters"
@@ -1938,6 +1976,21 @@ msgstr ""
 
 #: jellyfin_mpv_shim/mpvtk_browser/config.py
 msgid ""
+"Stops MPV's own shortcuts -- picture adjustment, screenshots, subtitle and "
+"audio switching -- from acting while you are in the library, where there is "
+"no video for them to act on. Turn it off to use your own MPV key bindings "
+"there."
+msgstr ""
+
+#: jellyfin_mpv_shim/mpvtk_browser/config.py
+msgid ""
+"Activates whatever is highlighted, in the library and on the player "
+"controls. An mpv key name; changing it hands Enter back to MPV. The game "
+"controller's Confirm button and a phone's Select follow it."
+msgstr ""
+
+#: jellyfin_mpv_shim/mpvtk_browser/config.py
+msgid ""
 "Leave these blank unless downloads are waking your disks too often. Set both "
 "of the first two together: episodes are then fetched in one batch when a "
 "series runs low, instead of one at a time."
@@ -1954,9 +2007,14 @@ msgstr ""
 "har set endnu."
 
 #: jellyfin_mpv_shim/mpvtk_browser/config.py
+#, fuzzy
+#| msgid ""
+#| "Off gives MPV's own mouse behaviour instead: drag the video to move the "
+#| "window, and right click to pause. Double click is full screen either way."
 msgid ""
 "Off gives MPV's own mouse behaviour instead: drag the video to move the "
-"window, and right click to pause. Double click is full screen either way."
+"window, and the right button does whatever your MPV config gives it. Double "
+"click is full screen either way."
 msgstr ""
 "Fra vil gøre at MPV's egen musse adfærd bruges i stedet: ryk vinduet ved at "
 "trække videoen, pause når der højreklikkes. Dobbeltklik vil være fuldskærm "
@@ -2095,6 +2153,30 @@ msgstr ""
 
 #: jellyfin_mpv_shim/mpvtk_browser/config.py
 msgid ""
+"Full screen has no title bar anywhere and nothing to move or maximize, so "
+"the buttons are normally hidden there. Turn this on to keep a way out of "
+"full screen that is not a keyboard shortcut."
+msgstr ""
+
+#: jellyfin_mpv_shim/mpvtk_browser/config.py
+msgid ""
+"Asks the desktop for no title bar on the player window, so the top bar above "
+"is the only one. Pairs with the setting above: on \"Only when the window has "
+"no title bar\" the buttons appear as soon as this is on. Leave both off "
+"unless you want them, since a window with neither can be awkward to move on "
+"some desktops."
+msgstr ""
+
+#: jellyfin_mpv_shim/mpvtk_browser/config.py
+msgid ""
+"Shows a preview frame while you drag the seek bar. Works with every player "
+"control style, including your own OSC script if it supports thumbfast. The "
+"images are fetched from the server per video, which costs disk space and "
+"memory -- tens of MB for an episode, a few hundred for a long film."
+msgstr ""
+
+#: jellyfin_mpv_shim/mpvtk_browser/config.py
+msgid ""
 "Seek previews are normally fetched a few minutes at a time around where you "
 "are seeking, so scrubbing somewhere new waits briefly. Turn this on to load "
 "them all up front instead: nothing ever waits, but a long film can cost "
@@ -2198,6 +2280,13 @@ msgstr ""
 
 #: jellyfin_mpv_shim/mpvtk_browser/config.py
 msgid ""
+"Show times of day as \"8:30 PM\" rather than \"20:30\" — the Live TV guide "
+"and its air times, and the \"Ends at\" labels on a detail page and the "
+"player controls."
+msgstr ""
+
+#: jellyfin_mpv_shim/mpvtk_browser/config.py
+msgid ""
 "The controls have to stay legible over any frame. \"None\" gives the text a "
 "drop shadow instead of shading the picture behind it."
 msgstr ""
@@ -2212,6 +2301,13 @@ msgstr ""
 msgid ""
 "0 hides them as soon as the pointer is not on them, and forces \"Hide unless "
 "hovered\"."
+msgstr ""
+
+#: jellyfin_mpv_shim/mpvtk_browser/config.py
+msgid ""
+"Narrowing the window shrinks the controls until the smallest button reaches "
+"the accessibility minimum, instead of dropping buttons sooner. Off keeps the "
+"older, larger floor."
 msgstr ""
 
 #: jellyfin_mpv_shim/mpvtk_browser/config.py
@@ -3701,6 +3797,7 @@ msgid "More Like This"
 msgstr "Mere som dette"
 
 #: jellyfin_mpv_shim/mpvtk_browser/pages/detail.py
+#: jellyfin_mpv_shim/mpvtk_browser/tiles.py
 msgid "Go to Series"
 msgstr ""
 
@@ -4807,6 +4904,22 @@ msgstr ""
 msgid "There is nothing here to queue."
 msgstr ""
 
+#: jellyfin_mpv_shim/mpvtk_browser/timefmt.py
+#, python-brace-format
+msgctxt "12-hour clock"
+msgid "{time} {period}"
+msgstr ""
+
+#: jellyfin_mpv_shim/mpvtk_browser/timefmt.py
+msgctxt "12-hour clock"
+msgid "AM"
+msgstr ""
+
+#: jellyfin_mpv_shim/mpvtk_browser/timefmt.py
+msgctxt "12-hour clock"
+msgid "PM"
+msgstr ""
+
 # seeded from jellyfin-web: Search
 #: jellyfin_mpv_shim/mpvtk_browser/views.py
 #: jellyfin_mpv_shim/mpvtk_browser/window_chrome.py
@@ -4967,13 +5080,32 @@ msgid "Enable SVP"
 msgstr "Aktivér SVP"
 
 #: jellyfin_mpv_shim/sync/manager.py
+msgid "The downloads are already in that folder."
+msgstr ""
+
+#: jellyfin_mpv_shim/sync/manager.py
 msgid ""
 "Can't change the download folder while a download is in progress. Wait for "
 "it to finish, then try again."
 msgstr ""
 
 #: jellyfin_mpv_shim/sync/manager.py
+msgid ""
+"That folder is inside the current download folder. Choose one outside it."
+msgstr ""
+
+#: jellyfin_mpv_shim/sync/manager.py
+msgid "Can't read that folder. Check the path and its permissions."
+msgstr ""
+
+#: jellyfin_mpv_shim/sync/manager.py
 msgid "That folder already contains downloads. Choose an empty folder."
+msgstr ""
+
+#: jellyfin_mpv_shim/sync/manager.py
+msgid ""
+"That folder isn't empty. Choose an empty folder — the download folder is "
+"managed by this app and anything else in it can be moved or removed."
 msgstr ""
 
 #: jellyfin_mpv_shim/sync/manager.py
@@ -4982,6 +5114,12 @@ msgstr ""
 
 #: jellyfin_mpv_shim/sync/manager.py
 msgid "A download is still finishing. Wait for it to stop, then try again."
+msgstr ""
+
+#: jellyfin_mpv_shim/sync/manager.py
+msgid ""
+"There isn't enough space on that drive to move the downloads. Free some "
+"space and try again — nothing was moved."
 msgstr ""
 
 #: jellyfin_mpv_shim/sync/manager.py
@@ -5183,6 +5321,12 @@ msgstr "Videoafspilningsprofil"
 #: jellyfin_mpv_shim/video_profile.py
 msgid "Select Shader Profile"
 msgstr "Vælg shaderprofil"
+
+#~ msgid "MPV UI with thumbnails"
+#~ msgstr "MPV brugerflade med miniaturebilleder"
+
+#~ msgid "MPV built-in default"
+#~ msgstr "Indbygget standard fra MPV"
 
 #, fuzzy
 #~| msgid "Quit and Mark Unwatched"

--- a/jellyfin_mpv_shim/messages/de/LC_MESSAGES/base.po
+++ b/jellyfin_mpv_shim/messages/de/LC_MESSAGES/base.po
@@ -6,7 +6,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2026-08-30 22:19-0400\n"
+"POT-Creation-Date: 2026-09-07 17:35-0400\n"
 "PO-Revision-Date: 2026-09-06 13:13+0000\n"
 "Last-Translator: MrPlow <joachim.huffer@gmail.com>\n"
 "Language-Team: German <https://translate.jellyfin.org/projects/jellyfin/"
@@ -509,6 +509,11 @@ msgid "Night Mode (Auto Volume Adj)"
 msgstr "Nacht Modus (Automatische Lautstärken Regelung)"
 
 #: jellyfin_mpv_shim/mpvtk_browser/app.py
+#: jellyfin_mpv_shim/mpvtk_browser/auth.py
+msgid "Locked"
+msgstr "Gesperrt"
+
+#: jellyfin_mpv_shim/mpvtk_browser/app.py
 msgid "Failed to load. Check the connection."
 msgstr "Laden fehlgeschlagen. Überprüfen Sie die Verbindung."
 
@@ -752,10 +757,6 @@ msgid "Could not connect. Please check your details."
 msgstr "Verbindung fehlgeschlagen. Bitte überprüfen Sie die Anmeldedaten."
 
 #: jellyfin_mpv_shim/mpvtk_browser/auth.py
-msgid "Locked"
-msgstr "Gesperrt"
-
-#: jellyfin_mpv_shim/mpvtk_browser/auth.py
 #: jellyfin_mpv_shim/mpvtk_browser/pages/home.py
 msgid "Connecting to your server…"
 msgstr "Verbinde mit ihrem Server…"
@@ -826,6 +827,10 @@ msgstr "Angesehen"
 #: jellyfin_mpv_shim/mpvtk_browser/pages/books.py
 msgid "Favorite"
 msgstr "Favorit"
+
+#: jellyfin_mpv_shim/mpvtk_browser/components/detail.py
+msgid "Web"
+msgstr ""
 
 # seeded from jellyfin-web: HeaderVideos
 #: jellyfin_mpv_shim/mpvtk_browser/components/media_info.py
@@ -1393,12 +1398,8 @@ msgid "Jellyfin UI"
 msgstr "Jellyfin UI"
 
 #: jellyfin_mpv_shim/mpvtk_browser/config.py
-msgid "MPV UI with thumbnails"
-msgstr "MPV UI mit Vorschaubildern"
-
-#: jellyfin_mpv_shim/mpvtk_browser/config.py
-msgid "MPV built-in default"
-msgstr "MPV integrierter Standard"
+msgid "MPV UI"
+msgstr ""
 
 #: jellyfin_mpv_shim/mpvtk_browser/config.py
 msgid "Custom OSC"
@@ -1731,8 +1732,24 @@ msgid "Window Buttons in the Top Bar"
 msgstr "Fensterbuttons in oberer Leiste"
 
 #: jellyfin_mpv_shim/mpvtk_browser/config.py
+#, fuzzy
+#| msgid "Window Buttons in the Top Bar"
+msgid "Keep Window Buttons in Full Screen"
+msgstr "Fensterbuttons in oberer Leiste"
+
+#: jellyfin_mpv_shim/mpvtk_browser/config.py
+msgid "Hide the Desktop Title Bar"
+msgstr ""
+
+#: jellyfin_mpv_shim/mpvtk_browser/config.py
 msgid "Player Controls Style"
 msgstr "Stil der Wiedergabesteuerung"
+
+#: jellyfin_mpv_shim/mpvtk_browser/config.py
+#, fuzzy
+#| msgid "Enable thumbnail previews"
+msgid "Enable Trickplay Thumbnails"
+msgstr "Miniaturvorschauen aktivieren"
 
 #: jellyfin_mpv_shim/mpvtk_browser/config.py
 msgid "Load All Seek Previews at Once"
@@ -1762,6 +1779,10 @@ msgstr "Covergröße"
 #: jellyfin_mpv_shim/mpvtk_browser/config.py
 msgid "Full-Width Backdrops"
 msgstr "Hintergründe in voller Breite"
+
+#: jellyfin_mpv_shim/mpvtk_browser/config.py
+msgid "12-Hour Clock"
+msgstr ""
 
 #: jellyfin_mpv_shim/mpvtk_browser/config.py
 msgid "Grid Spacing"
@@ -1804,12 +1825,23 @@ msgid "Fullscreen Library Browser"
 msgstr "Vollbildschirm Bibliotheksbrowser"
 
 #: jellyfin_mpv_shim/mpvtk_browser/config.py
+msgid "Block Player Keybinds While Browsing"
+msgstr ""
+
+#: jellyfin_mpv_shim/mpvtk_browser/config.py
 msgid "Always Bind Arrow Keys to Player Controls"
 msgstr "Pfeiltasten immer an Wiedergabekontrolle binden"
 
 #: jellyfin_mpv_shim/mpvtk_browser/config.py
 msgid "Player Controls Activation Key"
 msgstr "Wiedergabekontrolle Aktivierungsschlüssel"
+
+# seeded from jellyfin-web: SelectAll
+#: jellyfin_mpv_shim/mpvtk_browser/config.py
+#, fuzzy
+#| msgid "Select All"
+msgid "Select Key"
+msgstr "Alles auswählen"
 
 #: jellyfin_mpv_shim/mpvtk_browser/config.py
 msgid "Shading Behind the Player Controls"
@@ -1822,6 +1854,12 @@ msgstr "Wenn die Spielersteuerung ausgeblendet wird"
 #: jellyfin_mpv_shim/mpvtk_browser/config.py
 msgid "Hide the Player Controls After (seconds)"
 msgstr "Bedienfeld nach (Sekunden) ausblenden"
+
+#: jellyfin_mpv_shim/mpvtk_browser/config.py
+#, fuzzy
+#| msgid "When the Player Controls Hide"
+msgid "Shrink the Player Controls on a Narrow Window"
+msgstr "Wenn die Spielersteuerung ausgeblendet wird"
 
 #: jellyfin_mpv_shim/mpvtk_browser/config.py
 msgid "Mouse Back/Forward Buttons Skip Chapters"
@@ -1915,6 +1953,21 @@ msgstr ""
 
 #: jellyfin_mpv_shim/mpvtk_browser/config.py
 msgid ""
+"Stops MPV's own shortcuts -- picture adjustment, screenshots, subtitle and "
+"audio switching -- from acting while you are in the library, where there is "
+"no video for them to act on. Turn it off to use your own MPV key bindings "
+"there."
+msgstr ""
+
+#: jellyfin_mpv_shim/mpvtk_browser/config.py
+msgid ""
+"Activates whatever is highlighted, in the library and on the player "
+"controls. An mpv key name; changing it hands Enter back to MPV. The game "
+"controller's Confirm button and a phone's Select follow it."
+msgstr ""
+
+#: jellyfin_mpv_shim/mpvtk_browser/config.py
+msgid ""
 "Leave these blank unless downloads are waking your disks too often. Set both "
 "of the first two together: episodes are then fetched in one batch when a "
 "series runs low, instead of one at a time."
@@ -1932,9 +1985,14 @@ msgstr ""
 "möglicherweise noch nicht gesehen hast."
 
 #: jellyfin_mpv_shim/mpvtk_browser/config.py
+#, fuzzy
+#| msgid ""
+#| "Off gives MPV's own mouse behaviour instead: drag the video to move the "
+#| "window, and right click to pause. Double click is full screen either way."
 msgid ""
 "Off gives MPV's own mouse behaviour instead: drag the video to move the "
-"window, and right click to pause. Double click is full screen either way."
+"window, and the right button does whatever your MPV config gives it. Double "
+"click is full screen either way."
 msgstr ""
 "Ausgeschaltet wird stattdessen das eigene Mausverhalten von MPV verwendet: "
 "Ziehe das Video, um das Fenster zu verschieben, und klicke mit der rechten "
@@ -2036,6 +2094,30 @@ msgid ""
 "maximize and close in the top bar instead, and lets you drag the window by "
 "it. On \"Only when the window has no title bar\", MPV is asked whether this "
 "window got one, so desktops that draw a title bar are left alone."
+msgstr ""
+
+#: jellyfin_mpv_shim/mpvtk_browser/config.py
+msgid ""
+"Full screen has no title bar anywhere and nothing to move or maximize, so "
+"the buttons are normally hidden there. Turn this on to keep a way out of "
+"full screen that is not a keyboard shortcut."
+msgstr ""
+
+#: jellyfin_mpv_shim/mpvtk_browser/config.py
+msgid ""
+"Asks the desktop for no title bar on the player window, so the top bar above "
+"is the only one. Pairs with the setting above: on \"Only when the window has "
+"no title bar\" the buttons appear as soon as this is on. Leave both off "
+"unless you want them, since a window with neither can be awkward to move on "
+"some desktops."
+msgstr ""
+
+#: jellyfin_mpv_shim/mpvtk_browser/config.py
+msgid ""
+"Shows a preview frame while you drag the seek bar. Works with every player "
+"control style, including your own OSC script if it supports thumbfast. The "
+"images are fetched from the server per video, which costs disk space and "
+"memory -- tens of MB for an episode, a few hundred for a long film."
 msgstr ""
 
 #: jellyfin_mpv_shim/mpvtk_browser/config.py
@@ -2145,6 +2227,13 @@ msgstr ""
 
 #: jellyfin_mpv_shim/mpvtk_browser/config.py
 msgid ""
+"Show times of day as \"8:30 PM\" rather than \"20:30\" — the Live TV guide "
+"and its air times, and the \"Ends at\" labels on a detail page and the "
+"player controls."
+msgstr ""
+
+#: jellyfin_mpv_shim/mpvtk_browser/config.py
+msgid ""
 "The controls have to stay legible over any frame. \"None\" gives the text a "
 "drop shadow instead of shading the picture behind it."
 msgstr ""
@@ -2167,6 +2256,13 @@ msgid ""
 msgstr ""
 "0 blendet sich aus, sobald der Zeiger nicht über ihnen ist und erzwingt "
 "\"Ausblenden , solange der Mauszeiger nicht darüber ist\"."
+
+#: jellyfin_mpv_shim/mpvtk_browser/config.py
+msgid ""
+"Narrowing the window shrinks the controls until the smallest button reaches "
+"the accessibility minimum, instead of dropping buttons sooner. Off keeps the "
+"older, larger floor."
+msgstr ""
 
 #: jellyfin_mpv_shim/mpvtk_browser/config.py
 msgid ""
@@ -3788,6 +3884,7 @@ msgid "More Like This"
 msgstr "Ähnliches"
 
 #: jellyfin_mpv_shim/mpvtk_browser/pages/detail.py
+#: jellyfin_mpv_shim/mpvtk_browser/tiles.py
 msgid "Go to Series"
 msgstr ""
 
@@ -4991,6 +5088,22 @@ msgstr "Server entfernen"
 msgid "There is nothing here to queue."
 msgstr ""
 
+#: jellyfin_mpv_shim/mpvtk_browser/timefmt.py
+#, python-brace-format
+msgctxt "12-hour clock"
+msgid "{time} {period}"
+msgstr ""
+
+#: jellyfin_mpv_shim/mpvtk_browser/timefmt.py
+msgctxt "12-hour clock"
+msgid "AM"
+msgstr ""
+
+#: jellyfin_mpv_shim/mpvtk_browser/timefmt.py
+msgctxt "12-hour clock"
+msgid "PM"
+msgstr ""
+
 # seeded from jellyfin-web: Search
 #: jellyfin_mpv_shim/mpvtk_browser/views.py
 #: jellyfin_mpv_shim/mpvtk_browser/window_chrome.py
@@ -5154,6 +5267,10 @@ msgid "Enable SVP"
 msgstr "SVP aktivieren"
 
 #: jellyfin_mpv_shim/sync/manager.py
+msgid "The downloads are already in that folder."
+msgstr ""
+
+#: jellyfin_mpv_shim/sync/manager.py
 msgid ""
 "Can't change the download folder while a download is in progress. Wait for "
 "it to finish, then try again."
@@ -5162,8 +5279,29 @@ msgstr ""
 "Warte bis er fertig ist und versuche es wieder."
 
 #: jellyfin_mpv_shim/sync/manager.py
+#, fuzzy
+#| msgid "That folder already contains downloads. Choose an empty folder."
+msgid ""
+"That folder is inside the current download folder. Choose one outside it."
+msgstr "Dieser Ordner enthält bereits Downloads. Wähle einen leeren Ordner."
+
+#: jellyfin_mpv_shim/sync/manager.py
+#, fuzzy
+#| msgid "Can't create that folder. Check the path and its permissions."
+msgid "Can't read that folder. Check the path and its permissions."
+msgstr ""
+"Dieser Ordner kann nicht erstellt werden. Prüfe den Pfad und die "
+"Berechtigungen."
+
+#: jellyfin_mpv_shim/sync/manager.py
 msgid "That folder already contains downloads. Choose an empty folder."
 msgstr "Dieser Ordner enthält bereits Downloads. Wähle einen leeren Ordner."
+
+#: jellyfin_mpv_shim/sync/manager.py
+msgid ""
+"That folder isn't empty. Choose an empty folder — the download folder is "
+"managed by this app and anything else in it can be moved or removed."
+msgstr ""
 
 #: jellyfin_mpv_shim/sync/manager.py
 msgid "Can't create that folder. Check the path and its permissions."
@@ -5176,6 +5314,12 @@ msgid "A download is still finishing. Wait for it to stop, then try again."
 msgstr ""
 "Ein Download wird immer noch fertig gestellt. Warte bis er stoppt, dann "
 "versuche es erneut."
+
+#: jellyfin_mpv_shim/sync/manager.py
+msgid ""
+"There isn't enough space on that drive to move the downloads. Free some "
+"space and try again — nothing was moved."
+msgstr ""
 
 #: jellyfin_mpv_shim/sync/manager.py
 msgid ""
@@ -5382,6 +5526,12 @@ msgstr "Videowiedergabeprofil"
 #: jellyfin_mpv_shim/video_profile.py
 msgid "Select Shader Profile"
 msgstr "Shaderprofil wählen"
+
+#~ msgid "MPV UI with thumbnails"
+#~ msgstr "MPV UI mit Vorschaubildern"
+
+#~ msgid "MPV built-in default"
+#~ msgstr "MPV integrierter Standard"
 
 #, fuzzy
 #~| msgid ""

--- a/jellyfin_mpv_shim/messages/dv/LC_MESSAGES/base.po
+++ b/jellyfin_mpv_shim/messages/dv/LC_MESSAGES/base.po
@@ -6,7 +6,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2026-08-30 22:19-0400\n"
+"POT-Creation-Date: 2026-09-07 17:35-0400\n"
 "PO-Revision-Date: 2026-06-21 23:00+0000\n"
 "Last-Translator: Naveed Ali Anwar <hello@naveedalianwar.com>\n"
 "Language-Team: Dhivehi <https://translate.jellyfin.org/projects/jellyfin/"
@@ -507,6 +507,11 @@ msgid "Night Mode (Auto Volume Adj)"
 msgstr ""
 
 #: jellyfin_mpv_shim/mpvtk_browser/app.py
+#: jellyfin_mpv_shim/mpvtk_browser/auth.py
+msgid "Locked"
+msgstr ""
+
+#: jellyfin_mpv_shim/mpvtk_browser/app.py
 msgid "Failed to load. Check the connection."
 msgstr ""
 
@@ -753,10 +758,6 @@ msgid "Could not connect. Please check your details."
 msgstr ""
 
 #: jellyfin_mpv_shim/mpvtk_browser/auth.py
-msgid "Locked"
-msgstr ""
-
-#: jellyfin_mpv_shim/mpvtk_browser/auth.py
 #: jellyfin_mpv_shim/mpvtk_browser/pages/home.py
 msgid "Connecting to your server…"
 msgstr ""
@@ -827,6 +828,10 @@ msgstr ""
 #: jellyfin_mpv_shim/mpvtk_browser/hud.py
 #: jellyfin_mpv_shim/mpvtk_browser/pages/books.py
 msgid "Favorite"
+msgstr ""
+
+#: jellyfin_mpv_shim/mpvtk_browser/components/detail.py
+msgid "Web"
 msgstr ""
 
 #: jellyfin_mpv_shim/mpvtk_browser/components/media_info.py
@@ -1347,11 +1352,7 @@ msgid "Jellyfin UI"
 msgstr ""
 
 #: jellyfin_mpv_shim/mpvtk_browser/config.py
-msgid "MPV UI with thumbnails"
-msgstr ""
-
-#: jellyfin_mpv_shim/mpvtk_browser/config.py
-msgid "MPV built-in default"
+msgid "MPV UI"
 msgstr ""
 
 #: jellyfin_mpv_shim/mpvtk_browser/config.py
@@ -1684,7 +1685,19 @@ msgid "Window Buttons in the Top Bar"
 msgstr ""
 
 #: jellyfin_mpv_shim/mpvtk_browser/config.py
+msgid "Keep Window Buttons in Full Screen"
+msgstr ""
+
+#: jellyfin_mpv_shim/mpvtk_browser/config.py
+msgid "Hide the Desktop Title Bar"
+msgstr ""
+
+#: jellyfin_mpv_shim/mpvtk_browser/config.py
 msgid "Player Controls Style"
+msgstr ""
+
+#: jellyfin_mpv_shim/mpvtk_browser/config.py
+msgid "Enable Trickplay Thumbnails"
 msgstr ""
 
 #: jellyfin_mpv_shim/mpvtk_browser/config.py
@@ -1714,6 +1727,10 @@ msgstr ""
 
 #: jellyfin_mpv_shim/mpvtk_browser/config.py
 msgid "Full-Width Backdrops"
+msgstr ""
+
+#: jellyfin_mpv_shim/mpvtk_browser/config.py
+msgid "12-Hour Clock"
 msgstr ""
 
 #: jellyfin_mpv_shim/mpvtk_browser/config.py
@@ -1757,11 +1774,19 @@ msgid "Fullscreen Library Browser"
 msgstr ""
 
 #: jellyfin_mpv_shim/mpvtk_browser/config.py
+msgid "Block Player Keybinds While Browsing"
+msgstr ""
+
+#: jellyfin_mpv_shim/mpvtk_browser/config.py
 msgid "Always Bind Arrow Keys to Player Controls"
 msgstr ""
 
 #: jellyfin_mpv_shim/mpvtk_browser/config.py
 msgid "Player Controls Activation Key"
+msgstr ""
+
+#: jellyfin_mpv_shim/mpvtk_browser/config.py
+msgid "Select Key"
 msgstr ""
 
 #: jellyfin_mpv_shim/mpvtk_browser/config.py
@@ -1774,6 +1799,10 @@ msgstr ""
 
 #: jellyfin_mpv_shim/mpvtk_browser/config.py
 msgid "Hide the Player Controls After (seconds)"
+msgstr ""
+
+#: jellyfin_mpv_shim/mpvtk_browser/config.py
+msgid "Shrink the Player Controls on a Narrow Window"
 msgstr ""
 
 #: jellyfin_mpv_shim/mpvtk_browser/config.py
@@ -1856,6 +1885,21 @@ msgstr ""
 
 #: jellyfin_mpv_shim/mpvtk_browser/config.py
 msgid ""
+"Stops MPV's own shortcuts -- picture adjustment, screenshots, subtitle and "
+"audio switching -- from acting while you are in the library, where there is "
+"no video for them to act on. Turn it off to use your own MPV key bindings "
+"there."
+msgstr ""
+
+#: jellyfin_mpv_shim/mpvtk_browser/config.py
+msgid ""
+"Activates whatever is highlighted, in the library and on the player "
+"controls. An mpv key name; changing it hands Enter back to MPV. The game "
+"controller's Confirm button and a phone's Select follow it."
+msgstr ""
+
+#: jellyfin_mpv_shim/mpvtk_browser/config.py
+msgid ""
 "Leave these blank unless downloads are waking your disks too often. Set both "
 "of the first two together: episodes are then fetched in one batch when a "
 "series runs low, instead of one at a time."
@@ -1869,7 +1913,8 @@ msgstr ""
 #: jellyfin_mpv_shim/mpvtk_browser/config.py
 msgid ""
 "Off gives MPV's own mouse behaviour instead: drag the video to move the "
-"window, and right click to pause. Double click is full screen either way."
+"window, and the right button does whatever your MPV config gives it. Double "
+"click is full screen either way."
 msgstr ""
 
 #: jellyfin_mpv_shim/mpvtk_browser/config.py
@@ -1959,6 +2004,30 @@ msgid ""
 "maximize and close in the top bar instead, and lets you drag the window by "
 "it. On \"Only when the window has no title bar\", MPV is asked whether this "
 "window got one, so desktops that draw a title bar are left alone."
+msgstr ""
+
+#: jellyfin_mpv_shim/mpvtk_browser/config.py
+msgid ""
+"Full screen has no title bar anywhere and nothing to move or maximize, so "
+"the buttons are normally hidden there. Turn this on to keep a way out of "
+"full screen that is not a keyboard shortcut."
+msgstr ""
+
+#: jellyfin_mpv_shim/mpvtk_browser/config.py
+msgid ""
+"Asks the desktop for no title bar on the player window, so the top bar above "
+"is the only one. Pairs with the setting above: on \"Only when the window has "
+"no title bar\" the buttons appear as soon as this is on. Leave both off "
+"unless you want them, since a window with neither can be awkward to move on "
+"some desktops."
+msgstr ""
+
+#: jellyfin_mpv_shim/mpvtk_browser/config.py
+msgid ""
+"Shows a preview frame while you drag the seek bar. Works with every player "
+"control style, including your own OSC script if it supports thumbfast. The "
+"images are fetched from the server per video, which costs disk space and "
+"memory -- tens of MB for an episode, a few hundred for a long film."
 msgstr ""
 
 #: jellyfin_mpv_shim/mpvtk_browser/config.py
@@ -2066,6 +2135,13 @@ msgstr ""
 
 #: jellyfin_mpv_shim/mpvtk_browser/config.py
 msgid ""
+"Show times of day as \"8:30 PM\" rather than \"20:30\" — the Live TV guide "
+"and its air times, and the \"Ends at\" labels on a detail page and the "
+"player controls."
+msgstr ""
+
+#: jellyfin_mpv_shim/mpvtk_browser/config.py
+msgid ""
 "The controls have to stay legible over any frame. \"None\" gives the text a "
 "drop shadow instead of shading the picture behind it."
 msgstr ""
@@ -2080,6 +2156,13 @@ msgstr ""
 msgid ""
 "0 hides them as soon as the pointer is not on them, and forces \"Hide unless "
 "hovered\"."
+msgstr ""
+
+#: jellyfin_mpv_shim/mpvtk_browser/config.py
+msgid ""
+"Narrowing the window shrinks the controls until the smallest button reaches "
+"the accessibility minimum, instead of dropping buttons sooner. Off keeps the "
+"older, larger floor."
 msgstr ""
 
 #: jellyfin_mpv_shim/mpvtk_browser/config.py
@@ -3460,6 +3543,7 @@ msgid "More Like This"
 msgstr ""
 
 #: jellyfin_mpv_shim/mpvtk_browser/pages/detail.py
+#: jellyfin_mpv_shim/mpvtk_browser/tiles.py
 msgid "Go to Series"
 msgstr ""
 
@@ -4479,6 +4563,22 @@ msgstr ""
 msgid "There is nothing here to queue."
 msgstr ""
 
+#: jellyfin_mpv_shim/mpvtk_browser/timefmt.py
+#, python-brace-format
+msgctxt "12-hour clock"
+msgid "{time} {period}"
+msgstr ""
+
+#: jellyfin_mpv_shim/mpvtk_browser/timefmt.py
+msgctxt "12-hour clock"
+msgid "AM"
+msgstr ""
+
+#: jellyfin_mpv_shim/mpvtk_browser/timefmt.py
+msgctxt "12-hour clock"
+msgid "PM"
+msgstr ""
+
 #: jellyfin_mpv_shim/mpvtk_browser/views.py
 #: jellyfin_mpv_shim/mpvtk_browser/window_chrome.py
 msgid "Search"
@@ -4631,13 +4731,32 @@ msgid "Enable SVP"
 msgstr ""
 
 #: jellyfin_mpv_shim/sync/manager.py
+msgid "The downloads are already in that folder."
+msgstr ""
+
+#: jellyfin_mpv_shim/sync/manager.py
 msgid ""
 "Can't change the download folder while a download is in progress. Wait for "
 "it to finish, then try again."
 msgstr ""
 
 #: jellyfin_mpv_shim/sync/manager.py
+msgid ""
+"That folder is inside the current download folder. Choose one outside it."
+msgstr ""
+
+#: jellyfin_mpv_shim/sync/manager.py
+msgid "Can't read that folder. Check the path and its permissions."
+msgstr ""
+
+#: jellyfin_mpv_shim/sync/manager.py
 msgid "That folder already contains downloads. Choose an empty folder."
+msgstr ""
+
+#: jellyfin_mpv_shim/sync/manager.py
+msgid ""
+"That folder isn't empty. Choose an empty folder — the download folder is "
+"managed by this app and anything else in it can be moved or removed."
 msgstr ""
 
 #: jellyfin_mpv_shim/sync/manager.py
@@ -4646,6 +4765,12 @@ msgstr ""
 
 #: jellyfin_mpv_shim/sync/manager.py
 msgid "A download is still finishing. Wait for it to stop, then try again."
+msgstr ""
+
+#: jellyfin_mpv_shim/sync/manager.py
+msgid ""
+"There isn't enough space on that drive to move the downloads. Free some "
+"space and try again — nothing was moved."
 msgstr ""
 
 #: jellyfin_mpv_shim/sync/manager.py

--- a/jellyfin_mpv_shim/messages/el/LC_MESSAGES/base.po
+++ b/jellyfin_mpv_shim/messages/el/LC_MESSAGES/base.po
@@ -6,7 +6,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2026-08-30 22:19-0400\n"
+"POT-Creation-Date: 2026-09-07 17:35-0400\n"
 "PO-Revision-Date: 2026-06-08 11:26+0000\n"
 "Last-Translator: Thunderstrike116 <thunderstrike116@gmail.com>\n"
 "Language-Team: Greek <https://translate.jellyfin.org/projects/jellyfin/"
@@ -548,6 +548,11 @@ msgid "Night Mode (Auto Volume Adj)"
 msgstr ""
 
 #: jellyfin_mpv_shim/mpvtk_browser/app.py
+#: jellyfin_mpv_shim/mpvtk_browser/auth.py
+msgid "Locked"
+msgstr ""
+
+#: jellyfin_mpv_shim/mpvtk_browser/app.py
 msgid "Failed to load. Check the connection."
 msgstr ""
 
@@ -827,10 +832,6 @@ msgstr ""
 "Ελέγξτε τις πληροφορίες σύνδεσής σας."
 
 #: jellyfin_mpv_shim/mpvtk_browser/auth.py
-msgid "Locked"
-msgstr ""
-
-#: jellyfin_mpv_shim/mpvtk_browser/auth.py
 #: jellyfin_mpv_shim/mpvtk_browser/pages/home.py
 msgid "Connecting to your server…"
 msgstr ""
@@ -911,6 +912,10 @@ msgstr "Έξοδος και Επισήμανση Χωρίς παρακολούθ
 #: jellyfin_mpv_shim/mpvtk_browser/pages/books.py
 msgid "Favorite"
 msgstr "Αγαπημένο"
+
+#: jellyfin_mpv_shim/mpvtk_browser/components/detail.py
+msgid "Web"
+msgstr ""
 
 # seeded from jellyfin-web: HeaderVideos
 #: jellyfin_mpv_shim/mpvtk_browser/components/media_info.py
@@ -1528,11 +1533,7 @@ msgid "Jellyfin UI"
 msgstr ""
 
 #: jellyfin_mpv_shim/mpvtk_browser/config.py
-msgid "MPV UI with thumbnails"
-msgstr ""
-
-#: jellyfin_mpv_shim/mpvtk_browser/config.py
-msgid "MPV built-in default"
+msgid "MPV UI"
 msgstr ""
 
 #: jellyfin_mpv_shim/mpvtk_browser/config.py
@@ -1881,8 +1882,22 @@ msgid "Window Buttons in the Top Bar"
 msgstr ""
 
 #: jellyfin_mpv_shim/mpvtk_browser/config.py
+msgid "Keep Window Buttons in Full Screen"
+msgstr ""
+
+#: jellyfin_mpv_shim/mpvtk_browser/config.py
+msgid "Hide the Desktop Title Bar"
+msgstr ""
+
+#: jellyfin_mpv_shim/mpvtk_browser/config.py
 msgid "Player Controls Style"
 msgstr ""
+
+#: jellyfin_mpv_shim/mpvtk_browser/config.py
+#, fuzzy
+#| msgid "Enable thumbnail previews"
+msgid "Enable Trickplay Thumbnails"
+msgstr "Προεπισκόπηση μικρογραφίας ενεργή"
 
 #: jellyfin_mpv_shim/mpvtk_browser/config.py
 msgid "Load All Seek Previews at Once"
@@ -1912,6 +1927,10 @@ msgstr ""
 
 #: jellyfin_mpv_shim/mpvtk_browser/config.py
 msgid "Full-Width Backdrops"
+msgstr ""
+
+#: jellyfin_mpv_shim/mpvtk_browser/config.py
+msgid "12-Hour Clock"
 msgstr ""
 
 #: jellyfin_mpv_shim/mpvtk_browser/config.py
@@ -1957,12 +1976,23 @@ msgid "Fullscreen Library Browser"
 msgstr ""
 
 #: jellyfin_mpv_shim/mpvtk_browser/config.py
+msgid "Block Player Keybinds While Browsing"
+msgstr ""
+
+#: jellyfin_mpv_shim/mpvtk_browser/config.py
 msgid "Always Bind Arrow Keys to Player Controls"
 msgstr ""
 
 #: jellyfin_mpv_shim/mpvtk_browser/config.py
 msgid "Player Controls Activation Key"
 msgstr ""
+
+# seeded from jellyfin-web: SelectAll
+#: jellyfin_mpv_shim/mpvtk_browser/config.py
+#, fuzzy
+#| msgid "Select All"
+msgid "Select Key"
+msgstr "Επιλογή Όλων"
 
 #: jellyfin_mpv_shim/mpvtk_browser/config.py
 msgid "Shading Behind the Player Controls"
@@ -1974,6 +2004,10 @@ msgstr ""
 
 #: jellyfin_mpv_shim/mpvtk_browser/config.py
 msgid "Hide the Player Controls After (seconds)"
+msgstr ""
+
+#: jellyfin_mpv_shim/mpvtk_browser/config.py
+msgid "Shrink the Player Controls on a Narrow Window"
 msgstr ""
 
 #: jellyfin_mpv_shim/mpvtk_browser/config.py
@@ -2060,6 +2094,21 @@ msgstr ""
 
 #: jellyfin_mpv_shim/mpvtk_browser/config.py
 msgid ""
+"Stops MPV's own shortcuts -- picture adjustment, screenshots, subtitle and "
+"audio switching -- from acting while you are in the library, where there is "
+"no video for them to act on. Turn it off to use your own MPV key bindings "
+"there."
+msgstr ""
+
+#: jellyfin_mpv_shim/mpvtk_browser/config.py
+msgid ""
+"Activates whatever is highlighted, in the library and on the player "
+"controls. An mpv key name; changing it hands Enter back to MPV. The game "
+"controller's Confirm button and a phone's Select follow it."
+msgstr ""
+
+#: jellyfin_mpv_shim/mpvtk_browser/config.py
+msgid ""
 "Leave these blank unless downloads are waking your disks too often. Set both "
 "of the first two together: episodes are then fetched in one batch when a "
 "series runs low, instead of one at a time."
@@ -2073,7 +2122,8 @@ msgstr ""
 #: jellyfin_mpv_shim/mpvtk_browser/config.py
 msgid ""
 "Off gives MPV's own mouse behaviour instead: drag the video to move the "
-"window, and right click to pause. Double click is full screen either way."
+"window, and the right button does whatever your MPV config gives it. Double "
+"click is full screen either way."
 msgstr ""
 
 #: jellyfin_mpv_shim/mpvtk_browser/config.py
@@ -2163,6 +2213,30 @@ msgid ""
 "maximize and close in the top bar instead, and lets you drag the window by "
 "it. On \"Only when the window has no title bar\", MPV is asked whether this "
 "window got one, so desktops that draw a title bar are left alone."
+msgstr ""
+
+#: jellyfin_mpv_shim/mpvtk_browser/config.py
+msgid ""
+"Full screen has no title bar anywhere and nothing to move or maximize, so "
+"the buttons are normally hidden there. Turn this on to keep a way out of "
+"full screen that is not a keyboard shortcut."
+msgstr ""
+
+#: jellyfin_mpv_shim/mpvtk_browser/config.py
+msgid ""
+"Asks the desktop for no title bar on the player window, so the top bar above "
+"is the only one. Pairs with the setting above: on \"Only when the window has "
+"no title bar\" the buttons appear as soon as this is on. Leave both off "
+"unless you want them, since a window with neither can be awkward to move on "
+"some desktops."
+msgstr ""
+
+#: jellyfin_mpv_shim/mpvtk_browser/config.py
+msgid ""
+"Shows a preview frame while you drag the seek bar. Works with every player "
+"control style, including your own OSC script if it supports thumbfast. The "
+"images are fetched from the server per video, which costs disk space and "
+"memory -- tens of MB for an episode, a few hundred for a long film."
 msgstr ""
 
 #: jellyfin_mpv_shim/mpvtk_browser/config.py
@@ -2272,6 +2346,13 @@ msgstr ""
 
 #: jellyfin_mpv_shim/mpvtk_browser/config.py
 msgid ""
+"Show times of day as \"8:30 PM\" rather than \"20:30\" — the Live TV guide "
+"and its air times, and the \"Ends at\" labels on a detail page and the "
+"player controls."
+msgstr ""
+
+#: jellyfin_mpv_shim/mpvtk_browser/config.py
+msgid ""
 "The controls have to stay legible over any frame. \"None\" gives the text a "
 "drop shadow instead of shading the picture behind it."
 msgstr ""
@@ -2286,6 +2367,13 @@ msgstr ""
 msgid ""
 "0 hides them as soon as the pointer is not on them, and forces \"Hide unless "
 "hovered\"."
+msgstr ""
+
+#: jellyfin_mpv_shim/mpvtk_browser/config.py
+msgid ""
+"Narrowing the window shrinks the controls until the smallest button reaches "
+"the accessibility minimum, instead of dropping buttons sooner. Off keeps the "
+"older, larger floor."
 msgstr ""
 
 #: jellyfin_mpv_shim/mpvtk_browser/config.py
@@ -3892,6 +3980,7 @@ msgid "More Like This"
 msgstr "Περισσότερα Σαν Αυτό"
 
 #: jellyfin_mpv_shim/mpvtk_browser/pages/detail.py
+#: jellyfin_mpv_shim/mpvtk_browser/tiles.py
 msgid "Go to Series"
 msgstr ""
 
@@ -5086,6 +5175,22 @@ msgstr "Κατάργηση Διακομιστή"
 msgid "There is nothing here to queue."
 msgstr ""
 
+#: jellyfin_mpv_shim/mpvtk_browser/timefmt.py
+#, python-brace-format
+msgctxt "12-hour clock"
+msgid "{time} {period}"
+msgstr ""
+
+#: jellyfin_mpv_shim/mpvtk_browser/timefmt.py
+msgctxt "12-hour clock"
+msgid "AM"
+msgstr ""
+
+#: jellyfin_mpv_shim/mpvtk_browser/timefmt.py
+msgctxt "12-hour clock"
+msgid "PM"
+msgstr ""
+
 # seeded from jellyfin-web: Search
 #: jellyfin_mpv_shim/mpvtk_browser/views.py
 #: jellyfin_mpv_shim/mpvtk_browser/window_chrome.py
@@ -5254,13 +5359,32 @@ msgid "Enable SVP"
 msgstr "Ενεργοποίηση SVP"
 
 #: jellyfin_mpv_shim/sync/manager.py
+msgid "The downloads are already in that folder."
+msgstr ""
+
+#: jellyfin_mpv_shim/sync/manager.py
 msgid ""
 "Can't change the download folder while a download is in progress. Wait for "
 "it to finish, then try again."
 msgstr ""
 
 #: jellyfin_mpv_shim/sync/manager.py
+msgid ""
+"That folder is inside the current download folder. Choose one outside it."
+msgstr ""
+
+#: jellyfin_mpv_shim/sync/manager.py
+msgid "Can't read that folder. Check the path and its permissions."
+msgstr ""
+
+#: jellyfin_mpv_shim/sync/manager.py
 msgid "That folder already contains downloads. Choose an empty folder."
+msgstr ""
+
+#: jellyfin_mpv_shim/sync/manager.py
+msgid ""
+"That folder isn't empty. Choose an empty folder — the download folder is "
+"managed by this app and anything else in it can be moved or removed."
 msgstr ""
 
 #: jellyfin_mpv_shim/sync/manager.py
@@ -5269,6 +5393,12 @@ msgstr ""
 
 #: jellyfin_mpv_shim/sync/manager.py
 msgid "A download is still finishing. Wait for it to stop, then try again."
+msgstr ""
+
+#: jellyfin_mpv_shim/sync/manager.py
+msgid ""
+"There isn't enough space on that drive to move the downloads. Free some "
+"space and try again — nothing was moved."
 msgstr ""
 
 #: jellyfin_mpv_shim/sync/manager.py

--- a/jellyfin_mpv_shim/messages/en@pirate/LC_MESSAGES/base.po
+++ b/jellyfin_mpv_shim/messages/en@pirate/LC_MESSAGES/base.po
@@ -6,7 +6,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2026-08-30 22:19-0400\n"
+"POT-Creation-Date: 2026-09-07 17:35-0400\n"
 "PO-Revision-Date: 2025-11-18 08:19+0000\n"
 "Last-Translator: Rufis72 <milo.games.silverstein@gmail.com>\n"
 "Language-Team: English (Pirate) <https://translate.jellyfin.org/projects/"
@@ -506,6 +506,11 @@ msgid "Night Mode (Auto Volume Adj)"
 msgstr ""
 
 #: jellyfin_mpv_shim/mpvtk_browser/app.py
+#: jellyfin_mpv_shim/mpvtk_browser/auth.py
+msgid "Locked"
+msgstr ""
+
+#: jellyfin_mpv_shim/mpvtk_browser/app.py
 msgid "Failed to load. Check the connection."
 msgstr ""
 
@@ -746,10 +751,6 @@ msgid "Could not connect. Please check your details."
 msgstr ""
 
 #: jellyfin_mpv_shim/mpvtk_browser/auth.py
-msgid "Locked"
-msgstr ""
-
-#: jellyfin_mpv_shim/mpvtk_browser/auth.py
 #: jellyfin_mpv_shim/mpvtk_browser/pages/home.py
 msgid "Connecting to your server…"
 msgstr ""
@@ -819,6 +820,10 @@ msgstr ""
 #: jellyfin_mpv_shim/mpvtk_browser/hud.py
 #: jellyfin_mpv_shim/mpvtk_browser/pages/books.py
 msgid "Favorite"
+msgstr ""
+
+#: jellyfin_mpv_shim/mpvtk_browser/components/detail.py
+msgid "Web"
 msgstr ""
 
 #: jellyfin_mpv_shim/mpvtk_browser/components/media_info.py
@@ -1324,11 +1329,7 @@ msgid "Jellyfin UI"
 msgstr ""
 
 #: jellyfin_mpv_shim/mpvtk_browser/config.py
-msgid "MPV UI with thumbnails"
-msgstr ""
-
-#: jellyfin_mpv_shim/mpvtk_browser/config.py
-msgid "MPV built-in default"
+msgid "MPV UI"
 msgstr ""
 
 #: jellyfin_mpv_shim/mpvtk_browser/config.py
@@ -1661,7 +1662,19 @@ msgid "Window Buttons in the Top Bar"
 msgstr ""
 
 #: jellyfin_mpv_shim/mpvtk_browser/config.py
+msgid "Keep Window Buttons in Full Screen"
+msgstr ""
+
+#: jellyfin_mpv_shim/mpvtk_browser/config.py
+msgid "Hide the Desktop Title Bar"
+msgstr ""
+
+#: jellyfin_mpv_shim/mpvtk_browser/config.py
 msgid "Player Controls Style"
+msgstr ""
+
+#: jellyfin_mpv_shim/mpvtk_browser/config.py
+msgid "Enable Trickplay Thumbnails"
 msgstr ""
 
 #: jellyfin_mpv_shim/mpvtk_browser/config.py
@@ -1691,6 +1704,10 @@ msgstr ""
 
 #: jellyfin_mpv_shim/mpvtk_browser/config.py
 msgid "Full-Width Backdrops"
+msgstr ""
+
+#: jellyfin_mpv_shim/mpvtk_browser/config.py
+msgid "12-Hour Clock"
 msgstr ""
 
 #: jellyfin_mpv_shim/mpvtk_browser/config.py
@@ -1734,11 +1751,19 @@ msgid "Fullscreen Library Browser"
 msgstr ""
 
 #: jellyfin_mpv_shim/mpvtk_browser/config.py
+msgid "Block Player Keybinds While Browsing"
+msgstr ""
+
+#: jellyfin_mpv_shim/mpvtk_browser/config.py
 msgid "Always Bind Arrow Keys to Player Controls"
 msgstr ""
 
 #: jellyfin_mpv_shim/mpvtk_browser/config.py
 msgid "Player Controls Activation Key"
+msgstr ""
+
+#: jellyfin_mpv_shim/mpvtk_browser/config.py
+msgid "Select Key"
 msgstr ""
 
 #: jellyfin_mpv_shim/mpvtk_browser/config.py
@@ -1751,6 +1776,10 @@ msgstr ""
 
 #: jellyfin_mpv_shim/mpvtk_browser/config.py
 msgid "Hide the Player Controls After (seconds)"
+msgstr ""
+
+#: jellyfin_mpv_shim/mpvtk_browser/config.py
+msgid "Shrink the Player Controls on a Narrow Window"
 msgstr ""
 
 #: jellyfin_mpv_shim/mpvtk_browser/config.py
@@ -1833,6 +1862,21 @@ msgstr ""
 
 #: jellyfin_mpv_shim/mpvtk_browser/config.py
 msgid ""
+"Stops MPV's own shortcuts -- picture adjustment, screenshots, subtitle and "
+"audio switching -- from acting while you are in the library, where there is "
+"no video for them to act on. Turn it off to use your own MPV key bindings "
+"there."
+msgstr ""
+
+#: jellyfin_mpv_shim/mpvtk_browser/config.py
+msgid ""
+"Activates whatever is highlighted, in the library and on the player "
+"controls. An mpv key name; changing it hands Enter back to MPV. The game "
+"controller's Confirm button and a phone's Select follow it."
+msgstr ""
+
+#: jellyfin_mpv_shim/mpvtk_browser/config.py
+msgid ""
 "Leave these blank unless downloads are waking your disks too often. Set both "
 "of the first two together: episodes are then fetched in one batch when a "
 "series runs low, instead of one at a time."
@@ -1846,7 +1890,8 @@ msgstr ""
 #: jellyfin_mpv_shim/mpvtk_browser/config.py
 msgid ""
 "Off gives MPV's own mouse behaviour instead: drag the video to move the "
-"window, and right click to pause. Double click is full screen either way."
+"window, and the right button does whatever your MPV config gives it. Double "
+"click is full screen either way."
 msgstr ""
 
 #: jellyfin_mpv_shim/mpvtk_browser/config.py
@@ -1936,6 +1981,30 @@ msgid ""
 "maximize and close in the top bar instead, and lets you drag the window by "
 "it. On \"Only when the window has no title bar\", MPV is asked whether this "
 "window got one, so desktops that draw a title bar are left alone."
+msgstr ""
+
+#: jellyfin_mpv_shim/mpvtk_browser/config.py
+msgid ""
+"Full screen has no title bar anywhere and nothing to move or maximize, so "
+"the buttons are normally hidden there. Turn this on to keep a way out of "
+"full screen that is not a keyboard shortcut."
+msgstr ""
+
+#: jellyfin_mpv_shim/mpvtk_browser/config.py
+msgid ""
+"Asks the desktop for no title bar on the player window, so the top bar above "
+"is the only one. Pairs with the setting above: on \"Only when the window has "
+"no title bar\" the buttons appear as soon as this is on. Leave both off "
+"unless you want them, since a window with neither can be awkward to move on "
+"some desktops."
+msgstr ""
+
+#: jellyfin_mpv_shim/mpvtk_browser/config.py
+msgid ""
+"Shows a preview frame while you drag the seek bar. Works with every player "
+"control style, including your own OSC script if it supports thumbfast. The "
+"images are fetched from the server per video, which costs disk space and "
+"memory -- tens of MB for an episode, a few hundred for a long film."
 msgstr ""
 
 #: jellyfin_mpv_shim/mpvtk_browser/config.py
@@ -2043,6 +2112,13 @@ msgstr ""
 
 #: jellyfin_mpv_shim/mpvtk_browser/config.py
 msgid ""
+"Show times of day as \"8:30 PM\" rather than \"20:30\" — the Live TV guide "
+"and its air times, and the \"Ends at\" labels on a detail page and the "
+"player controls."
+msgstr ""
+
+#: jellyfin_mpv_shim/mpvtk_browser/config.py
+msgid ""
 "The controls have to stay legible over any frame. \"None\" gives the text a "
 "drop shadow instead of shading the picture behind it."
 msgstr ""
@@ -2057,6 +2133,13 @@ msgstr ""
 msgid ""
 "0 hides them as soon as the pointer is not on them, and forces \"Hide unless "
 "hovered\"."
+msgstr ""
+
+#: jellyfin_mpv_shim/mpvtk_browser/config.py
+msgid ""
+"Narrowing the window shrinks the controls until the smallest button reaches "
+"the accessibility minimum, instead of dropping buttons sooner. Off keeps the "
+"older, larger floor."
 msgstr ""
 
 #: jellyfin_mpv_shim/mpvtk_browser/config.py
@@ -3383,6 +3466,7 @@ msgid "More Like This"
 msgstr ""
 
 #: jellyfin_mpv_shim/mpvtk_browser/pages/detail.py
+#: jellyfin_mpv_shim/mpvtk_browser/tiles.py
 msgid "Go to Series"
 msgstr ""
 
@@ -4377,6 +4461,22 @@ msgstr ""
 msgid "There is nothing here to queue."
 msgstr ""
 
+#: jellyfin_mpv_shim/mpvtk_browser/timefmt.py
+#, python-brace-format
+msgctxt "12-hour clock"
+msgid "{time} {period}"
+msgstr ""
+
+#: jellyfin_mpv_shim/mpvtk_browser/timefmt.py
+msgctxt "12-hour clock"
+msgid "AM"
+msgstr ""
+
+#: jellyfin_mpv_shim/mpvtk_browser/timefmt.py
+msgctxt "12-hour clock"
+msgid "PM"
+msgstr ""
+
 #: jellyfin_mpv_shim/mpvtk_browser/views.py
 #: jellyfin_mpv_shim/mpvtk_browser/window_chrome.py
 msgid "Search"
@@ -4527,13 +4627,32 @@ msgid "Enable SVP"
 msgstr ""
 
 #: jellyfin_mpv_shim/sync/manager.py
+msgid "The downloads are already in that folder."
+msgstr ""
+
+#: jellyfin_mpv_shim/sync/manager.py
 msgid ""
 "Can't change the download folder while a download is in progress. Wait for "
 "it to finish, then try again."
 msgstr ""
 
 #: jellyfin_mpv_shim/sync/manager.py
+msgid ""
+"That folder is inside the current download folder. Choose one outside it."
+msgstr ""
+
+#: jellyfin_mpv_shim/sync/manager.py
+msgid "Can't read that folder. Check the path and its permissions."
+msgstr ""
+
+#: jellyfin_mpv_shim/sync/manager.py
 msgid "That folder already contains downloads. Choose an empty folder."
+msgstr ""
+
+#: jellyfin_mpv_shim/sync/manager.py
+msgid ""
+"That folder isn't empty. Choose an empty folder — the download folder is "
+"managed by this app and anything else in it can be moved or removed."
 msgstr ""
 
 #: jellyfin_mpv_shim/sync/manager.py
@@ -4542,6 +4661,12 @@ msgstr ""
 
 #: jellyfin_mpv_shim/sync/manager.py
 msgid "A download is still finishing. Wait for it to stop, then try again."
+msgstr ""
+
+#: jellyfin_mpv_shim/sync/manager.py
+msgid ""
+"There isn't enough space on that drive to move the downloads. Free some "
+"space and try again — nothing was moved."
 msgstr ""
 
 #: jellyfin_mpv_shim/sync/manager.py

--- a/jellyfin_mpv_shim/messages/en_GB/LC_MESSAGES/base.po
+++ b/jellyfin_mpv_shim/messages/en_GB/LC_MESSAGES/base.po
@@ -6,7 +6,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2026-08-30 22:19-0400\n"
+"POT-Creation-Date: 2026-09-07 17:35-0400\n"
 "PO-Revision-Date: 2026-08-26 14:18+0000\n"
 "Last-Translator: Dan Bishop <d@nbishop.uk>\n"
 "Language-Team: English (United Kingdom) <https://translate.jellyfin.org/"
@@ -513,6 +513,11 @@ msgid "Night Mode (Auto Volume Adj)"
 msgstr "Night Mode (Auto Volume Adj)"
 
 #: jellyfin_mpv_shim/mpvtk_browser/app.py
+#: jellyfin_mpv_shim/mpvtk_browser/auth.py
+msgid "Locked"
+msgstr "Locked"
+
+#: jellyfin_mpv_shim/mpvtk_browser/app.py
 msgid "Failed to load. Check the connection."
 msgstr "Failed to load. Check the connection."
 
@@ -794,10 +799,6 @@ msgstr ""
 "Please check your connection information."
 
 #: jellyfin_mpv_shim/mpvtk_browser/auth.py
-msgid "Locked"
-msgstr "Locked"
-
-#: jellyfin_mpv_shim/mpvtk_browser/auth.py
 #: jellyfin_mpv_shim/mpvtk_browser/pages/home.py
 msgid "Connecting to your server…"
 msgstr "Connecting to your server…"
@@ -878,6 +879,10 @@ msgstr "Quit and Mark Unwatched"
 #: jellyfin_mpv_shim/mpvtk_browser/pages/books.py
 msgid "Favorite"
 msgstr "Favourite"
+
+#: jellyfin_mpv_shim/mpvtk_browser/components/detail.py
+msgid "Web"
+msgstr ""
 
 # seeded from jellyfin-web: HeaderVideos
 #: jellyfin_mpv_shim/mpvtk_browser/components/media_info.py
@@ -1497,12 +1502,8 @@ msgid "Jellyfin UI"
 msgstr "Jellyfin UI"
 
 #: jellyfin_mpv_shim/mpvtk_browser/config.py
-msgid "MPV UI with thumbnails"
-msgstr "MPV UI with thumbnails"
-
-#: jellyfin_mpv_shim/mpvtk_browser/config.py
-msgid "MPV built-in default"
-msgstr "MPV built-in default"
+msgid "MPV UI"
+msgstr ""
 
 #: jellyfin_mpv_shim/mpvtk_browser/config.py
 msgid "Custom OSC"
@@ -1850,8 +1851,24 @@ msgid "Window Buttons in the Top Bar"
 msgstr "Window Buttons in the Top Bar"
 
 #: jellyfin_mpv_shim/mpvtk_browser/config.py
+#, fuzzy
+#| msgid "Window Buttons in the Top Bar"
+msgid "Keep Window Buttons in Full Screen"
+msgstr "Window Buttons in the Top Bar"
+
+#: jellyfin_mpv_shim/mpvtk_browser/config.py
+msgid "Hide the Desktop Title Bar"
+msgstr ""
+
+#: jellyfin_mpv_shim/mpvtk_browser/config.py
 msgid "Player Controls Style"
 msgstr "Player Controls Style"
+
+#: jellyfin_mpv_shim/mpvtk_browser/config.py
+#, fuzzy
+#| msgid "Enable thumbnail previews"
+msgid "Enable Trickplay Thumbnails"
+msgstr "Enable thumbnail previews"
 
 #: jellyfin_mpv_shim/mpvtk_browser/config.py
 msgid "Load All Seek Previews at Once"
@@ -1882,6 +1899,10 @@ msgstr "Cover Size"
 #: jellyfin_mpv_shim/mpvtk_browser/config.py
 msgid "Full-Width Backdrops"
 msgstr "Full-Width Backdrops"
+
+#: jellyfin_mpv_shim/mpvtk_browser/config.py
+msgid "12-Hour Clock"
+msgstr ""
 
 #: jellyfin_mpv_shim/mpvtk_browser/config.py
 msgid "Grid Spacing"
@@ -1926,12 +1947,23 @@ msgid "Fullscreen Library Browser"
 msgstr "Fullscreen Library Browser"
 
 #: jellyfin_mpv_shim/mpvtk_browser/config.py
+msgid "Block Player Keybinds While Browsing"
+msgstr ""
+
+#: jellyfin_mpv_shim/mpvtk_browser/config.py
 msgid "Always Bind Arrow Keys to Player Controls"
 msgstr "Always Bind Arrow Keys to Player Controls"
 
 #: jellyfin_mpv_shim/mpvtk_browser/config.py
 msgid "Player Controls Activation Key"
 msgstr "Player Controls Activation Key"
+
+# seeded from jellyfin-web: SelectAll
+#: jellyfin_mpv_shim/mpvtk_browser/config.py
+#, fuzzy
+#| msgid "Select All"
+msgid "Select Key"
+msgstr "Select All"
 
 #: jellyfin_mpv_shim/mpvtk_browser/config.py
 msgid "Shading Behind the Player Controls"
@@ -1944,6 +1976,12 @@ msgstr "When the Player Controls Hide"
 #: jellyfin_mpv_shim/mpvtk_browser/config.py
 msgid "Hide the Player Controls After (seconds)"
 msgstr "Hide the Player Controls After (seconds)"
+
+#: jellyfin_mpv_shim/mpvtk_browser/config.py
+#, fuzzy
+#| msgid "When the Player Controls Hide"
+msgid "Shrink the Player Controls on a Narrow Window"
+msgstr "When the Player Controls Hide"
 
 #: jellyfin_mpv_shim/mpvtk_browser/config.py
 msgid "Mouse Back/Forward Buttons Skip Chapters"
@@ -2029,6 +2067,21 @@ msgstr ""
 
 #: jellyfin_mpv_shim/mpvtk_browser/config.py
 msgid ""
+"Stops MPV's own shortcuts -- picture adjustment, screenshots, subtitle and "
+"audio switching -- from acting while you are in the library, where there is "
+"no video for them to act on. Turn it off to use your own MPV key bindings "
+"there."
+msgstr ""
+
+#: jellyfin_mpv_shim/mpvtk_browser/config.py
+msgid ""
+"Activates whatever is highlighted, in the library and on the player "
+"controls. An mpv key name; changing it hands Enter back to MPV. The game "
+"controller's Confirm button and a phone's Select follow it."
+msgstr ""
+
+#: jellyfin_mpv_shim/mpvtk_browser/config.py
+msgid ""
 "Leave these blank unless downloads are waking your disks too often. Set both "
 "of the first two together: episodes are then fetched in one batch when a "
 "series runs low, instead of one at a time."
@@ -2042,7 +2095,8 @@ msgstr ""
 #: jellyfin_mpv_shim/mpvtk_browser/config.py
 msgid ""
 "Off gives MPV's own mouse behaviour instead: drag the video to move the "
-"window, and right click to pause. Double click is full screen either way."
+"window, and the right button does whatever your MPV config gives it. Double "
+"click is full screen either way."
 msgstr ""
 
 #: jellyfin_mpv_shim/mpvtk_browser/config.py
@@ -2132,6 +2186,30 @@ msgid ""
 "maximize and close in the top bar instead, and lets you drag the window by "
 "it. On \"Only when the window has no title bar\", MPV is asked whether this "
 "window got one, so desktops that draw a title bar are left alone."
+msgstr ""
+
+#: jellyfin_mpv_shim/mpvtk_browser/config.py
+msgid ""
+"Full screen has no title bar anywhere and nothing to move or maximize, so "
+"the buttons are normally hidden there. Turn this on to keep a way out of "
+"full screen that is not a keyboard shortcut."
+msgstr ""
+
+#: jellyfin_mpv_shim/mpvtk_browser/config.py
+msgid ""
+"Asks the desktop for no title bar on the player window, so the top bar above "
+"is the only one. Pairs with the setting above: on \"Only when the window has "
+"no title bar\" the buttons appear as soon as this is on. Leave both off "
+"unless you want them, since a window with neither can be awkward to move on "
+"some desktops."
+msgstr ""
+
+#: jellyfin_mpv_shim/mpvtk_browser/config.py
+msgid ""
+"Shows a preview frame while you drag the seek bar. Works with every player "
+"control style, including your own OSC script if it supports thumbfast. The "
+"images are fetched from the server per video, which costs disk space and "
+"memory -- tens of MB for an episode, a few hundred for a long film."
 msgstr ""
 
 #: jellyfin_mpv_shim/mpvtk_browser/config.py
@@ -2241,6 +2319,13 @@ msgstr ""
 
 #: jellyfin_mpv_shim/mpvtk_browser/config.py
 msgid ""
+"Show times of day as \"8:30 PM\" rather than \"20:30\" — the Live TV guide "
+"and its air times, and the \"Ends at\" labels on a detail page and the "
+"player controls."
+msgstr ""
+
+#: jellyfin_mpv_shim/mpvtk_browser/config.py
+msgid ""
 "The controls have to stay legible over any frame. \"None\" gives the text a "
 "drop shadow instead of shading the picture behind it."
 msgstr ""
@@ -2255,6 +2340,13 @@ msgstr ""
 msgid ""
 "0 hides them as soon as the pointer is not on them, and forces \"Hide unless "
 "hovered\"."
+msgstr ""
+
+#: jellyfin_mpv_shim/mpvtk_browser/config.py
+msgid ""
+"Narrowing the window shrinks the controls until the smallest button reaches "
+"the accessibility minimum, instead of dropping buttons sooner. Off keeps the "
+"older, larger floor."
 msgstr ""
 
 #: jellyfin_mpv_shim/mpvtk_browser/config.py
@@ -3859,6 +3951,7 @@ msgid "More Like This"
 msgstr "More Like This"
 
 #: jellyfin_mpv_shim/mpvtk_browser/pages/detail.py
+#: jellyfin_mpv_shim/mpvtk_browser/tiles.py
 msgid "Go to Series"
 msgstr ""
 
@@ -5053,6 +5146,22 @@ msgstr "Remove Server"
 msgid "There is nothing here to queue."
 msgstr ""
 
+#: jellyfin_mpv_shim/mpvtk_browser/timefmt.py
+#, python-brace-format
+msgctxt "12-hour clock"
+msgid "{time} {period}"
+msgstr ""
+
+#: jellyfin_mpv_shim/mpvtk_browser/timefmt.py
+msgctxt "12-hour clock"
+msgid "AM"
+msgstr ""
+
+#: jellyfin_mpv_shim/mpvtk_browser/timefmt.py
+msgctxt "12-hour clock"
+msgid "PM"
+msgstr ""
+
 # seeded from jellyfin-web: Search
 #: jellyfin_mpv_shim/mpvtk_browser/views.py
 #: jellyfin_mpv_shim/mpvtk_browser/window_chrome.py
@@ -5220,13 +5329,32 @@ msgid "Enable SVP"
 msgstr "Enable SVP"
 
 #: jellyfin_mpv_shim/sync/manager.py
+msgid "The downloads are already in that folder."
+msgstr ""
+
+#: jellyfin_mpv_shim/sync/manager.py
 msgid ""
 "Can't change the download folder while a download is in progress. Wait for "
 "it to finish, then try again."
 msgstr ""
 
 #: jellyfin_mpv_shim/sync/manager.py
+msgid ""
+"That folder is inside the current download folder. Choose one outside it."
+msgstr ""
+
+#: jellyfin_mpv_shim/sync/manager.py
+msgid "Can't read that folder. Check the path and its permissions."
+msgstr ""
+
+#: jellyfin_mpv_shim/sync/manager.py
 msgid "That folder already contains downloads. Choose an empty folder."
+msgstr ""
+
+#: jellyfin_mpv_shim/sync/manager.py
+msgid ""
+"That folder isn't empty. Choose an empty folder — the download folder is "
+"managed by this app and anything else in it can be moved or removed."
 msgstr ""
 
 #: jellyfin_mpv_shim/sync/manager.py
@@ -5235,6 +5363,12 @@ msgstr ""
 
 #: jellyfin_mpv_shim/sync/manager.py
 msgid "A download is still finishing. Wait for it to stop, then try again."
+msgstr ""
+
+#: jellyfin_mpv_shim/sync/manager.py
+msgid ""
+"There isn't enough space on that drive to move the downloads. Free some "
+"space and try again — nothing was moved."
 msgstr ""
 
 #: jellyfin_mpv_shim/sync/manager.py
@@ -5436,6 +5570,12 @@ msgstr "Video Playback Profiles"
 #: jellyfin_mpv_shim/video_profile.py
 msgid "Select Shader Profile"
 msgstr "Select Shader Profile"
+
+#~ msgid "MPV UI with thumbnails"
+#~ msgstr "MPV UI with thumbnails"
+
+#~ msgid "MPV built-in default"
+#~ msgstr "MPV built-in default"
 
 #, fuzzy
 #~| msgid ""

--- a/jellyfin_mpv_shim/messages/eo/LC_MESSAGES/base.po
+++ b/jellyfin_mpv_shim/messages/eo/LC_MESSAGES/base.po
@@ -6,7 +6,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2026-08-30 22:19-0400\n"
+"POT-Creation-Date: 2026-09-07 17:35-0400\n"
 "PO-Revision-Date: 2025-03-17 10:01+0000\n"
 "Last-Translator: Joesph boukolos <joseph+weblate@boukolos.com>\n"
 "Language-Team: Esperanto <https://translate.jellyfin.org/projects/jellyfin/"
@@ -521,6 +521,11 @@ msgid "Night Mode (Auto Volume Adj)"
 msgstr ""
 
 #: jellyfin_mpv_shim/mpvtk_browser/app.py
+#: jellyfin_mpv_shim/mpvtk_browser/auth.py
+msgid "Locked"
+msgstr ""
+
+#: jellyfin_mpv_shim/mpvtk_browser/app.py
 msgid "Failed to load. Check the connection."
 msgstr ""
 
@@ -800,10 +805,6 @@ msgstr ""
 "Kontrolu viajn konektajn informojn."
 
 #: jellyfin_mpv_shim/mpvtk_browser/auth.py
-msgid "Locked"
-msgstr ""
-
-#: jellyfin_mpv_shim/mpvtk_browser/auth.py
 #: jellyfin_mpv_shim/mpvtk_browser/pages/home.py
 msgid "Connecting to your server…"
 msgstr ""
@@ -884,6 +885,10 @@ msgstr "Ĉesi kaj Marki Nespektata"
 #: jellyfin_mpv_shim/mpvtk_browser/pages/books.py
 msgid "Favorite"
 msgstr "Favorata"
+
+#: jellyfin_mpv_shim/mpvtk_browser/components/detail.py
+msgid "Web"
+msgstr ""
 
 # seeded from jellyfin-web: HeaderVideos
 #: jellyfin_mpv_shim/mpvtk_browser/components/media_info.py
@@ -1491,11 +1496,7 @@ msgid "Jellyfin UI"
 msgstr ""
 
 #: jellyfin_mpv_shim/mpvtk_browser/config.py
-msgid "MPV UI with thumbnails"
-msgstr ""
-
-#: jellyfin_mpv_shim/mpvtk_browser/config.py
-msgid "MPV built-in default"
+msgid "MPV UI"
 msgstr ""
 
 #: jellyfin_mpv_shim/mpvtk_browser/config.py
@@ -1842,7 +1843,19 @@ msgid "Window Buttons in the Top Bar"
 msgstr ""
 
 #: jellyfin_mpv_shim/mpvtk_browser/config.py
+msgid "Keep Window Buttons in Full Screen"
+msgstr ""
+
+#: jellyfin_mpv_shim/mpvtk_browser/config.py
+msgid "Hide the Desktop Title Bar"
+msgstr ""
+
+#: jellyfin_mpv_shim/mpvtk_browser/config.py
 msgid "Player Controls Style"
+msgstr ""
+
+#: jellyfin_mpv_shim/mpvtk_browser/config.py
+msgid "Enable Trickplay Thumbnails"
 msgstr ""
 
 #: jellyfin_mpv_shim/mpvtk_browser/config.py
@@ -1873,6 +1886,10 @@ msgstr ""
 
 #: jellyfin_mpv_shim/mpvtk_browser/config.py
 msgid "Full-Width Backdrops"
+msgstr ""
+
+#: jellyfin_mpv_shim/mpvtk_browser/config.py
+msgid "12-Hour Clock"
 msgstr ""
 
 #: jellyfin_mpv_shim/mpvtk_browser/config.py
@@ -1918,12 +1935,23 @@ msgid "Fullscreen Library Browser"
 msgstr ""
 
 #: jellyfin_mpv_shim/mpvtk_browser/config.py
+msgid "Block Player Keybinds While Browsing"
+msgstr ""
+
+#: jellyfin_mpv_shim/mpvtk_browser/config.py
 msgid "Always Bind Arrow Keys to Player Controls"
 msgstr ""
 
 #: jellyfin_mpv_shim/mpvtk_browser/config.py
 msgid "Player Controls Activation Key"
 msgstr ""
+
+# seeded from jellyfin-web: SelectAll
+#: jellyfin_mpv_shim/mpvtk_browser/config.py
+#, fuzzy
+#| msgid "Select All"
+msgid "Select Key"
+msgstr "Elekti Ĉiujn"
 
 #: jellyfin_mpv_shim/mpvtk_browser/config.py
 msgid "Shading Behind the Player Controls"
@@ -1935,6 +1963,10 @@ msgstr ""
 
 #: jellyfin_mpv_shim/mpvtk_browser/config.py
 msgid "Hide the Player Controls After (seconds)"
+msgstr ""
+
+#: jellyfin_mpv_shim/mpvtk_browser/config.py
+msgid "Shrink the Player Controls on a Narrow Window"
 msgstr ""
 
 #: jellyfin_mpv_shim/mpvtk_browser/config.py
@@ -2021,6 +2053,21 @@ msgstr ""
 
 #: jellyfin_mpv_shim/mpvtk_browser/config.py
 msgid ""
+"Stops MPV's own shortcuts -- picture adjustment, screenshots, subtitle and "
+"audio switching -- from acting while you are in the library, where there is "
+"no video for them to act on. Turn it off to use your own MPV key bindings "
+"there."
+msgstr ""
+
+#: jellyfin_mpv_shim/mpvtk_browser/config.py
+msgid ""
+"Activates whatever is highlighted, in the library and on the player "
+"controls. An mpv key name; changing it hands Enter back to MPV. The game "
+"controller's Confirm button and a phone's Select follow it."
+msgstr ""
+
+#: jellyfin_mpv_shim/mpvtk_browser/config.py
+msgid ""
 "Leave these blank unless downloads are waking your disks too often. Set both "
 "of the first two together: episodes are then fetched in one batch when a "
 "series runs low, instead of one at a time."
@@ -2034,7 +2081,8 @@ msgstr ""
 #: jellyfin_mpv_shim/mpvtk_browser/config.py
 msgid ""
 "Off gives MPV's own mouse behaviour instead: drag the video to move the "
-"window, and right click to pause. Double click is full screen either way."
+"window, and the right button does whatever your MPV config gives it. Double "
+"click is full screen either way."
 msgstr ""
 
 #: jellyfin_mpv_shim/mpvtk_browser/config.py
@@ -2124,6 +2172,30 @@ msgid ""
 "maximize and close in the top bar instead, and lets you drag the window by "
 "it. On \"Only when the window has no title bar\", MPV is asked whether this "
 "window got one, so desktops that draw a title bar are left alone."
+msgstr ""
+
+#: jellyfin_mpv_shim/mpvtk_browser/config.py
+msgid ""
+"Full screen has no title bar anywhere and nothing to move or maximize, so "
+"the buttons are normally hidden there. Turn this on to keep a way out of "
+"full screen that is not a keyboard shortcut."
+msgstr ""
+
+#: jellyfin_mpv_shim/mpvtk_browser/config.py
+msgid ""
+"Asks the desktop for no title bar on the player window, so the top bar above "
+"is the only one. Pairs with the setting above: on \"Only when the window has "
+"no title bar\" the buttons appear as soon as this is on. Leave both off "
+"unless you want them, since a window with neither can be awkward to move on "
+"some desktops."
+msgstr ""
+
+#: jellyfin_mpv_shim/mpvtk_browser/config.py
+msgid ""
+"Shows a preview frame while you drag the seek bar. Works with every player "
+"control style, including your own OSC script if it supports thumbfast. The "
+"images are fetched from the server per video, which costs disk space and "
+"memory -- tens of MB for an episode, a few hundred for a long film."
 msgstr ""
 
 #: jellyfin_mpv_shim/mpvtk_browser/config.py
@@ -2233,6 +2305,13 @@ msgstr ""
 
 #: jellyfin_mpv_shim/mpvtk_browser/config.py
 msgid ""
+"Show times of day as \"8:30 PM\" rather than \"20:30\" — the Live TV guide "
+"and its air times, and the \"Ends at\" labels on a detail page and the "
+"player controls."
+msgstr ""
+
+#: jellyfin_mpv_shim/mpvtk_browser/config.py
+msgid ""
 "The controls have to stay legible over any frame. \"None\" gives the text a "
 "drop shadow instead of shading the picture behind it."
 msgstr ""
@@ -2247,6 +2326,13 @@ msgstr ""
 msgid ""
 "0 hides them as soon as the pointer is not on them, and forces \"Hide unless "
 "hovered\"."
+msgstr ""
+
+#: jellyfin_mpv_shim/mpvtk_browser/config.py
+msgid ""
+"Narrowing the window shrinks the controls until the smallest button reaches "
+"the accessibility minimum, instead of dropping buttons sooner. Off keeps the "
+"older, larger floor."
 msgstr ""
 
 #: jellyfin_mpv_shim/mpvtk_browser/config.py
@@ -3852,6 +3938,7 @@ msgid "More Like This"
 msgstr "Pli Ĉi Tiel"
 
 #: jellyfin_mpv_shim/mpvtk_browser/pages/detail.py
+#: jellyfin_mpv_shim/mpvtk_browser/tiles.py
 msgid "Go to Series"
 msgstr ""
 
@@ -5046,6 +5133,22 @@ msgstr "Forigi Servilon"
 msgid "There is nothing here to queue."
 msgstr ""
 
+#: jellyfin_mpv_shim/mpvtk_browser/timefmt.py
+#, python-brace-format
+msgctxt "12-hour clock"
+msgid "{time} {period}"
+msgstr ""
+
+#: jellyfin_mpv_shim/mpvtk_browser/timefmt.py
+msgctxt "12-hour clock"
+msgid "AM"
+msgstr ""
+
+#: jellyfin_mpv_shim/mpvtk_browser/timefmt.py
+msgctxt "12-hour clock"
+msgid "PM"
+msgstr ""
+
 # seeded from jellyfin-web: Search
 #: jellyfin_mpv_shim/mpvtk_browser/views.py
 #: jellyfin_mpv_shim/mpvtk_browser/window_chrome.py
@@ -5212,13 +5315,32 @@ msgid "Enable SVP"
 msgstr "Ebligi SVP"
 
 #: jellyfin_mpv_shim/sync/manager.py
+msgid "The downloads are already in that folder."
+msgstr ""
+
+#: jellyfin_mpv_shim/sync/manager.py
 msgid ""
 "Can't change the download folder while a download is in progress. Wait for "
 "it to finish, then try again."
 msgstr ""
 
 #: jellyfin_mpv_shim/sync/manager.py
+msgid ""
+"That folder is inside the current download folder. Choose one outside it."
+msgstr ""
+
+#: jellyfin_mpv_shim/sync/manager.py
+msgid "Can't read that folder. Check the path and its permissions."
+msgstr ""
+
+#: jellyfin_mpv_shim/sync/manager.py
 msgid "That folder already contains downloads. Choose an empty folder."
+msgstr ""
+
+#: jellyfin_mpv_shim/sync/manager.py
+msgid ""
+"That folder isn't empty. Choose an empty folder — the download folder is "
+"managed by this app and anything else in it can be moved or removed."
 msgstr ""
 
 #: jellyfin_mpv_shim/sync/manager.py
@@ -5227,6 +5349,12 @@ msgstr ""
 
 #: jellyfin_mpv_shim/sync/manager.py
 msgid "A download is still finishing. Wait for it to stop, then try again."
+msgstr ""
+
+#: jellyfin_mpv_shim/sync/manager.py
+msgid ""
+"There isn't enough space on that drive to move the downloads. Free some "
+"space and try again — nothing was moved."
 msgstr ""
 
 #: jellyfin_mpv_shim/sync/manager.py

--- a/jellyfin_mpv_shim/messages/es/LC_MESSAGES/base.po
+++ b/jellyfin_mpv_shim/messages/es/LC_MESSAGES/base.po
@@ -6,7 +6,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2026-08-30 22:19-0400\n"
+"POT-Creation-Date: 2026-09-07 17:35-0400\n"
 "PO-Revision-Date: 2026-09-02 16:00+0000\n"
 "Last-Translator: ern3stoGH <ern3sto@gmail.com>\n"
 "Language-Team: Spanish <https://translate.jellyfin.org/projects/jellyfin/"
@@ -511,6 +511,11 @@ msgid "Night Mode (Auto Volume Adj)"
 msgstr "Modo nocturno (ajuste automático del volumen)"
 
 #: jellyfin_mpv_shim/mpvtk_browser/app.py
+#: jellyfin_mpv_shim/mpvtk_browser/auth.py
+msgid "Locked"
+msgstr "Bloqueado"
+
+#: jellyfin_mpv_shim/mpvtk_browser/app.py
 msgid "Failed to load. Check the connection."
 msgstr "No se pudo cargar. Compruebe la conexión."
 
@@ -754,10 +759,6 @@ msgid "Could not connect. Please check your details."
 msgstr "No se pudo conectar. Compruebe los datos."
 
 #: jellyfin_mpv_shim/mpvtk_browser/auth.py
-msgid "Locked"
-msgstr "Bloqueado"
-
-#: jellyfin_mpv_shim/mpvtk_browser/auth.py
 #: jellyfin_mpv_shim/mpvtk_browser/pages/home.py
 msgid "Connecting to your server…"
 msgstr "Conectando con tu servidor…"
@@ -828,6 +829,10 @@ msgstr "Visto"
 #: jellyfin_mpv_shim/mpvtk_browser/pages/books.py
 msgid "Favorite"
 msgstr "Favoritos"
+
+#: jellyfin_mpv_shim/mpvtk_browser/components/detail.py
+msgid "Web"
+msgstr ""
 
 # seeded from jellyfin-web: HeaderVideos
 #: jellyfin_mpv_shim/mpvtk_browser/components/media_info.py
@@ -1392,12 +1397,8 @@ msgid "Jellyfin UI"
 msgstr "Interfaz de Jellyfin"
 
 #: jellyfin_mpv_shim/mpvtk_browser/config.py
-msgid "MPV UI with thumbnails"
-msgstr "Interfaz MPV con miniaturas"
-
-#: jellyfin_mpv_shim/mpvtk_browser/config.py
-msgid "MPV built-in default"
-msgstr "Configuración por defecto de MPV"
+msgid "MPV UI"
+msgstr ""
 
 #: jellyfin_mpv_shim/mpvtk_browser/config.py
 msgid "Custom OSC"
@@ -1737,8 +1738,24 @@ msgid "Window Buttons in the Top Bar"
 msgstr "Botones de ventana en la barra superior"
 
 #: jellyfin_mpv_shim/mpvtk_browser/config.py
+#, fuzzy
+#| msgid "Window Buttons in the Top Bar"
+msgid "Keep Window Buttons in Full Screen"
+msgstr "Botones de ventana en la barra superior"
+
+#: jellyfin_mpv_shim/mpvtk_browser/config.py
+msgid "Hide the Desktop Title Bar"
+msgstr ""
+
+#: jellyfin_mpv_shim/mpvtk_browser/config.py
 msgid "Player Controls Style"
 msgstr "Estilo de los controles del reproductor"
+
+#: jellyfin_mpv_shim/mpvtk_browser/config.py
+#, fuzzy
+#| msgid "Enable thumbnail previews"
+msgid "Enable Trickplay Thumbnails"
+msgstr "Activar vistas previas en miniatura"
 
 #: jellyfin_mpv_shim/mpvtk_browser/config.py
 msgid "Load All Seek Previews at Once"
@@ -1769,6 +1786,10 @@ msgstr "Tamaño de la portada"
 
 #: jellyfin_mpv_shim/mpvtk_browser/config.py
 msgid "Full-Width Backdrops"
+msgstr ""
+
+#: jellyfin_mpv_shim/mpvtk_browser/config.py
+msgid "12-Hour Clock"
 msgstr ""
 
 #: jellyfin_mpv_shim/mpvtk_browser/config.py
@@ -1814,6 +1835,10 @@ msgid "Fullscreen Library Browser"
 msgstr "Navegador de biblioteca en pantalla completa"
 
 #: jellyfin_mpv_shim/mpvtk_browser/config.py
+msgid "Block Player Keybinds While Browsing"
+msgstr ""
+
+#: jellyfin_mpv_shim/mpvtk_browser/config.py
 msgid "Always Bind Arrow Keys to Player Controls"
 msgstr ""
 "Siempre asignar las teclas de dirección a los controles del reproductor"
@@ -1821,6 +1846,13 @@ msgstr ""
 #: jellyfin_mpv_shim/mpvtk_browser/config.py
 msgid "Player Controls Activation Key"
 msgstr "Tecla de activación de los controles del reproductor"
+
+# seeded from jellyfin-web: SelectAll
+#: jellyfin_mpv_shim/mpvtk_browser/config.py
+#, fuzzy
+#| msgid "Select All"
+msgid "Select Key"
+msgstr "Seleccionar todo"
 
 #: jellyfin_mpv_shim/mpvtk_browser/config.py
 msgid "Shading Behind the Player Controls"
@@ -1833,6 +1865,12 @@ msgstr "Cuando se esconden los controles del reproductor"
 #: jellyfin_mpv_shim/mpvtk_browser/config.py
 msgid "Hide the Player Controls After (seconds)"
 msgstr "Esconder los controles del reproductor tras (segundos)"
+
+#: jellyfin_mpv_shim/mpvtk_browser/config.py
+#, fuzzy
+#| msgid "When the Player Controls Hide"
+msgid "Shrink the Player Controls on a Narrow Window"
+msgstr "Cuando se esconden los controles del reproductor"
 
 #: jellyfin_mpv_shim/mpvtk_browser/config.py
 msgid "Mouse Back/Forward Buttons Skip Chapters"
@@ -1918,6 +1956,21 @@ msgstr ""
 
 #: jellyfin_mpv_shim/mpvtk_browser/config.py
 msgid ""
+"Stops MPV's own shortcuts -- picture adjustment, screenshots, subtitle and "
+"audio switching -- from acting while you are in the library, where there is "
+"no video for them to act on. Turn it off to use your own MPV key bindings "
+"there."
+msgstr ""
+
+#: jellyfin_mpv_shim/mpvtk_browser/config.py
+msgid ""
+"Activates whatever is highlighted, in the library and on the player "
+"controls. An mpv key name; changing it hands Enter back to MPV. The game "
+"controller's Confirm button and a phone's Select follow it."
+msgstr ""
+
+#: jellyfin_mpv_shim/mpvtk_browser/config.py
+msgid ""
 "Leave these blank unless downloads are waking your disks too often. Set both "
 "of the first two together: episodes are then fetched in one batch when a "
 "series runs low, instead of one at a time."
@@ -1935,9 +1988,14 @@ msgstr ""
 "visto aún."
 
 #: jellyfin_mpv_shim/mpvtk_browser/config.py
+#, fuzzy
+#| msgid ""
+#| "Off gives MPV's own mouse behaviour instead: drag the video to move the "
+#| "window, and right click to pause. Double click is full screen either way."
 msgid ""
 "Off gives MPV's own mouse behaviour instead: drag the video to move the "
-"window, and right click to pause. Double click is full screen either way."
+"window, and the right button does whatever your MPV config gives it. Double "
+"click is full screen either way."
 msgstr ""
 "Cuando esta desactivado se utiliza el comportamiento de ratón de MPV: "
 "arrastra el video para mover la ventana, click derecho para pausar. Doble "
@@ -2048,6 +2106,30 @@ msgid ""
 "maximize and close in the top bar instead, and lets you drag the window by "
 "it. On \"Only when the window has no title bar\", MPV is asked whether this "
 "window got one, so desktops that draw a title bar are left alone."
+msgstr ""
+
+#: jellyfin_mpv_shim/mpvtk_browser/config.py
+msgid ""
+"Full screen has no title bar anywhere and nothing to move or maximize, so "
+"the buttons are normally hidden there. Turn this on to keep a way out of "
+"full screen that is not a keyboard shortcut."
+msgstr ""
+
+#: jellyfin_mpv_shim/mpvtk_browser/config.py
+msgid ""
+"Asks the desktop for no title bar on the player window, so the top bar above "
+"is the only one. Pairs with the setting above: on \"Only when the window has "
+"no title bar\" the buttons appear as soon as this is on. Leave both off "
+"unless you want them, since a window with neither can be awkward to move on "
+"some desktops."
+msgstr ""
+
+#: jellyfin_mpv_shim/mpvtk_browser/config.py
+msgid ""
+"Shows a preview frame while you drag the seek bar. Works with every player "
+"control style, including your own OSC script if it supports thumbfast. The "
+"images are fetched from the server per video, which costs disk space and "
+"memory -- tens of MB for an episode, a few hundred for a long film."
 msgstr ""
 
 #: jellyfin_mpv_shim/mpvtk_browser/config.py
@@ -2180,6 +2262,13 @@ msgstr ""
 
 #: jellyfin_mpv_shim/mpvtk_browser/config.py
 msgid ""
+"Show times of day as \"8:30 PM\" rather than \"20:30\" — the Live TV guide "
+"and its air times, and the \"Ends at\" labels on a detail page and the "
+"player controls."
+msgstr ""
+
+#: jellyfin_mpv_shim/mpvtk_browser/config.py
+msgid ""
 "The controls have to stay legible over any frame. \"None\" gives the text a "
 "drop shadow instead of shading the picture behind it."
 msgstr ""
@@ -2194,6 +2283,13 @@ msgstr ""
 msgid ""
 "0 hides them as soon as the pointer is not on them, and forces \"Hide unless "
 "hovered\"."
+msgstr ""
+
+#: jellyfin_mpv_shim/mpvtk_browser/config.py
+msgid ""
+"Narrowing the window shrinks the controls until the smallest button reaches "
+"the accessibility minimum, instead of dropping buttons sooner. Off keeps the "
+"older, larger floor."
 msgstr ""
 
 #: jellyfin_mpv_shim/mpvtk_browser/config.py
@@ -3771,6 +3867,7 @@ msgid "More Like This"
 msgstr "Más como este"
 
 #: jellyfin_mpv_shim/mpvtk_browser/pages/detail.py
+#: jellyfin_mpv_shim/mpvtk_browser/tiles.py
 msgid "Go to Series"
 msgstr ""
 
@@ -4920,6 +5017,22 @@ msgstr "Eliminar servidor"
 msgid "There is nothing here to queue."
 msgstr ""
 
+#: jellyfin_mpv_shim/mpvtk_browser/timefmt.py
+#, python-brace-format
+msgctxt "12-hour clock"
+msgid "{time} {period}"
+msgstr ""
+
+#: jellyfin_mpv_shim/mpvtk_browser/timefmt.py
+msgctxt "12-hour clock"
+msgid "AM"
+msgstr ""
+
+#: jellyfin_mpv_shim/mpvtk_browser/timefmt.py
+msgctxt "12-hour clock"
+msgid "PM"
+msgstr ""
+
 # seeded from jellyfin-web: Search
 #: jellyfin_mpv_shim/mpvtk_browser/views.py
 #: jellyfin_mpv_shim/mpvtk_browser/window_chrome.py
@@ -5084,13 +5197,34 @@ msgid "Enable SVP"
 msgstr "Habilitar SVP"
 
 #: jellyfin_mpv_shim/sync/manager.py
+#, fuzzy
+#| msgid "The download could not be started."
+msgid "The downloads are already in that folder."
+msgstr "La descarga no pudo empezar."
+
+#: jellyfin_mpv_shim/sync/manager.py
 msgid ""
 "Can't change the download folder while a download is in progress. Wait for "
 "it to finish, then try again."
 msgstr ""
 
 #: jellyfin_mpv_shim/sync/manager.py
+msgid ""
+"That folder is inside the current download folder. Choose one outside it."
+msgstr ""
+
+#: jellyfin_mpv_shim/sync/manager.py
+msgid "Can't read that folder. Check the path and its permissions."
+msgstr ""
+
+#: jellyfin_mpv_shim/sync/manager.py
 msgid "That folder already contains downloads. Choose an empty folder."
+msgstr ""
+
+#: jellyfin_mpv_shim/sync/manager.py
+msgid ""
+"That folder isn't empty. Choose an empty folder — the download folder is "
+"managed by this app and anything else in it can be moved or removed."
 msgstr ""
 
 #: jellyfin_mpv_shim/sync/manager.py
@@ -5099,6 +5233,12 @@ msgstr ""
 
 #: jellyfin_mpv_shim/sync/manager.py
 msgid "A download is still finishing. Wait for it to stop, then try again."
+msgstr ""
+
+#: jellyfin_mpv_shim/sync/manager.py
+msgid ""
+"There isn't enough space on that drive to move the downloads. Free some "
+"space and try again — nothing was moved."
 msgstr ""
 
 #: jellyfin_mpv_shim/sync/manager.py
@@ -5298,6 +5438,12 @@ msgstr "Perfil de Reproducción de Video"
 #: jellyfin_mpv_shim/video_profile.py
 msgid "Select Shader Profile"
 msgstr "Seleccionar Perfil de Sombras"
+
+#~ msgid "MPV UI with thumbnails"
+#~ msgstr "Interfaz MPV con miniaturas"
+
+#~ msgid "MPV built-in default"
+#~ msgstr "Configuración por defecto de MPV"
 
 #~ msgid "Could not copy the text."
 #~ msgstr "No se pudo copiar el texto."

--- a/jellyfin_mpv_shim/messages/es_419/LC_MESSAGES/base.po
+++ b/jellyfin_mpv_shim/messages/es_419/LC_MESSAGES/base.po
@@ -6,7 +6,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2026-08-30 22:19-0400\n"
+"POT-Creation-Date: 2026-09-07 17:35-0400\n"
 "PO-Revision-Date: 2026-08-26 19:19+0000\n"
 "Last-Translator: lolomanzanillo <lolomanzanillo@gmail.com>\n"
 "Language-Team: Spanish (Latin America) <https://translate.jellyfin.org/"
@@ -511,6 +511,11 @@ msgid "Night Mode (Auto Volume Adj)"
 msgstr "Modo Noche (Auto Ajuste de Volumen)"
 
 #: jellyfin_mpv_shim/mpvtk_browser/app.py
+#: jellyfin_mpv_shim/mpvtk_browser/auth.py
+msgid "Locked"
+msgstr "Bloqueado"
+
+#: jellyfin_mpv_shim/mpvtk_browser/app.py
 msgid "Failed to load. Check the connection."
 msgstr "No se pudo conectar. Revisa tu conexión."
 
@@ -765,10 +770,6 @@ msgid "Could not connect. Please check your details."
 msgstr "No se pudo establecer la conexión. Por favor, verifique sus datos."
 
 #: jellyfin_mpv_shim/mpvtk_browser/auth.py
-msgid "Locked"
-msgstr "Bloqueado"
-
-#: jellyfin_mpv_shim/mpvtk_browser/auth.py
 #: jellyfin_mpv_shim/mpvtk_browser/pages/home.py
 msgid "Connecting to your server…"
 msgstr "Conectando a tu servidor…"
@@ -845,6 +846,10 @@ msgstr "Salir y Marcar como no Visto"
 #: jellyfin_mpv_shim/mpvtk_browser/pages/books.py
 msgid "Favorite"
 msgstr "Favorito"
+
+#: jellyfin_mpv_shim/mpvtk_browser/components/detail.py
+msgid "Web"
+msgstr ""
 
 # seeded from jellyfin-web: HeaderVideos
 #: jellyfin_mpv_shim/mpvtk_browser/components/media_info.py
@@ -1440,11 +1445,7 @@ msgid "Jellyfin UI"
 msgstr ""
 
 #: jellyfin_mpv_shim/mpvtk_browser/config.py
-msgid "MPV UI with thumbnails"
-msgstr ""
-
-#: jellyfin_mpv_shim/mpvtk_browser/config.py
-msgid "MPV built-in default"
+msgid "MPV UI"
 msgstr ""
 
 #: jellyfin_mpv_shim/mpvtk_browser/config.py
@@ -1795,8 +1796,22 @@ msgid "Window Buttons in the Top Bar"
 msgstr ""
 
 #: jellyfin_mpv_shim/mpvtk_browser/config.py
+msgid "Keep Window Buttons in Full Screen"
+msgstr ""
+
+#: jellyfin_mpv_shim/mpvtk_browser/config.py
+msgid "Hide the Desktop Title Bar"
+msgstr ""
+
+#: jellyfin_mpv_shim/mpvtk_browser/config.py
 msgid "Player Controls Style"
 msgstr ""
+
+#: jellyfin_mpv_shim/mpvtk_browser/config.py
+#, fuzzy
+#| msgid "Enable thumbnail previews"
+msgid "Enable Trickplay Thumbnails"
+msgstr "Activar vista previa de miniaturas"
 
 #: jellyfin_mpv_shim/mpvtk_browser/config.py
 msgid "Load All Seek Previews at Once"
@@ -1826,6 +1841,10 @@ msgstr ""
 
 #: jellyfin_mpv_shim/mpvtk_browser/config.py
 msgid "Full-Width Backdrops"
+msgstr ""
+
+#: jellyfin_mpv_shim/mpvtk_browser/config.py
+msgid "12-Hour Clock"
 msgstr ""
 
 #: jellyfin_mpv_shim/mpvtk_browser/config.py
@@ -1871,12 +1890,22 @@ msgid "Fullscreen Library Browser"
 msgstr ""
 
 #: jellyfin_mpv_shim/mpvtk_browser/config.py
+msgid "Block Player Keybinds While Browsing"
+msgstr ""
+
+#: jellyfin_mpv_shim/mpvtk_browser/config.py
 msgid "Always Bind Arrow Keys to Player Controls"
 msgstr ""
 
 #: jellyfin_mpv_shim/mpvtk_browser/config.py
 msgid "Player Controls Activation Key"
 msgstr ""
+
+#: jellyfin_mpv_shim/mpvtk_browser/config.py
+#, fuzzy
+#| msgid "Selected: %s"
+msgid "Select Key"
+msgstr "Selecciónado: %s"
 
 #: jellyfin_mpv_shim/mpvtk_browser/config.py
 msgid "Shading Behind the Player Controls"
@@ -1888,6 +1917,10 @@ msgstr ""
 
 #: jellyfin_mpv_shim/mpvtk_browser/config.py
 msgid "Hide the Player Controls After (seconds)"
+msgstr ""
+
+#: jellyfin_mpv_shim/mpvtk_browser/config.py
+msgid "Shrink the Player Controls on a Narrow Window"
 msgstr ""
 
 #: jellyfin_mpv_shim/mpvtk_browser/config.py
@@ -1974,6 +2007,21 @@ msgstr ""
 
 #: jellyfin_mpv_shim/mpvtk_browser/config.py
 msgid ""
+"Stops MPV's own shortcuts -- picture adjustment, screenshots, subtitle and "
+"audio switching -- from acting while you are in the library, where there is "
+"no video for them to act on. Turn it off to use your own MPV key bindings "
+"there."
+msgstr ""
+
+#: jellyfin_mpv_shim/mpvtk_browser/config.py
+msgid ""
+"Activates whatever is highlighted, in the library and on the player "
+"controls. An mpv key name; changing it hands Enter back to MPV. The game "
+"controller's Confirm button and a phone's Select follow it."
+msgstr ""
+
+#: jellyfin_mpv_shim/mpvtk_browser/config.py
+msgid ""
 "Leave these blank unless downloads are waking your disks too often. Set both "
 "of the first two together: episodes are then fetched in one batch when a "
 "series runs low, instead of one at a time."
@@ -1987,7 +2035,8 @@ msgstr ""
 #: jellyfin_mpv_shim/mpvtk_browser/config.py
 msgid ""
 "Off gives MPV's own mouse behaviour instead: drag the video to move the "
-"window, and right click to pause. Double click is full screen either way."
+"window, and the right button does whatever your MPV config gives it. Double "
+"click is full screen either way."
 msgstr ""
 
 #: jellyfin_mpv_shim/mpvtk_browser/config.py
@@ -2077,6 +2126,30 @@ msgid ""
 "maximize and close in the top bar instead, and lets you drag the window by "
 "it. On \"Only when the window has no title bar\", MPV is asked whether this "
 "window got one, so desktops that draw a title bar are left alone."
+msgstr ""
+
+#: jellyfin_mpv_shim/mpvtk_browser/config.py
+msgid ""
+"Full screen has no title bar anywhere and nothing to move or maximize, so "
+"the buttons are normally hidden there. Turn this on to keep a way out of "
+"full screen that is not a keyboard shortcut."
+msgstr ""
+
+#: jellyfin_mpv_shim/mpvtk_browser/config.py
+msgid ""
+"Asks the desktop for no title bar on the player window, so the top bar above "
+"is the only one. Pairs with the setting above: on \"Only when the window has "
+"no title bar\" the buttons appear as soon as this is on. Leave both off "
+"unless you want them, since a window with neither can be awkward to move on "
+"some desktops."
+msgstr ""
+
+#: jellyfin_mpv_shim/mpvtk_browser/config.py
+msgid ""
+"Shows a preview frame while you drag the seek bar. Works with every player "
+"control style, including your own OSC script if it supports thumbfast. The "
+"images are fetched from the server per video, which costs disk space and "
+"memory -- tens of MB for an episode, a few hundred for a long film."
 msgstr ""
 
 #: jellyfin_mpv_shim/mpvtk_browser/config.py
@@ -2186,6 +2259,13 @@ msgstr ""
 
 #: jellyfin_mpv_shim/mpvtk_browser/config.py
 msgid ""
+"Show times of day as \"8:30 PM\" rather than \"20:30\" — the Live TV guide "
+"and its air times, and the \"Ends at\" labels on a detail page and the "
+"player controls."
+msgstr ""
+
+#: jellyfin_mpv_shim/mpvtk_browser/config.py
+msgid ""
 "The controls have to stay legible over any frame. \"None\" gives the text a "
 "drop shadow instead of shading the picture behind it."
 msgstr ""
@@ -2200,6 +2280,13 @@ msgstr ""
 msgid ""
 "0 hides them as soon as the pointer is not on them, and forces \"Hide unless "
 "hovered\"."
+msgstr ""
+
+#: jellyfin_mpv_shim/mpvtk_browser/config.py
+msgid ""
+"Narrowing the window shrinks the controls until the smallest button reaches "
+"the accessibility minimum, instead of dropping buttons sooner. Off keeps the "
+"older, larger floor."
 msgstr ""
 
 #: jellyfin_mpv_shim/mpvtk_browser/config.py
@@ -3808,6 +3895,7 @@ msgid "More Like This"
 msgstr "Más como esto"
 
 #: jellyfin_mpv_shim/mpvtk_browser/pages/detail.py
+#: jellyfin_mpv_shim/mpvtk_browser/tiles.py
 msgid "Go to Series"
 msgstr ""
 
@@ -5003,6 +5091,22 @@ msgstr "Eliminar servidor"
 msgid "There is nothing here to queue."
 msgstr ""
 
+#: jellyfin_mpv_shim/mpvtk_browser/timefmt.py
+#, python-brace-format
+msgctxt "12-hour clock"
+msgid "{time} {period}"
+msgstr ""
+
+#: jellyfin_mpv_shim/mpvtk_browser/timefmt.py
+msgctxt "12-hour clock"
+msgid "AM"
+msgstr ""
+
+#: jellyfin_mpv_shim/mpvtk_browser/timefmt.py
+msgctxt "12-hour clock"
+msgid "PM"
+msgstr ""
+
 # seeded from jellyfin-web: Search
 #: jellyfin_mpv_shim/mpvtk_browser/views.py
 #: jellyfin_mpv_shim/mpvtk_browser/window_chrome.py
@@ -5171,13 +5275,32 @@ msgid "Enable SVP"
 msgstr "Habilitar SVP (Conversión de Velocidad de Fotogramas)"
 
 #: jellyfin_mpv_shim/sync/manager.py
+msgid "The downloads are already in that folder."
+msgstr ""
+
+#: jellyfin_mpv_shim/sync/manager.py
 msgid ""
 "Can't change the download folder while a download is in progress. Wait for "
 "it to finish, then try again."
 msgstr ""
 
 #: jellyfin_mpv_shim/sync/manager.py
+msgid ""
+"That folder is inside the current download folder. Choose one outside it."
+msgstr ""
+
+#: jellyfin_mpv_shim/sync/manager.py
+msgid "Can't read that folder. Check the path and its permissions."
+msgstr ""
+
+#: jellyfin_mpv_shim/sync/manager.py
 msgid "That folder already contains downloads. Choose an empty folder."
+msgstr ""
+
+#: jellyfin_mpv_shim/sync/manager.py
+msgid ""
+"That folder isn't empty. Choose an empty folder — the download folder is "
+"managed by this app and anything else in it can be moved or removed."
 msgstr ""
 
 #: jellyfin_mpv_shim/sync/manager.py
@@ -5186,6 +5309,12 @@ msgstr ""
 
 #: jellyfin_mpv_shim/sync/manager.py
 msgid "A download is still finishing. Wait for it to stop, then try again."
+msgstr ""
+
+#: jellyfin_mpv_shim/sync/manager.py
+msgid ""
+"There isn't enough space on that drive to move the downloads. Free some "
+"space and try again — nothing was moved."
 msgstr ""
 
 #: jellyfin_mpv_shim/sync/manager.py

--- a/jellyfin_mpv_shim/messages/es_AR/LC_MESSAGES/base.po
+++ b/jellyfin_mpv_shim/messages/es_AR/LC_MESSAGES/base.po
@@ -6,7 +6,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2026-08-30 22:19-0400\n"
+"POT-Creation-Date: 2026-09-07 17:35-0400\n"
 "PO-Revision-Date: 2026-02-01 17:36+0000\n"
 "Last-Translator: Augusto <tasken@gmail.com>\n"
 "Language-Team: Spanish (Argentina) <https://translate.jellyfin.org/projects/"
@@ -547,6 +547,11 @@ msgid "Night Mode (Auto Volume Adj)"
 msgstr ""
 
 #: jellyfin_mpv_shim/mpvtk_browser/app.py
+#: jellyfin_mpv_shim/mpvtk_browser/auth.py
+msgid "Locked"
+msgstr ""
+
+#: jellyfin_mpv_shim/mpvtk_browser/app.py
 msgid "Failed to load. Check the connection."
 msgstr ""
 
@@ -826,10 +831,6 @@ msgstr ""
 "Verificá la información de conexión."
 
 #: jellyfin_mpv_shim/mpvtk_browser/auth.py
-msgid "Locked"
-msgstr ""
-
-#: jellyfin_mpv_shim/mpvtk_browser/auth.py
 #: jellyfin_mpv_shim/mpvtk_browser/pages/home.py
 msgid "Connecting to your server…"
 msgstr ""
@@ -910,6 +911,10 @@ msgstr "Salir y marcar como no visto"
 #: jellyfin_mpv_shim/mpvtk_browser/pages/books.py
 msgid "Favorite"
 msgstr "Favorito"
+
+#: jellyfin_mpv_shim/mpvtk_browser/components/detail.py
+msgid "Web"
+msgstr ""
 
 # seeded from jellyfin-web: HeaderVideos
 #: jellyfin_mpv_shim/mpvtk_browser/components/media_info.py
@@ -1528,11 +1533,7 @@ msgid "Jellyfin UI"
 msgstr ""
 
 #: jellyfin_mpv_shim/mpvtk_browser/config.py
-msgid "MPV UI with thumbnails"
-msgstr ""
-
-#: jellyfin_mpv_shim/mpvtk_browser/config.py
-msgid "MPV built-in default"
+msgid "MPV UI"
 msgstr ""
 
 #: jellyfin_mpv_shim/mpvtk_browser/config.py
@@ -1881,8 +1882,22 @@ msgid "Window Buttons in the Top Bar"
 msgstr ""
 
 #: jellyfin_mpv_shim/mpvtk_browser/config.py
+msgid "Keep Window Buttons in Full Screen"
+msgstr ""
+
+#: jellyfin_mpv_shim/mpvtk_browser/config.py
+msgid "Hide the Desktop Title Bar"
+msgstr ""
+
+#: jellyfin_mpv_shim/mpvtk_browser/config.py
 msgid "Player Controls Style"
 msgstr ""
+
+#: jellyfin_mpv_shim/mpvtk_browser/config.py
+#, fuzzy
+#| msgid "Enable thumbnail previews"
+msgid "Enable Trickplay Thumbnails"
+msgstr "Activar la vista previa de miniaturas"
 
 #: jellyfin_mpv_shim/mpvtk_browser/config.py
 msgid "Load All Seek Previews at Once"
@@ -1912,6 +1927,10 @@ msgstr ""
 
 #: jellyfin_mpv_shim/mpvtk_browser/config.py
 msgid "Full-Width Backdrops"
+msgstr ""
+
+#: jellyfin_mpv_shim/mpvtk_browser/config.py
+msgid "12-Hour Clock"
 msgstr ""
 
 #: jellyfin_mpv_shim/mpvtk_browser/config.py
@@ -1957,12 +1976,23 @@ msgid "Fullscreen Library Browser"
 msgstr ""
 
 #: jellyfin_mpv_shim/mpvtk_browser/config.py
+msgid "Block Player Keybinds While Browsing"
+msgstr ""
+
+#: jellyfin_mpv_shim/mpvtk_browser/config.py
 msgid "Always Bind Arrow Keys to Player Controls"
 msgstr ""
 
 #: jellyfin_mpv_shim/mpvtk_browser/config.py
 msgid "Player Controls Activation Key"
 msgstr ""
+
+# seeded from jellyfin-web: SelectAll
+#: jellyfin_mpv_shim/mpvtk_browser/config.py
+#, fuzzy
+#| msgid "Select All"
+msgid "Select Key"
+msgstr "Seleccionar todo"
 
 #: jellyfin_mpv_shim/mpvtk_browser/config.py
 msgid "Shading Behind the Player Controls"
@@ -1974,6 +2004,10 @@ msgstr ""
 
 #: jellyfin_mpv_shim/mpvtk_browser/config.py
 msgid "Hide the Player Controls After (seconds)"
+msgstr ""
+
+#: jellyfin_mpv_shim/mpvtk_browser/config.py
+msgid "Shrink the Player Controls on a Narrow Window"
 msgstr ""
 
 #: jellyfin_mpv_shim/mpvtk_browser/config.py
@@ -2060,6 +2094,21 @@ msgstr ""
 
 #: jellyfin_mpv_shim/mpvtk_browser/config.py
 msgid ""
+"Stops MPV's own shortcuts -- picture adjustment, screenshots, subtitle and "
+"audio switching -- from acting while you are in the library, where there is "
+"no video for them to act on. Turn it off to use your own MPV key bindings "
+"there."
+msgstr ""
+
+#: jellyfin_mpv_shim/mpvtk_browser/config.py
+msgid ""
+"Activates whatever is highlighted, in the library and on the player "
+"controls. An mpv key name; changing it hands Enter back to MPV. The game "
+"controller's Confirm button and a phone's Select follow it."
+msgstr ""
+
+#: jellyfin_mpv_shim/mpvtk_browser/config.py
+msgid ""
 "Leave these blank unless downloads are waking your disks too often. Set both "
 "of the first two together: episodes are then fetched in one batch when a "
 "series runs low, instead of one at a time."
@@ -2073,7 +2122,8 @@ msgstr ""
 #: jellyfin_mpv_shim/mpvtk_browser/config.py
 msgid ""
 "Off gives MPV's own mouse behaviour instead: drag the video to move the "
-"window, and right click to pause. Double click is full screen either way."
+"window, and the right button does whatever your MPV config gives it. Double "
+"click is full screen either way."
 msgstr ""
 
 #: jellyfin_mpv_shim/mpvtk_browser/config.py
@@ -2163,6 +2213,30 @@ msgid ""
 "maximize and close in the top bar instead, and lets you drag the window by "
 "it. On \"Only when the window has no title bar\", MPV is asked whether this "
 "window got one, so desktops that draw a title bar are left alone."
+msgstr ""
+
+#: jellyfin_mpv_shim/mpvtk_browser/config.py
+msgid ""
+"Full screen has no title bar anywhere and nothing to move or maximize, so "
+"the buttons are normally hidden there. Turn this on to keep a way out of "
+"full screen that is not a keyboard shortcut."
+msgstr ""
+
+#: jellyfin_mpv_shim/mpvtk_browser/config.py
+msgid ""
+"Asks the desktop for no title bar on the player window, so the top bar above "
+"is the only one. Pairs with the setting above: on \"Only when the window has "
+"no title bar\" the buttons appear as soon as this is on. Leave both off "
+"unless you want them, since a window with neither can be awkward to move on "
+"some desktops."
+msgstr ""
+
+#: jellyfin_mpv_shim/mpvtk_browser/config.py
+msgid ""
+"Shows a preview frame while you drag the seek bar. Works with every player "
+"control style, including your own OSC script if it supports thumbfast. The "
+"images are fetched from the server per video, which costs disk space and "
+"memory -- tens of MB for an episode, a few hundred for a long film."
 msgstr ""
 
 #: jellyfin_mpv_shim/mpvtk_browser/config.py
@@ -2272,6 +2346,13 @@ msgstr ""
 
 #: jellyfin_mpv_shim/mpvtk_browser/config.py
 msgid ""
+"Show times of day as \"8:30 PM\" rather than \"20:30\" — the Live TV guide "
+"and its air times, and the \"Ends at\" labels on a detail page and the "
+"player controls."
+msgstr ""
+
+#: jellyfin_mpv_shim/mpvtk_browser/config.py
+msgid ""
 "The controls have to stay legible over any frame. \"None\" gives the text a "
 "drop shadow instead of shading the picture behind it."
 msgstr ""
@@ -2286,6 +2367,13 @@ msgstr ""
 msgid ""
 "0 hides them as soon as the pointer is not on them, and forces \"Hide unless "
 "hovered\"."
+msgstr ""
+
+#: jellyfin_mpv_shim/mpvtk_browser/config.py
+msgid ""
+"Narrowing the window shrinks the controls until the smallest button reaches "
+"the accessibility minimum, instead of dropping buttons sooner. Off keeps the "
+"older, larger floor."
 msgstr ""
 
 #: jellyfin_mpv_shim/mpvtk_browser/config.py
@@ -3892,6 +3980,7 @@ msgid "More Like This"
 msgstr "Más como esto"
 
 #: jellyfin_mpv_shim/mpvtk_browser/pages/detail.py
+#: jellyfin_mpv_shim/mpvtk_browser/tiles.py
 msgid "Go to Series"
 msgstr ""
 
@@ -5086,6 +5175,22 @@ msgstr "Eliminar servidor"
 msgid "There is nothing here to queue."
 msgstr ""
 
+#: jellyfin_mpv_shim/mpvtk_browser/timefmt.py
+#, python-brace-format
+msgctxt "12-hour clock"
+msgid "{time} {period}"
+msgstr ""
+
+#: jellyfin_mpv_shim/mpvtk_browser/timefmt.py
+msgctxt "12-hour clock"
+msgid "AM"
+msgstr ""
+
+#: jellyfin_mpv_shim/mpvtk_browser/timefmt.py
+msgctxt "12-hour clock"
+msgid "PM"
+msgstr ""
+
 # seeded from jellyfin-web: Search
 #: jellyfin_mpv_shim/mpvtk_browser/views.py
 #: jellyfin_mpv_shim/mpvtk_browser/window_chrome.py
@@ -5254,13 +5359,32 @@ msgid "Enable SVP"
 msgstr "Habilitar SVP"
 
 #: jellyfin_mpv_shim/sync/manager.py
+msgid "The downloads are already in that folder."
+msgstr ""
+
+#: jellyfin_mpv_shim/sync/manager.py
 msgid ""
 "Can't change the download folder while a download is in progress. Wait for "
 "it to finish, then try again."
 msgstr ""
 
 #: jellyfin_mpv_shim/sync/manager.py
+msgid ""
+"That folder is inside the current download folder. Choose one outside it."
+msgstr ""
+
+#: jellyfin_mpv_shim/sync/manager.py
+msgid "Can't read that folder. Check the path and its permissions."
+msgstr ""
+
+#: jellyfin_mpv_shim/sync/manager.py
 msgid "That folder already contains downloads. Choose an empty folder."
+msgstr ""
+
+#: jellyfin_mpv_shim/sync/manager.py
+msgid ""
+"That folder isn't empty. Choose an empty folder — the download folder is "
+"managed by this app and anything else in it can be moved or removed."
 msgstr ""
 
 #: jellyfin_mpv_shim/sync/manager.py
@@ -5269,6 +5393,12 @@ msgstr ""
 
 #: jellyfin_mpv_shim/sync/manager.py
 msgid "A download is still finishing. Wait for it to stop, then try again."
+msgstr ""
+
+#: jellyfin_mpv_shim/sync/manager.py
+msgid ""
+"There isn't enough space on that drive to move the downloads. Free some "
+"space and try again — nothing was moved."
 msgstr ""
 
 #: jellyfin_mpv_shim/sync/manager.py

--- a/jellyfin_mpv_shim/messages/es_MX/LC_MESSAGES/base.po
+++ b/jellyfin_mpv_shim/messages/es_MX/LC_MESSAGES/base.po
@@ -6,7 +6,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2026-08-30 22:19-0400\n"
+"POT-Creation-Date: 2026-09-07 17:35-0400\n"
 "PO-Revision-Date: 2025-12-20 05:23+0000\n"
 "Last-Translator: Warper <warper@ymail.com>\n"
 "Language-Team: Spanish (Mexico) <https://translate.jellyfin.org/projects/"
@@ -534,6 +534,11 @@ msgid "Night Mode (Auto Volume Adj)"
 msgstr ""
 
 #: jellyfin_mpv_shim/mpvtk_browser/app.py
+#: jellyfin_mpv_shim/mpvtk_browser/auth.py
+msgid "Locked"
+msgstr ""
+
+#: jellyfin_mpv_shim/mpvtk_browser/app.py
 msgid "Failed to load. Check the connection."
 msgstr ""
 
@@ -808,10 +813,6 @@ msgstr ""
 "Porfsvor revise su información de conexión."
 
 #: jellyfin_mpv_shim/mpvtk_browser/auth.py
-msgid "Locked"
-msgstr ""
-
-#: jellyfin_mpv_shim/mpvtk_browser/auth.py
 #: jellyfin_mpv_shim/mpvtk_browser/pages/home.py
 msgid "Connecting to your server…"
 msgstr ""
@@ -887,6 +888,10 @@ msgstr "Visto"
 #: jellyfin_mpv_shim/mpvtk_browser/pages/books.py
 msgid "Favorite"
 msgstr "Favorito"
+
+#: jellyfin_mpv_shim/mpvtk_browser/components/detail.py
+msgid "Web"
+msgstr ""
 
 # seeded from jellyfin-web: HeaderVideos
 #: jellyfin_mpv_shim/mpvtk_browser/components/media_info.py
@@ -1495,11 +1500,7 @@ msgid "Jellyfin UI"
 msgstr ""
 
 #: jellyfin_mpv_shim/mpvtk_browser/config.py
-msgid "MPV UI with thumbnails"
-msgstr ""
-
-#: jellyfin_mpv_shim/mpvtk_browser/config.py
-msgid "MPV built-in default"
+msgid "MPV UI"
 msgstr ""
 
 #: jellyfin_mpv_shim/mpvtk_browser/config.py
@@ -1841,7 +1842,19 @@ msgid "Window Buttons in the Top Bar"
 msgstr ""
 
 #: jellyfin_mpv_shim/mpvtk_browser/config.py
+msgid "Keep Window Buttons in Full Screen"
+msgstr ""
+
+#: jellyfin_mpv_shim/mpvtk_browser/config.py
+msgid "Hide the Desktop Title Bar"
+msgstr ""
+
+#: jellyfin_mpv_shim/mpvtk_browser/config.py
 msgid "Player Controls Style"
+msgstr ""
+
+#: jellyfin_mpv_shim/mpvtk_browser/config.py
+msgid "Enable Trickplay Thumbnails"
 msgstr ""
 
 #: jellyfin_mpv_shim/mpvtk_browser/config.py
@@ -1872,6 +1885,10 @@ msgstr ""
 
 #: jellyfin_mpv_shim/mpvtk_browser/config.py
 msgid "Full-Width Backdrops"
+msgstr ""
+
+#: jellyfin_mpv_shim/mpvtk_browser/config.py
+msgid "12-Hour Clock"
 msgstr ""
 
 #: jellyfin_mpv_shim/mpvtk_browser/config.py
@@ -1917,12 +1934,23 @@ msgid "Fullscreen Library Browser"
 msgstr ""
 
 #: jellyfin_mpv_shim/mpvtk_browser/config.py
+msgid "Block Player Keybinds While Browsing"
+msgstr ""
+
+#: jellyfin_mpv_shim/mpvtk_browser/config.py
 msgid "Always Bind Arrow Keys to Player Controls"
 msgstr ""
 
 #: jellyfin_mpv_shim/mpvtk_browser/config.py
 msgid "Player Controls Activation Key"
 msgstr ""
+
+# seeded from jellyfin-web: SelectAll
+#: jellyfin_mpv_shim/mpvtk_browser/config.py
+#, fuzzy
+#| msgid "Select All"
+msgid "Select Key"
+msgstr "Seleccionar Todo"
 
 #: jellyfin_mpv_shim/mpvtk_browser/config.py
 msgid "Shading Behind the Player Controls"
@@ -1934,6 +1962,10 @@ msgstr ""
 
 #: jellyfin_mpv_shim/mpvtk_browser/config.py
 msgid "Hide the Player Controls After (seconds)"
+msgstr ""
+
+#: jellyfin_mpv_shim/mpvtk_browser/config.py
+msgid "Shrink the Player Controls on a Narrow Window"
 msgstr ""
 
 #: jellyfin_mpv_shim/mpvtk_browser/config.py
@@ -2016,6 +2048,21 @@ msgstr ""
 
 #: jellyfin_mpv_shim/mpvtk_browser/config.py
 msgid ""
+"Stops MPV's own shortcuts -- picture adjustment, screenshots, subtitle and "
+"audio switching -- from acting while you are in the library, where there is "
+"no video for them to act on. Turn it off to use your own MPV key bindings "
+"there."
+msgstr ""
+
+#: jellyfin_mpv_shim/mpvtk_browser/config.py
+msgid ""
+"Activates whatever is highlighted, in the library and on the player "
+"controls. An mpv key name; changing it hands Enter back to MPV. The game "
+"controller's Confirm button and a phone's Select follow it."
+msgstr ""
+
+#: jellyfin_mpv_shim/mpvtk_browser/config.py
+msgid ""
 "Leave these blank unless downloads are waking your disks too often. Set both "
 "of the first two together: episodes are then fetched in one batch when a "
 "series runs low, instead of one at a time."
@@ -2029,7 +2076,8 @@ msgstr ""
 #: jellyfin_mpv_shim/mpvtk_browser/config.py
 msgid ""
 "Off gives MPV's own mouse behaviour instead: drag the video to move the "
-"window, and right click to pause. Double click is full screen either way."
+"window, and the right button does whatever your MPV config gives it. Double "
+"click is full screen either way."
 msgstr ""
 
 #: jellyfin_mpv_shim/mpvtk_browser/config.py
@@ -2119,6 +2167,30 @@ msgid ""
 "maximize and close in the top bar instead, and lets you drag the window by "
 "it. On \"Only when the window has no title bar\", MPV is asked whether this "
 "window got one, so desktops that draw a title bar are left alone."
+msgstr ""
+
+#: jellyfin_mpv_shim/mpvtk_browser/config.py
+msgid ""
+"Full screen has no title bar anywhere and nothing to move or maximize, so "
+"the buttons are normally hidden there. Turn this on to keep a way out of "
+"full screen that is not a keyboard shortcut."
+msgstr ""
+
+#: jellyfin_mpv_shim/mpvtk_browser/config.py
+msgid ""
+"Asks the desktop for no title bar on the player window, so the top bar above "
+"is the only one. Pairs with the setting above: on \"Only when the window has "
+"no title bar\" the buttons appear as soon as this is on. Leave both off "
+"unless you want them, since a window with neither can be awkward to move on "
+"some desktops."
+msgstr ""
+
+#: jellyfin_mpv_shim/mpvtk_browser/config.py
+msgid ""
+"Shows a preview frame while you drag the seek bar. Works with every player "
+"control style, including your own OSC script if it supports thumbfast. The "
+"images are fetched from the server per video, which costs disk space and "
+"memory -- tens of MB for an episode, a few hundred for a long film."
 msgstr ""
 
 #: jellyfin_mpv_shim/mpvtk_browser/config.py
@@ -2226,6 +2298,13 @@ msgstr ""
 
 #: jellyfin_mpv_shim/mpvtk_browser/config.py
 msgid ""
+"Show times of day as \"8:30 PM\" rather than \"20:30\" — the Live TV guide "
+"and its air times, and the \"Ends at\" labels on a detail page and the "
+"player controls."
+msgstr ""
+
+#: jellyfin_mpv_shim/mpvtk_browser/config.py
+msgid ""
 "The controls have to stay legible over any frame. \"None\" gives the text a "
 "drop shadow instead of shading the picture behind it."
 msgstr ""
@@ -2240,6 +2319,13 @@ msgstr ""
 msgid ""
 "0 hides them as soon as the pointer is not on them, and forces \"Hide unless "
 "hovered\"."
+msgstr ""
+
+#: jellyfin_mpv_shim/mpvtk_browser/config.py
+msgid ""
+"Narrowing the window shrinks the controls until the smallest button reaches "
+"the accessibility minimum, instead of dropping buttons sooner. Off keeps the "
+"older, larger floor."
 msgstr ""
 
 #: jellyfin_mpv_shim/mpvtk_browser/config.py
@@ -3795,6 +3881,7 @@ msgid "More Like This"
 msgstr "Más como esto"
 
 #: jellyfin_mpv_shim/mpvtk_browser/pages/detail.py
+#: jellyfin_mpv_shim/mpvtk_browser/tiles.py
 msgid "Go to Series"
 msgstr ""
 
@@ -4959,6 +5046,22 @@ msgstr ""
 msgid "There is nothing here to queue."
 msgstr ""
 
+#: jellyfin_mpv_shim/mpvtk_browser/timefmt.py
+#, python-brace-format
+msgctxt "12-hour clock"
+msgid "{time} {period}"
+msgstr ""
+
+#: jellyfin_mpv_shim/mpvtk_browser/timefmt.py
+msgctxt "12-hour clock"
+msgid "AM"
+msgstr ""
+
+#: jellyfin_mpv_shim/mpvtk_browser/timefmt.py
+msgctxt "12-hour clock"
+msgid "PM"
+msgstr ""
+
 # seeded from jellyfin-web: Search
 #: jellyfin_mpv_shim/mpvtk_browser/views.py
 #: jellyfin_mpv_shim/mpvtk_browser/window_chrome.py
@@ -5121,13 +5224,32 @@ msgid "Enable SVP"
 msgstr ""
 
 #: jellyfin_mpv_shim/sync/manager.py
+msgid "The downloads are already in that folder."
+msgstr ""
+
+#: jellyfin_mpv_shim/sync/manager.py
 msgid ""
 "Can't change the download folder while a download is in progress. Wait for "
 "it to finish, then try again."
 msgstr ""
 
 #: jellyfin_mpv_shim/sync/manager.py
+msgid ""
+"That folder is inside the current download folder. Choose one outside it."
+msgstr ""
+
+#: jellyfin_mpv_shim/sync/manager.py
+msgid "Can't read that folder. Check the path and its permissions."
+msgstr ""
+
+#: jellyfin_mpv_shim/sync/manager.py
 msgid "That folder already contains downloads. Choose an empty folder."
+msgstr ""
+
+#: jellyfin_mpv_shim/sync/manager.py
+msgid ""
+"That folder isn't empty. Choose an empty folder — the download folder is "
+"managed by this app and anything else in it can be moved or removed."
 msgstr ""
 
 #: jellyfin_mpv_shim/sync/manager.py
@@ -5136,6 +5258,12 @@ msgstr ""
 
 #: jellyfin_mpv_shim/sync/manager.py
 msgid "A download is still finishing. Wait for it to stop, then try again."
+msgstr ""
+
+#: jellyfin_mpv_shim/sync/manager.py
+msgid ""
+"There isn't enough space on that drive to move the downloads. Free some "
+"space and try again — nothing was moved."
 msgstr ""
 
 #: jellyfin_mpv_shim/sync/manager.py

--- a/jellyfin_mpv_shim/messages/et/LC_MESSAGES/base.po
+++ b/jellyfin_mpv_shim/messages/et/LC_MESSAGES/base.po
@@ -6,7 +6,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2026-08-30 22:19-0400\n"
+"POT-Creation-Date: 2026-09-07 17:35-0400\n"
 "PO-Revision-Date: 2026-08-05 14:32+0000\n"
 "Last-Translator: rimasx <riks_12@hot.ee>\n"
 "Language-Team: Estonian <https://translate.jellyfin.org/projects/jellyfin/"
@@ -520,6 +520,11 @@ msgid "Night Mode (Auto Volume Adj)"
 msgstr ""
 
 #: jellyfin_mpv_shim/mpvtk_browser/app.py
+#: jellyfin_mpv_shim/mpvtk_browser/auth.py
+msgid "Locked"
+msgstr ""
+
+#: jellyfin_mpv_shim/mpvtk_browser/app.py
 msgid "Failed to load. Check the connection."
 msgstr ""
 
@@ -799,10 +804,6 @@ msgstr ""
 "Kontrolli ühenduse andmeid."
 
 #: jellyfin_mpv_shim/mpvtk_browser/auth.py
-msgid "Locked"
-msgstr ""
-
-#: jellyfin_mpv_shim/mpvtk_browser/auth.py
 #: jellyfin_mpv_shim/mpvtk_browser/pages/home.py
 msgid "Connecting to your server…"
 msgstr ""
@@ -883,6 +884,10 @@ msgstr "Lõpeta ja märgi mittevaadatuks"
 #: jellyfin_mpv_shim/mpvtk_browser/pages/books.py
 msgid "Favorite"
 msgstr "Lemmik"
+
+#: jellyfin_mpv_shim/mpvtk_browser/components/detail.py
+msgid "Web"
+msgstr ""
 
 # seeded from jellyfin-web: HeaderVideos
 #: jellyfin_mpv_shim/mpvtk_browser/components/media_info.py
@@ -1502,11 +1507,7 @@ msgid "Jellyfin UI"
 msgstr ""
 
 #: jellyfin_mpv_shim/mpvtk_browser/config.py
-msgid "MPV UI with thumbnails"
-msgstr ""
-
-#: jellyfin_mpv_shim/mpvtk_browser/config.py
-msgid "MPV built-in default"
+msgid "MPV UI"
 msgstr ""
 
 #: jellyfin_mpv_shim/mpvtk_browser/config.py
@@ -1855,8 +1856,22 @@ msgid "Window Buttons in the Top Bar"
 msgstr ""
 
 #: jellyfin_mpv_shim/mpvtk_browser/config.py
+msgid "Keep Window Buttons in Full Screen"
+msgstr ""
+
+#: jellyfin_mpv_shim/mpvtk_browser/config.py
+msgid "Hide the Desktop Title Bar"
+msgstr ""
+
+#: jellyfin_mpv_shim/mpvtk_browser/config.py
 msgid "Player Controls Style"
 msgstr ""
+
+#: jellyfin_mpv_shim/mpvtk_browser/config.py
+#, fuzzy
+#| msgid "Enable thumbnail previews"
+msgid "Enable Trickplay Thumbnails"
+msgstr "Luba pisipiltide eelvaade"
 
 #: jellyfin_mpv_shim/mpvtk_browser/config.py
 msgid "Load All Seek Previews at Once"
@@ -1886,6 +1901,10 @@ msgstr ""
 
 #: jellyfin_mpv_shim/mpvtk_browser/config.py
 msgid "Full-Width Backdrops"
+msgstr ""
+
+#: jellyfin_mpv_shim/mpvtk_browser/config.py
+msgid "12-Hour Clock"
 msgstr ""
 
 #: jellyfin_mpv_shim/mpvtk_browser/config.py
@@ -1931,12 +1950,23 @@ msgid "Fullscreen Library Browser"
 msgstr ""
 
 #: jellyfin_mpv_shim/mpvtk_browser/config.py
+msgid "Block Player Keybinds While Browsing"
+msgstr ""
+
+#: jellyfin_mpv_shim/mpvtk_browser/config.py
 msgid "Always Bind Arrow Keys to Player Controls"
 msgstr ""
 
 #: jellyfin_mpv_shim/mpvtk_browser/config.py
 msgid "Player Controls Activation Key"
 msgstr ""
+
+# seeded from jellyfin-web: SelectAll
+#: jellyfin_mpv_shim/mpvtk_browser/config.py
+#, fuzzy
+#| msgid "Select All"
+msgid "Select Key"
+msgstr "Vali kõik"
 
 #: jellyfin_mpv_shim/mpvtk_browser/config.py
 msgid "Shading Behind the Player Controls"
@@ -1948,6 +1978,10 @@ msgstr ""
 
 #: jellyfin_mpv_shim/mpvtk_browser/config.py
 msgid "Hide the Player Controls After (seconds)"
+msgstr ""
+
+#: jellyfin_mpv_shim/mpvtk_browser/config.py
+msgid "Shrink the Player Controls on a Narrow Window"
 msgstr ""
 
 #: jellyfin_mpv_shim/mpvtk_browser/config.py
@@ -2034,6 +2068,21 @@ msgstr ""
 
 #: jellyfin_mpv_shim/mpvtk_browser/config.py
 msgid ""
+"Stops MPV's own shortcuts -- picture adjustment, screenshots, subtitle and "
+"audio switching -- from acting while you are in the library, where there is "
+"no video for them to act on. Turn it off to use your own MPV key bindings "
+"there."
+msgstr ""
+
+#: jellyfin_mpv_shim/mpvtk_browser/config.py
+msgid ""
+"Activates whatever is highlighted, in the library and on the player "
+"controls. An mpv key name; changing it hands Enter back to MPV. The game "
+"controller's Confirm button and a phone's Select follow it."
+msgstr ""
+
+#: jellyfin_mpv_shim/mpvtk_browser/config.py
+msgid ""
 "Leave these blank unless downloads are waking your disks too often. Set both "
 "of the first two together: episodes are then fetched in one batch when a "
 "series runs low, instead of one at a time."
@@ -2047,7 +2096,8 @@ msgstr ""
 #: jellyfin_mpv_shim/mpvtk_browser/config.py
 msgid ""
 "Off gives MPV's own mouse behaviour instead: drag the video to move the "
-"window, and right click to pause. Double click is full screen either way."
+"window, and the right button does whatever your MPV config gives it. Double "
+"click is full screen either way."
 msgstr ""
 
 #: jellyfin_mpv_shim/mpvtk_browser/config.py
@@ -2137,6 +2187,30 @@ msgid ""
 "maximize and close in the top bar instead, and lets you drag the window by "
 "it. On \"Only when the window has no title bar\", MPV is asked whether this "
 "window got one, so desktops that draw a title bar are left alone."
+msgstr ""
+
+#: jellyfin_mpv_shim/mpvtk_browser/config.py
+msgid ""
+"Full screen has no title bar anywhere and nothing to move or maximize, so "
+"the buttons are normally hidden there. Turn this on to keep a way out of "
+"full screen that is not a keyboard shortcut."
+msgstr ""
+
+#: jellyfin_mpv_shim/mpvtk_browser/config.py
+msgid ""
+"Asks the desktop for no title bar on the player window, so the top bar above "
+"is the only one. Pairs with the setting above: on \"Only when the window has "
+"no title bar\" the buttons appear as soon as this is on. Leave both off "
+"unless you want them, since a window with neither can be awkward to move on "
+"some desktops."
+msgstr ""
+
+#: jellyfin_mpv_shim/mpvtk_browser/config.py
+msgid ""
+"Shows a preview frame while you drag the seek bar. Works with every player "
+"control style, including your own OSC script if it supports thumbfast. The "
+"images are fetched from the server per video, which costs disk space and "
+"memory -- tens of MB for an episode, a few hundred for a long film."
 msgstr ""
 
 #: jellyfin_mpv_shim/mpvtk_browser/config.py
@@ -2246,6 +2320,13 @@ msgstr ""
 
 #: jellyfin_mpv_shim/mpvtk_browser/config.py
 msgid ""
+"Show times of day as \"8:30 PM\" rather than \"20:30\" — the Live TV guide "
+"and its air times, and the \"Ends at\" labels on a detail page and the "
+"player controls."
+msgstr ""
+
+#: jellyfin_mpv_shim/mpvtk_browser/config.py
+msgid ""
 "The controls have to stay legible over any frame. \"None\" gives the text a "
 "drop shadow instead of shading the picture behind it."
 msgstr ""
@@ -2260,6 +2341,13 @@ msgstr ""
 msgid ""
 "0 hides them as soon as the pointer is not on them, and forces \"Hide unless "
 "hovered\"."
+msgstr ""
+
+#: jellyfin_mpv_shim/mpvtk_browser/config.py
+msgid ""
+"Narrowing the window shrinks the controls until the smallest button reaches "
+"the accessibility minimum, instead of dropping buttons sooner. Off keeps the "
+"older, larger floor."
 msgstr ""
 
 #: jellyfin_mpv_shim/mpvtk_browser/config.py
@@ -3867,6 +3955,7 @@ msgid "More Like This"
 msgstr "Veel sarnaseid"
 
 #: jellyfin_mpv_shim/mpvtk_browser/pages/detail.py
+#: jellyfin_mpv_shim/mpvtk_browser/tiles.py
 msgid "Go to Series"
 msgstr ""
 
@@ -5061,6 +5150,22 @@ msgstr "Eemalda server"
 msgid "There is nothing here to queue."
 msgstr ""
 
+#: jellyfin_mpv_shim/mpvtk_browser/timefmt.py
+#, python-brace-format
+msgctxt "12-hour clock"
+msgid "{time} {period}"
+msgstr ""
+
+#: jellyfin_mpv_shim/mpvtk_browser/timefmt.py
+msgctxt "12-hour clock"
+msgid "AM"
+msgstr ""
+
+#: jellyfin_mpv_shim/mpvtk_browser/timefmt.py
+msgctxt "12-hour clock"
+msgid "PM"
+msgstr ""
+
 # seeded from jellyfin-web: Search
 #: jellyfin_mpv_shim/mpvtk_browser/views.py
 #: jellyfin_mpv_shim/mpvtk_browser/window_chrome.py
@@ -5228,13 +5333,32 @@ msgid "Enable SVP"
 msgstr "Luba SVP"
 
 #: jellyfin_mpv_shim/sync/manager.py
+msgid "The downloads are already in that folder."
+msgstr ""
+
+#: jellyfin_mpv_shim/sync/manager.py
 msgid ""
 "Can't change the download folder while a download is in progress. Wait for "
 "it to finish, then try again."
 msgstr ""
 
 #: jellyfin_mpv_shim/sync/manager.py
+msgid ""
+"That folder is inside the current download folder. Choose one outside it."
+msgstr ""
+
+#: jellyfin_mpv_shim/sync/manager.py
+msgid "Can't read that folder. Check the path and its permissions."
+msgstr ""
+
+#: jellyfin_mpv_shim/sync/manager.py
 msgid "That folder already contains downloads. Choose an empty folder."
+msgstr ""
+
+#: jellyfin_mpv_shim/sync/manager.py
+msgid ""
+"That folder isn't empty. Choose an empty folder — the download folder is "
+"managed by this app and anything else in it can be moved or removed."
 msgstr ""
 
 #: jellyfin_mpv_shim/sync/manager.py
@@ -5243,6 +5367,12 @@ msgstr ""
 
 #: jellyfin_mpv_shim/sync/manager.py
 msgid "A download is still finishing. Wait for it to stop, then try again."
+msgstr ""
+
+#: jellyfin_mpv_shim/sync/manager.py
+msgid ""
+"There isn't enough space on that drive to move the downloads. Free some "
+"space and try again — nothing was moved."
 msgstr ""
 
 #: jellyfin_mpv_shim/sync/manager.py

--- a/jellyfin_mpv_shim/messages/eu/LC_MESSAGES/base.po
+++ b/jellyfin_mpv_shim/messages/eu/LC_MESSAGES/base.po
@@ -6,7 +6,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2026-08-30 22:19-0400\n"
+"POT-Creation-Date: 2026-09-07 17:35-0400\n"
 "PO-Revision-Date: 2026-08-16 00:23+0000\n"
 "Last-Translator: \"Thadah D. Denyse\" <thadahdenyse@protonmail.com>\n"
 "Language-Team: Basque <https://translate.jellyfin.org/projects/jellyfin/"
@@ -532,6 +532,11 @@ msgid "Night Mode (Auto Volume Adj)"
 msgstr ""
 
 #: jellyfin_mpv_shim/mpvtk_browser/app.py
+#: jellyfin_mpv_shim/mpvtk_browser/auth.py
+msgid "Locked"
+msgstr ""
+
+#: jellyfin_mpv_shim/mpvtk_browser/app.py
 msgid "Failed to load. Check the connection."
 msgstr ""
 
@@ -811,10 +816,6 @@ msgstr ""
 "Egiaztatu zure konexioaren informazioa."
 
 #: jellyfin_mpv_shim/mpvtk_browser/auth.py
-msgid "Locked"
-msgstr ""
-
-#: jellyfin_mpv_shim/mpvtk_browser/auth.py
 #: jellyfin_mpv_shim/mpvtk_browser/pages/home.py
 msgid "Connecting to your server…"
 msgstr ""
@@ -895,6 +896,10 @@ msgstr "Irten eta Ikusi Gabe Bezala Markatu"
 #: jellyfin_mpv_shim/mpvtk_browser/pages/books.py
 msgid "Favorite"
 msgstr "Gogokoa"
+
+#: jellyfin_mpv_shim/mpvtk_browser/components/detail.py
+msgid "Web"
+msgstr ""
 
 # seeded from jellyfin-web: HeaderVideos
 #: jellyfin_mpv_shim/mpvtk_browser/components/media_info.py
@@ -1506,11 +1511,7 @@ msgid "Jellyfin UI"
 msgstr ""
 
 #: jellyfin_mpv_shim/mpvtk_browser/config.py
-msgid "MPV UI with thumbnails"
-msgstr ""
-
-#: jellyfin_mpv_shim/mpvtk_browser/config.py
-msgid "MPV built-in default"
+msgid "MPV UI"
 msgstr ""
 
 #: jellyfin_mpv_shim/mpvtk_browser/config.py
@@ -1859,8 +1860,22 @@ msgid "Window Buttons in the Top Bar"
 msgstr ""
 
 #: jellyfin_mpv_shim/mpvtk_browser/config.py
+msgid "Keep Window Buttons in Full Screen"
+msgstr ""
+
+#: jellyfin_mpv_shim/mpvtk_browser/config.py
+msgid "Hide the Desktop Title Bar"
+msgstr ""
+
+#: jellyfin_mpv_shim/mpvtk_browser/config.py
 msgid "Player Controls Style"
 msgstr ""
+
+#: jellyfin_mpv_shim/mpvtk_browser/config.py
+#, fuzzy
+#| msgid "Enable thumbnail previews"
+msgid "Enable Trickplay Thumbnails"
+msgstr "Aurreikusi-Miniaturak Aktibatu"
 
 #: jellyfin_mpv_shim/mpvtk_browser/config.py
 msgid "Load All Seek Previews at Once"
@@ -1890,6 +1905,10 @@ msgstr ""
 
 #: jellyfin_mpv_shim/mpvtk_browser/config.py
 msgid "Full-Width Backdrops"
+msgstr ""
+
+#: jellyfin_mpv_shim/mpvtk_browser/config.py
+msgid "12-Hour Clock"
 msgstr ""
 
 #: jellyfin_mpv_shim/mpvtk_browser/config.py
@@ -1935,12 +1954,23 @@ msgid "Fullscreen Library Browser"
 msgstr ""
 
 #: jellyfin_mpv_shim/mpvtk_browser/config.py
+msgid "Block Player Keybinds While Browsing"
+msgstr ""
+
+#: jellyfin_mpv_shim/mpvtk_browser/config.py
 msgid "Always Bind Arrow Keys to Player Controls"
 msgstr ""
 
 #: jellyfin_mpv_shim/mpvtk_browser/config.py
 msgid "Player Controls Activation Key"
 msgstr ""
+
+# seeded from jellyfin-web: SelectAll
+#: jellyfin_mpv_shim/mpvtk_browser/config.py
+#, fuzzy
+#| msgid "Select All"
+msgid "Select Key"
+msgstr "Denak aukeratu"
 
 #: jellyfin_mpv_shim/mpvtk_browser/config.py
 msgid "Shading Behind the Player Controls"
@@ -1952,6 +1982,10 @@ msgstr ""
 
 #: jellyfin_mpv_shim/mpvtk_browser/config.py
 msgid "Hide the Player Controls After (seconds)"
+msgstr ""
+
+#: jellyfin_mpv_shim/mpvtk_browser/config.py
+msgid "Shrink the Player Controls on a Narrow Window"
 msgstr ""
 
 #: jellyfin_mpv_shim/mpvtk_browser/config.py
@@ -2038,6 +2072,21 @@ msgstr ""
 
 #: jellyfin_mpv_shim/mpvtk_browser/config.py
 msgid ""
+"Stops MPV's own shortcuts -- picture adjustment, screenshots, subtitle and "
+"audio switching -- from acting while you are in the library, where there is "
+"no video for them to act on. Turn it off to use your own MPV key bindings "
+"there."
+msgstr ""
+
+#: jellyfin_mpv_shim/mpvtk_browser/config.py
+msgid ""
+"Activates whatever is highlighted, in the library and on the player "
+"controls. An mpv key name; changing it hands Enter back to MPV. The game "
+"controller's Confirm button and a phone's Select follow it."
+msgstr ""
+
+#: jellyfin_mpv_shim/mpvtk_browser/config.py
+msgid ""
 "Leave these blank unless downloads are waking your disks too often. Set both "
 "of the first two together: episodes are then fetched in one batch when a "
 "series runs low, instead of one at a time."
@@ -2051,7 +2100,8 @@ msgstr ""
 #: jellyfin_mpv_shim/mpvtk_browser/config.py
 msgid ""
 "Off gives MPV's own mouse behaviour instead: drag the video to move the "
-"window, and right click to pause. Double click is full screen either way."
+"window, and the right button does whatever your MPV config gives it. Double "
+"click is full screen either way."
 msgstr ""
 
 #: jellyfin_mpv_shim/mpvtk_browser/config.py
@@ -2141,6 +2191,30 @@ msgid ""
 "maximize and close in the top bar instead, and lets you drag the window by "
 "it. On \"Only when the window has no title bar\", MPV is asked whether this "
 "window got one, so desktops that draw a title bar are left alone."
+msgstr ""
+
+#: jellyfin_mpv_shim/mpvtk_browser/config.py
+msgid ""
+"Full screen has no title bar anywhere and nothing to move or maximize, so "
+"the buttons are normally hidden there. Turn this on to keep a way out of "
+"full screen that is not a keyboard shortcut."
+msgstr ""
+
+#: jellyfin_mpv_shim/mpvtk_browser/config.py
+msgid ""
+"Asks the desktop for no title bar on the player window, so the top bar above "
+"is the only one. Pairs with the setting above: on \"Only when the window has "
+"no title bar\" the buttons appear as soon as this is on. Leave both off "
+"unless you want them, since a window with neither can be awkward to move on "
+"some desktops."
+msgstr ""
+
+#: jellyfin_mpv_shim/mpvtk_browser/config.py
+msgid ""
+"Shows a preview frame while you drag the seek bar. Works with every player "
+"control style, including your own OSC script if it supports thumbfast. The "
+"images are fetched from the server per video, which costs disk space and "
+"memory -- tens of MB for an episode, a few hundred for a long film."
 msgstr ""
 
 #: jellyfin_mpv_shim/mpvtk_browser/config.py
@@ -2250,6 +2324,13 @@ msgstr ""
 
 #: jellyfin_mpv_shim/mpvtk_browser/config.py
 msgid ""
+"Show times of day as \"8:30 PM\" rather than \"20:30\" — the Live TV guide "
+"and its air times, and the \"Ends at\" labels on a detail page and the "
+"player controls."
+msgstr ""
+
+#: jellyfin_mpv_shim/mpvtk_browser/config.py
+msgid ""
 "The controls have to stay legible over any frame. \"None\" gives the text a "
 "drop shadow instead of shading the picture behind it."
 msgstr ""
@@ -2264,6 +2345,13 @@ msgstr ""
 msgid ""
 "0 hides them as soon as the pointer is not on them, and forces \"Hide unless "
 "hovered\"."
+msgstr ""
+
+#: jellyfin_mpv_shim/mpvtk_browser/config.py
+msgid ""
+"Narrowing the window shrinks the controls until the smallest button reaches "
+"the accessibility minimum, instead of dropping buttons sooner. Off keeps the "
+"older, larger floor."
 msgstr ""
 
 #: jellyfin_mpv_shim/mpvtk_browser/config.py
@@ -3870,6 +3958,7 @@ msgid "More Like This"
 msgstr "Hau bezalakoa"
 
 #: jellyfin_mpv_shim/mpvtk_browser/pages/detail.py
+#: jellyfin_mpv_shim/mpvtk_browser/tiles.py
 msgid "Go to Series"
 msgstr ""
 
@@ -5064,6 +5153,22 @@ msgstr "Zerbitzaria ezabatu"
 msgid "There is nothing here to queue."
 msgstr ""
 
+#: jellyfin_mpv_shim/mpvtk_browser/timefmt.py
+#, python-brace-format
+msgctxt "12-hour clock"
+msgid "{time} {period}"
+msgstr ""
+
+#: jellyfin_mpv_shim/mpvtk_browser/timefmt.py
+msgctxt "12-hour clock"
+msgid "AM"
+msgstr ""
+
+#: jellyfin_mpv_shim/mpvtk_browser/timefmt.py
+msgctxt "12-hour clock"
+msgid "PM"
+msgstr ""
+
 # seeded from jellyfin-web: Search
 #: jellyfin_mpv_shim/mpvtk_browser/views.py
 #: jellyfin_mpv_shim/mpvtk_browser/window_chrome.py
@@ -5231,13 +5336,32 @@ msgid "Enable SVP"
 msgstr "SVP Aktibatu"
 
 #: jellyfin_mpv_shim/sync/manager.py
+msgid "The downloads are already in that folder."
+msgstr ""
+
+#: jellyfin_mpv_shim/sync/manager.py
 msgid ""
 "Can't change the download folder while a download is in progress. Wait for "
 "it to finish, then try again."
 msgstr ""
 
 #: jellyfin_mpv_shim/sync/manager.py
+msgid ""
+"That folder is inside the current download folder. Choose one outside it."
+msgstr ""
+
+#: jellyfin_mpv_shim/sync/manager.py
+msgid "Can't read that folder. Check the path and its permissions."
+msgstr ""
+
+#: jellyfin_mpv_shim/sync/manager.py
 msgid "That folder already contains downloads. Choose an empty folder."
+msgstr ""
+
+#: jellyfin_mpv_shim/sync/manager.py
+msgid ""
+"That folder isn't empty. Choose an empty folder — the download folder is "
+"managed by this app and anything else in it can be moved or removed."
 msgstr ""
 
 #: jellyfin_mpv_shim/sync/manager.py
@@ -5246,6 +5370,12 @@ msgstr ""
 
 #: jellyfin_mpv_shim/sync/manager.py
 msgid "A download is still finishing. Wait for it to stop, then try again."
+msgstr ""
+
+#: jellyfin_mpv_shim/sync/manager.py
+msgid ""
+"There isn't enough space on that drive to move the downloads. Free some "
+"space and try again — nothing was moved."
 msgstr ""
 
 #: jellyfin_mpv_shim/sync/manager.py

--- a/jellyfin_mpv_shim/messages/fa/LC_MESSAGES/base.po
+++ b/jellyfin_mpv_shim/messages/fa/LC_MESSAGES/base.po
@@ -6,7 +6,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2026-08-30 22:19-0400\n"
+"POT-Creation-Date: 2026-09-07 17:35-0400\n"
 "PO-Revision-Date: 2025-08-23 13:20+0000\n"
 "Last-Translator: RadvinM <tworadvin@gmail.com>\n"
 "Language-Team: Persian <https://translate.jellyfin.org/projects/jellyfin/"
@@ -548,6 +548,11 @@ msgid "Night Mode (Auto Volume Adj)"
 msgstr ""
 
 #: jellyfin_mpv_shim/mpvtk_browser/app.py
+#: jellyfin_mpv_shim/mpvtk_browser/auth.py
+msgid "Locked"
+msgstr ""
+
+#: jellyfin_mpv_shim/mpvtk_browser/app.py
 msgid "Failed to load. Check the connection."
 msgstr ""
 
@@ -827,10 +832,6 @@ msgstr ""
 "لطفاً اطلاعات اتصال خود را بررسی کنید."
 
 #: jellyfin_mpv_shim/mpvtk_browser/auth.py
-msgid "Locked"
-msgstr ""
-
-#: jellyfin_mpv_shim/mpvtk_browser/auth.py
 #: jellyfin_mpv_shim/mpvtk_browser/pages/home.py
 msgid "Connecting to your server…"
 msgstr ""
@@ -911,6 +912,10 @@ msgstr "ترک و علامت گذاری نشده"
 #: jellyfin_mpv_shim/mpvtk_browser/pages/books.py
 msgid "Favorite"
 msgstr "مورد علاقه"
+
+#: jellyfin_mpv_shim/mpvtk_browser/components/detail.py
+msgid "Web"
+msgstr ""
 
 # seeded from jellyfin-web: HeaderVideos
 #: jellyfin_mpv_shim/mpvtk_browser/components/media_info.py
@@ -1489,11 +1494,7 @@ msgid "Jellyfin UI"
 msgstr ""
 
 #: jellyfin_mpv_shim/mpvtk_browser/config.py
-msgid "MPV UI with thumbnails"
-msgstr ""
-
-#: jellyfin_mpv_shim/mpvtk_browser/config.py
-msgid "MPV built-in default"
+msgid "MPV UI"
 msgstr ""
 
 #: jellyfin_mpv_shim/mpvtk_browser/config.py
@@ -1842,8 +1843,22 @@ msgid "Window Buttons in the Top Bar"
 msgstr ""
 
 #: jellyfin_mpv_shim/mpvtk_browser/config.py
+msgid "Keep Window Buttons in Full Screen"
+msgstr ""
+
+#: jellyfin_mpv_shim/mpvtk_browser/config.py
+msgid "Hide the Desktop Title Bar"
+msgstr ""
+
+#: jellyfin_mpv_shim/mpvtk_browser/config.py
 msgid "Player Controls Style"
 msgstr ""
+
+#: jellyfin_mpv_shim/mpvtk_browser/config.py
+#, fuzzy
+#| msgid "Enable thumbnail previews"
+msgid "Enable Trickplay Thumbnails"
+msgstr "فعال کردن پیش نمایش تصاویر"
 
 #: jellyfin_mpv_shim/mpvtk_browser/config.py
 msgid "Load All Seek Previews at Once"
@@ -1873,6 +1888,10 @@ msgstr ""
 
 #: jellyfin_mpv_shim/mpvtk_browser/config.py
 msgid "Full-Width Backdrops"
+msgstr ""
+
+#: jellyfin_mpv_shim/mpvtk_browser/config.py
+msgid "12-Hour Clock"
 msgstr ""
 
 #: jellyfin_mpv_shim/mpvtk_browser/config.py
@@ -1918,12 +1937,23 @@ msgid "Fullscreen Library Browser"
 msgstr ""
 
 #: jellyfin_mpv_shim/mpvtk_browser/config.py
+msgid "Block Player Keybinds While Browsing"
+msgstr ""
+
+#: jellyfin_mpv_shim/mpvtk_browser/config.py
 msgid "Always Bind Arrow Keys to Player Controls"
 msgstr ""
 
 #: jellyfin_mpv_shim/mpvtk_browser/config.py
 msgid "Player Controls Activation Key"
 msgstr ""
+
+# seeded from jellyfin-web: SelectAll
+#: jellyfin_mpv_shim/mpvtk_browser/config.py
+#, fuzzy
+#| msgid "Select All"
+msgid "Select Key"
+msgstr "انتخاب همه"
 
 #: jellyfin_mpv_shim/mpvtk_browser/config.py
 msgid "Shading Behind the Player Controls"
@@ -1935,6 +1965,10 @@ msgstr ""
 
 #: jellyfin_mpv_shim/mpvtk_browser/config.py
 msgid "Hide the Player Controls After (seconds)"
+msgstr ""
+
+#: jellyfin_mpv_shim/mpvtk_browser/config.py
+msgid "Shrink the Player Controls on a Narrow Window"
 msgstr ""
 
 #: jellyfin_mpv_shim/mpvtk_browser/config.py
@@ -2021,6 +2055,21 @@ msgstr ""
 
 #: jellyfin_mpv_shim/mpvtk_browser/config.py
 msgid ""
+"Stops MPV's own shortcuts -- picture adjustment, screenshots, subtitle and "
+"audio switching -- from acting while you are in the library, where there is "
+"no video for them to act on. Turn it off to use your own MPV key bindings "
+"there."
+msgstr ""
+
+#: jellyfin_mpv_shim/mpvtk_browser/config.py
+msgid ""
+"Activates whatever is highlighted, in the library and on the player "
+"controls. An mpv key name; changing it hands Enter back to MPV. The game "
+"controller's Confirm button and a phone's Select follow it."
+msgstr ""
+
+#: jellyfin_mpv_shim/mpvtk_browser/config.py
+msgid ""
 "Leave these blank unless downloads are waking your disks too often. Set both "
 "of the first two together: episodes are then fetched in one batch when a "
 "series runs low, instead of one at a time."
@@ -2034,7 +2083,8 @@ msgstr ""
 #: jellyfin_mpv_shim/mpvtk_browser/config.py
 msgid ""
 "Off gives MPV's own mouse behaviour instead: drag the video to move the "
-"window, and right click to pause. Double click is full screen either way."
+"window, and the right button does whatever your MPV config gives it. Double "
+"click is full screen either way."
 msgstr ""
 
 #: jellyfin_mpv_shim/mpvtk_browser/config.py
@@ -2124,6 +2174,30 @@ msgid ""
 "maximize and close in the top bar instead, and lets you drag the window by "
 "it. On \"Only when the window has no title bar\", MPV is asked whether this "
 "window got one, so desktops that draw a title bar are left alone."
+msgstr ""
+
+#: jellyfin_mpv_shim/mpvtk_browser/config.py
+msgid ""
+"Full screen has no title bar anywhere and nothing to move or maximize, so "
+"the buttons are normally hidden there. Turn this on to keep a way out of "
+"full screen that is not a keyboard shortcut."
+msgstr ""
+
+#: jellyfin_mpv_shim/mpvtk_browser/config.py
+msgid ""
+"Asks the desktop for no title bar on the player window, so the top bar above "
+"is the only one. Pairs with the setting above: on \"Only when the window has "
+"no title bar\" the buttons appear as soon as this is on. Leave both off "
+"unless you want them, since a window with neither can be awkward to move on "
+"some desktops."
+msgstr ""
+
+#: jellyfin_mpv_shim/mpvtk_browser/config.py
+msgid ""
+"Shows a preview frame while you drag the seek bar. Works with every player "
+"control style, including your own OSC script if it supports thumbfast. The "
+"images are fetched from the server per video, which costs disk space and "
+"memory -- tens of MB for an episode, a few hundred for a long film."
 msgstr ""
 
 #: jellyfin_mpv_shim/mpvtk_browser/config.py
@@ -2233,6 +2307,13 @@ msgstr ""
 
 #: jellyfin_mpv_shim/mpvtk_browser/config.py
 msgid ""
+"Show times of day as \"8:30 PM\" rather than \"20:30\" — the Live TV guide "
+"and its air times, and the \"Ends at\" labels on a detail page and the "
+"player controls."
+msgstr ""
+
+#: jellyfin_mpv_shim/mpvtk_browser/config.py
+msgid ""
 "The controls have to stay legible over any frame. \"None\" gives the text a "
 "drop shadow instead of shading the picture behind it."
 msgstr ""
@@ -2247,6 +2328,13 @@ msgstr ""
 msgid ""
 "0 hides them as soon as the pointer is not on them, and forces \"Hide unless "
 "hovered\"."
+msgstr ""
+
+#: jellyfin_mpv_shim/mpvtk_browser/config.py
+msgid ""
+"Narrowing the window shrinks the controls until the smallest button reaches "
+"the accessibility minimum, instead of dropping buttons sooner. Off keeps the "
+"older, larger floor."
 msgstr ""
 
 #: jellyfin_mpv_shim/mpvtk_browser/config.py
@@ -3852,6 +3940,7 @@ msgid "More Like This"
 msgstr "موارد مشابه با این"
 
 #: jellyfin_mpv_shim/mpvtk_browser/pages/detail.py
+#: jellyfin_mpv_shim/mpvtk_browser/tiles.py
 msgid "Go to Series"
 msgstr ""
 
@@ -5038,6 +5127,22 @@ msgstr "حذف سرور"
 msgid "There is nothing here to queue."
 msgstr ""
 
+#: jellyfin_mpv_shim/mpvtk_browser/timefmt.py
+#, python-brace-format
+msgctxt "12-hour clock"
+msgid "{time} {period}"
+msgstr ""
+
+#: jellyfin_mpv_shim/mpvtk_browser/timefmt.py
+msgctxt "12-hour clock"
+msgid "AM"
+msgstr ""
+
+#: jellyfin_mpv_shim/mpvtk_browser/timefmt.py
+msgctxt "12-hour clock"
+msgid "PM"
+msgstr ""
+
 # seeded from jellyfin-web: Search
 #: jellyfin_mpv_shim/mpvtk_browser/views.py
 #: jellyfin_mpv_shim/mpvtk_browser/window_chrome.py
@@ -5205,13 +5310,32 @@ msgid "Enable SVP"
 msgstr "SVP را فعال کنید"
 
 #: jellyfin_mpv_shim/sync/manager.py
+msgid "The downloads are already in that folder."
+msgstr ""
+
+#: jellyfin_mpv_shim/sync/manager.py
 msgid ""
 "Can't change the download folder while a download is in progress. Wait for "
 "it to finish, then try again."
 msgstr ""
 
 #: jellyfin_mpv_shim/sync/manager.py
+msgid ""
+"That folder is inside the current download folder. Choose one outside it."
+msgstr ""
+
+#: jellyfin_mpv_shim/sync/manager.py
+msgid "Can't read that folder. Check the path and its permissions."
+msgstr ""
+
+#: jellyfin_mpv_shim/sync/manager.py
 msgid "That folder already contains downloads. Choose an empty folder."
+msgstr ""
+
+#: jellyfin_mpv_shim/sync/manager.py
+msgid ""
+"That folder isn't empty. Choose an empty folder — the download folder is "
+"managed by this app and anything else in it can be moved or removed."
 msgstr ""
 
 #: jellyfin_mpv_shim/sync/manager.py
@@ -5220,6 +5344,12 @@ msgstr ""
 
 #: jellyfin_mpv_shim/sync/manager.py
 msgid "A download is still finishing. Wait for it to stop, then try again."
+msgstr ""
+
+#: jellyfin_mpv_shim/sync/manager.py
+msgid ""
+"There isn't enough space on that drive to move the downloads. Free some "
+"space and try again — nothing was moved."
 msgstr ""
 
 #: jellyfin_mpv_shim/sync/manager.py

--- a/jellyfin_mpv_shim/messages/fi/LC_MESSAGES/base.po
+++ b/jellyfin_mpv_shim/messages/fi/LC_MESSAGES/base.po
@@ -6,7 +6,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2026-08-30 22:19-0400\n"
+"POT-Creation-Date: 2026-09-07 17:35-0400\n"
 "PO-Revision-Date: 2026-08-17 17:57+0000\n"
 "Last-Translator: aleksantero <roiha.aleksanteri@gmail.com>\n"
 "Language-Team: Finnish <https://translate.jellyfin.org/projects/jellyfin/"
@@ -529,6 +529,11 @@ msgid "Night Mode (Auto Volume Adj)"
 msgstr ""
 
 #: jellyfin_mpv_shim/mpvtk_browser/app.py
+#: jellyfin_mpv_shim/mpvtk_browser/auth.py
+msgid "Locked"
+msgstr ""
+
+#: jellyfin_mpv_shim/mpvtk_browser/app.py
 msgid "Failed to load. Check the connection."
 msgstr ""
 
@@ -808,10 +813,6 @@ msgstr ""
 "Tarkista yhteyden tiedot."
 
 #: jellyfin_mpv_shim/mpvtk_browser/auth.py
-msgid "Locked"
-msgstr ""
-
-#: jellyfin_mpv_shim/mpvtk_browser/auth.py
 #: jellyfin_mpv_shim/mpvtk_browser/pages/home.py
 msgid "Connecting to your server…"
 msgstr ""
@@ -892,6 +893,10 @@ msgstr "Lopeta ja merkitse katsomattomaksi"
 #: jellyfin_mpv_shim/mpvtk_browser/pages/books.py
 msgid "Favorite"
 msgstr "Suosikki"
+
+#: jellyfin_mpv_shim/mpvtk_browser/components/detail.py
+msgid "Web"
+msgstr ""
 
 # seeded from jellyfin-web: HeaderVideos
 #: jellyfin_mpv_shim/mpvtk_browser/components/media_info.py
@@ -1507,11 +1512,7 @@ msgid "Jellyfin UI"
 msgstr ""
 
 #: jellyfin_mpv_shim/mpvtk_browser/config.py
-msgid "MPV UI with thumbnails"
-msgstr ""
-
-#: jellyfin_mpv_shim/mpvtk_browser/config.py
-msgid "MPV built-in default"
+msgid "MPV UI"
 msgstr ""
 
 #: jellyfin_mpv_shim/mpvtk_browser/config.py
@@ -1860,8 +1861,22 @@ msgid "Window Buttons in the Top Bar"
 msgstr ""
 
 #: jellyfin_mpv_shim/mpvtk_browser/config.py
+msgid "Keep Window Buttons in Full Screen"
+msgstr ""
+
+#: jellyfin_mpv_shim/mpvtk_browser/config.py
+msgid "Hide the Desktop Title Bar"
+msgstr ""
+
+#: jellyfin_mpv_shim/mpvtk_browser/config.py
 msgid "Player Controls Style"
 msgstr ""
+
+#: jellyfin_mpv_shim/mpvtk_browser/config.py
+#, fuzzy
+#| msgid "Enable thumbnail previews"
+msgid "Enable Trickplay Thumbnails"
+msgstr "Käytä esikatselukuvia"
 
 #: jellyfin_mpv_shim/mpvtk_browser/config.py
 msgid "Load All Seek Previews at Once"
@@ -1891,6 +1906,10 @@ msgstr ""
 
 #: jellyfin_mpv_shim/mpvtk_browser/config.py
 msgid "Full-Width Backdrops"
+msgstr ""
+
+#: jellyfin_mpv_shim/mpvtk_browser/config.py
+msgid "12-Hour Clock"
 msgstr ""
 
 #: jellyfin_mpv_shim/mpvtk_browser/config.py
@@ -1936,12 +1955,23 @@ msgid "Fullscreen Library Browser"
 msgstr ""
 
 #: jellyfin_mpv_shim/mpvtk_browser/config.py
+msgid "Block Player Keybinds While Browsing"
+msgstr ""
+
+#: jellyfin_mpv_shim/mpvtk_browser/config.py
 msgid "Always Bind Arrow Keys to Player Controls"
 msgstr ""
 
 #: jellyfin_mpv_shim/mpvtk_browser/config.py
 msgid "Player Controls Activation Key"
 msgstr ""
+
+# seeded from jellyfin-web: SelectAll
+#: jellyfin_mpv_shim/mpvtk_browser/config.py
+#, fuzzy
+#| msgid "Select All"
+msgid "Select Key"
+msgstr "Valitse kaikki"
 
 #: jellyfin_mpv_shim/mpvtk_browser/config.py
 msgid "Shading Behind the Player Controls"
@@ -1953,6 +1983,10 @@ msgstr ""
 
 #: jellyfin_mpv_shim/mpvtk_browser/config.py
 msgid "Hide the Player Controls After (seconds)"
+msgstr ""
+
+#: jellyfin_mpv_shim/mpvtk_browser/config.py
+msgid "Shrink the Player Controls on a Narrow Window"
 msgstr ""
 
 #: jellyfin_mpv_shim/mpvtk_browser/config.py
@@ -2039,6 +2073,21 @@ msgstr ""
 
 #: jellyfin_mpv_shim/mpvtk_browser/config.py
 msgid ""
+"Stops MPV's own shortcuts -- picture adjustment, screenshots, subtitle and "
+"audio switching -- from acting while you are in the library, where there is "
+"no video for them to act on. Turn it off to use your own MPV key bindings "
+"there."
+msgstr ""
+
+#: jellyfin_mpv_shim/mpvtk_browser/config.py
+msgid ""
+"Activates whatever is highlighted, in the library and on the player "
+"controls. An mpv key name; changing it hands Enter back to MPV. The game "
+"controller's Confirm button and a phone's Select follow it."
+msgstr ""
+
+#: jellyfin_mpv_shim/mpvtk_browser/config.py
+msgid ""
 "Leave these blank unless downloads are waking your disks too often. Set both "
 "of the first two together: episodes are then fetched in one batch when a "
 "series runs low, instead of one at a time."
@@ -2052,7 +2101,8 @@ msgstr ""
 #: jellyfin_mpv_shim/mpvtk_browser/config.py
 msgid ""
 "Off gives MPV's own mouse behaviour instead: drag the video to move the "
-"window, and right click to pause. Double click is full screen either way."
+"window, and the right button does whatever your MPV config gives it. Double "
+"click is full screen either way."
 msgstr ""
 
 #: jellyfin_mpv_shim/mpvtk_browser/config.py
@@ -2142,6 +2192,30 @@ msgid ""
 "maximize and close in the top bar instead, and lets you drag the window by "
 "it. On \"Only when the window has no title bar\", MPV is asked whether this "
 "window got one, so desktops that draw a title bar are left alone."
+msgstr ""
+
+#: jellyfin_mpv_shim/mpvtk_browser/config.py
+msgid ""
+"Full screen has no title bar anywhere and nothing to move or maximize, so "
+"the buttons are normally hidden there. Turn this on to keep a way out of "
+"full screen that is not a keyboard shortcut."
+msgstr ""
+
+#: jellyfin_mpv_shim/mpvtk_browser/config.py
+msgid ""
+"Asks the desktop for no title bar on the player window, so the top bar above "
+"is the only one. Pairs with the setting above: on \"Only when the window has "
+"no title bar\" the buttons appear as soon as this is on. Leave both off "
+"unless you want them, since a window with neither can be awkward to move on "
+"some desktops."
+msgstr ""
+
+#: jellyfin_mpv_shim/mpvtk_browser/config.py
+msgid ""
+"Shows a preview frame while you drag the seek bar. Works with every player "
+"control style, including your own OSC script if it supports thumbfast. The "
+"images are fetched from the server per video, which costs disk space and "
+"memory -- tens of MB for an episode, a few hundred for a long film."
 msgstr ""
 
 #: jellyfin_mpv_shim/mpvtk_browser/config.py
@@ -2251,6 +2325,13 @@ msgstr ""
 
 #: jellyfin_mpv_shim/mpvtk_browser/config.py
 msgid ""
+"Show times of day as \"8:30 PM\" rather than \"20:30\" — the Live TV guide "
+"and its air times, and the \"Ends at\" labels on a detail page and the "
+"player controls."
+msgstr ""
+
+#: jellyfin_mpv_shim/mpvtk_browser/config.py
+msgid ""
 "The controls have to stay legible over any frame. \"None\" gives the text a "
 "drop shadow instead of shading the picture behind it."
 msgstr ""
@@ -2265,6 +2346,13 @@ msgstr ""
 msgid ""
 "0 hides them as soon as the pointer is not on them, and forces \"Hide unless "
 "hovered\"."
+msgstr ""
+
+#: jellyfin_mpv_shim/mpvtk_browser/config.py
+msgid ""
+"Narrowing the window shrinks the controls until the smallest button reaches "
+"the accessibility minimum, instead of dropping buttons sooner. Off keeps the "
+"older, larger floor."
 msgstr ""
 
 #: jellyfin_mpv_shim/mpvtk_browser/config.py
@@ -3868,6 +3956,7 @@ msgid "More Like This"
 msgstr "Lisää tällaista"
 
 #: jellyfin_mpv_shim/mpvtk_browser/pages/detail.py
+#: jellyfin_mpv_shim/mpvtk_browser/tiles.py
 msgid "Go to Series"
 msgstr ""
 
@@ -5060,6 +5149,22 @@ msgstr "Poista palvelin"
 msgid "There is nothing here to queue."
 msgstr ""
 
+#: jellyfin_mpv_shim/mpvtk_browser/timefmt.py
+#, python-brace-format
+msgctxt "12-hour clock"
+msgid "{time} {period}"
+msgstr ""
+
+#: jellyfin_mpv_shim/mpvtk_browser/timefmt.py
+msgctxt "12-hour clock"
+msgid "AM"
+msgstr ""
+
+#: jellyfin_mpv_shim/mpvtk_browser/timefmt.py
+msgctxt "12-hour clock"
+msgid "PM"
+msgstr ""
+
 # seeded from jellyfin-web: Search
 #: jellyfin_mpv_shim/mpvtk_browser/views.py
 #: jellyfin_mpv_shim/mpvtk_browser/window_chrome.py
@@ -5227,13 +5332,32 @@ msgid "Enable SVP"
 msgstr "Ota SVP käyttöön"
 
 #: jellyfin_mpv_shim/sync/manager.py
+msgid "The downloads are already in that folder."
+msgstr ""
+
+#: jellyfin_mpv_shim/sync/manager.py
 msgid ""
 "Can't change the download folder while a download is in progress. Wait for "
 "it to finish, then try again."
 msgstr ""
 
 #: jellyfin_mpv_shim/sync/manager.py
+msgid ""
+"That folder is inside the current download folder. Choose one outside it."
+msgstr ""
+
+#: jellyfin_mpv_shim/sync/manager.py
+msgid "Can't read that folder. Check the path and its permissions."
+msgstr ""
+
+#: jellyfin_mpv_shim/sync/manager.py
 msgid "That folder already contains downloads. Choose an empty folder."
+msgstr ""
+
+#: jellyfin_mpv_shim/sync/manager.py
+msgid ""
+"That folder isn't empty. Choose an empty folder — the download folder is "
+"managed by this app and anything else in it can be moved or removed."
 msgstr ""
 
 #: jellyfin_mpv_shim/sync/manager.py
@@ -5242,6 +5366,12 @@ msgstr ""
 
 #: jellyfin_mpv_shim/sync/manager.py
 msgid "A download is still finishing. Wait for it to stop, then try again."
+msgstr ""
+
+#: jellyfin_mpv_shim/sync/manager.py
+msgid ""
+"There isn't enough space on that drive to move the downloads. Free some "
+"space and try again — nothing was moved."
 msgstr ""
 
 #: jellyfin_mpv_shim/sync/manager.py

--- a/jellyfin_mpv_shim/messages/fil/LC_MESSAGES/base.po
+++ b/jellyfin_mpv_shim/messages/fil/LC_MESSAGES/base.po
@@ -6,7 +6,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2026-08-30 22:19-0400\n"
+"POT-Creation-Date: 2026-09-07 17:35-0400\n"
 "PO-Revision-Date: 2026-08-25 14:58+0000\n"
 "Last-Translator: Justin A Exito <katylar@gmail.com>\n"
 "Language-Team: Filipino <https://translate.jellyfin.org/projects/jellyfin/"
@@ -552,6 +552,11 @@ msgid "Night Mode (Auto Volume Adj)"
 msgstr ""
 
 #: jellyfin_mpv_shim/mpvtk_browser/app.py
+#: jellyfin_mpv_shim/mpvtk_browser/auth.py
+msgid "Locked"
+msgstr ""
+
+#: jellyfin_mpv_shim/mpvtk_browser/app.py
 msgid "Failed to load. Check the connection."
 msgstr ""
 
@@ -831,10 +836,6 @@ msgstr ""
 "Pakisuri ang iyong impormasyon sa koneksyon."
 
 #: jellyfin_mpv_shim/mpvtk_browser/auth.py
-msgid "Locked"
-msgstr ""
-
-#: jellyfin_mpv_shim/mpvtk_browser/auth.py
 #: jellyfin_mpv_shim/mpvtk_browser/pages/home.py
 msgid "Connecting to your server…"
 msgstr ""
@@ -915,6 +916,10 @@ msgstr "Umalis at Markang Hindi Napanood"
 #: jellyfin_mpv_shim/mpvtk_browser/pages/books.py
 msgid "Favorite"
 msgstr "Paborito"
+
+#: jellyfin_mpv_shim/mpvtk_browser/components/detail.py
+msgid "Web"
+msgstr ""
 
 # seeded from jellyfin-web: Video
 #: jellyfin_mpv_shim/mpvtk_browser/components/media_info.py
@@ -1518,11 +1523,7 @@ msgid "Jellyfin UI"
 msgstr ""
 
 #: jellyfin_mpv_shim/mpvtk_browser/config.py
-msgid "MPV UI with thumbnails"
-msgstr ""
-
-#: jellyfin_mpv_shim/mpvtk_browser/config.py
-msgid "MPV built-in default"
+msgid "MPV UI"
 msgstr ""
 
 #: jellyfin_mpv_shim/mpvtk_browser/config.py
@@ -1871,8 +1872,22 @@ msgid "Window Buttons in the Top Bar"
 msgstr ""
 
 #: jellyfin_mpv_shim/mpvtk_browser/config.py
+msgid "Keep Window Buttons in Full Screen"
+msgstr ""
+
+#: jellyfin_mpv_shim/mpvtk_browser/config.py
+msgid "Hide the Desktop Title Bar"
+msgstr ""
+
+#: jellyfin_mpv_shim/mpvtk_browser/config.py
 msgid "Player Controls Style"
 msgstr ""
+
+#: jellyfin_mpv_shim/mpvtk_browser/config.py
+#, fuzzy
+#| msgid "Enable thumbnail previews"
+msgid "Enable Trickplay Thumbnails"
+msgstr "Magpakita ng thumbnail"
 
 #: jellyfin_mpv_shim/mpvtk_browser/config.py
 msgid "Load All Seek Previews at Once"
@@ -1902,6 +1917,10 @@ msgstr ""
 
 #: jellyfin_mpv_shim/mpvtk_browser/config.py
 msgid "Full-Width Backdrops"
+msgstr ""
+
+#: jellyfin_mpv_shim/mpvtk_browser/config.py
+msgid "12-Hour Clock"
 msgstr ""
 
 #: jellyfin_mpv_shim/mpvtk_browser/config.py
@@ -1947,12 +1966,23 @@ msgid "Fullscreen Library Browser"
 msgstr ""
 
 #: jellyfin_mpv_shim/mpvtk_browser/config.py
+msgid "Block Player Keybinds While Browsing"
+msgstr ""
+
+#: jellyfin_mpv_shim/mpvtk_browser/config.py
 msgid "Always Bind Arrow Keys to Player Controls"
 msgstr ""
 
 #: jellyfin_mpv_shim/mpvtk_browser/config.py
 msgid "Player Controls Activation Key"
 msgstr ""
+
+# seeded from jellyfin-web: SelectAll
+#: jellyfin_mpv_shim/mpvtk_browser/config.py
+#, fuzzy
+#| msgid "Select All"
+msgid "Select Key"
+msgstr "Piliin lahat"
 
 #: jellyfin_mpv_shim/mpvtk_browser/config.py
 msgid "Shading Behind the Player Controls"
@@ -1964,6 +1994,10 @@ msgstr ""
 
 #: jellyfin_mpv_shim/mpvtk_browser/config.py
 msgid "Hide the Player Controls After (seconds)"
+msgstr ""
+
+#: jellyfin_mpv_shim/mpvtk_browser/config.py
+msgid "Shrink the Player Controls on a Narrow Window"
 msgstr ""
 
 #: jellyfin_mpv_shim/mpvtk_browser/config.py
@@ -2050,6 +2084,21 @@ msgstr ""
 
 #: jellyfin_mpv_shim/mpvtk_browser/config.py
 msgid ""
+"Stops MPV's own shortcuts -- picture adjustment, screenshots, subtitle and "
+"audio switching -- from acting while you are in the library, where there is "
+"no video for them to act on. Turn it off to use your own MPV key bindings "
+"there."
+msgstr ""
+
+#: jellyfin_mpv_shim/mpvtk_browser/config.py
+msgid ""
+"Activates whatever is highlighted, in the library and on the player "
+"controls. An mpv key name; changing it hands Enter back to MPV. The game "
+"controller's Confirm button and a phone's Select follow it."
+msgstr ""
+
+#: jellyfin_mpv_shim/mpvtk_browser/config.py
+msgid ""
 "Leave these blank unless downloads are waking your disks too often. Set both "
 "of the first two together: episodes are then fetched in one batch when a "
 "series runs low, instead of one at a time."
@@ -2063,7 +2112,8 @@ msgstr ""
 #: jellyfin_mpv_shim/mpvtk_browser/config.py
 msgid ""
 "Off gives MPV's own mouse behaviour instead: drag the video to move the "
-"window, and right click to pause. Double click is full screen either way."
+"window, and the right button does whatever your MPV config gives it. Double "
+"click is full screen either way."
 msgstr ""
 
 #: jellyfin_mpv_shim/mpvtk_browser/config.py
@@ -2153,6 +2203,30 @@ msgid ""
 "maximize and close in the top bar instead, and lets you drag the window by "
 "it. On \"Only when the window has no title bar\", MPV is asked whether this "
 "window got one, so desktops that draw a title bar are left alone."
+msgstr ""
+
+#: jellyfin_mpv_shim/mpvtk_browser/config.py
+msgid ""
+"Full screen has no title bar anywhere and nothing to move or maximize, so "
+"the buttons are normally hidden there. Turn this on to keep a way out of "
+"full screen that is not a keyboard shortcut."
+msgstr ""
+
+#: jellyfin_mpv_shim/mpvtk_browser/config.py
+msgid ""
+"Asks the desktop for no title bar on the player window, so the top bar above "
+"is the only one. Pairs with the setting above: on \"Only when the window has "
+"no title bar\" the buttons appear as soon as this is on. Leave both off "
+"unless you want them, since a window with neither can be awkward to move on "
+"some desktops."
+msgstr ""
+
+#: jellyfin_mpv_shim/mpvtk_browser/config.py
+msgid ""
+"Shows a preview frame while you drag the seek bar. Works with every player "
+"control style, including your own OSC script if it supports thumbfast. The "
+"images are fetched from the server per video, which costs disk space and "
+"memory -- tens of MB for an episode, a few hundred for a long film."
 msgstr ""
 
 #: jellyfin_mpv_shim/mpvtk_browser/config.py
@@ -2262,6 +2336,13 @@ msgstr ""
 
 #: jellyfin_mpv_shim/mpvtk_browser/config.py
 msgid ""
+"Show times of day as \"8:30 PM\" rather than \"20:30\" — the Live TV guide "
+"and its air times, and the \"Ends at\" labels on a detail page and the "
+"player controls."
+msgstr ""
+
+#: jellyfin_mpv_shim/mpvtk_browser/config.py
+msgid ""
 "The controls have to stay legible over any frame. \"None\" gives the text a "
 "drop shadow instead of shading the picture behind it."
 msgstr ""
@@ -2276,6 +2357,13 @@ msgstr ""
 msgid ""
 "0 hides them as soon as the pointer is not on them, and forces \"Hide unless "
 "hovered\"."
+msgstr ""
+
+#: jellyfin_mpv_shim/mpvtk_browser/config.py
+msgid ""
+"Narrowing the window shrinks the controls until the smallest button reaches "
+"the accessibility minimum, instead of dropping buttons sooner. Off keeps the "
+"older, larger floor."
 msgstr ""
 
 #: jellyfin_mpv_shim/mpvtk_browser/config.py
@@ -3878,6 +3966,7 @@ msgid "More Like This"
 msgstr "Higit pang Tulad nito"
 
 #: jellyfin_mpv_shim/mpvtk_browser/pages/detail.py
+#: jellyfin_mpv_shim/mpvtk_browser/tiles.py
 msgid "Go to Series"
 msgstr ""
 
@@ -5070,6 +5159,22 @@ msgstr "Alisin ang Server"
 msgid "There is nothing here to queue."
 msgstr ""
 
+#: jellyfin_mpv_shim/mpvtk_browser/timefmt.py
+#, python-brace-format
+msgctxt "12-hour clock"
+msgid "{time} {period}"
+msgstr ""
+
+#: jellyfin_mpv_shim/mpvtk_browser/timefmt.py
+msgctxt "12-hour clock"
+msgid "AM"
+msgstr ""
+
+#: jellyfin_mpv_shim/mpvtk_browser/timefmt.py
+msgctxt "12-hour clock"
+msgid "PM"
+msgstr ""
+
 # seeded from jellyfin-web: Search
 #: jellyfin_mpv_shim/mpvtk_browser/views.py
 #: jellyfin_mpv_shim/mpvtk_browser/window_chrome.py
@@ -5237,13 +5342,32 @@ msgid "Enable SVP"
 msgstr "I-enable ang SVP"
 
 #: jellyfin_mpv_shim/sync/manager.py
+msgid "The downloads are already in that folder."
+msgstr ""
+
+#: jellyfin_mpv_shim/sync/manager.py
 msgid ""
 "Can't change the download folder while a download is in progress. Wait for "
 "it to finish, then try again."
 msgstr ""
 
 #: jellyfin_mpv_shim/sync/manager.py
+msgid ""
+"That folder is inside the current download folder. Choose one outside it."
+msgstr ""
+
+#: jellyfin_mpv_shim/sync/manager.py
+msgid "Can't read that folder. Check the path and its permissions."
+msgstr ""
+
+#: jellyfin_mpv_shim/sync/manager.py
 msgid "That folder already contains downloads. Choose an empty folder."
+msgstr ""
+
+#: jellyfin_mpv_shim/sync/manager.py
+msgid ""
+"That folder isn't empty. Choose an empty folder — the download folder is "
+"managed by this app and anything else in it can be moved or removed."
 msgstr ""
 
 #: jellyfin_mpv_shim/sync/manager.py
@@ -5252,6 +5376,12 @@ msgstr ""
 
 #: jellyfin_mpv_shim/sync/manager.py
 msgid "A download is still finishing. Wait for it to stop, then try again."
+msgstr ""
+
+#: jellyfin_mpv_shim/sync/manager.py
+msgid ""
+"There isn't enough space on that drive to move the downloads. Free some "
+"space and try again — nothing was moved."
 msgstr ""
 
 #: jellyfin_mpv_shim/sync/manager.py

--- a/jellyfin_mpv_shim/messages/fr/LC_MESSAGES/base.po
+++ b/jellyfin_mpv_shim/messages/fr/LC_MESSAGES/base.po
@@ -6,7 +6,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2026-08-30 22:19-0400\n"
+"POT-Creation-Date: 2026-09-07 17:35-0400\n"
 "PO-Revision-Date: 2026-08-18 18:37+0000\n"
 "Last-Translator: Lionel Morin <aidensingh2@gmail.com>\n"
 "Language-Team: French <https://translate.jellyfin.org/projects/jellyfin/"
@@ -536,6 +536,11 @@ msgid "Night Mode (Auto Volume Adj)"
 msgstr "Mode nuit (Ajustement automatique du volume)"
 
 #: jellyfin_mpv_shim/mpvtk_browser/app.py
+#: jellyfin_mpv_shim/mpvtk_browser/auth.py
+msgid "Locked"
+msgstr "Verrouillé"
+
+#: jellyfin_mpv_shim/mpvtk_browser/app.py
 msgid "Failed to load. Check the connection."
 msgstr "Échec du chargement. Vérifiez votre connexion."
 
@@ -781,10 +786,6 @@ msgid "Could not connect. Please check your details."
 msgstr "Échec de la connection. Merci de vérifier vos informations."
 
 #: jellyfin_mpv_shim/mpvtk_browser/auth.py
-msgid "Locked"
-msgstr "Verrouillé"
-
-#: jellyfin_mpv_shim/mpvtk_browser/auth.py
 #: jellyfin_mpv_shim/mpvtk_browser/pages/home.py
 msgid "Connecting to your server…"
 msgstr ""
@@ -857,6 +858,10 @@ msgstr "Déjà lu"
 #: jellyfin_mpv_shim/mpvtk_browser/pages/books.py
 msgid "Favorite"
 msgstr "Favoris"
+
+#: jellyfin_mpv_shim/mpvtk_browser/components/detail.py
+msgid "Web"
+msgstr ""
 
 # seeded from jellyfin-web: HeaderVideos
 #: jellyfin_mpv_shim/mpvtk_browser/components/media_info.py
@@ -1473,11 +1478,7 @@ msgid "Jellyfin UI"
 msgstr ""
 
 #: jellyfin_mpv_shim/mpvtk_browser/config.py
-msgid "MPV UI with thumbnails"
-msgstr ""
-
-#: jellyfin_mpv_shim/mpvtk_browser/config.py
-msgid "MPV built-in default"
+msgid "MPV UI"
 msgstr ""
 
 #: jellyfin_mpv_shim/mpvtk_browser/config.py
@@ -1827,8 +1828,22 @@ msgid "Window Buttons in the Top Bar"
 msgstr ""
 
 #: jellyfin_mpv_shim/mpvtk_browser/config.py
+msgid "Keep Window Buttons in Full Screen"
+msgstr ""
+
+#: jellyfin_mpv_shim/mpvtk_browser/config.py
+msgid "Hide the Desktop Title Bar"
+msgstr ""
+
+#: jellyfin_mpv_shim/mpvtk_browser/config.py
 msgid "Player Controls Style"
 msgstr ""
+
+#: jellyfin_mpv_shim/mpvtk_browser/config.py
+#, fuzzy
+#| msgid "Enable thumbnail previews"
+msgid "Enable Trickplay Thumbnails"
+msgstr "Activer la prévisualisation des miniatures"
 
 #: jellyfin_mpv_shim/mpvtk_browser/config.py
 msgid "Load All Seek Previews at Once"
@@ -1858,6 +1873,10 @@ msgstr ""
 
 #: jellyfin_mpv_shim/mpvtk_browser/config.py
 msgid "Full-Width Backdrops"
+msgstr ""
+
+#: jellyfin_mpv_shim/mpvtk_browser/config.py
+msgid "12-Hour Clock"
 msgstr ""
 
 #: jellyfin_mpv_shim/mpvtk_browser/config.py
@@ -1903,12 +1922,23 @@ msgid "Fullscreen Library Browser"
 msgstr ""
 
 #: jellyfin_mpv_shim/mpvtk_browser/config.py
+msgid "Block Player Keybinds While Browsing"
+msgstr ""
+
+#: jellyfin_mpv_shim/mpvtk_browser/config.py
 msgid "Always Bind Arrow Keys to Player Controls"
 msgstr ""
 
 #: jellyfin_mpv_shim/mpvtk_browser/config.py
 msgid "Player Controls Activation Key"
 msgstr ""
+
+# seeded from jellyfin-web: SelectAll
+#: jellyfin_mpv_shim/mpvtk_browser/config.py
+#, fuzzy
+#| msgid "Select All"
+msgid "Select Key"
+msgstr "Tout sélectionner"
 
 #: jellyfin_mpv_shim/mpvtk_browser/config.py
 msgid "Shading Behind the Player Controls"
@@ -1920,6 +1950,10 @@ msgstr ""
 
 #: jellyfin_mpv_shim/mpvtk_browser/config.py
 msgid "Hide the Player Controls After (seconds)"
+msgstr ""
+
+#: jellyfin_mpv_shim/mpvtk_browser/config.py
+msgid "Shrink the Player Controls on a Narrow Window"
 msgstr ""
 
 #: jellyfin_mpv_shim/mpvtk_browser/config.py
@@ -2006,6 +2040,21 @@ msgstr ""
 
 #: jellyfin_mpv_shim/mpvtk_browser/config.py
 msgid ""
+"Stops MPV's own shortcuts -- picture adjustment, screenshots, subtitle and "
+"audio switching -- from acting while you are in the library, where there is "
+"no video for them to act on. Turn it off to use your own MPV key bindings "
+"there."
+msgstr ""
+
+#: jellyfin_mpv_shim/mpvtk_browser/config.py
+msgid ""
+"Activates whatever is highlighted, in the library and on the player "
+"controls. An mpv key name; changing it hands Enter back to MPV. The game "
+"controller's Confirm button and a phone's Select follow it."
+msgstr ""
+
+#: jellyfin_mpv_shim/mpvtk_browser/config.py
+msgid ""
 "Leave these blank unless downloads are waking your disks too often. Set both "
 "of the first two together: episodes are then fetched in one batch when a "
 "series runs low, instead of one at a time."
@@ -2019,7 +2068,8 @@ msgstr ""
 #: jellyfin_mpv_shim/mpvtk_browser/config.py
 msgid ""
 "Off gives MPV's own mouse behaviour instead: drag the video to move the "
-"window, and right click to pause. Double click is full screen either way."
+"window, and the right button does whatever your MPV config gives it. Double "
+"click is full screen either way."
 msgstr ""
 
 #: jellyfin_mpv_shim/mpvtk_browser/config.py
@@ -2109,6 +2159,30 @@ msgid ""
 "maximize and close in the top bar instead, and lets you drag the window by "
 "it. On \"Only when the window has no title bar\", MPV is asked whether this "
 "window got one, so desktops that draw a title bar are left alone."
+msgstr ""
+
+#: jellyfin_mpv_shim/mpvtk_browser/config.py
+msgid ""
+"Full screen has no title bar anywhere and nothing to move or maximize, so "
+"the buttons are normally hidden there. Turn this on to keep a way out of "
+"full screen that is not a keyboard shortcut."
+msgstr ""
+
+#: jellyfin_mpv_shim/mpvtk_browser/config.py
+msgid ""
+"Asks the desktop for no title bar on the player window, so the top bar above "
+"is the only one. Pairs with the setting above: on \"Only when the window has "
+"no title bar\" the buttons appear as soon as this is on. Leave both off "
+"unless you want them, since a window with neither can be awkward to move on "
+"some desktops."
+msgstr ""
+
+#: jellyfin_mpv_shim/mpvtk_browser/config.py
+msgid ""
+"Shows a preview frame while you drag the seek bar. Works with every player "
+"control style, including your own OSC script if it supports thumbfast. The "
+"images are fetched from the server per video, which costs disk space and "
+"memory -- tens of MB for an episode, a few hundred for a long film."
 msgstr ""
 
 #: jellyfin_mpv_shim/mpvtk_browser/config.py
@@ -2218,6 +2292,13 @@ msgstr ""
 
 #: jellyfin_mpv_shim/mpvtk_browser/config.py
 msgid ""
+"Show times of day as \"8:30 PM\" rather than \"20:30\" — the Live TV guide "
+"and its air times, and the \"Ends at\" labels on a detail page and the "
+"player controls."
+msgstr ""
+
+#: jellyfin_mpv_shim/mpvtk_browser/config.py
+msgid ""
 "The controls have to stay legible over any frame. \"None\" gives the text a "
 "drop shadow instead of shading the picture behind it."
 msgstr ""
@@ -2232,6 +2313,13 @@ msgstr ""
 msgid ""
 "0 hides them as soon as the pointer is not on them, and forces \"Hide unless "
 "hovered\"."
+msgstr ""
+
+#: jellyfin_mpv_shim/mpvtk_browser/config.py
+msgid ""
+"Narrowing the window shrinks the controls until the smallest button reaches "
+"the accessibility minimum, instead of dropping buttons sooner. Off keeps the "
+"older, larger floor."
 msgstr ""
 
 #: jellyfin_mpv_shim/mpvtk_browser/config.py
@@ -3820,6 +3908,7 @@ msgid "More Like This"
 msgstr "Plus de ce genre"
 
 #: jellyfin_mpv_shim/mpvtk_browser/pages/detail.py
+#: jellyfin_mpv_shim/mpvtk_browser/tiles.py
 msgid "Go to Series"
 msgstr ""
 
@@ -4978,6 +5067,22 @@ msgstr "Supprimer le serveur"
 msgid "There is nothing here to queue."
 msgstr ""
 
+#: jellyfin_mpv_shim/mpvtk_browser/timefmt.py
+#, python-brace-format
+msgctxt "12-hour clock"
+msgid "{time} {period}"
+msgstr ""
+
+#: jellyfin_mpv_shim/mpvtk_browser/timefmt.py
+msgctxt "12-hour clock"
+msgid "AM"
+msgstr ""
+
+#: jellyfin_mpv_shim/mpvtk_browser/timefmt.py
+msgctxt "12-hour clock"
+msgid "PM"
+msgstr ""
+
 # seeded from jellyfin-web: Search
 #: jellyfin_mpv_shim/mpvtk_browser/views.py
 #: jellyfin_mpv_shim/mpvtk_browser/window_chrome.py
@@ -5146,13 +5251,32 @@ msgid "Enable SVP"
 msgstr "Activer SVP"
 
 #: jellyfin_mpv_shim/sync/manager.py
+msgid "The downloads are already in that folder."
+msgstr ""
+
+#: jellyfin_mpv_shim/sync/manager.py
 msgid ""
 "Can't change the download folder while a download is in progress. Wait for "
 "it to finish, then try again."
 msgstr ""
 
 #: jellyfin_mpv_shim/sync/manager.py
+msgid ""
+"That folder is inside the current download folder. Choose one outside it."
+msgstr ""
+
+#: jellyfin_mpv_shim/sync/manager.py
+msgid "Can't read that folder. Check the path and its permissions."
+msgstr ""
+
+#: jellyfin_mpv_shim/sync/manager.py
 msgid "That folder already contains downloads. Choose an empty folder."
+msgstr ""
+
+#: jellyfin_mpv_shim/sync/manager.py
+msgid ""
+"That folder isn't empty. Choose an empty folder — the download folder is "
+"managed by this app and anything else in it can be moved or removed."
 msgstr ""
 
 #: jellyfin_mpv_shim/sync/manager.py
@@ -5161,6 +5285,12 @@ msgstr ""
 
 #: jellyfin_mpv_shim/sync/manager.py
 msgid "A download is still finishing. Wait for it to stop, then try again."
+msgstr ""
+
+#: jellyfin_mpv_shim/sync/manager.py
+msgid ""
+"There isn't enough space on that drive to move the downloads. Free some "
+"space and try again — nothing was moved."
 msgstr ""
 
 #: jellyfin_mpv_shim/sync/manager.py

--- a/jellyfin_mpv_shim/messages/ga/LC_MESSAGES/base.po
+++ b/jellyfin_mpv_shim/messages/ga/LC_MESSAGES/base.po
@@ -6,7 +6,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2026-08-30 22:19-0400\n"
+"POT-Creation-Date: 2026-09-07 17:35-0400\n"
 "PO-Revision-Date: 2026-05-04 14:15+0000\n"
 "Last-Translator: Aindriú Mac Giolla Eoin <aindriu80@gmail.com>\n"
 "Language-Team: Irish <https://translate.jellyfin.org/projects/jellyfin/"
@@ -548,6 +548,11 @@ msgid "Night Mode (Auto Volume Adj)"
 msgstr ""
 
 #: jellyfin_mpv_shim/mpvtk_browser/app.py
+#: jellyfin_mpv_shim/mpvtk_browser/auth.py
+msgid "Locked"
+msgstr ""
+
+#: jellyfin_mpv_shim/mpvtk_browser/app.py
 msgid "Failed to load. Check the connection."
 msgstr ""
 
@@ -827,10 +832,6 @@ msgstr ""
 "Seiceáil faisnéis do naisc le do thoil."
 
 #: jellyfin_mpv_shim/mpvtk_browser/auth.py
-msgid "Locked"
-msgstr ""
-
-#: jellyfin_mpv_shim/mpvtk_browser/auth.py
 #: jellyfin_mpv_shim/mpvtk_browser/pages/home.py
 msgid "Connecting to your server…"
 msgstr ""
@@ -911,6 +912,10 @@ msgstr "Scoir agus marcáil gan faire"
 #: jellyfin_mpv_shim/mpvtk_browser/pages/books.py
 msgid "Favorite"
 msgstr "An ceann is fearr leat"
+
+#: jellyfin_mpv_shim/mpvtk_browser/components/detail.py
+msgid "Web"
+msgstr ""
 
 # seeded from jellyfin-web: HeaderVideos
 #: jellyfin_mpv_shim/mpvtk_browser/components/media_info.py
@@ -1530,11 +1535,7 @@ msgid "Jellyfin UI"
 msgstr ""
 
 #: jellyfin_mpv_shim/mpvtk_browser/config.py
-msgid "MPV UI with thumbnails"
-msgstr ""
-
-#: jellyfin_mpv_shim/mpvtk_browser/config.py
-msgid "MPV built-in default"
+msgid "MPV UI"
 msgstr ""
 
 #: jellyfin_mpv_shim/mpvtk_browser/config.py
@@ -1883,8 +1884,22 @@ msgid "Window Buttons in the Top Bar"
 msgstr ""
 
 #: jellyfin_mpv_shim/mpvtk_browser/config.py
+msgid "Keep Window Buttons in Full Screen"
+msgstr ""
+
+#: jellyfin_mpv_shim/mpvtk_browser/config.py
+msgid "Hide the Desktop Title Bar"
+msgstr ""
+
+#: jellyfin_mpv_shim/mpvtk_browser/config.py
 msgid "Player Controls Style"
 msgstr ""
+
+#: jellyfin_mpv_shim/mpvtk_browser/config.py
+#, fuzzy
+#| msgid "Enable thumbnail previews"
+msgid "Enable Trickplay Thumbnails"
+msgstr "Cumasaigh réamhamhairc mhionsamhlacha"
 
 #: jellyfin_mpv_shim/mpvtk_browser/config.py
 msgid "Load All Seek Previews at Once"
@@ -1914,6 +1929,10 @@ msgstr ""
 
 #: jellyfin_mpv_shim/mpvtk_browser/config.py
 msgid "Full-Width Backdrops"
+msgstr ""
+
+#: jellyfin_mpv_shim/mpvtk_browser/config.py
+msgid "12-Hour Clock"
 msgstr ""
 
 #: jellyfin_mpv_shim/mpvtk_browser/config.py
@@ -1959,12 +1978,23 @@ msgid "Fullscreen Library Browser"
 msgstr ""
 
 #: jellyfin_mpv_shim/mpvtk_browser/config.py
+msgid "Block Player Keybinds While Browsing"
+msgstr ""
+
+#: jellyfin_mpv_shim/mpvtk_browser/config.py
 msgid "Always Bind Arrow Keys to Player Controls"
 msgstr ""
 
 #: jellyfin_mpv_shim/mpvtk_browser/config.py
 msgid "Player Controls Activation Key"
 msgstr ""
+
+# seeded from jellyfin-web: SelectAll
+#: jellyfin_mpv_shim/mpvtk_browser/config.py
+#, fuzzy
+#| msgid "Select All"
+msgid "Select Key"
+msgstr "Roghnaigh Gach Rud"
 
 #: jellyfin_mpv_shim/mpvtk_browser/config.py
 msgid "Shading Behind the Player Controls"
@@ -1976,6 +2006,10 @@ msgstr ""
 
 #: jellyfin_mpv_shim/mpvtk_browser/config.py
 msgid "Hide the Player Controls After (seconds)"
+msgstr ""
+
+#: jellyfin_mpv_shim/mpvtk_browser/config.py
+msgid "Shrink the Player Controls on a Narrow Window"
 msgstr ""
 
 #: jellyfin_mpv_shim/mpvtk_browser/config.py
@@ -2062,6 +2096,21 @@ msgstr ""
 
 #: jellyfin_mpv_shim/mpvtk_browser/config.py
 msgid ""
+"Stops MPV's own shortcuts -- picture adjustment, screenshots, subtitle and "
+"audio switching -- from acting while you are in the library, where there is "
+"no video for them to act on. Turn it off to use your own MPV key bindings "
+"there."
+msgstr ""
+
+#: jellyfin_mpv_shim/mpvtk_browser/config.py
+msgid ""
+"Activates whatever is highlighted, in the library and on the player "
+"controls. An mpv key name; changing it hands Enter back to MPV. The game "
+"controller's Confirm button and a phone's Select follow it."
+msgstr ""
+
+#: jellyfin_mpv_shim/mpvtk_browser/config.py
+msgid ""
 "Leave these blank unless downloads are waking your disks too often. Set both "
 "of the first two together: episodes are then fetched in one batch when a "
 "series runs low, instead of one at a time."
@@ -2075,7 +2124,8 @@ msgstr ""
 #: jellyfin_mpv_shim/mpvtk_browser/config.py
 msgid ""
 "Off gives MPV's own mouse behaviour instead: drag the video to move the "
-"window, and right click to pause. Double click is full screen either way."
+"window, and the right button does whatever your MPV config gives it. Double "
+"click is full screen either way."
 msgstr ""
 
 #: jellyfin_mpv_shim/mpvtk_browser/config.py
@@ -2165,6 +2215,30 @@ msgid ""
 "maximize and close in the top bar instead, and lets you drag the window by "
 "it. On \"Only when the window has no title bar\", MPV is asked whether this "
 "window got one, so desktops that draw a title bar are left alone."
+msgstr ""
+
+#: jellyfin_mpv_shim/mpvtk_browser/config.py
+msgid ""
+"Full screen has no title bar anywhere and nothing to move or maximize, so "
+"the buttons are normally hidden there. Turn this on to keep a way out of "
+"full screen that is not a keyboard shortcut."
+msgstr ""
+
+#: jellyfin_mpv_shim/mpvtk_browser/config.py
+msgid ""
+"Asks the desktop for no title bar on the player window, so the top bar above "
+"is the only one. Pairs with the setting above: on \"Only when the window has "
+"no title bar\" the buttons appear as soon as this is on. Leave both off "
+"unless you want them, since a window with neither can be awkward to move on "
+"some desktops."
+msgstr ""
+
+#: jellyfin_mpv_shim/mpvtk_browser/config.py
+msgid ""
+"Shows a preview frame while you drag the seek bar. Works with every player "
+"control style, including your own OSC script if it supports thumbfast. The "
+"images are fetched from the server per video, which costs disk space and "
+"memory -- tens of MB for an episode, a few hundred for a long film."
 msgstr ""
 
 #: jellyfin_mpv_shim/mpvtk_browser/config.py
@@ -2274,6 +2348,13 @@ msgstr ""
 
 #: jellyfin_mpv_shim/mpvtk_browser/config.py
 msgid ""
+"Show times of day as \"8:30 PM\" rather than \"20:30\" — the Live TV guide "
+"and its air times, and the \"Ends at\" labels on a detail page and the "
+"player controls."
+msgstr ""
+
+#: jellyfin_mpv_shim/mpvtk_browser/config.py
+msgid ""
 "The controls have to stay legible over any frame. \"None\" gives the text a "
 "drop shadow instead of shading the picture behind it."
 msgstr ""
@@ -2288,6 +2369,13 @@ msgstr ""
 msgid ""
 "0 hides them as soon as the pointer is not on them, and forces \"Hide unless "
 "hovered\"."
+msgstr ""
+
+#: jellyfin_mpv_shim/mpvtk_browser/config.py
+msgid ""
+"Narrowing the window shrinks the controls until the smallest button reaches "
+"the accessibility minimum, instead of dropping buttons sooner. Off keeps the "
+"older, larger floor."
 msgstr ""
 
 #: jellyfin_mpv_shim/mpvtk_browser/config.py
@@ -3895,6 +3983,7 @@ msgid "More Like This"
 msgstr "Níos mó cosúil leis seo"
 
 #: jellyfin_mpv_shim/mpvtk_browser/pages/detail.py
+#: jellyfin_mpv_shim/mpvtk_browser/tiles.py
 msgid "Go to Series"
 msgstr ""
 
@@ -5090,6 +5179,22 @@ msgstr "Bain Freastalaí"
 msgid "There is nothing here to queue."
 msgstr ""
 
+#: jellyfin_mpv_shim/mpvtk_browser/timefmt.py
+#, python-brace-format
+msgctxt "12-hour clock"
+msgid "{time} {period}"
+msgstr ""
+
+#: jellyfin_mpv_shim/mpvtk_browser/timefmt.py
+msgctxt "12-hour clock"
+msgid "AM"
+msgstr ""
+
+#: jellyfin_mpv_shim/mpvtk_browser/timefmt.py
+msgctxt "12-hour clock"
+msgid "PM"
+msgstr ""
+
 # seeded from jellyfin-web: Search
 #: jellyfin_mpv_shim/mpvtk_browser/views.py
 #: jellyfin_mpv_shim/mpvtk_browser/window_chrome.py
@@ -5257,13 +5362,32 @@ msgid "Enable SVP"
 msgstr "Cumasaigh SVP"
 
 #: jellyfin_mpv_shim/sync/manager.py
+msgid "The downloads are already in that folder."
+msgstr ""
+
+#: jellyfin_mpv_shim/sync/manager.py
 msgid ""
 "Can't change the download folder while a download is in progress. Wait for "
 "it to finish, then try again."
 msgstr ""
 
 #: jellyfin_mpv_shim/sync/manager.py
+msgid ""
+"That folder is inside the current download folder. Choose one outside it."
+msgstr ""
+
+#: jellyfin_mpv_shim/sync/manager.py
+msgid "Can't read that folder. Check the path and its permissions."
+msgstr ""
+
+#: jellyfin_mpv_shim/sync/manager.py
 msgid "That folder already contains downloads. Choose an empty folder."
+msgstr ""
+
+#: jellyfin_mpv_shim/sync/manager.py
+msgid ""
+"That folder isn't empty. Choose an empty folder — the download folder is "
+"managed by this app and anything else in it can be moved or removed."
 msgstr ""
 
 #: jellyfin_mpv_shim/sync/manager.py
@@ -5272,6 +5396,12 @@ msgstr ""
 
 #: jellyfin_mpv_shim/sync/manager.py
 msgid "A download is still finishing. Wait for it to stop, then try again."
+msgstr ""
+
+#: jellyfin_mpv_shim/sync/manager.py
+msgid ""
+"There isn't enough space on that drive to move the downloads. Free some "
+"space and try again — nothing was moved."
 msgstr ""
 
 #: jellyfin_mpv_shim/sync/manager.py

--- a/jellyfin_mpv_shim/messages/gl/LC_MESSAGES/base.po
+++ b/jellyfin_mpv_shim/messages/gl/LC_MESSAGES/base.po
@@ -6,7 +6,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2026-08-30 22:19-0400\n"
+"POT-Creation-Date: 2026-09-07 17:35-0400\n"
 "PO-Revision-Date: 2026-08-25 22:07+0000\n"
 "Last-Translator: Manuel Cid <manuelcidrodriguez@gmail.com>\n"
 "Language-Team: Galician <https://translate.jellyfin.org/projects/jellyfin/"
@@ -545,6 +545,11 @@ msgid "Night Mode (Auto Volume Adj)"
 msgstr "Modo nocturno (axuste automático de volume)"
 
 #: jellyfin_mpv_shim/mpvtk_browser/app.py
+#: jellyfin_mpv_shim/mpvtk_browser/auth.py
+msgid "Locked"
+msgstr "Bloqueado"
+
+#: jellyfin_mpv_shim/mpvtk_browser/app.py
 msgid "Failed to load. Check the connection."
 msgstr "Non se puido cargar. Comprobe a conexión."
 
@@ -824,10 +829,6 @@ msgstr ""
 "Por favor, revise os parámetros de conexión."
 
 #: jellyfin_mpv_shim/mpvtk_browser/auth.py
-msgid "Locked"
-msgstr "Bloqueado"
-
-#: jellyfin_mpv_shim/mpvtk_browser/auth.py
 #: jellyfin_mpv_shim/mpvtk_browser/pages/home.py
 msgid "Connecting to your server…"
 msgstr "Conectando ó teu servidor…"
@@ -909,6 +910,10 @@ msgstr "Saír e Marcar como Non visto"
 #: jellyfin_mpv_shim/mpvtk_browser/pages/books.py
 msgid "Favorite"
 msgstr "Favorito"
+
+#: jellyfin_mpv_shim/mpvtk_browser/components/detail.py
+msgid "Web"
+msgstr ""
 
 # seeded from jellyfin-web: HeaderVideos
 #: jellyfin_mpv_shim/mpvtk_browser/components/media_info.py
@@ -1486,11 +1491,7 @@ msgid "Jellyfin UI"
 msgstr ""
 
 #: jellyfin_mpv_shim/mpvtk_browser/config.py
-msgid "MPV UI with thumbnails"
-msgstr ""
-
-#: jellyfin_mpv_shim/mpvtk_browser/config.py
-msgid "MPV built-in default"
+msgid "MPV UI"
 msgstr ""
 
 #: jellyfin_mpv_shim/mpvtk_browser/config.py
@@ -1839,8 +1840,22 @@ msgid "Window Buttons in the Top Bar"
 msgstr ""
 
 #: jellyfin_mpv_shim/mpvtk_browser/config.py
+msgid "Keep Window Buttons in Full Screen"
+msgstr ""
+
+#: jellyfin_mpv_shim/mpvtk_browser/config.py
+msgid "Hide the Desktop Title Bar"
+msgstr ""
+
+#: jellyfin_mpv_shim/mpvtk_browser/config.py
 msgid "Player Controls Style"
 msgstr ""
+
+#: jellyfin_mpv_shim/mpvtk_browser/config.py
+#, fuzzy
+#| msgid "Enable thumbnail previews"
+msgid "Enable Trickplay Thumbnails"
+msgstr "Activar vistas previas na miniatura"
 
 #: jellyfin_mpv_shim/mpvtk_browser/config.py
 msgid "Load All Seek Previews at Once"
@@ -1870,6 +1885,10 @@ msgstr ""
 
 #: jellyfin_mpv_shim/mpvtk_browser/config.py
 msgid "Full-Width Backdrops"
+msgstr ""
+
+#: jellyfin_mpv_shim/mpvtk_browser/config.py
+msgid "12-Hour Clock"
 msgstr ""
 
 #: jellyfin_mpv_shim/mpvtk_browser/config.py
@@ -1915,12 +1934,23 @@ msgid "Fullscreen Library Browser"
 msgstr ""
 
 #: jellyfin_mpv_shim/mpvtk_browser/config.py
+msgid "Block Player Keybinds While Browsing"
+msgstr ""
+
+#: jellyfin_mpv_shim/mpvtk_browser/config.py
 msgid "Always Bind Arrow Keys to Player Controls"
 msgstr ""
 
 #: jellyfin_mpv_shim/mpvtk_browser/config.py
 msgid "Player Controls Activation Key"
 msgstr ""
+
+# seeded from jellyfin-web: SelectAll
+#: jellyfin_mpv_shim/mpvtk_browser/config.py
+#, fuzzy
+#| msgid "Select All"
+msgid "Select Key"
+msgstr "Seleccionar todo"
 
 #: jellyfin_mpv_shim/mpvtk_browser/config.py
 msgid "Shading Behind the Player Controls"
@@ -1932,6 +1962,10 @@ msgstr ""
 
 #: jellyfin_mpv_shim/mpvtk_browser/config.py
 msgid "Hide the Player Controls After (seconds)"
+msgstr ""
+
+#: jellyfin_mpv_shim/mpvtk_browser/config.py
+msgid "Shrink the Player Controls on a Narrow Window"
 msgstr ""
 
 #: jellyfin_mpv_shim/mpvtk_browser/config.py
@@ -2018,6 +2052,21 @@ msgstr ""
 
 #: jellyfin_mpv_shim/mpvtk_browser/config.py
 msgid ""
+"Stops MPV's own shortcuts -- picture adjustment, screenshots, subtitle and "
+"audio switching -- from acting while you are in the library, where there is "
+"no video for them to act on. Turn it off to use your own MPV key bindings "
+"there."
+msgstr ""
+
+#: jellyfin_mpv_shim/mpvtk_browser/config.py
+msgid ""
+"Activates whatever is highlighted, in the library and on the player "
+"controls. An mpv key name; changing it hands Enter back to MPV. The game "
+"controller's Confirm button and a phone's Select follow it."
+msgstr ""
+
+#: jellyfin_mpv_shim/mpvtk_browser/config.py
+msgid ""
 "Leave these blank unless downloads are waking your disks too often. Set both "
 "of the first two together: episodes are then fetched in one batch when a "
 "series runs low, instead of one at a time."
@@ -2031,7 +2080,8 @@ msgstr ""
 #: jellyfin_mpv_shim/mpvtk_browser/config.py
 msgid ""
 "Off gives MPV's own mouse behaviour instead: drag the video to move the "
-"window, and right click to pause. Double click is full screen either way."
+"window, and the right button does whatever your MPV config gives it. Double "
+"click is full screen either way."
 msgstr ""
 
 #: jellyfin_mpv_shim/mpvtk_browser/config.py
@@ -2121,6 +2171,30 @@ msgid ""
 "maximize and close in the top bar instead, and lets you drag the window by "
 "it. On \"Only when the window has no title bar\", MPV is asked whether this "
 "window got one, so desktops that draw a title bar are left alone."
+msgstr ""
+
+#: jellyfin_mpv_shim/mpvtk_browser/config.py
+msgid ""
+"Full screen has no title bar anywhere and nothing to move or maximize, so "
+"the buttons are normally hidden there. Turn this on to keep a way out of "
+"full screen that is not a keyboard shortcut."
+msgstr ""
+
+#: jellyfin_mpv_shim/mpvtk_browser/config.py
+msgid ""
+"Asks the desktop for no title bar on the player window, so the top bar above "
+"is the only one. Pairs with the setting above: on \"Only when the window has "
+"no title bar\" the buttons appear as soon as this is on. Leave both off "
+"unless you want them, since a window with neither can be awkward to move on "
+"some desktops."
+msgstr ""
+
+#: jellyfin_mpv_shim/mpvtk_browser/config.py
+msgid ""
+"Shows a preview frame while you drag the seek bar. Works with every player "
+"control style, including your own OSC script if it supports thumbfast. The "
+"images are fetched from the server per video, which costs disk space and "
+"memory -- tens of MB for an episode, a few hundred for a long film."
 msgstr ""
 
 #: jellyfin_mpv_shim/mpvtk_browser/config.py
@@ -2230,6 +2304,13 @@ msgstr ""
 
 #: jellyfin_mpv_shim/mpvtk_browser/config.py
 msgid ""
+"Show times of day as \"8:30 PM\" rather than \"20:30\" — the Live TV guide "
+"and its air times, and the \"Ends at\" labels on a detail page and the "
+"player controls."
+msgstr ""
+
+#: jellyfin_mpv_shim/mpvtk_browser/config.py
+msgid ""
 "The controls have to stay legible over any frame. \"None\" gives the text a "
 "drop shadow instead of shading the picture behind it."
 msgstr ""
@@ -2244,6 +2325,13 @@ msgstr ""
 msgid ""
 "0 hides them as soon as the pointer is not on them, and forces \"Hide unless "
 "hovered\"."
+msgstr ""
+
+#: jellyfin_mpv_shim/mpvtk_browser/config.py
+msgid ""
+"Narrowing the window shrinks the controls until the smallest button reaches "
+"the accessibility minimum, instead of dropping buttons sooner. Off keeps the "
+"older, larger floor."
 msgstr ""
 
 #: jellyfin_mpv_shim/mpvtk_browser/config.py
@@ -3833,6 +3921,7 @@ msgid "More Like This"
 msgstr "Máis Así"
 
 #: jellyfin_mpv_shim/mpvtk_browser/pages/detail.py
+#: jellyfin_mpv_shim/mpvtk_browser/tiles.py
 msgid "Go to Series"
 msgstr ""
 
@@ -5012,6 +5101,22 @@ msgstr "Eliminar Servidor"
 msgid "There is nothing here to queue."
 msgstr ""
 
+#: jellyfin_mpv_shim/mpvtk_browser/timefmt.py
+#, python-brace-format
+msgctxt "12-hour clock"
+msgid "{time} {period}"
+msgstr ""
+
+#: jellyfin_mpv_shim/mpvtk_browser/timefmt.py
+msgctxt "12-hour clock"
+msgid "AM"
+msgstr ""
+
+#: jellyfin_mpv_shim/mpvtk_browser/timefmt.py
+msgctxt "12-hour clock"
+msgid "PM"
+msgstr ""
+
 # seeded from jellyfin-web: Search
 #: jellyfin_mpv_shim/mpvtk_browser/views.py
 #: jellyfin_mpv_shim/mpvtk_browser/window_chrome.py
@@ -5177,13 +5282,32 @@ msgid "Enable SVP"
 msgstr "Habilitar SVP"
 
 #: jellyfin_mpv_shim/sync/manager.py
+msgid "The downloads are already in that folder."
+msgstr ""
+
+#: jellyfin_mpv_shim/sync/manager.py
 msgid ""
 "Can't change the download folder while a download is in progress. Wait for "
 "it to finish, then try again."
 msgstr ""
 
 #: jellyfin_mpv_shim/sync/manager.py
+msgid ""
+"That folder is inside the current download folder. Choose one outside it."
+msgstr ""
+
+#: jellyfin_mpv_shim/sync/manager.py
+msgid "Can't read that folder. Check the path and its permissions."
+msgstr ""
+
+#: jellyfin_mpv_shim/sync/manager.py
 msgid "That folder already contains downloads. Choose an empty folder."
+msgstr ""
+
+#: jellyfin_mpv_shim/sync/manager.py
+msgid ""
+"That folder isn't empty. Choose an empty folder — the download folder is "
+"managed by this app and anything else in it can be moved or removed."
 msgstr ""
 
 #: jellyfin_mpv_shim/sync/manager.py
@@ -5192,6 +5316,12 @@ msgstr ""
 
 #: jellyfin_mpv_shim/sync/manager.py
 msgid "A download is still finishing. Wait for it to stop, then try again."
+msgstr ""
+
+#: jellyfin_mpv_shim/sync/manager.py
+msgid ""
+"There isn't enough space on that drive to move the downloads. Free some "
+"space and try again — nothing was moved."
 msgstr ""
 
 #: jellyfin_mpv_shim/sync/manager.py

--- a/jellyfin_mpv_shim/messages/gsw/LC_MESSAGES/base.po
+++ b/jellyfin_mpv_shim/messages/gsw/LC_MESSAGES/base.po
@@ -6,7 +6,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2026-08-30 22:19-0400\n"
+"POT-Creation-Date: 2026-09-07 17:35-0400\n"
 "PO-Revision-Date: 2025-12-29 17:50+0000\n"
 "Last-Translator: wrecker454 <jellyfin.wrecker454@passmail.net>\n"
 "Language-Team: Alemannic <https://translate.jellyfin.org/projects/jellyfin/"
@@ -517,6 +517,11 @@ msgid "Night Mode (Auto Volume Adj)"
 msgstr ""
 
 #: jellyfin_mpv_shim/mpvtk_browser/app.py
+#: jellyfin_mpv_shim/mpvtk_browser/auth.py
+msgid "Locked"
+msgstr ""
+
+#: jellyfin_mpv_shim/mpvtk_browser/app.py
 msgid "Failed to load. Check the connection."
 msgstr ""
 
@@ -790,10 +795,6 @@ msgstr ""
 "Bitte überprüef dini Verbindigsinformatione."
 
 #: jellyfin_mpv_shim/mpvtk_browser/auth.py
-msgid "Locked"
-msgstr ""
-
-#: jellyfin_mpv_shim/mpvtk_browser/auth.py
 #: jellyfin_mpv_shim/mpvtk_browser/pages/home.py
 msgid "Connecting to your server…"
 msgstr ""
@@ -868,6 +869,10 @@ msgstr ""
 #: jellyfin_mpv_shim/mpvtk_browser/hud.py
 #: jellyfin_mpv_shim/mpvtk_browser/pages/books.py
 msgid "Favorite"
+msgstr ""
+
+#: jellyfin_mpv_shim/mpvtk_browser/components/detail.py
+msgid "Web"
 msgstr ""
 
 #: jellyfin_mpv_shim/mpvtk_browser/components/media_info.py
@@ -1389,11 +1394,7 @@ msgid "Jellyfin UI"
 msgstr ""
 
 #: jellyfin_mpv_shim/mpvtk_browser/config.py
-msgid "MPV UI with thumbnails"
-msgstr ""
-
-#: jellyfin_mpv_shim/mpvtk_browser/config.py
-msgid "MPV built-in default"
+msgid "MPV UI"
 msgstr ""
 
 #: jellyfin_mpv_shim/mpvtk_browser/config.py
@@ -1732,7 +1733,19 @@ msgid "Window Buttons in the Top Bar"
 msgstr ""
 
 #: jellyfin_mpv_shim/mpvtk_browser/config.py
+msgid "Keep Window Buttons in Full Screen"
+msgstr ""
+
+#: jellyfin_mpv_shim/mpvtk_browser/config.py
+msgid "Hide the Desktop Title Bar"
+msgstr ""
+
+#: jellyfin_mpv_shim/mpvtk_browser/config.py
 msgid "Player Controls Style"
+msgstr ""
+
+#: jellyfin_mpv_shim/mpvtk_browser/config.py
+msgid "Enable Trickplay Thumbnails"
 msgstr ""
 
 #: jellyfin_mpv_shim/mpvtk_browser/config.py
@@ -1762,6 +1775,10 @@ msgstr ""
 
 #: jellyfin_mpv_shim/mpvtk_browser/config.py
 msgid "Full-Width Backdrops"
+msgstr ""
+
+#: jellyfin_mpv_shim/mpvtk_browser/config.py
+msgid "12-Hour Clock"
 msgstr ""
 
 #: jellyfin_mpv_shim/mpvtk_browser/config.py
@@ -1805,11 +1822,19 @@ msgid "Fullscreen Library Browser"
 msgstr ""
 
 #: jellyfin_mpv_shim/mpvtk_browser/config.py
+msgid "Block Player Keybinds While Browsing"
+msgstr ""
+
+#: jellyfin_mpv_shim/mpvtk_browser/config.py
 msgid "Always Bind Arrow Keys to Player Controls"
 msgstr ""
 
 #: jellyfin_mpv_shim/mpvtk_browser/config.py
 msgid "Player Controls Activation Key"
+msgstr ""
+
+#: jellyfin_mpv_shim/mpvtk_browser/config.py
+msgid "Select Key"
 msgstr ""
 
 #: jellyfin_mpv_shim/mpvtk_browser/config.py
@@ -1822,6 +1847,10 @@ msgstr ""
 
 #: jellyfin_mpv_shim/mpvtk_browser/config.py
 msgid "Hide the Player Controls After (seconds)"
+msgstr ""
+
+#: jellyfin_mpv_shim/mpvtk_browser/config.py
+msgid "Shrink the Player Controls on a Narrow Window"
 msgstr ""
 
 #: jellyfin_mpv_shim/mpvtk_browser/config.py
@@ -1904,6 +1933,21 @@ msgstr ""
 
 #: jellyfin_mpv_shim/mpvtk_browser/config.py
 msgid ""
+"Stops MPV's own shortcuts -- picture adjustment, screenshots, subtitle and "
+"audio switching -- from acting while you are in the library, where there is "
+"no video for them to act on. Turn it off to use your own MPV key bindings "
+"there."
+msgstr ""
+
+#: jellyfin_mpv_shim/mpvtk_browser/config.py
+msgid ""
+"Activates whatever is highlighted, in the library and on the player "
+"controls. An mpv key name; changing it hands Enter back to MPV. The game "
+"controller's Confirm button and a phone's Select follow it."
+msgstr ""
+
+#: jellyfin_mpv_shim/mpvtk_browser/config.py
+msgid ""
 "Leave these blank unless downloads are waking your disks too often. Set both "
 "of the first two together: episodes are then fetched in one batch when a "
 "series runs low, instead of one at a time."
@@ -1917,7 +1961,8 @@ msgstr ""
 #: jellyfin_mpv_shim/mpvtk_browser/config.py
 msgid ""
 "Off gives MPV's own mouse behaviour instead: drag the video to move the "
-"window, and right click to pause. Double click is full screen either way."
+"window, and the right button does whatever your MPV config gives it. Double "
+"click is full screen either way."
 msgstr ""
 
 #: jellyfin_mpv_shim/mpvtk_browser/config.py
@@ -2007,6 +2052,30 @@ msgid ""
 "maximize and close in the top bar instead, and lets you drag the window by "
 "it. On \"Only when the window has no title bar\", MPV is asked whether this "
 "window got one, so desktops that draw a title bar are left alone."
+msgstr ""
+
+#: jellyfin_mpv_shim/mpvtk_browser/config.py
+msgid ""
+"Full screen has no title bar anywhere and nothing to move or maximize, so "
+"the buttons are normally hidden there. Turn this on to keep a way out of "
+"full screen that is not a keyboard shortcut."
+msgstr ""
+
+#: jellyfin_mpv_shim/mpvtk_browser/config.py
+msgid ""
+"Asks the desktop for no title bar on the player window, so the top bar above "
+"is the only one. Pairs with the setting above: on \"Only when the window has "
+"no title bar\" the buttons appear as soon as this is on. Leave both off "
+"unless you want them, since a window with neither can be awkward to move on "
+"some desktops."
+msgstr ""
+
+#: jellyfin_mpv_shim/mpvtk_browser/config.py
+msgid ""
+"Shows a preview frame while you drag the seek bar. Works with every player "
+"control style, including your own OSC script if it supports thumbfast. The "
+"images are fetched from the server per video, which costs disk space and "
+"memory -- tens of MB for an episode, a few hundred for a long film."
 msgstr ""
 
 #: jellyfin_mpv_shim/mpvtk_browser/config.py
@@ -2114,6 +2183,13 @@ msgstr ""
 
 #: jellyfin_mpv_shim/mpvtk_browser/config.py
 msgid ""
+"Show times of day as \"8:30 PM\" rather than \"20:30\" — the Live TV guide "
+"and its air times, and the \"Ends at\" labels on a detail page and the "
+"player controls."
+msgstr ""
+
+#: jellyfin_mpv_shim/mpvtk_browser/config.py
+msgid ""
 "The controls have to stay legible over any frame. \"None\" gives the text a "
 "drop shadow instead of shading the picture behind it."
 msgstr ""
@@ -2128,6 +2204,13 @@ msgstr ""
 msgid ""
 "0 hides them as soon as the pointer is not on them, and forces \"Hide unless "
 "hovered\"."
+msgstr ""
+
+#: jellyfin_mpv_shim/mpvtk_browser/config.py
+msgid ""
+"Narrowing the window shrinks the controls until the smallest button reaches "
+"the accessibility minimum, instead of dropping buttons sooner. Off keeps the "
+"older, larger floor."
 msgstr ""
 
 #: jellyfin_mpv_shim/mpvtk_browser/config.py
@@ -3600,6 +3683,7 @@ msgid "More Like This"
 msgstr ""
 
 #: jellyfin_mpv_shim/mpvtk_browser/pages/detail.py
+#: jellyfin_mpv_shim/mpvtk_browser/tiles.py
 msgid "Go to Series"
 msgstr ""
 
@@ -4732,6 +4816,22 @@ msgstr "Server entfärne"
 msgid "There is nothing here to queue."
 msgstr ""
 
+#: jellyfin_mpv_shim/mpvtk_browser/timefmt.py
+#, python-brace-format
+msgctxt "12-hour clock"
+msgid "{time} {period}"
+msgstr ""
+
+#: jellyfin_mpv_shim/mpvtk_browser/timefmt.py
+msgctxt "12-hour clock"
+msgid "AM"
+msgstr ""
+
+#: jellyfin_mpv_shim/mpvtk_browser/timefmt.py
+msgctxt "12-hour clock"
+msgid "PM"
+msgstr ""
+
 # seeded from jellyfin-web: Search
 #: jellyfin_mpv_shim/mpvtk_browser/views.py
 #: jellyfin_mpv_shim/mpvtk_browser/window_chrome.py
@@ -4890,13 +4990,32 @@ msgid "Enable SVP"
 msgstr ""
 
 #: jellyfin_mpv_shim/sync/manager.py
+msgid "The downloads are already in that folder."
+msgstr ""
+
+#: jellyfin_mpv_shim/sync/manager.py
 msgid ""
 "Can't change the download folder while a download is in progress. Wait for "
 "it to finish, then try again."
 msgstr ""
 
 #: jellyfin_mpv_shim/sync/manager.py
+msgid ""
+"That folder is inside the current download folder. Choose one outside it."
+msgstr ""
+
+#: jellyfin_mpv_shim/sync/manager.py
+msgid "Can't read that folder. Check the path and its permissions."
+msgstr ""
+
+#: jellyfin_mpv_shim/sync/manager.py
 msgid "That folder already contains downloads. Choose an empty folder."
+msgstr ""
+
+#: jellyfin_mpv_shim/sync/manager.py
+msgid ""
+"That folder isn't empty. Choose an empty folder — the download folder is "
+"managed by this app and anything else in it can be moved or removed."
 msgstr ""
 
 #: jellyfin_mpv_shim/sync/manager.py
@@ -4905,6 +5024,12 @@ msgstr ""
 
 #: jellyfin_mpv_shim/sync/manager.py
 msgid "A download is still finishing. Wait for it to stop, then try again."
+msgstr ""
+
+#: jellyfin_mpv_shim/sync/manager.py
+msgid ""
+"There isn't enough space on that drive to move the downloads. Free some "
+"space and try again — nothing was moved."
 msgstr ""
 
 #: jellyfin_mpv_shim/sync/manager.py

--- a/jellyfin_mpv_shim/messages/he/LC_MESSAGES/base.po
+++ b/jellyfin_mpv_shim/messages/he/LC_MESSAGES/base.po
@@ -6,7 +6,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2026-08-30 22:19-0400\n"
+"POT-Creation-Date: 2026-09-07 17:35-0400\n"
 "PO-Revision-Date: 2026-08-18 18:37+0000\n"
 "Last-Translator: Jonathan Biton <jonathannbiton@gmail.com>\n"
 "Language-Team: Hebrew <https://translate.jellyfin.org/projects/jellyfin/"
@@ -535,6 +535,11 @@ msgid "Night Mode (Auto Volume Adj)"
 msgstr ""
 
 #: jellyfin_mpv_shim/mpvtk_browser/app.py
+#: jellyfin_mpv_shim/mpvtk_browser/auth.py
+msgid "Locked"
+msgstr ""
+
+#: jellyfin_mpv_shim/mpvtk_browser/app.py
 msgid "Failed to load. Check the connection."
 msgstr ""
 
@@ -795,10 +800,6 @@ msgid "Could not connect. Please check your details."
 msgstr "לא ניתן היה להתחבר. בדוק את הפרטים שלך."
 
 #: jellyfin_mpv_shim/mpvtk_browser/auth.py
-msgid "Locked"
-msgstr ""
-
-#: jellyfin_mpv_shim/mpvtk_browser/auth.py
 #: jellyfin_mpv_shim/mpvtk_browser/pages/home.py
 msgid "Connecting to your server…"
 msgstr ""
@@ -879,6 +880,10 @@ msgstr "צא וסמן כלא נצפה"
 #: jellyfin_mpv_shim/mpvtk_browser/pages/books.py
 msgid "Favorite"
 msgstr "מועדף"
+
+#: jellyfin_mpv_shim/mpvtk_browser/components/detail.py
+msgid "Web"
+msgstr ""
 
 # seeded from jellyfin-web: Video
 #: jellyfin_mpv_shim/mpvtk_browser/components/media_info.py
@@ -1490,11 +1495,7 @@ msgid "Jellyfin UI"
 msgstr ""
 
 #: jellyfin_mpv_shim/mpvtk_browser/config.py
-msgid "MPV UI with thumbnails"
-msgstr ""
-
-#: jellyfin_mpv_shim/mpvtk_browser/config.py
-msgid "MPV built-in default"
+msgid "MPV UI"
 msgstr ""
 
 #: jellyfin_mpv_shim/mpvtk_browser/config.py
@@ -1843,8 +1844,22 @@ msgid "Window Buttons in the Top Bar"
 msgstr ""
 
 #: jellyfin_mpv_shim/mpvtk_browser/config.py
+msgid "Keep Window Buttons in Full Screen"
+msgstr ""
+
+#: jellyfin_mpv_shim/mpvtk_browser/config.py
+msgid "Hide the Desktop Title Bar"
+msgstr ""
+
+#: jellyfin_mpv_shim/mpvtk_browser/config.py
 msgid "Player Controls Style"
 msgstr ""
+
+#: jellyfin_mpv_shim/mpvtk_browser/config.py
+#, fuzzy
+#| msgid "Enable thumbnail previews"
+msgid "Enable Trickplay Thumbnails"
+msgstr "הפעל תצוגה מקדימה של תמונות קטנות"
 
 #: jellyfin_mpv_shim/mpvtk_browser/config.py
 msgid "Load All Seek Previews at Once"
@@ -1874,6 +1889,10 @@ msgstr ""
 
 #: jellyfin_mpv_shim/mpvtk_browser/config.py
 msgid "Full-Width Backdrops"
+msgstr ""
+
+#: jellyfin_mpv_shim/mpvtk_browser/config.py
+msgid "12-Hour Clock"
 msgstr ""
 
 #: jellyfin_mpv_shim/mpvtk_browser/config.py
@@ -1919,12 +1938,23 @@ msgid "Fullscreen Library Browser"
 msgstr ""
 
 #: jellyfin_mpv_shim/mpvtk_browser/config.py
+msgid "Block Player Keybinds While Browsing"
+msgstr ""
+
+#: jellyfin_mpv_shim/mpvtk_browser/config.py
 msgid "Always Bind Arrow Keys to Player Controls"
 msgstr ""
 
 #: jellyfin_mpv_shim/mpvtk_browser/config.py
 msgid "Player Controls Activation Key"
 msgstr ""
+
+# seeded from jellyfin-web: SelectAll
+#: jellyfin_mpv_shim/mpvtk_browser/config.py
+#, fuzzy
+#| msgid "Select All"
+msgid "Select Key"
+msgstr "בחירת הכל"
 
 #: jellyfin_mpv_shim/mpvtk_browser/config.py
 msgid "Shading Behind the Player Controls"
@@ -1936,6 +1966,10 @@ msgstr ""
 
 #: jellyfin_mpv_shim/mpvtk_browser/config.py
 msgid "Hide the Player Controls After (seconds)"
+msgstr ""
+
+#: jellyfin_mpv_shim/mpvtk_browser/config.py
+msgid "Shrink the Player Controls on a Narrow Window"
 msgstr ""
 
 #: jellyfin_mpv_shim/mpvtk_browser/config.py
@@ -2022,6 +2056,21 @@ msgstr ""
 
 #: jellyfin_mpv_shim/mpvtk_browser/config.py
 msgid ""
+"Stops MPV's own shortcuts -- picture adjustment, screenshots, subtitle and "
+"audio switching -- from acting while you are in the library, where there is "
+"no video for them to act on. Turn it off to use your own MPV key bindings "
+"there."
+msgstr ""
+
+#: jellyfin_mpv_shim/mpvtk_browser/config.py
+msgid ""
+"Activates whatever is highlighted, in the library and on the player "
+"controls. An mpv key name; changing it hands Enter back to MPV. The game "
+"controller's Confirm button and a phone's Select follow it."
+msgstr ""
+
+#: jellyfin_mpv_shim/mpvtk_browser/config.py
+msgid ""
 "Leave these blank unless downloads are waking your disks too often. Set both "
 "of the first two together: episodes are then fetched in one batch when a "
 "series runs low, instead of one at a time."
@@ -2035,7 +2084,8 @@ msgstr ""
 #: jellyfin_mpv_shim/mpvtk_browser/config.py
 msgid ""
 "Off gives MPV's own mouse behaviour instead: drag the video to move the "
-"window, and right click to pause. Double click is full screen either way."
+"window, and the right button does whatever your MPV config gives it. Double "
+"click is full screen either way."
 msgstr ""
 
 #: jellyfin_mpv_shim/mpvtk_browser/config.py
@@ -2125,6 +2175,30 @@ msgid ""
 "maximize and close in the top bar instead, and lets you drag the window by "
 "it. On \"Only when the window has no title bar\", MPV is asked whether this "
 "window got one, so desktops that draw a title bar are left alone."
+msgstr ""
+
+#: jellyfin_mpv_shim/mpvtk_browser/config.py
+msgid ""
+"Full screen has no title bar anywhere and nothing to move or maximize, so "
+"the buttons are normally hidden there. Turn this on to keep a way out of "
+"full screen that is not a keyboard shortcut."
+msgstr ""
+
+#: jellyfin_mpv_shim/mpvtk_browser/config.py
+msgid ""
+"Asks the desktop for no title bar on the player window, so the top bar above "
+"is the only one. Pairs with the setting above: on \"Only when the window has "
+"no title bar\" the buttons appear as soon as this is on. Leave both off "
+"unless you want them, since a window with neither can be awkward to move on "
+"some desktops."
+msgstr ""
+
+#: jellyfin_mpv_shim/mpvtk_browser/config.py
+msgid ""
+"Shows a preview frame while you drag the seek bar. Works with every player "
+"control style, including your own OSC script if it supports thumbfast. The "
+"images are fetched from the server per video, which costs disk space and "
+"memory -- tens of MB for an episode, a few hundred for a long film."
 msgstr ""
 
 #: jellyfin_mpv_shim/mpvtk_browser/config.py
@@ -2234,6 +2308,13 @@ msgstr ""
 
 #: jellyfin_mpv_shim/mpvtk_browser/config.py
 msgid ""
+"Show times of day as \"8:30 PM\" rather than \"20:30\" — the Live TV guide "
+"and its air times, and the \"Ends at\" labels on a detail page and the "
+"player controls."
+msgstr ""
+
+#: jellyfin_mpv_shim/mpvtk_browser/config.py
+msgid ""
 "The controls have to stay legible over any frame. \"None\" gives the text a "
 "drop shadow instead of shading the picture behind it."
 msgstr ""
@@ -2248,6 +2329,13 @@ msgstr ""
 msgid ""
 "0 hides them as soon as the pointer is not on them, and forces \"Hide unless "
 "hovered\"."
+msgstr ""
+
+#: jellyfin_mpv_shim/mpvtk_browser/config.py
+msgid ""
+"Narrowing the window shrinks the controls until the smallest button reaches "
+"the accessibility minimum, instead of dropping buttons sooner. Off keeps the "
+"older, larger floor."
 msgstr ""
 
 #: jellyfin_mpv_shim/mpvtk_browser/config.py
@@ -3803,6 +3891,7 @@ msgid "More Like This"
 msgstr "עוד כמו זה"
 
 #: jellyfin_mpv_shim/mpvtk_browser/pages/detail.py
+#: jellyfin_mpv_shim/mpvtk_browser/tiles.py
 msgid "Go to Series"
 msgstr ""
 
@@ -4940,6 +5029,22 @@ msgstr "הסר את %s מאוסף זה?"
 msgid "There is nothing here to queue."
 msgstr ""
 
+#: jellyfin_mpv_shim/mpvtk_browser/timefmt.py
+#, python-brace-format
+msgctxt "12-hour clock"
+msgid "{time} {period}"
+msgstr ""
+
+#: jellyfin_mpv_shim/mpvtk_browser/timefmt.py
+msgctxt "12-hour clock"
+msgid "AM"
+msgstr ""
+
+#: jellyfin_mpv_shim/mpvtk_browser/timefmt.py
+msgctxt "12-hour clock"
+msgid "PM"
+msgstr ""
+
 # seeded from jellyfin-web: Search
 #: jellyfin_mpv_shim/mpvtk_browser/views.py
 #: jellyfin_mpv_shim/mpvtk_browser/window_chrome.py
@@ -5105,13 +5210,32 @@ msgid "Enable SVP"
 msgstr "הפעל SVP"
 
 #: jellyfin_mpv_shim/sync/manager.py
+msgid "The downloads are already in that folder."
+msgstr ""
+
+#: jellyfin_mpv_shim/sync/manager.py
 msgid ""
 "Can't change the download folder while a download is in progress. Wait for "
 "it to finish, then try again."
 msgstr ""
 
 #: jellyfin_mpv_shim/sync/manager.py
+msgid ""
+"That folder is inside the current download folder. Choose one outside it."
+msgstr ""
+
+#: jellyfin_mpv_shim/sync/manager.py
+msgid "Can't read that folder. Check the path and its permissions."
+msgstr ""
+
+#: jellyfin_mpv_shim/sync/manager.py
 msgid "That folder already contains downloads. Choose an empty folder."
+msgstr ""
+
+#: jellyfin_mpv_shim/sync/manager.py
+msgid ""
+"That folder isn't empty. Choose an empty folder — the download folder is "
+"managed by this app and anything else in it can be moved or removed."
 msgstr ""
 
 #: jellyfin_mpv_shim/sync/manager.py
@@ -5120,6 +5244,12 @@ msgstr ""
 
 #: jellyfin_mpv_shim/sync/manager.py
 msgid "A download is still finishing. Wait for it to stop, then try again."
+msgstr ""
+
+#: jellyfin_mpv_shim/sync/manager.py
+msgid ""
+"There isn't enough space on that drive to move the downloads. Free some "
+"space and try again — nothing was moved."
 msgstr ""
 
 #: jellyfin_mpv_shim/sync/manager.py

--- a/jellyfin_mpv_shim/messages/hi/LC_MESSAGES/base.po
+++ b/jellyfin_mpv_shim/messages/hi/LC_MESSAGES/base.po
@@ -6,7 +6,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2026-08-30 22:19-0400\n"
+"POT-Creation-Date: 2026-09-07 17:35-0400\n"
 "PO-Revision-Date: 2026-05-21 07:45+0000\n"
 "Last-Translator: Dart og <onice757@gmail.com>\n"
 "Language-Team: Hindi <https://translate.jellyfin.org/projects/jellyfin/"
@@ -518,6 +518,11 @@ msgid "Night Mode (Auto Volume Adj)"
 msgstr ""
 
 #: jellyfin_mpv_shim/mpvtk_browser/app.py
+#: jellyfin_mpv_shim/mpvtk_browser/auth.py
+msgid "Locked"
+msgstr ""
+
+#: jellyfin_mpv_shim/mpvtk_browser/app.py
 msgid "Failed to load. Check the connection."
 msgstr ""
 
@@ -789,10 +794,6 @@ msgstr ""
 "कृपया अपनी कनेक्शन जानकारी जांचें।"
 
 #: jellyfin_mpv_shim/mpvtk_browser/auth.py
-msgid "Locked"
-msgstr ""
-
-#: jellyfin_mpv_shim/mpvtk_browser/auth.py
 #: jellyfin_mpv_shim/mpvtk_browser/pages/home.py
 msgid "Connecting to your server…"
 msgstr ""
@@ -868,6 +869,10 @@ msgstr "छोड़ें और अनदेखा चिह्नित क�
 #: jellyfin_mpv_shim/mpvtk_browser/hud.py
 #: jellyfin_mpv_shim/mpvtk_browser/pages/books.py
 msgid "Favorite"
+msgstr ""
+
+#: jellyfin_mpv_shim/mpvtk_browser/components/detail.py
+msgid "Web"
 msgstr ""
 
 #: jellyfin_mpv_shim/mpvtk_browser/components/media_info.py
@@ -1391,11 +1396,7 @@ msgid "Jellyfin UI"
 msgstr ""
 
 #: jellyfin_mpv_shim/mpvtk_browser/config.py
-msgid "MPV UI with thumbnails"
-msgstr ""
-
-#: jellyfin_mpv_shim/mpvtk_browser/config.py
-msgid "MPV built-in default"
+msgid "MPV UI"
 msgstr ""
 
 #: jellyfin_mpv_shim/mpvtk_browser/config.py
@@ -1736,7 +1737,19 @@ msgid "Window Buttons in the Top Bar"
 msgstr ""
 
 #: jellyfin_mpv_shim/mpvtk_browser/config.py
+msgid "Keep Window Buttons in Full Screen"
+msgstr ""
+
+#: jellyfin_mpv_shim/mpvtk_browser/config.py
+msgid "Hide the Desktop Title Bar"
+msgstr ""
+
+#: jellyfin_mpv_shim/mpvtk_browser/config.py
 msgid "Player Controls Style"
+msgstr ""
+
+#: jellyfin_mpv_shim/mpvtk_browser/config.py
+msgid "Enable Trickplay Thumbnails"
 msgstr ""
 
 #: jellyfin_mpv_shim/mpvtk_browser/config.py
@@ -1766,6 +1779,10 @@ msgstr ""
 
 #: jellyfin_mpv_shim/mpvtk_browser/config.py
 msgid "Full-Width Backdrops"
+msgstr ""
+
+#: jellyfin_mpv_shim/mpvtk_browser/config.py
+msgid "12-Hour Clock"
 msgstr ""
 
 #: jellyfin_mpv_shim/mpvtk_browser/config.py
@@ -1809,11 +1826,19 @@ msgid "Fullscreen Library Browser"
 msgstr ""
 
 #: jellyfin_mpv_shim/mpvtk_browser/config.py
+msgid "Block Player Keybinds While Browsing"
+msgstr ""
+
+#: jellyfin_mpv_shim/mpvtk_browser/config.py
 msgid "Always Bind Arrow Keys to Player Controls"
 msgstr ""
 
 #: jellyfin_mpv_shim/mpvtk_browser/config.py
 msgid "Player Controls Activation Key"
+msgstr ""
+
+#: jellyfin_mpv_shim/mpvtk_browser/config.py
+msgid "Select Key"
 msgstr ""
 
 #: jellyfin_mpv_shim/mpvtk_browser/config.py
@@ -1826,6 +1851,10 @@ msgstr ""
 
 #: jellyfin_mpv_shim/mpvtk_browser/config.py
 msgid "Hide the Player Controls After (seconds)"
+msgstr ""
+
+#: jellyfin_mpv_shim/mpvtk_browser/config.py
+msgid "Shrink the Player Controls on a Narrow Window"
 msgstr ""
 
 #: jellyfin_mpv_shim/mpvtk_browser/config.py
@@ -1910,6 +1939,21 @@ msgstr ""
 
 #: jellyfin_mpv_shim/mpvtk_browser/config.py
 msgid ""
+"Stops MPV's own shortcuts -- picture adjustment, screenshots, subtitle and "
+"audio switching -- from acting while you are in the library, where there is "
+"no video for them to act on. Turn it off to use your own MPV key bindings "
+"there."
+msgstr ""
+
+#: jellyfin_mpv_shim/mpvtk_browser/config.py
+msgid ""
+"Activates whatever is highlighted, in the library and on the player "
+"controls. An mpv key name; changing it hands Enter back to MPV. The game "
+"controller's Confirm button and a phone's Select follow it."
+msgstr ""
+
+#: jellyfin_mpv_shim/mpvtk_browser/config.py
+msgid ""
 "Leave these blank unless downloads are waking your disks too often. Set both "
 "of the first two together: episodes are then fetched in one batch when a "
 "series runs low, instead of one at a time."
@@ -1923,7 +1967,8 @@ msgstr ""
 #: jellyfin_mpv_shim/mpvtk_browser/config.py
 msgid ""
 "Off gives MPV's own mouse behaviour instead: drag the video to move the "
-"window, and right click to pause. Double click is full screen either way."
+"window, and the right button does whatever your MPV config gives it. Double "
+"click is full screen either way."
 msgstr ""
 
 #: jellyfin_mpv_shim/mpvtk_browser/config.py
@@ -2013,6 +2058,30 @@ msgid ""
 "maximize and close in the top bar instead, and lets you drag the window by "
 "it. On \"Only when the window has no title bar\", MPV is asked whether this "
 "window got one, so desktops that draw a title bar are left alone."
+msgstr ""
+
+#: jellyfin_mpv_shim/mpvtk_browser/config.py
+msgid ""
+"Full screen has no title bar anywhere and nothing to move or maximize, so "
+"the buttons are normally hidden there. Turn this on to keep a way out of "
+"full screen that is not a keyboard shortcut."
+msgstr ""
+
+#: jellyfin_mpv_shim/mpvtk_browser/config.py
+msgid ""
+"Asks the desktop for no title bar on the player window, so the top bar above "
+"is the only one. Pairs with the setting above: on \"Only when the window has "
+"no title bar\" the buttons appear as soon as this is on. Leave both off "
+"unless you want them, since a window with neither can be awkward to move on "
+"some desktops."
+msgstr ""
+
+#: jellyfin_mpv_shim/mpvtk_browser/config.py
+msgid ""
+"Shows a preview frame while you drag the seek bar. Works with every player "
+"control style, including your own OSC script if it supports thumbfast. The "
+"images are fetched from the server per video, which costs disk space and "
+"memory -- tens of MB for an episode, a few hundred for a long film."
 msgstr ""
 
 #: jellyfin_mpv_shim/mpvtk_browser/config.py
@@ -2120,6 +2189,13 @@ msgstr ""
 
 #: jellyfin_mpv_shim/mpvtk_browser/config.py
 msgid ""
+"Show times of day as \"8:30 PM\" rather than \"20:30\" — the Live TV guide "
+"and its air times, and the \"Ends at\" labels on a detail page and the "
+"player controls."
+msgstr ""
+
+#: jellyfin_mpv_shim/mpvtk_browser/config.py
+msgid ""
 "The controls have to stay legible over any frame. \"None\" gives the text a "
 "drop shadow instead of shading the picture behind it."
 msgstr ""
@@ -2134,6 +2210,13 @@ msgstr ""
 msgid ""
 "0 hides them as soon as the pointer is not on them, and forces \"Hide unless "
 "hovered\"."
+msgstr ""
+
+#: jellyfin_mpv_shim/mpvtk_browser/config.py
+msgid ""
+"Narrowing the window shrinks the controls until the smallest button reaches "
+"the accessibility minimum, instead of dropping buttons sooner. Off keeps the "
+"older, larger floor."
 msgstr ""
 
 #: jellyfin_mpv_shim/mpvtk_browser/config.py
@@ -3597,6 +3680,7 @@ msgid "More Like This"
 msgstr ""
 
 #: jellyfin_mpv_shim/mpvtk_browser/pages/detail.py
+#: jellyfin_mpv_shim/mpvtk_browser/tiles.py
 msgid "Go to Series"
 msgstr ""
 
@@ -4722,6 +4806,22 @@ msgstr "सर्वर हटाएं"
 msgid "There is nothing here to queue."
 msgstr ""
 
+#: jellyfin_mpv_shim/mpvtk_browser/timefmt.py
+#, python-brace-format
+msgctxt "12-hour clock"
+msgid "{time} {period}"
+msgstr ""
+
+#: jellyfin_mpv_shim/mpvtk_browser/timefmt.py
+msgctxt "12-hour clock"
+msgid "AM"
+msgstr ""
+
+#: jellyfin_mpv_shim/mpvtk_browser/timefmt.py
+msgctxt "12-hour clock"
+msgid "PM"
+msgstr ""
+
 #: jellyfin_mpv_shim/mpvtk_browser/views.py
 #: jellyfin_mpv_shim/mpvtk_browser/window_chrome.py
 msgid "Search"
@@ -4880,13 +4980,32 @@ msgid "Enable SVP"
 msgstr ""
 
 #: jellyfin_mpv_shim/sync/manager.py
+msgid "The downloads are already in that folder."
+msgstr ""
+
+#: jellyfin_mpv_shim/sync/manager.py
 msgid ""
 "Can't change the download folder while a download is in progress. Wait for "
 "it to finish, then try again."
 msgstr ""
 
 #: jellyfin_mpv_shim/sync/manager.py
+msgid ""
+"That folder is inside the current download folder. Choose one outside it."
+msgstr ""
+
+#: jellyfin_mpv_shim/sync/manager.py
+msgid "Can't read that folder. Check the path and its permissions."
+msgstr ""
+
+#: jellyfin_mpv_shim/sync/manager.py
 msgid "That folder already contains downloads. Choose an empty folder."
+msgstr ""
+
+#: jellyfin_mpv_shim/sync/manager.py
+msgid ""
+"That folder isn't empty. Choose an empty folder — the download folder is "
+"managed by this app and anything else in it can be moved or removed."
 msgstr ""
 
 #: jellyfin_mpv_shim/sync/manager.py
@@ -4895,6 +5014,12 @@ msgstr ""
 
 #: jellyfin_mpv_shim/sync/manager.py
 msgid "A download is still finishing. Wait for it to stop, then try again."
+msgstr ""
+
+#: jellyfin_mpv_shim/sync/manager.py
+msgid ""
+"There isn't enough space on that drive to move the downloads. Free some "
+"space and try again — nothing was moved."
 msgstr ""
 
 #: jellyfin_mpv_shim/sync/manager.py

--- a/jellyfin_mpv_shim/messages/hr/LC_MESSAGES/base.po
+++ b/jellyfin_mpv_shim/messages/hr/LC_MESSAGES/base.po
@@ -6,7 +6,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2026-08-30 22:19-0400\n"
+"POT-Creation-Date: 2026-09-07 17:35-0400\n"
 "PO-Revision-Date: 2026-04-15 13:45+0000\n"
 "Last-Translator: Milo Ivir <mail@milotype.de>\n"
 "Language-Team: Croatian <https://translate.jellyfin.org/projects/jellyfin/"
@@ -549,6 +549,11 @@ msgid "Night Mode (Auto Volume Adj)"
 msgstr ""
 
 #: jellyfin_mpv_shim/mpvtk_browser/app.py
+#: jellyfin_mpv_shim/mpvtk_browser/auth.py
+msgid "Locked"
+msgstr ""
+
+#: jellyfin_mpv_shim/mpvtk_browser/app.py
 msgid "Failed to load. Check the connection."
 msgstr ""
 
@@ -828,10 +833,6 @@ msgstr ""
 "Molimo provjerite postavke veze."
 
 #: jellyfin_mpv_shim/mpvtk_browser/auth.py
-msgid "Locked"
-msgstr ""
-
-#: jellyfin_mpv_shim/mpvtk_browser/auth.py
 #: jellyfin_mpv_shim/mpvtk_browser/pages/home.py
 msgid "Connecting to your server…"
 msgstr ""
@@ -914,6 +915,10 @@ msgstr "Izađi i označi kao nepogledano"
 #: jellyfin_mpv_shim/mpvtk_browser/pages/books.py
 msgid "Favorite"
 msgstr "Omiljeni"
+
+#: jellyfin_mpv_shim/mpvtk_browser/components/detail.py
+msgid "Web"
+msgstr ""
 
 # seeded from jellyfin-web: Video
 #: jellyfin_mpv_shim/mpvtk_browser/components/media_info.py
@@ -1531,11 +1536,7 @@ msgid "Jellyfin UI"
 msgstr ""
 
 #: jellyfin_mpv_shim/mpvtk_browser/config.py
-msgid "MPV UI with thumbnails"
-msgstr ""
-
-#: jellyfin_mpv_shim/mpvtk_browser/config.py
-msgid "MPV built-in default"
+msgid "MPV UI"
 msgstr ""
 
 #: jellyfin_mpv_shim/mpvtk_browser/config.py
@@ -1884,8 +1885,22 @@ msgid "Window Buttons in the Top Bar"
 msgstr ""
 
 #: jellyfin_mpv_shim/mpvtk_browser/config.py
+msgid "Keep Window Buttons in Full Screen"
+msgstr ""
+
+#: jellyfin_mpv_shim/mpvtk_browser/config.py
+msgid "Hide the Desktop Title Bar"
+msgstr ""
+
+#: jellyfin_mpv_shim/mpvtk_browser/config.py
 msgid "Player Controls Style"
 msgstr ""
+
+#: jellyfin_mpv_shim/mpvtk_browser/config.py
+#, fuzzy
+#| msgid "Enable thumbnail previews"
+msgid "Enable Trickplay Thumbnails"
+msgstr "Omogući pregled sličica"
 
 #: jellyfin_mpv_shim/mpvtk_browser/config.py
 msgid "Load All Seek Previews at Once"
@@ -1915,6 +1930,10 @@ msgstr ""
 
 #: jellyfin_mpv_shim/mpvtk_browser/config.py
 msgid "Full-Width Backdrops"
+msgstr ""
+
+#: jellyfin_mpv_shim/mpvtk_browser/config.py
+msgid "12-Hour Clock"
 msgstr ""
 
 #: jellyfin_mpv_shim/mpvtk_browser/config.py
@@ -1960,12 +1979,23 @@ msgid "Fullscreen Library Browser"
 msgstr ""
 
 #: jellyfin_mpv_shim/mpvtk_browser/config.py
+msgid "Block Player Keybinds While Browsing"
+msgstr ""
+
+#: jellyfin_mpv_shim/mpvtk_browser/config.py
 msgid "Always Bind Arrow Keys to Player Controls"
 msgstr ""
 
 #: jellyfin_mpv_shim/mpvtk_browser/config.py
 msgid "Player Controls Activation Key"
 msgstr ""
+
+# seeded from jellyfin-web: SelectAll
+#: jellyfin_mpv_shim/mpvtk_browser/config.py
+#, fuzzy
+#| msgid "Select All"
+msgid "Select Key"
+msgstr "Odaberi sve"
 
 #: jellyfin_mpv_shim/mpvtk_browser/config.py
 msgid "Shading Behind the Player Controls"
@@ -1977,6 +2007,10 @@ msgstr ""
 
 #: jellyfin_mpv_shim/mpvtk_browser/config.py
 msgid "Hide the Player Controls After (seconds)"
+msgstr ""
+
+#: jellyfin_mpv_shim/mpvtk_browser/config.py
+msgid "Shrink the Player Controls on a Narrow Window"
 msgstr ""
 
 #: jellyfin_mpv_shim/mpvtk_browser/config.py
@@ -2063,6 +2097,21 @@ msgstr ""
 
 #: jellyfin_mpv_shim/mpvtk_browser/config.py
 msgid ""
+"Stops MPV's own shortcuts -- picture adjustment, screenshots, subtitle and "
+"audio switching -- from acting while you are in the library, where there is "
+"no video for them to act on. Turn it off to use your own MPV key bindings "
+"there."
+msgstr ""
+
+#: jellyfin_mpv_shim/mpvtk_browser/config.py
+msgid ""
+"Activates whatever is highlighted, in the library and on the player "
+"controls. An mpv key name; changing it hands Enter back to MPV. The game "
+"controller's Confirm button and a phone's Select follow it."
+msgstr ""
+
+#: jellyfin_mpv_shim/mpvtk_browser/config.py
+msgid ""
 "Leave these blank unless downloads are waking your disks too often. Set both "
 "of the first two together: episodes are then fetched in one batch when a "
 "series runs low, instead of one at a time."
@@ -2076,7 +2125,8 @@ msgstr ""
 #: jellyfin_mpv_shim/mpvtk_browser/config.py
 msgid ""
 "Off gives MPV's own mouse behaviour instead: drag the video to move the "
-"window, and right click to pause. Double click is full screen either way."
+"window, and the right button does whatever your MPV config gives it. Double "
+"click is full screen either way."
 msgstr ""
 
 #: jellyfin_mpv_shim/mpvtk_browser/config.py
@@ -2166,6 +2216,30 @@ msgid ""
 "maximize and close in the top bar instead, and lets you drag the window by "
 "it. On \"Only when the window has no title bar\", MPV is asked whether this "
 "window got one, so desktops that draw a title bar are left alone."
+msgstr ""
+
+#: jellyfin_mpv_shim/mpvtk_browser/config.py
+msgid ""
+"Full screen has no title bar anywhere and nothing to move or maximize, so "
+"the buttons are normally hidden there. Turn this on to keep a way out of "
+"full screen that is not a keyboard shortcut."
+msgstr ""
+
+#: jellyfin_mpv_shim/mpvtk_browser/config.py
+msgid ""
+"Asks the desktop for no title bar on the player window, so the top bar above "
+"is the only one. Pairs with the setting above: on \"Only when the window has "
+"no title bar\" the buttons appear as soon as this is on. Leave both off "
+"unless you want them, since a window with neither can be awkward to move on "
+"some desktops."
+msgstr ""
+
+#: jellyfin_mpv_shim/mpvtk_browser/config.py
+msgid ""
+"Shows a preview frame while you drag the seek bar. Works with every player "
+"control style, including your own OSC script if it supports thumbfast. The "
+"images are fetched from the server per video, which costs disk space and "
+"memory -- tens of MB for an episode, a few hundred for a long film."
 msgstr ""
 
 #: jellyfin_mpv_shim/mpvtk_browser/config.py
@@ -2275,6 +2349,13 @@ msgstr ""
 
 #: jellyfin_mpv_shim/mpvtk_browser/config.py
 msgid ""
+"Show times of day as \"8:30 PM\" rather than \"20:30\" — the Live TV guide "
+"and its air times, and the \"Ends at\" labels on a detail page and the "
+"player controls."
+msgstr ""
+
+#: jellyfin_mpv_shim/mpvtk_browser/config.py
+msgid ""
 "The controls have to stay legible over any frame. \"None\" gives the text a "
 "drop shadow instead of shading the picture behind it."
 msgstr ""
@@ -2289,6 +2370,13 @@ msgstr ""
 msgid ""
 "0 hides them as soon as the pointer is not on them, and forces \"Hide unless "
 "hovered\"."
+msgstr ""
+
+#: jellyfin_mpv_shim/mpvtk_browser/config.py
+msgid ""
+"Narrowing the window shrinks the controls until the smallest button reaches "
+"the accessibility minimum, instead of dropping buttons sooner. Off keeps the "
+"older, larger floor."
 msgstr ""
 
 #: jellyfin_mpv_shim/mpvtk_browser/config.py
@@ -3895,6 +3983,7 @@ msgid "More Like This"
 msgstr "Više ovakvih"
 
 #: jellyfin_mpv_shim/mpvtk_browser/pages/detail.py
+#: jellyfin_mpv_shim/mpvtk_browser/tiles.py
 msgid "Go to Series"
 msgstr ""
 
@@ -5088,6 +5177,22 @@ msgstr "Ukloni server"
 msgid "There is nothing here to queue."
 msgstr ""
 
+#: jellyfin_mpv_shim/mpvtk_browser/timefmt.py
+#, python-brace-format
+msgctxt "12-hour clock"
+msgid "{time} {period}"
+msgstr ""
+
+#: jellyfin_mpv_shim/mpvtk_browser/timefmt.py
+msgctxt "12-hour clock"
+msgid "AM"
+msgstr ""
+
+#: jellyfin_mpv_shim/mpvtk_browser/timefmt.py
+msgctxt "12-hour clock"
+msgid "PM"
+msgstr ""
+
 # seeded from jellyfin-web: Search
 #: jellyfin_mpv_shim/mpvtk_browser/views.py
 #: jellyfin_mpv_shim/mpvtk_browser/window_chrome.py
@@ -5256,13 +5361,32 @@ msgid "Enable SVP"
 msgstr "Omogući SVP"
 
 #: jellyfin_mpv_shim/sync/manager.py
+msgid "The downloads are already in that folder."
+msgstr ""
+
+#: jellyfin_mpv_shim/sync/manager.py
 msgid ""
 "Can't change the download folder while a download is in progress. Wait for "
 "it to finish, then try again."
 msgstr ""
 
 #: jellyfin_mpv_shim/sync/manager.py
+msgid ""
+"That folder is inside the current download folder. Choose one outside it."
+msgstr ""
+
+#: jellyfin_mpv_shim/sync/manager.py
+msgid "Can't read that folder. Check the path and its permissions."
+msgstr ""
+
+#: jellyfin_mpv_shim/sync/manager.py
 msgid "That folder already contains downloads. Choose an empty folder."
+msgstr ""
+
+#: jellyfin_mpv_shim/sync/manager.py
+msgid ""
+"That folder isn't empty. Choose an empty folder — the download folder is "
+"managed by this app and anything else in it can be moved or removed."
 msgstr ""
 
 #: jellyfin_mpv_shim/sync/manager.py
@@ -5271,6 +5395,12 @@ msgstr ""
 
 #: jellyfin_mpv_shim/sync/manager.py
 msgid "A download is still finishing. Wait for it to stop, then try again."
+msgstr ""
+
+#: jellyfin_mpv_shim/sync/manager.py
+msgid ""
+"There isn't enough space on that drive to move the downloads. Free some "
+"space and try again — nothing was moved."
 msgstr ""
 
 #: jellyfin_mpv_shim/sync/manager.py

--- a/jellyfin_mpv_shim/messages/hu/LC_MESSAGES/base.po
+++ b/jellyfin_mpv_shim/messages/hu/LC_MESSAGES/base.po
@@ -6,7 +6,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2026-08-30 22:19-0400\n"
+"POT-Creation-Date: 2026-09-07 17:35-0400\n"
 "PO-Revision-Date: 2026-08-17 17:57+0000\n"
 "Last-Translator: Szilki077 <szilkimappa@gmail.com>\n"
 "Language-Team: Hungarian <https://translate.jellyfin.org/projects/jellyfin/"
@@ -547,6 +547,11 @@ msgid "Night Mode (Auto Volume Adj)"
 msgstr "Éjszakai mód (automata hangerő állítás)"
 
 #: jellyfin_mpv_shim/mpvtk_browser/app.py
+#: jellyfin_mpv_shim/mpvtk_browser/auth.py
+msgid "Locked"
+msgstr "Zárolva"
+
+#: jellyfin_mpv_shim/mpvtk_browser/app.py
 msgid "Failed to load. Check the connection."
 msgstr "A betöltés sikertelen. Ellenőrizd a kapcsolatot."
 
@@ -826,10 +831,6 @@ msgstr ""
 "Ellenőrizze a kapcsolódási információkat."
 
 #: jellyfin_mpv_shim/mpvtk_browser/auth.py
-msgid "Locked"
-msgstr "Zárolva"
-
-#: jellyfin_mpv_shim/mpvtk_browser/auth.py
 #: jellyfin_mpv_shim/mpvtk_browser/pages/home.py
 msgid "Connecting to your server…"
 msgstr "Csatlakozás a szerveredre…"
@@ -910,6 +911,10 @@ msgstr "Kilépés és nem nézettnek jelölés"
 #: jellyfin_mpv_shim/mpvtk_browser/pages/books.py
 msgid "Favorite"
 msgstr "Kedvenc"
+
+#: jellyfin_mpv_shim/mpvtk_browser/components/detail.py
+msgid "Web"
+msgstr ""
 
 # seeded from jellyfin-web: HeaderVideos
 #: jellyfin_mpv_shim/mpvtk_browser/components/media_info.py
@@ -1528,12 +1533,8 @@ msgid "Jellyfin UI"
 msgstr "Jellyfin felület"
 
 #: jellyfin_mpv_shim/mpvtk_browser/config.py
-msgid "MPV UI with thumbnails"
-msgstr "MPV felület bélyegképekkel"
-
-#: jellyfin_mpv_shim/mpvtk_browser/config.py
-msgid "MPV built-in default"
-msgstr "Beépített alapértelmezett MPV"
+msgid "MPV UI"
+msgstr ""
 
 #: jellyfin_mpv_shim/mpvtk_browser/config.py
 msgid "Custom OSC"
@@ -1881,8 +1882,22 @@ msgid "Window Buttons in the Top Bar"
 msgstr ""
 
 #: jellyfin_mpv_shim/mpvtk_browser/config.py
+msgid "Keep Window Buttons in Full Screen"
+msgstr ""
+
+#: jellyfin_mpv_shim/mpvtk_browser/config.py
+msgid "Hide the Desktop Title Bar"
+msgstr ""
+
+#: jellyfin_mpv_shim/mpvtk_browser/config.py
 msgid "Player Controls Style"
 msgstr ""
+
+#: jellyfin_mpv_shim/mpvtk_browser/config.py
+#, fuzzy
+#| msgid "Enable thumbnail previews"
+msgid "Enable Trickplay Thumbnails"
+msgstr "Bélyegképek-előnézetek engedélyezése"
 
 #: jellyfin_mpv_shim/mpvtk_browser/config.py
 msgid "Load All Seek Previews at Once"
@@ -1913,6 +1928,10 @@ msgstr ""
 
 #: jellyfin_mpv_shim/mpvtk_browser/config.py
 msgid "Full-Width Backdrops"
+msgstr ""
+
+#: jellyfin_mpv_shim/mpvtk_browser/config.py
+msgid "12-Hour Clock"
 msgstr ""
 
 #: jellyfin_mpv_shim/mpvtk_browser/config.py
@@ -1958,12 +1977,23 @@ msgid "Fullscreen Library Browser"
 msgstr ""
 
 #: jellyfin_mpv_shim/mpvtk_browser/config.py
+msgid "Block Player Keybinds While Browsing"
+msgstr ""
+
+#: jellyfin_mpv_shim/mpvtk_browser/config.py
 msgid "Always Bind Arrow Keys to Player Controls"
 msgstr ""
 
 #: jellyfin_mpv_shim/mpvtk_browser/config.py
 msgid "Player Controls Activation Key"
 msgstr ""
+
+# seeded from jellyfin-web: SelectAll
+#: jellyfin_mpv_shim/mpvtk_browser/config.py
+#, fuzzy
+#| msgid "Select All"
+msgid "Select Key"
+msgstr "Összes kiválasztása"
 
 #: jellyfin_mpv_shim/mpvtk_browser/config.py
 msgid "Shading Behind the Player Controls"
@@ -1975,6 +2005,10 @@ msgstr ""
 
 #: jellyfin_mpv_shim/mpvtk_browser/config.py
 msgid "Hide the Player Controls After (seconds)"
+msgstr ""
+
+#: jellyfin_mpv_shim/mpvtk_browser/config.py
+msgid "Shrink the Player Controls on a Narrow Window"
 msgstr ""
 
 #: jellyfin_mpv_shim/mpvtk_browser/config.py
@@ -2061,6 +2095,21 @@ msgstr ""
 
 #: jellyfin_mpv_shim/mpvtk_browser/config.py
 msgid ""
+"Stops MPV's own shortcuts -- picture adjustment, screenshots, subtitle and "
+"audio switching -- from acting while you are in the library, where there is "
+"no video for them to act on. Turn it off to use your own MPV key bindings "
+"there."
+msgstr ""
+
+#: jellyfin_mpv_shim/mpvtk_browser/config.py
+msgid ""
+"Activates whatever is highlighted, in the library and on the player "
+"controls. An mpv key name; changing it hands Enter back to MPV. The game "
+"controller's Confirm button and a phone's Select follow it."
+msgstr ""
+
+#: jellyfin_mpv_shim/mpvtk_browser/config.py
+msgid ""
 "Leave these blank unless downloads are waking your disks too often. Set both "
 "of the first two together: episodes are then fetched in one batch when a "
 "series runs low, instead of one at a time."
@@ -2074,7 +2123,8 @@ msgstr ""
 #: jellyfin_mpv_shim/mpvtk_browser/config.py
 msgid ""
 "Off gives MPV's own mouse behaviour instead: drag the video to move the "
-"window, and right click to pause. Double click is full screen either way."
+"window, and the right button does whatever your MPV config gives it. Double "
+"click is full screen either way."
 msgstr ""
 
 #: jellyfin_mpv_shim/mpvtk_browser/config.py
@@ -2164,6 +2214,30 @@ msgid ""
 "maximize and close in the top bar instead, and lets you drag the window by "
 "it. On \"Only when the window has no title bar\", MPV is asked whether this "
 "window got one, so desktops that draw a title bar are left alone."
+msgstr ""
+
+#: jellyfin_mpv_shim/mpvtk_browser/config.py
+msgid ""
+"Full screen has no title bar anywhere and nothing to move or maximize, so "
+"the buttons are normally hidden there. Turn this on to keep a way out of "
+"full screen that is not a keyboard shortcut."
+msgstr ""
+
+#: jellyfin_mpv_shim/mpvtk_browser/config.py
+msgid ""
+"Asks the desktop for no title bar on the player window, so the top bar above "
+"is the only one. Pairs with the setting above: on \"Only when the window has "
+"no title bar\" the buttons appear as soon as this is on. Leave both off "
+"unless you want them, since a window with neither can be awkward to move on "
+"some desktops."
+msgstr ""
+
+#: jellyfin_mpv_shim/mpvtk_browser/config.py
+msgid ""
+"Shows a preview frame while you drag the seek bar. Works with every player "
+"control style, including your own OSC script if it supports thumbfast. The "
+"images are fetched from the server per video, which costs disk space and "
+"memory -- tens of MB for an episode, a few hundred for a long film."
 msgstr ""
 
 #: jellyfin_mpv_shim/mpvtk_browser/config.py
@@ -2273,6 +2347,13 @@ msgstr ""
 
 #: jellyfin_mpv_shim/mpvtk_browser/config.py
 msgid ""
+"Show times of day as \"8:30 PM\" rather than \"20:30\" — the Live TV guide "
+"and its air times, and the \"Ends at\" labels on a detail page and the "
+"player controls."
+msgstr ""
+
+#: jellyfin_mpv_shim/mpvtk_browser/config.py
+msgid ""
 "The controls have to stay legible over any frame. \"None\" gives the text a "
 "drop shadow instead of shading the picture behind it."
 msgstr ""
@@ -2287,6 +2368,13 @@ msgstr ""
 msgid ""
 "0 hides them as soon as the pointer is not on them, and forces \"Hide unless "
 "hovered\"."
+msgstr ""
+
+#: jellyfin_mpv_shim/mpvtk_browser/config.py
+msgid ""
+"Narrowing the window shrinks the controls until the smallest button reaches "
+"the accessibility minimum, instead of dropping buttons sooner. Off keeps the "
+"older, larger floor."
 msgstr ""
 
 #: jellyfin_mpv_shim/mpvtk_browser/config.py
@@ -3893,6 +3981,7 @@ msgid "More Like This"
 msgstr "Több ehhez hasonló"
 
 #: jellyfin_mpv_shim/mpvtk_browser/pages/detail.py
+#: jellyfin_mpv_shim/mpvtk_browser/tiles.py
 msgid "Go to Series"
 msgstr ""
 
@@ -5089,6 +5178,22 @@ msgstr "Kiszolgáló eltávolítása"
 msgid "There is nothing here to queue."
 msgstr ""
 
+#: jellyfin_mpv_shim/mpvtk_browser/timefmt.py
+#, python-brace-format
+msgctxt "12-hour clock"
+msgid "{time} {period}"
+msgstr ""
+
+#: jellyfin_mpv_shim/mpvtk_browser/timefmt.py
+msgctxt "12-hour clock"
+msgid "AM"
+msgstr ""
+
+#: jellyfin_mpv_shim/mpvtk_browser/timefmt.py
+msgctxt "12-hour clock"
+msgid "PM"
+msgstr ""
+
 # seeded from jellyfin-web: Search
 #: jellyfin_mpv_shim/mpvtk_browser/views.py
 #: jellyfin_mpv_shim/mpvtk_browser/window_chrome.py
@@ -5251,6 +5356,10 @@ msgid "Enable SVP"
 msgstr "SVP engedélyezése"
 
 #: jellyfin_mpv_shim/sync/manager.py
+msgid "The downloads are already in that folder."
+msgstr ""
+
+#: jellyfin_mpv_shim/sync/manager.py
 msgid ""
 "Can't change the download folder while a download is in progress. Wait for "
 "it to finish, then try again."
@@ -5259,8 +5368,29 @@ msgstr ""
 "befejeződését, majd próbálja újra."
 
 #: jellyfin_mpv_shim/sync/manager.py
+#, fuzzy
+#| msgid "That folder already contains downloads. Choose an empty folder."
+msgid ""
+"That folder is inside the current download folder. Choose one outside it."
+msgstr "Az a mappa már tartalmaz letöltéseket. Válassz egy üres mappát."
+
+#: jellyfin_mpv_shim/sync/manager.py
+#, fuzzy
+#| msgid "Can't create that folder. Check the path and its permissions."
+msgid "Can't read that folder. Check the path and its permissions."
+msgstr ""
+"Nem hozható létre a mappa. Ellenőrizze az elérési utat és a hozzá tartozó "
+"jogosultságokat."
+
+#: jellyfin_mpv_shim/sync/manager.py
 msgid "That folder already contains downloads. Choose an empty folder."
 msgstr "Az a mappa már tartalmaz letöltéseket. Válassz egy üres mappát."
+
+#: jellyfin_mpv_shim/sync/manager.py
+msgid ""
+"That folder isn't empty. Choose an empty folder — the download folder is "
+"managed by this app and anything else in it can be moved or removed."
+msgstr ""
 
 #: jellyfin_mpv_shim/sync/manager.py
 msgid "Can't create that folder. Check the path and its permissions."
@@ -5273,6 +5403,12 @@ msgid "A download is still finishing. Wait for it to stop, then try again."
 msgstr ""
 "Még folyamatban van egy letöltés. Várja meg, amíg befejeződik, majd próbálja "
 "újra."
+
+#: jellyfin_mpv_shim/sync/manager.py
+msgid ""
+"There isn't enough space on that drive to move the downloads. Free some "
+"space and try again — nothing was moved."
+msgstr ""
 
 #: jellyfin_mpv_shim/sync/manager.py
 msgid ""
@@ -5483,6 +5619,12 @@ msgstr "Videólejátszási profilok"
 #: jellyfin_mpv_shim/video_profile.py
 msgid "Select Shader Profile"
 msgstr "Árnyalóprofil kiválasztása"
+
+#~ msgid "MPV UI with thumbnails"
+#~ msgstr "MPV felület bélyegképekkel"
+
+#~ msgid "MPV built-in default"
+#~ msgstr "Beépített alapértelmezett MPV"
 
 #, fuzzy
 #~| msgid ""

--- a/jellyfin_mpv_shim/messages/id/LC_MESSAGES/base.po
+++ b/jellyfin_mpv_shim/messages/id/LC_MESSAGES/base.po
@@ -6,7 +6,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2026-08-30 22:19-0400\n"
+"POT-Creation-Date: 2026-09-07 17:35-0400\n"
 "PO-Revision-Date: 2026-07-28 10:04+0000\n"
 "Last-Translator: arz <arizmuajianisan@gmail.com>\n"
 "Language-Team: Indonesian <https://translate.jellyfin.org/projects/jellyfin/"
@@ -548,6 +548,11 @@ msgid "Night Mode (Auto Volume Adj)"
 msgstr ""
 
 #: jellyfin_mpv_shim/mpvtk_browser/app.py
+#: jellyfin_mpv_shim/mpvtk_browser/auth.py
+msgid "Locked"
+msgstr ""
+
+#: jellyfin_mpv_shim/mpvtk_browser/app.py
 msgid "Failed to load. Check the connection."
 msgstr ""
 
@@ -827,10 +832,6 @@ msgstr ""
 "Harap cek kembali koneksi Anda."
 
 #: jellyfin_mpv_shim/mpvtk_browser/auth.py
-msgid "Locked"
-msgstr ""
-
-#: jellyfin_mpv_shim/mpvtk_browser/auth.py
 #: jellyfin_mpv_shim/mpvtk_browser/pages/home.py
 msgid "Connecting to your server…"
 msgstr ""
@@ -911,6 +912,10 @@ msgstr "Keluar dan Tandai Belum Ditonton"
 #: jellyfin_mpv_shim/mpvtk_browser/pages/books.py
 msgid "Favorite"
 msgstr "Favorit"
+
+#: jellyfin_mpv_shim/mpvtk_browser/components/detail.py
+msgid "Web"
+msgstr ""
 
 # seeded from jellyfin-web: HeaderVideos
 #: jellyfin_mpv_shim/mpvtk_browser/components/media_info.py
@@ -1522,11 +1527,7 @@ msgid "Jellyfin UI"
 msgstr ""
 
 #: jellyfin_mpv_shim/mpvtk_browser/config.py
-msgid "MPV UI with thumbnails"
-msgstr ""
-
-#: jellyfin_mpv_shim/mpvtk_browser/config.py
-msgid "MPV built-in default"
+msgid "MPV UI"
 msgstr ""
 
 #: jellyfin_mpv_shim/mpvtk_browser/config.py
@@ -1875,8 +1876,22 @@ msgid "Window Buttons in the Top Bar"
 msgstr ""
 
 #: jellyfin_mpv_shim/mpvtk_browser/config.py
+msgid "Keep Window Buttons in Full Screen"
+msgstr ""
+
+#: jellyfin_mpv_shim/mpvtk_browser/config.py
+msgid "Hide the Desktop Title Bar"
+msgstr ""
+
+#: jellyfin_mpv_shim/mpvtk_browser/config.py
 msgid "Player Controls Style"
 msgstr ""
+
+#: jellyfin_mpv_shim/mpvtk_browser/config.py
+#, fuzzy
+#| msgid "Enable thumbnail previews"
+msgid "Enable Trickplay Thumbnails"
+msgstr "Aktifkan tampilan gambar mini"
 
 #: jellyfin_mpv_shim/mpvtk_browser/config.py
 msgid "Load All Seek Previews at Once"
@@ -1906,6 +1921,10 @@ msgstr ""
 
 #: jellyfin_mpv_shim/mpvtk_browser/config.py
 msgid "Full-Width Backdrops"
+msgstr ""
+
+#: jellyfin_mpv_shim/mpvtk_browser/config.py
+msgid "12-Hour Clock"
 msgstr ""
 
 #: jellyfin_mpv_shim/mpvtk_browser/config.py
@@ -1951,12 +1970,23 @@ msgid "Fullscreen Library Browser"
 msgstr ""
 
 #: jellyfin_mpv_shim/mpvtk_browser/config.py
+msgid "Block Player Keybinds While Browsing"
+msgstr ""
+
+#: jellyfin_mpv_shim/mpvtk_browser/config.py
 msgid "Always Bind Arrow Keys to Player Controls"
 msgstr ""
 
 #: jellyfin_mpv_shim/mpvtk_browser/config.py
 msgid "Player Controls Activation Key"
 msgstr ""
+
+# seeded from jellyfin-web: SelectAll
+#: jellyfin_mpv_shim/mpvtk_browser/config.py
+#, fuzzy
+#| msgid "Select All"
+msgid "Select Key"
+msgstr "Pilih Semua"
 
 #: jellyfin_mpv_shim/mpvtk_browser/config.py
 msgid "Shading Behind the Player Controls"
@@ -1968,6 +1998,10 @@ msgstr ""
 
 #: jellyfin_mpv_shim/mpvtk_browser/config.py
 msgid "Hide the Player Controls After (seconds)"
+msgstr ""
+
+#: jellyfin_mpv_shim/mpvtk_browser/config.py
+msgid "Shrink the Player Controls on a Narrow Window"
 msgstr ""
 
 #: jellyfin_mpv_shim/mpvtk_browser/config.py
@@ -2054,6 +2088,21 @@ msgstr ""
 
 #: jellyfin_mpv_shim/mpvtk_browser/config.py
 msgid ""
+"Stops MPV's own shortcuts -- picture adjustment, screenshots, subtitle and "
+"audio switching -- from acting while you are in the library, where there is "
+"no video for them to act on. Turn it off to use your own MPV key bindings "
+"there."
+msgstr ""
+
+#: jellyfin_mpv_shim/mpvtk_browser/config.py
+msgid ""
+"Activates whatever is highlighted, in the library and on the player "
+"controls. An mpv key name; changing it hands Enter back to MPV. The game "
+"controller's Confirm button and a phone's Select follow it."
+msgstr ""
+
+#: jellyfin_mpv_shim/mpvtk_browser/config.py
+msgid ""
 "Leave these blank unless downloads are waking your disks too often. Set both "
 "of the first two together: episodes are then fetched in one batch when a "
 "series runs low, instead of one at a time."
@@ -2067,7 +2116,8 @@ msgstr ""
 #: jellyfin_mpv_shim/mpvtk_browser/config.py
 msgid ""
 "Off gives MPV's own mouse behaviour instead: drag the video to move the "
-"window, and right click to pause. Double click is full screen either way."
+"window, and the right button does whatever your MPV config gives it. Double "
+"click is full screen either way."
 msgstr ""
 
 #: jellyfin_mpv_shim/mpvtk_browser/config.py
@@ -2157,6 +2207,30 @@ msgid ""
 "maximize and close in the top bar instead, and lets you drag the window by "
 "it. On \"Only when the window has no title bar\", MPV is asked whether this "
 "window got one, so desktops that draw a title bar are left alone."
+msgstr ""
+
+#: jellyfin_mpv_shim/mpvtk_browser/config.py
+msgid ""
+"Full screen has no title bar anywhere and nothing to move or maximize, so "
+"the buttons are normally hidden there. Turn this on to keep a way out of "
+"full screen that is not a keyboard shortcut."
+msgstr ""
+
+#: jellyfin_mpv_shim/mpvtk_browser/config.py
+msgid ""
+"Asks the desktop for no title bar on the player window, so the top bar above "
+"is the only one. Pairs with the setting above: on \"Only when the window has "
+"no title bar\" the buttons appear as soon as this is on. Leave both off "
+"unless you want them, since a window with neither can be awkward to move on "
+"some desktops."
+msgstr ""
+
+#: jellyfin_mpv_shim/mpvtk_browser/config.py
+msgid ""
+"Shows a preview frame while you drag the seek bar. Works with every player "
+"control style, including your own OSC script if it supports thumbfast. The "
+"images are fetched from the server per video, which costs disk space and "
+"memory -- tens of MB for an episode, a few hundred for a long film."
 msgstr ""
 
 #: jellyfin_mpv_shim/mpvtk_browser/config.py
@@ -2266,6 +2340,13 @@ msgstr ""
 
 #: jellyfin_mpv_shim/mpvtk_browser/config.py
 msgid ""
+"Show times of day as \"8:30 PM\" rather than \"20:30\" — the Live TV guide "
+"and its air times, and the \"Ends at\" labels on a detail page and the "
+"player controls."
+msgstr ""
+
+#: jellyfin_mpv_shim/mpvtk_browser/config.py
+msgid ""
 "The controls have to stay legible over any frame. \"None\" gives the text a "
 "drop shadow instead of shading the picture behind it."
 msgstr ""
@@ -2280,6 +2361,13 @@ msgstr ""
 msgid ""
 "0 hides them as soon as the pointer is not on them, and forces \"Hide unless "
 "hovered\"."
+msgstr ""
+
+#: jellyfin_mpv_shim/mpvtk_browser/config.py
+msgid ""
+"Narrowing the window shrinks the controls until the smallest button reaches "
+"the accessibility minimum, instead of dropping buttons sooner. Off keeps the "
+"older, larger floor."
 msgstr ""
 
 #: jellyfin_mpv_shim/mpvtk_browser/config.py
@@ -3882,6 +3970,7 @@ msgid "More Like This"
 msgstr "Lainnya Seperti Ini"
 
 #: jellyfin_mpv_shim/mpvtk_browser/pages/detail.py
+#: jellyfin_mpv_shim/mpvtk_browser/tiles.py
 msgid "Go to Series"
 msgstr ""
 
@@ -5069,6 +5158,22 @@ msgstr "Hapus Server"
 msgid "There is nothing here to queue."
 msgstr ""
 
+#: jellyfin_mpv_shim/mpvtk_browser/timefmt.py
+#, python-brace-format
+msgctxt "12-hour clock"
+msgid "{time} {period}"
+msgstr ""
+
+#: jellyfin_mpv_shim/mpvtk_browser/timefmt.py
+msgctxt "12-hour clock"
+msgid "AM"
+msgstr ""
+
+#: jellyfin_mpv_shim/mpvtk_browser/timefmt.py
+msgctxt "12-hour clock"
+msgid "PM"
+msgstr ""
+
 # seeded from jellyfin-web: Search
 #: jellyfin_mpv_shim/mpvtk_browser/views.py
 #: jellyfin_mpv_shim/mpvtk_browser/window_chrome.py
@@ -5236,13 +5341,32 @@ msgid "Enable SVP"
 msgstr "Aktifkan SVP"
 
 #: jellyfin_mpv_shim/sync/manager.py
+msgid "The downloads are already in that folder."
+msgstr ""
+
+#: jellyfin_mpv_shim/sync/manager.py
 msgid ""
 "Can't change the download folder while a download is in progress. Wait for "
 "it to finish, then try again."
 msgstr ""
 
 #: jellyfin_mpv_shim/sync/manager.py
+msgid ""
+"That folder is inside the current download folder. Choose one outside it."
+msgstr ""
+
+#: jellyfin_mpv_shim/sync/manager.py
+msgid "Can't read that folder. Check the path and its permissions."
+msgstr ""
+
+#: jellyfin_mpv_shim/sync/manager.py
 msgid "That folder already contains downloads. Choose an empty folder."
+msgstr ""
+
+#: jellyfin_mpv_shim/sync/manager.py
+msgid ""
+"That folder isn't empty. Choose an empty folder — the download folder is "
+"managed by this app and anything else in it can be moved or removed."
 msgstr ""
 
 #: jellyfin_mpv_shim/sync/manager.py
@@ -5251,6 +5375,12 @@ msgstr ""
 
 #: jellyfin_mpv_shim/sync/manager.py
 msgid "A download is still finishing. Wait for it to stop, then try again."
+msgstr ""
+
+#: jellyfin_mpv_shim/sync/manager.py
+msgid ""
+"There isn't enough space on that drive to move the downloads. Free some "
+"space and try again — nothing was moved."
 msgstr ""
 
 #: jellyfin_mpv_shim/sync/manager.py

--- a/jellyfin_mpv_shim/messages/it/LC_MESSAGES/base.po
+++ b/jellyfin_mpv_shim/messages/it/LC_MESSAGES/base.po
@@ -6,7 +6,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2026-08-30 22:19-0400\n"
+"POT-Creation-Date: 2026-09-07 17:35-0400\n"
 "PO-Revision-Date: 2026-09-02 06:52+0000\n"
 "Last-Translator: Riccardo <r.vecchi92@gmail.com>\n"
 "Language-Team: Italian <https://translate.jellyfin.org/projects/jellyfin/"
@@ -509,6 +509,11 @@ msgid "Night Mode (Auto Volume Adj)"
 msgstr "Modalità notte (regolazione automatica del volume)"
 
 #: jellyfin_mpv_shim/mpvtk_browser/app.py
+#: jellyfin_mpv_shim/mpvtk_browser/auth.py
+msgid "Locked"
+msgstr "Bloccato"
+
+#: jellyfin_mpv_shim/mpvtk_browser/app.py
 msgid "Failed to load. Check the connection."
 msgstr "Impossibile caricare. Verifica la connessione."
 
@@ -751,10 +756,6 @@ msgid "Could not connect. Please check your details."
 msgstr "Impossibile connettersi. Verifica i tuoi dati."
 
 #: jellyfin_mpv_shim/mpvtk_browser/auth.py
-msgid "Locked"
-msgstr "Bloccato"
-
-#: jellyfin_mpv_shim/mpvtk_browser/auth.py
 #: jellyfin_mpv_shim/mpvtk_browser/pages/home.py
 msgid "Connecting to your server…"
 msgstr "Connessione al tuo server…"
@@ -826,6 +827,10 @@ msgstr "Visti"
 #: jellyfin_mpv_shim/mpvtk_browser/pages/books.py
 msgid "Favorite"
 msgstr "Preferito"
+
+#: jellyfin_mpv_shim/mpvtk_browser/components/detail.py
+msgid "Web"
+msgstr ""
 
 #: jellyfin_mpv_shim/mpvtk_browser/components/media_info.py
 msgid "Video"
@@ -1381,12 +1386,8 @@ msgid "Jellyfin UI"
 msgstr "Interfaccia di Jellyfin"
 
 #: jellyfin_mpv_shim/mpvtk_browser/config.py
-msgid "MPV UI with thumbnails"
-msgstr "Interfaccia MPV con miniature"
-
-#: jellyfin_mpv_shim/mpvtk_browser/config.py
-msgid "MPV built-in default"
-msgstr "MPV integrato predefinito"
+msgid "MPV UI"
+msgstr ""
 
 #: jellyfin_mpv_shim/mpvtk_browser/config.py
 msgid "Custom OSC"
@@ -1719,8 +1720,24 @@ msgid "Window Buttons in the Top Bar"
 msgstr "Pulsanti della finestra nella barra superiore"
 
 #: jellyfin_mpv_shim/mpvtk_browser/config.py
+#, fuzzy
+#| msgid "Window Buttons in the Top Bar"
+msgid "Keep Window Buttons in Full Screen"
+msgstr "Pulsanti della finestra nella barra superiore"
+
+#: jellyfin_mpv_shim/mpvtk_browser/config.py
+msgid "Hide the Desktop Title Bar"
+msgstr ""
+
+#: jellyfin_mpv_shim/mpvtk_browser/config.py
 msgid "Player Controls Style"
 msgstr "Stile controlli del lettore"
+
+#: jellyfin_mpv_shim/mpvtk_browser/config.py
+#, fuzzy
+#| msgid "Enable thumbnail previews"
+msgid "Enable Trickplay Thumbnails"
+msgstr "Abilita le anteprime in miniatura"
 
 #: jellyfin_mpv_shim/mpvtk_browser/config.py
 msgid "Load All Seek Previews at Once"
@@ -1750,6 +1767,10 @@ msgstr "Dimensione copertina"
 #: jellyfin_mpv_shim/mpvtk_browser/config.py
 msgid "Full-Width Backdrops"
 msgstr "Sfondi a larghezza piena"
+
+#: jellyfin_mpv_shim/mpvtk_browser/config.py
+msgid "12-Hour Clock"
+msgstr ""
 
 #: jellyfin_mpv_shim/mpvtk_browser/config.py
 msgid "Grid Spacing"
@@ -1792,12 +1813,23 @@ msgid "Fullscreen Library Browser"
 msgstr "Navigatore della libreria a schermo intero"
 
 #: jellyfin_mpv_shim/mpvtk_browser/config.py
+msgid "Block Player Keybinds While Browsing"
+msgstr ""
+
+#: jellyfin_mpv_shim/mpvtk_browser/config.py
 msgid "Always Bind Arrow Keys to Player Controls"
 msgstr "Associa sempre le frecce direzionali ai controlli del lettore"
 
 #: jellyfin_mpv_shim/mpvtk_browser/config.py
 msgid "Player Controls Activation Key"
 msgstr "Tasto di attivazione dei controlli del lettore"
+
+# seeded from jellyfin-web: SelectAll
+#: jellyfin_mpv_shim/mpvtk_browser/config.py
+#, fuzzy
+#| msgid "Select All"
+msgid "Select Key"
+msgstr "Seleziona tutto"
 
 #: jellyfin_mpv_shim/mpvtk_browser/config.py
 msgid "Shading Behind the Player Controls"
@@ -1810,6 +1842,12 @@ msgstr "Quando i controlli del lettore sono nascosti"
 #: jellyfin_mpv_shim/mpvtk_browser/config.py
 msgid "Hide the Player Controls After (seconds)"
 msgstr "Nascondi i controlli del lettore dopo (secondi)"
+
+#: jellyfin_mpv_shim/mpvtk_browser/config.py
+#, fuzzy
+#| msgid "When the Player Controls Hide"
+msgid "Shrink the Player Controls on a Narrow Window"
+msgstr "Quando i controlli del lettore sono nascosti"
 
 #: jellyfin_mpv_shim/mpvtk_browser/config.py
 msgid "Mouse Back/Forward Buttons Skip Chapters"
@@ -1905,6 +1943,21 @@ msgstr ""
 
 #: jellyfin_mpv_shim/mpvtk_browser/config.py
 msgid ""
+"Stops MPV's own shortcuts -- picture adjustment, screenshots, subtitle and "
+"audio switching -- from acting while you are in the library, where there is "
+"no video for them to act on. Turn it off to use your own MPV key bindings "
+"there."
+msgstr ""
+
+#: jellyfin_mpv_shim/mpvtk_browser/config.py
+msgid ""
+"Activates whatever is highlighted, in the library and on the player "
+"controls. An mpv key name; changing it hands Enter back to MPV. The game "
+"controller's Confirm button and a phone's Select follow it."
+msgstr ""
+
+#: jellyfin_mpv_shim/mpvtk_browser/config.py
+msgid ""
 "Leave these blank unless downloads are waking your disks too often. Set both "
 "of the first two together: episodes are then fetched in one batch when a "
 "series runs low, instead of one at a time."
@@ -1922,9 +1975,14 @@ msgstr ""
 "aver ancora visto."
 
 #: jellyfin_mpv_shim/mpvtk_browser/config.py
+#, fuzzy
+#| msgid ""
+#| "Off gives MPV's own mouse behaviour instead: drag the video to move the "
+#| "window, and right click to pause. Double click is full screen either way."
 msgid ""
 "Off gives MPV's own mouse behaviour instead: drag the video to move the "
-"window, and right click to pause. Double click is full screen either way."
+"window, and the right button does whatever your MPV config gives it. Double "
+"click is full screen either way."
 msgstr ""
 "La modalità disattivata attiva il comportamento del mouse specifico di MPV: "
 "trascina il video per spostare la finestra e fai clic con il pulsante destro "
@@ -2081,6 +2139,30 @@ msgstr ""
 "non ha la barra del titolo\", MPV viene interrogato sulla presenza o meno di "
 "una barra del titolo nella finestra, in modo da non modificarla negli "
 "ambienti desktop che la includono."
+
+#: jellyfin_mpv_shim/mpvtk_browser/config.py
+msgid ""
+"Full screen has no title bar anywhere and nothing to move or maximize, so "
+"the buttons are normally hidden there. Turn this on to keep a way out of "
+"full screen that is not a keyboard shortcut."
+msgstr ""
+
+#: jellyfin_mpv_shim/mpvtk_browser/config.py
+msgid ""
+"Asks the desktop for no title bar on the player window, so the top bar above "
+"is the only one. Pairs with the setting above: on \"Only when the window has "
+"no title bar\" the buttons appear as soon as this is on. Leave both off "
+"unless you want them, since a window with neither can be awkward to move on "
+"some desktops."
+msgstr ""
+
+#: jellyfin_mpv_shim/mpvtk_browser/config.py
+msgid ""
+"Shows a preview frame while you drag the seek bar. Works with every player "
+"control style, including your own OSC script if it supports thumbfast. The "
+"images are fetched from the server per video, which costs disk space and "
+"memory -- tens of MB for an episode, a few hundred for a long film."
+msgstr ""
 
 #: jellyfin_mpv_shim/mpvtk_browser/config.py
 msgid ""
@@ -2253,6 +2335,13 @@ msgstr ""
 
 #: jellyfin_mpv_shim/mpvtk_browser/config.py
 msgid ""
+"Show times of day as \"8:30 PM\" rather than \"20:30\" — the Live TV guide "
+"and its air times, and the \"Ends at\" labels on a detail page and the "
+"player controls."
+msgstr ""
+
+#: jellyfin_mpv_shim/mpvtk_browser/config.py
+msgid ""
 "The controls have to stay legible over any frame. \"None\" gives the text a "
 "drop shadow instead of shading the picture behind it."
 msgstr ""
@@ -2275,6 +2364,13 @@ msgid ""
 msgstr ""
 "Il valore 0 li nasconde non appena il puntatore non si trova su di essi e "
 "forza l'opzione \"Nascondi a meno che non si sorvoli con il puntatore\"."
+
+#: jellyfin_mpv_shim/mpvtk_browser/config.py
+msgid ""
+"Narrowing the window shrinks the controls until the smallest button reaches "
+"the accessibility minimum, instead of dropping buttons sooner. Off keeps the "
+"older, larger floor."
+msgstr ""
 
 #: jellyfin_mpv_shim/mpvtk_browser/config.py
 msgid ""
@@ -3705,6 +3801,7 @@ msgid "More Like This"
 msgstr "Altri contenuti simili"
 
 #: jellyfin_mpv_shim/mpvtk_browser/pages/detail.py
+#: jellyfin_mpv_shim/mpvtk_browser/tiles.py
 msgid "Go to Series"
 msgstr "Vai alla serie"
 
@@ -4775,6 +4872,22 @@ msgstr "Vuoi rimuovere %s da questa collezione?"
 msgid "There is nothing here to queue."
 msgstr "Qui non c'è niente da accodare."
 
+#: jellyfin_mpv_shim/mpvtk_browser/timefmt.py
+#, python-brace-format
+msgctxt "12-hour clock"
+msgid "{time} {period}"
+msgstr ""
+
+#: jellyfin_mpv_shim/mpvtk_browser/timefmt.py
+msgctxt "12-hour clock"
+msgid "AM"
+msgstr ""
+
+#: jellyfin_mpv_shim/mpvtk_browser/timefmt.py
+msgctxt "12-hour clock"
+msgid "PM"
+msgstr ""
+
 #: jellyfin_mpv_shim/mpvtk_browser/views.py
 #: jellyfin_mpv_shim/mpvtk_browser/window_chrome.py
 msgid "Search"
@@ -4930,6 +5043,12 @@ msgid "Enable SVP"
 msgstr "Attiva SVP"
 
 #: jellyfin_mpv_shim/sync/manager.py
+#, fuzzy
+#| msgid "Move the downloads back to the default folder?"
+msgid "The downloads are already in that folder."
+msgstr "Vuoi spostare gli scaricamenti nella cartella predefinita?"
+
+#: jellyfin_mpv_shim/sync/manager.py
 msgid ""
 "Can't change the download folder while a download is in progress. Wait for "
 "it to finish, then try again."
@@ -4938,9 +5057,30 @@ msgstr ""
 "in corso. Attendi che termini, poi riprova."
 
 #: jellyfin_mpv_shim/sync/manager.py
+#, fuzzy
+#| msgid "That folder already contains downloads. Choose an empty folder."
+msgid ""
+"That folder is inside the current download folder. Choose one outside it."
+msgstr ""
+"Quella cartella contiene già degli scaricamenti. Scegli una cartella vuota."
+
+#: jellyfin_mpv_shim/sync/manager.py
+#, fuzzy
+#| msgid "Can't create that folder. Check the path and its permissions."
+msgid "Can't read that folder. Check the path and its permissions."
+msgstr ""
+"Impossibile creare la cartella. Verifica il percorso e i relativi permessi."
+
+#: jellyfin_mpv_shim/sync/manager.py
 msgid "That folder already contains downloads. Choose an empty folder."
 msgstr ""
 "Quella cartella contiene già degli scaricamenti. Scegli una cartella vuota."
+
+#: jellyfin_mpv_shim/sync/manager.py
+msgid ""
+"That folder isn't empty. Choose an empty folder — the download folder is "
+"managed by this app and anything else in it can be moved or removed."
+msgstr ""
 
 #: jellyfin_mpv_shim/sync/manager.py
 msgid "Can't create that folder. Check the path and its permissions."
@@ -4951,6 +5091,12 @@ msgstr ""
 msgid "A download is still finishing. Wait for it to stop, then try again."
 msgstr ""
 "Lo scaricamento non è ancora terminato. Attendi che si concluda, poi riprova."
+
+#: jellyfin_mpv_shim/sync/manager.py
+msgid ""
+"There isn't enough space on that drive to move the downloads. Free some "
+"space and try again — nothing was moved."
+msgstr ""
 
 #: jellyfin_mpv_shim/sync/manager.py
 msgid ""
@@ -5155,6 +5301,12 @@ msgstr "Profili riproduzione video"
 #: jellyfin_mpv_shim/video_profile.py
 msgid "Select Shader Profile"
 msgstr "Seleziona profilo shader"
+
+#~ msgid "MPV UI with thumbnails"
+#~ msgstr "Interfaccia MPV con miniature"
+
+#~ msgid "MPV built-in default"
+#~ msgstr "MPV integrato predefinito"
 
 #~ msgid "Discord Rich Presence. Takes effect after a restart."
 #~ msgstr "Presenza avanzata su Discord. Ha effetto dopo il riavvio."

--- a/jellyfin_mpv_shim/messages/ja/LC_MESSAGES/base.po
+++ b/jellyfin_mpv_shim/messages/ja/LC_MESSAGES/base.po
@@ -6,7 +6,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2026-08-30 22:19-0400\n"
+"POT-Creation-Date: 2026-09-07 17:35-0400\n"
 "PO-Revision-Date: 2026-01-09 10:54+0000\n"
 "Last-Translator: mf_Mii <myomyonn.exfat32@gmail.com>\n"
 "Language-Team: Japanese <https://translate.jellyfin.org/projects/jellyfin/"
@@ -547,6 +547,11 @@ msgid "Night Mode (Auto Volume Adj)"
 msgstr ""
 
 #: jellyfin_mpv_shim/mpvtk_browser/app.py
+#: jellyfin_mpv_shim/mpvtk_browser/auth.py
+msgid "Locked"
+msgstr ""
+
+#: jellyfin_mpv_shim/mpvtk_browser/app.py
 msgid "Failed to load. Check the connection."
 msgstr ""
 
@@ -826,10 +831,6 @@ msgstr ""
 "接続設定を確認してください。"
 
 #: jellyfin_mpv_shim/mpvtk_browser/auth.py
-msgid "Locked"
-msgstr ""
-
-#: jellyfin_mpv_shim/mpvtk_browser/auth.py
 #: jellyfin_mpv_shim/mpvtk_browser/pages/home.py
 msgid "Connecting to your server…"
 msgstr ""
@@ -910,6 +911,10 @@ msgstr "未視聴に設定して中止"
 #: jellyfin_mpv_shim/mpvtk_browser/pages/books.py
 msgid "Favorite"
 msgstr "お気に入り"
+
+#: jellyfin_mpv_shim/mpvtk_browser/components/detail.py
+msgid "Web"
+msgstr ""
 
 # seeded from jellyfin-web: HeaderVideos
 #: jellyfin_mpv_shim/mpvtk_browser/components/media_info.py
@@ -1524,11 +1529,7 @@ msgid "Jellyfin UI"
 msgstr ""
 
 #: jellyfin_mpv_shim/mpvtk_browser/config.py
-msgid "MPV UI with thumbnails"
-msgstr ""
-
-#: jellyfin_mpv_shim/mpvtk_browser/config.py
-msgid "MPV built-in default"
+msgid "MPV UI"
 msgstr ""
 
 #: jellyfin_mpv_shim/mpvtk_browser/config.py
@@ -1877,8 +1878,22 @@ msgid "Window Buttons in the Top Bar"
 msgstr ""
 
 #: jellyfin_mpv_shim/mpvtk_browser/config.py
+msgid "Keep Window Buttons in Full Screen"
+msgstr ""
+
+#: jellyfin_mpv_shim/mpvtk_browser/config.py
+msgid "Hide the Desktop Title Bar"
+msgstr ""
+
+#: jellyfin_mpv_shim/mpvtk_browser/config.py
 msgid "Player Controls Style"
 msgstr ""
+
+#: jellyfin_mpv_shim/mpvtk_browser/config.py
+#, fuzzy
+#| msgid "Enable thumbnail previews"
+msgid "Enable Trickplay Thumbnails"
+msgstr "サムネイルのプレビューの有効化"
 
 #: jellyfin_mpv_shim/mpvtk_browser/config.py
 msgid "Load All Seek Previews at Once"
@@ -1908,6 +1923,10 @@ msgstr ""
 
 #: jellyfin_mpv_shim/mpvtk_browser/config.py
 msgid "Full-Width Backdrops"
+msgstr ""
+
+#: jellyfin_mpv_shim/mpvtk_browser/config.py
+msgid "12-Hour Clock"
 msgstr ""
 
 #: jellyfin_mpv_shim/mpvtk_browser/config.py
@@ -1953,12 +1972,23 @@ msgid "Fullscreen Library Browser"
 msgstr ""
 
 #: jellyfin_mpv_shim/mpvtk_browser/config.py
+msgid "Block Player Keybinds While Browsing"
+msgstr ""
+
+#: jellyfin_mpv_shim/mpvtk_browser/config.py
 msgid "Always Bind Arrow Keys to Player Controls"
 msgstr ""
 
 #: jellyfin_mpv_shim/mpvtk_browser/config.py
 msgid "Player Controls Activation Key"
 msgstr ""
+
+# seeded from jellyfin-web: SelectAll
+#: jellyfin_mpv_shim/mpvtk_browser/config.py
+#, fuzzy
+#| msgid "Select All"
+msgid "Select Key"
+msgstr "すべて選択"
 
 #: jellyfin_mpv_shim/mpvtk_browser/config.py
 msgid "Shading Behind the Player Controls"
@@ -1970,6 +2000,10 @@ msgstr ""
 
 #: jellyfin_mpv_shim/mpvtk_browser/config.py
 msgid "Hide the Player Controls After (seconds)"
+msgstr ""
+
+#: jellyfin_mpv_shim/mpvtk_browser/config.py
+msgid "Shrink the Player Controls on a Narrow Window"
 msgstr ""
 
 #: jellyfin_mpv_shim/mpvtk_browser/config.py
@@ -2056,6 +2090,21 @@ msgstr ""
 
 #: jellyfin_mpv_shim/mpvtk_browser/config.py
 msgid ""
+"Stops MPV's own shortcuts -- picture adjustment, screenshots, subtitle and "
+"audio switching -- from acting while you are in the library, where there is "
+"no video for them to act on. Turn it off to use your own MPV key bindings "
+"there."
+msgstr ""
+
+#: jellyfin_mpv_shim/mpvtk_browser/config.py
+msgid ""
+"Activates whatever is highlighted, in the library and on the player "
+"controls. An mpv key name; changing it hands Enter back to MPV. The game "
+"controller's Confirm button and a phone's Select follow it."
+msgstr ""
+
+#: jellyfin_mpv_shim/mpvtk_browser/config.py
+msgid ""
 "Leave these blank unless downloads are waking your disks too often. Set both "
 "of the first two together: episodes are then fetched in one batch when a "
 "series runs low, instead of one at a time."
@@ -2069,7 +2118,8 @@ msgstr ""
 #: jellyfin_mpv_shim/mpvtk_browser/config.py
 msgid ""
 "Off gives MPV's own mouse behaviour instead: drag the video to move the "
-"window, and right click to pause. Double click is full screen either way."
+"window, and the right button does whatever your MPV config gives it. Double "
+"click is full screen either way."
 msgstr ""
 
 #: jellyfin_mpv_shim/mpvtk_browser/config.py
@@ -2159,6 +2209,30 @@ msgid ""
 "maximize and close in the top bar instead, and lets you drag the window by "
 "it. On \"Only when the window has no title bar\", MPV is asked whether this "
 "window got one, so desktops that draw a title bar are left alone."
+msgstr ""
+
+#: jellyfin_mpv_shim/mpvtk_browser/config.py
+msgid ""
+"Full screen has no title bar anywhere and nothing to move or maximize, so "
+"the buttons are normally hidden there. Turn this on to keep a way out of "
+"full screen that is not a keyboard shortcut."
+msgstr ""
+
+#: jellyfin_mpv_shim/mpvtk_browser/config.py
+msgid ""
+"Asks the desktop for no title bar on the player window, so the top bar above "
+"is the only one. Pairs with the setting above: on \"Only when the window has "
+"no title bar\" the buttons appear as soon as this is on. Leave both off "
+"unless you want them, since a window with neither can be awkward to move on "
+"some desktops."
+msgstr ""
+
+#: jellyfin_mpv_shim/mpvtk_browser/config.py
+msgid ""
+"Shows a preview frame while you drag the seek bar. Works with every player "
+"control style, including your own OSC script if it supports thumbfast. The "
+"images are fetched from the server per video, which costs disk space and "
+"memory -- tens of MB for an episode, a few hundred for a long film."
 msgstr ""
 
 #: jellyfin_mpv_shim/mpvtk_browser/config.py
@@ -2268,6 +2342,13 @@ msgstr ""
 
 #: jellyfin_mpv_shim/mpvtk_browser/config.py
 msgid ""
+"Show times of day as \"8:30 PM\" rather than \"20:30\" — the Live TV guide "
+"and its air times, and the \"Ends at\" labels on a detail page and the "
+"player controls."
+msgstr ""
+
+#: jellyfin_mpv_shim/mpvtk_browser/config.py
+msgid ""
 "The controls have to stay legible over any frame. \"None\" gives the text a "
 "drop shadow instead of shading the picture behind it."
 msgstr ""
@@ -2282,6 +2363,13 @@ msgstr ""
 msgid ""
 "0 hides them as soon as the pointer is not on them, and forces \"Hide unless "
 "hovered\"."
+msgstr ""
+
+#: jellyfin_mpv_shim/mpvtk_browser/config.py
+msgid ""
+"Narrowing the window shrinks the controls until the smallest button reaches "
+"the accessibility minimum, instead of dropping buttons sooner. Off keeps the "
+"older, larger floor."
 msgstr ""
 
 #: jellyfin_mpv_shim/mpvtk_browser/config.py
@@ -3887,6 +3975,7 @@ msgid "More Like This"
 msgstr "これに似たもの"
 
 #: jellyfin_mpv_shim/mpvtk_browser/pages/detail.py
+#: jellyfin_mpv_shim/mpvtk_browser/tiles.py
 msgid "Go to Series"
 msgstr ""
 
@@ -5080,6 +5169,22 @@ msgstr "サーバーを削除"
 msgid "There is nothing here to queue."
 msgstr ""
 
+#: jellyfin_mpv_shim/mpvtk_browser/timefmt.py
+#, python-brace-format
+msgctxt "12-hour clock"
+msgid "{time} {period}"
+msgstr ""
+
+#: jellyfin_mpv_shim/mpvtk_browser/timefmt.py
+msgctxt "12-hour clock"
+msgid "AM"
+msgstr ""
+
+#: jellyfin_mpv_shim/mpvtk_browser/timefmt.py
+msgctxt "12-hour clock"
+msgid "PM"
+msgstr ""
+
 # seeded from jellyfin-web: Search
 #: jellyfin_mpv_shim/mpvtk_browser/views.py
 #: jellyfin_mpv_shim/mpvtk_browser/window_chrome.py
@@ -5247,13 +5352,32 @@ msgid "Enable SVP"
 msgstr "SVPを有効化"
 
 #: jellyfin_mpv_shim/sync/manager.py
+msgid "The downloads are already in that folder."
+msgstr ""
+
+#: jellyfin_mpv_shim/sync/manager.py
 msgid ""
 "Can't change the download folder while a download is in progress. Wait for "
 "it to finish, then try again."
 msgstr ""
 
 #: jellyfin_mpv_shim/sync/manager.py
+msgid ""
+"That folder is inside the current download folder. Choose one outside it."
+msgstr ""
+
+#: jellyfin_mpv_shim/sync/manager.py
+msgid "Can't read that folder. Check the path and its permissions."
+msgstr ""
+
+#: jellyfin_mpv_shim/sync/manager.py
 msgid "That folder already contains downloads. Choose an empty folder."
+msgstr ""
+
+#: jellyfin_mpv_shim/sync/manager.py
+msgid ""
+"That folder isn't empty. Choose an empty folder — the download folder is "
+"managed by this app and anything else in it can be moved or removed."
 msgstr ""
 
 #: jellyfin_mpv_shim/sync/manager.py
@@ -5262,6 +5386,12 @@ msgstr ""
 
 #: jellyfin_mpv_shim/sync/manager.py
 msgid "A download is still finishing. Wait for it to stop, then try again."
+msgstr ""
+
+#: jellyfin_mpv_shim/sync/manager.py
+msgid ""
+"There isn't enough space on that drive to move the downloads. Free some "
+"space and try again — nothing was moved."
 msgstr ""
 
 #: jellyfin_mpv_shim/sync/manager.py

--- a/jellyfin_mpv_shim/messages/jbo/LC_MESSAGES/base.po
+++ b/jellyfin_mpv_shim/messages/jbo/LC_MESSAGES/base.po
@@ -6,7 +6,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2026-08-30 22:19-0400\n"
+"POT-Creation-Date: 2026-09-07 17:35-0400\n"
 "PO-Revision-Date: 2022-10-19 21:50+0000\n"
 "Last-Translator: Polaris <axvantia@protonmail.com>\n"
 "Language-Team: Lojban <https://translate.jellyfin.org/projects/jellyfin/"
@@ -511,6 +511,11 @@ msgid "Night Mode (Auto Volume Adj)"
 msgstr ""
 
 #: jellyfin_mpv_shim/mpvtk_browser/app.py
+#: jellyfin_mpv_shim/mpvtk_browser/auth.py
+msgid "Locked"
+msgstr ""
+
+#: jellyfin_mpv_shim/mpvtk_browser/app.py
 msgid "Failed to load. Check the connection."
 msgstr ""
 
@@ -762,10 +767,6 @@ msgid "Could not connect. Please check your details."
 msgstr ""
 
 #: jellyfin_mpv_shim/mpvtk_browser/auth.py
-msgid "Locked"
-msgstr ""
-
-#: jellyfin_mpv_shim/mpvtk_browser/auth.py
 #: jellyfin_mpv_shim/mpvtk_browser/pages/home.py
 msgid "Connecting to your server…"
 msgstr ""
@@ -835,6 +836,10 @@ msgstr ""
 #: jellyfin_mpv_shim/mpvtk_browser/hud.py
 #: jellyfin_mpv_shim/mpvtk_browser/pages/books.py
 msgid "Favorite"
+msgstr ""
+
+#: jellyfin_mpv_shim/mpvtk_browser/components/detail.py
+msgid "Web"
 msgstr ""
 
 #: jellyfin_mpv_shim/mpvtk_browser/components/media_info.py
@@ -1347,11 +1352,7 @@ msgid "Jellyfin UI"
 msgstr ""
 
 #: jellyfin_mpv_shim/mpvtk_browser/config.py
-msgid "MPV UI with thumbnails"
-msgstr ""
-
-#: jellyfin_mpv_shim/mpvtk_browser/config.py
-msgid "MPV built-in default"
+msgid "MPV UI"
 msgstr ""
 
 #: jellyfin_mpv_shim/mpvtk_browser/config.py
@@ -1686,7 +1687,19 @@ msgid "Window Buttons in the Top Bar"
 msgstr ""
 
 #: jellyfin_mpv_shim/mpvtk_browser/config.py
+msgid "Keep Window Buttons in Full Screen"
+msgstr ""
+
+#: jellyfin_mpv_shim/mpvtk_browser/config.py
+msgid "Hide the Desktop Title Bar"
+msgstr ""
+
+#: jellyfin_mpv_shim/mpvtk_browser/config.py
 msgid "Player Controls Style"
+msgstr ""
+
+#: jellyfin_mpv_shim/mpvtk_browser/config.py
+msgid "Enable Trickplay Thumbnails"
 msgstr ""
 
 #: jellyfin_mpv_shim/mpvtk_browser/config.py
@@ -1716,6 +1729,10 @@ msgstr ""
 
 #: jellyfin_mpv_shim/mpvtk_browser/config.py
 msgid "Full-Width Backdrops"
+msgstr ""
+
+#: jellyfin_mpv_shim/mpvtk_browser/config.py
+msgid "12-Hour Clock"
 msgstr ""
 
 #: jellyfin_mpv_shim/mpvtk_browser/config.py
@@ -1759,11 +1776,19 @@ msgid "Fullscreen Library Browser"
 msgstr ""
 
 #: jellyfin_mpv_shim/mpvtk_browser/config.py
+msgid "Block Player Keybinds While Browsing"
+msgstr ""
+
+#: jellyfin_mpv_shim/mpvtk_browser/config.py
 msgid "Always Bind Arrow Keys to Player Controls"
 msgstr ""
 
 #: jellyfin_mpv_shim/mpvtk_browser/config.py
 msgid "Player Controls Activation Key"
+msgstr ""
+
+#: jellyfin_mpv_shim/mpvtk_browser/config.py
+msgid "Select Key"
 msgstr ""
 
 #: jellyfin_mpv_shim/mpvtk_browser/config.py
@@ -1776,6 +1801,10 @@ msgstr ""
 
 #: jellyfin_mpv_shim/mpvtk_browser/config.py
 msgid "Hide the Player Controls After (seconds)"
+msgstr ""
+
+#: jellyfin_mpv_shim/mpvtk_browser/config.py
+msgid "Shrink the Player Controls on a Narrow Window"
 msgstr ""
 
 #: jellyfin_mpv_shim/mpvtk_browser/config.py
@@ -1858,6 +1887,21 @@ msgstr ""
 
 #: jellyfin_mpv_shim/mpvtk_browser/config.py
 msgid ""
+"Stops MPV's own shortcuts -- picture adjustment, screenshots, subtitle and "
+"audio switching -- from acting while you are in the library, where there is "
+"no video for them to act on. Turn it off to use your own MPV key bindings "
+"there."
+msgstr ""
+
+#: jellyfin_mpv_shim/mpvtk_browser/config.py
+msgid ""
+"Activates whatever is highlighted, in the library and on the player "
+"controls. An mpv key name; changing it hands Enter back to MPV. The game "
+"controller's Confirm button and a phone's Select follow it."
+msgstr ""
+
+#: jellyfin_mpv_shim/mpvtk_browser/config.py
+msgid ""
 "Leave these blank unless downloads are waking your disks too often. Set both "
 "of the first two together: episodes are then fetched in one batch when a "
 "series runs low, instead of one at a time."
@@ -1871,7 +1915,8 @@ msgstr ""
 #: jellyfin_mpv_shim/mpvtk_browser/config.py
 msgid ""
 "Off gives MPV's own mouse behaviour instead: drag the video to move the "
-"window, and right click to pause. Double click is full screen either way."
+"window, and the right button does whatever your MPV config gives it. Double "
+"click is full screen either way."
 msgstr ""
 
 #: jellyfin_mpv_shim/mpvtk_browser/config.py
@@ -1961,6 +2006,30 @@ msgid ""
 "maximize and close in the top bar instead, and lets you drag the window by "
 "it. On \"Only when the window has no title bar\", MPV is asked whether this "
 "window got one, so desktops that draw a title bar are left alone."
+msgstr ""
+
+#: jellyfin_mpv_shim/mpvtk_browser/config.py
+msgid ""
+"Full screen has no title bar anywhere and nothing to move or maximize, so "
+"the buttons are normally hidden there. Turn this on to keep a way out of "
+"full screen that is not a keyboard shortcut."
+msgstr ""
+
+#: jellyfin_mpv_shim/mpvtk_browser/config.py
+msgid ""
+"Asks the desktop for no title bar on the player window, so the top bar above "
+"is the only one. Pairs with the setting above: on \"Only when the window has "
+"no title bar\" the buttons appear as soon as this is on. Leave both off "
+"unless you want them, since a window with neither can be awkward to move on "
+"some desktops."
+msgstr ""
+
+#: jellyfin_mpv_shim/mpvtk_browser/config.py
+msgid ""
+"Shows a preview frame while you drag the seek bar. Works with every player "
+"control style, including your own OSC script if it supports thumbfast. The "
+"images are fetched from the server per video, which costs disk space and "
+"memory -- tens of MB for an episode, a few hundred for a long film."
 msgstr ""
 
 #: jellyfin_mpv_shim/mpvtk_browser/config.py
@@ -2068,6 +2137,13 @@ msgstr ""
 
 #: jellyfin_mpv_shim/mpvtk_browser/config.py
 msgid ""
+"Show times of day as \"8:30 PM\" rather than \"20:30\" — the Live TV guide "
+"and its air times, and the \"Ends at\" labels on a detail page and the "
+"player controls."
+msgstr ""
+
+#: jellyfin_mpv_shim/mpvtk_browser/config.py
+msgid ""
 "The controls have to stay legible over any frame. \"None\" gives the text a "
 "drop shadow instead of shading the picture behind it."
 msgstr ""
@@ -2082,6 +2158,13 @@ msgstr ""
 msgid ""
 "0 hides them as soon as the pointer is not on them, and forces \"Hide unless "
 "hovered\"."
+msgstr ""
+
+#: jellyfin_mpv_shim/mpvtk_browser/config.py
+msgid ""
+"Narrowing the window shrinks the controls until the smallest button reaches "
+"the accessibility minimum, instead of dropping buttons sooner. Off keeps the "
+"older, larger floor."
 msgstr ""
 
 #: jellyfin_mpv_shim/mpvtk_browser/config.py
@@ -3442,6 +3525,7 @@ msgid "More Like This"
 msgstr ""
 
 #: jellyfin_mpv_shim/mpvtk_browser/pages/detail.py
+#: jellyfin_mpv_shim/mpvtk_browser/tiles.py
 msgid "Go to Series"
 msgstr ""
 
@@ -4476,6 +4560,22 @@ msgstr ""
 msgid "There is nothing here to queue."
 msgstr ""
 
+#: jellyfin_mpv_shim/mpvtk_browser/timefmt.py
+#, python-brace-format
+msgctxt "12-hour clock"
+msgid "{time} {period}"
+msgstr ""
+
+#: jellyfin_mpv_shim/mpvtk_browser/timefmt.py
+msgctxt "12-hour clock"
+msgid "AM"
+msgstr ""
+
+#: jellyfin_mpv_shim/mpvtk_browser/timefmt.py
+msgctxt "12-hour clock"
+msgid "PM"
+msgstr ""
+
 #: jellyfin_mpv_shim/mpvtk_browser/views.py
 #: jellyfin_mpv_shim/mpvtk_browser/window_chrome.py
 msgid "Search"
@@ -4630,13 +4730,32 @@ msgid "Enable SVP"
 msgstr ""
 
 #: jellyfin_mpv_shim/sync/manager.py
+msgid "The downloads are already in that folder."
+msgstr ""
+
+#: jellyfin_mpv_shim/sync/manager.py
 msgid ""
 "Can't change the download folder while a download is in progress. Wait for "
 "it to finish, then try again."
 msgstr ""
 
 #: jellyfin_mpv_shim/sync/manager.py
+msgid ""
+"That folder is inside the current download folder. Choose one outside it."
+msgstr ""
+
+#: jellyfin_mpv_shim/sync/manager.py
+msgid "Can't read that folder. Check the path and its permissions."
+msgstr ""
+
+#: jellyfin_mpv_shim/sync/manager.py
 msgid "That folder already contains downloads. Choose an empty folder."
+msgstr ""
+
+#: jellyfin_mpv_shim/sync/manager.py
+msgid ""
+"That folder isn't empty. Choose an empty folder — the download folder is "
+"managed by this app and anything else in it can be moved or removed."
 msgstr ""
 
 #: jellyfin_mpv_shim/sync/manager.py
@@ -4645,6 +4764,12 @@ msgstr ""
 
 #: jellyfin_mpv_shim/sync/manager.py
 msgid "A download is still finishing. Wait for it to stop, then try again."
+msgstr ""
+
+#: jellyfin_mpv_shim/sync/manager.py
+msgid ""
+"There isn't enough space on that drive to move the downloads. Free some "
+"space and try again — nothing was moved."
 msgstr ""
 
 #: jellyfin_mpv_shim/sync/manager.py

--- a/jellyfin_mpv_shim/messages/ka/LC_MESSAGES/base.po
+++ b/jellyfin_mpv_shim/messages/ka/LC_MESSAGES/base.po
@@ -6,7 +6,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2026-08-30 22:19-0400\n"
+"POT-Creation-Date: 2026-09-07 17:35-0400\n"
 "PO-Revision-Date: 2026-05-24 14:38+0000\n"
 "Last-Translator: Ekaterine Papava <papava.e@gtu.ge>\n"
 "Language-Team: Georgian <https://translate.jellyfin.org/projects/jellyfin/"
@@ -547,6 +547,11 @@ msgid "Night Mode (Auto Volume Adj)"
 msgstr ""
 
 #: jellyfin_mpv_shim/mpvtk_browser/app.py
+#: jellyfin_mpv_shim/mpvtk_browser/auth.py
+msgid "Locked"
+msgstr ""
+
+#: jellyfin_mpv_shim/mpvtk_browser/app.py
 msgid "Failed to load. Check the connection."
 msgstr ""
 
@@ -826,10 +831,6 @@ msgstr ""
 "შეამოწმეთ თქვენი კავშირის ინფორმაცია."
 
 #: jellyfin_mpv_shim/mpvtk_browser/auth.py
-msgid "Locked"
-msgstr ""
-
-#: jellyfin_mpv_shim/mpvtk_browser/auth.py
 #: jellyfin_mpv_shim/mpvtk_browser/pages/home.py
 msgid "Connecting to your server…"
 msgstr ""
@@ -910,6 +911,10 @@ msgstr "გასვლა და მონიშვნა, როგორც �
 #: jellyfin_mpv_shim/mpvtk_browser/pages/books.py
 msgid "Favorite"
 msgstr "რჩეული"
+
+#: jellyfin_mpv_shim/mpvtk_browser/components/detail.py
+msgid "Web"
+msgstr ""
 
 # seeded from jellyfin-web: HeaderVideos
 #: jellyfin_mpv_shim/mpvtk_browser/components/media_info.py
@@ -1507,11 +1512,7 @@ msgid "Jellyfin UI"
 msgstr ""
 
 #: jellyfin_mpv_shim/mpvtk_browser/config.py
-msgid "MPV UI with thumbnails"
-msgstr ""
-
-#: jellyfin_mpv_shim/mpvtk_browser/config.py
-msgid "MPV built-in default"
+msgid "MPV UI"
 msgstr ""
 
 #: jellyfin_mpv_shim/mpvtk_browser/config.py
@@ -1860,8 +1861,22 @@ msgid "Window Buttons in the Top Bar"
 msgstr ""
 
 #: jellyfin_mpv_shim/mpvtk_browser/config.py
+msgid "Keep Window Buttons in Full Screen"
+msgstr ""
+
+#: jellyfin_mpv_shim/mpvtk_browser/config.py
+msgid "Hide the Desktop Title Bar"
+msgstr ""
+
+#: jellyfin_mpv_shim/mpvtk_browser/config.py
 msgid "Player Controls Style"
 msgstr ""
+
+#: jellyfin_mpv_shim/mpvtk_browser/config.py
+#, fuzzy
+#| msgid "Enable thumbnail previews"
+msgid "Enable Trickplay Thumbnails"
+msgstr "მინიატურის გადახედვების ჩართვა"
 
 #: jellyfin_mpv_shim/mpvtk_browser/config.py
 msgid "Load All Seek Previews at Once"
@@ -1891,6 +1906,10 @@ msgstr ""
 
 #: jellyfin_mpv_shim/mpvtk_browser/config.py
 msgid "Full-Width Backdrops"
+msgstr ""
+
+#: jellyfin_mpv_shim/mpvtk_browser/config.py
+msgid "12-Hour Clock"
 msgstr ""
 
 #: jellyfin_mpv_shim/mpvtk_browser/config.py
@@ -1936,12 +1955,23 @@ msgid "Fullscreen Library Browser"
 msgstr ""
 
 #: jellyfin_mpv_shim/mpvtk_browser/config.py
+msgid "Block Player Keybinds While Browsing"
+msgstr ""
+
+#: jellyfin_mpv_shim/mpvtk_browser/config.py
 msgid "Always Bind Arrow Keys to Player Controls"
 msgstr ""
 
 #: jellyfin_mpv_shim/mpvtk_browser/config.py
 msgid "Player Controls Activation Key"
 msgstr ""
+
+# seeded from jellyfin-web: SelectAll
+#: jellyfin_mpv_shim/mpvtk_browser/config.py
+#, fuzzy
+#| msgid "Select All"
+msgid "Select Key"
+msgstr "ყველაფრის მონიშვნა"
 
 #: jellyfin_mpv_shim/mpvtk_browser/config.py
 msgid "Shading Behind the Player Controls"
@@ -1953,6 +1983,10 @@ msgstr ""
 
 #: jellyfin_mpv_shim/mpvtk_browser/config.py
 msgid "Hide the Player Controls After (seconds)"
+msgstr ""
+
+#: jellyfin_mpv_shim/mpvtk_browser/config.py
+msgid "Shrink the Player Controls on a Narrow Window"
 msgstr ""
 
 #: jellyfin_mpv_shim/mpvtk_browser/config.py
@@ -2039,6 +2073,21 @@ msgstr ""
 
 #: jellyfin_mpv_shim/mpvtk_browser/config.py
 msgid ""
+"Stops MPV's own shortcuts -- picture adjustment, screenshots, subtitle and "
+"audio switching -- from acting while you are in the library, where there is "
+"no video for them to act on. Turn it off to use your own MPV key bindings "
+"there."
+msgstr ""
+
+#: jellyfin_mpv_shim/mpvtk_browser/config.py
+msgid ""
+"Activates whatever is highlighted, in the library and on the player "
+"controls. An mpv key name; changing it hands Enter back to MPV. The game "
+"controller's Confirm button and a phone's Select follow it."
+msgstr ""
+
+#: jellyfin_mpv_shim/mpvtk_browser/config.py
+msgid ""
 "Leave these blank unless downloads are waking your disks too often. Set both "
 "of the first two together: episodes are then fetched in one batch when a "
 "series runs low, instead of one at a time."
@@ -2052,7 +2101,8 @@ msgstr ""
 #: jellyfin_mpv_shim/mpvtk_browser/config.py
 msgid ""
 "Off gives MPV's own mouse behaviour instead: drag the video to move the "
-"window, and right click to pause. Double click is full screen either way."
+"window, and the right button does whatever your MPV config gives it. Double "
+"click is full screen either way."
 msgstr ""
 
 #: jellyfin_mpv_shim/mpvtk_browser/config.py
@@ -2142,6 +2192,30 @@ msgid ""
 "maximize and close in the top bar instead, and lets you drag the window by "
 "it. On \"Only when the window has no title bar\", MPV is asked whether this "
 "window got one, so desktops that draw a title bar are left alone."
+msgstr ""
+
+#: jellyfin_mpv_shim/mpvtk_browser/config.py
+msgid ""
+"Full screen has no title bar anywhere and nothing to move or maximize, so "
+"the buttons are normally hidden there. Turn this on to keep a way out of "
+"full screen that is not a keyboard shortcut."
+msgstr ""
+
+#: jellyfin_mpv_shim/mpvtk_browser/config.py
+msgid ""
+"Asks the desktop for no title bar on the player window, so the top bar above "
+"is the only one. Pairs with the setting above: on \"Only when the window has "
+"no title bar\" the buttons appear as soon as this is on. Leave both off "
+"unless you want them, since a window with neither can be awkward to move on "
+"some desktops."
+msgstr ""
+
+#: jellyfin_mpv_shim/mpvtk_browser/config.py
+msgid ""
+"Shows a preview frame while you drag the seek bar. Works with every player "
+"control style, including your own OSC script if it supports thumbfast. The "
+"images are fetched from the server per video, which costs disk space and "
+"memory -- tens of MB for an episode, a few hundred for a long film."
 msgstr ""
 
 #: jellyfin_mpv_shim/mpvtk_browser/config.py
@@ -2251,6 +2325,13 @@ msgstr ""
 
 #: jellyfin_mpv_shim/mpvtk_browser/config.py
 msgid ""
+"Show times of day as \"8:30 PM\" rather than \"20:30\" — the Live TV guide "
+"and its air times, and the \"Ends at\" labels on a detail page and the "
+"player controls."
+msgstr ""
+
+#: jellyfin_mpv_shim/mpvtk_browser/config.py
+msgid ""
 "The controls have to stay legible over any frame. \"None\" gives the text a "
 "drop shadow instead of shading the picture behind it."
 msgstr ""
@@ -2265,6 +2346,13 @@ msgstr ""
 msgid ""
 "0 hides them as soon as the pointer is not on them, and forces \"Hide unless "
 "hovered\"."
+msgstr ""
+
+#: jellyfin_mpv_shim/mpvtk_browser/config.py
+msgid ""
+"Narrowing the window shrinks the controls until the smallest button reaches "
+"the accessibility minimum, instead of dropping buttons sooner. Off keeps the "
+"older, larger floor."
 msgstr ""
 
 #: jellyfin_mpv_shim/mpvtk_browser/config.py
@@ -3869,6 +3957,7 @@ msgid "More Like This"
 msgstr "მეტი ამნაირი"
 
 #: jellyfin_mpv_shim/mpvtk_browser/pages/detail.py
+#: jellyfin_mpv_shim/mpvtk_browser/tiles.py
 msgid "Go to Series"
 msgstr ""
 
@@ -5062,6 +5151,22 @@ msgstr "სერვერის წაშლა"
 msgid "There is nothing here to queue."
 msgstr ""
 
+#: jellyfin_mpv_shim/mpvtk_browser/timefmt.py
+#, python-brace-format
+msgctxt "12-hour clock"
+msgid "{time} {period}"
+msgstr ""
+
+#: jellyfin_mpv_shim/mpvtk_browser/timefmt.py
+msgctxt "12-hour clock"
+msgid "AM"
+msgstr ""
+
+#: jellyfin_mpv_shim/mpvtk_browser/timefmt.py
+msgctxt "12-hour clock"
+msgid "PM"
+msgstr ""
+
 # seeded from jellyfin-web: Search
 #: jellyfin_mpv_shim/mpvtk_browser/views.py
 #: jellyfin_mpv_shim/mpvtk_browser/window_chrome.py
@@ -5229,13 +5334,32 @@ msgid "Enable SVP"
 msgstr "SVP-ის ჩართვა"
 
 #: jellyfin_mpv_shim/sync/manager.py
+msgid "The downloads are already in that folder."
+msgstr ""
+
+#: jellyfin_mpv_shim/sync/manager.py
 msgid ""
 "Can't change the download folder while a download is in progress. Wait for "
 "it to finish, then try again."
 msgstr ""
 
 #: jellyfin_mpv_shim/sync/manager.py
+msgid ""
+"That folder is inside the current download folder. Choose one outside it."
+msgstr ""
+
+#: jellyfin_mpv_shim/sync/manager.py
+msgid "Can't read that folder. Check the path and its permissions."
+msgstr ""
+
+#: jellyfin_mpv_shim/sync/manager.py
 msgid "That folder already contains downloads. Choose an empty folder."
+msgstr ""
+
+#: jellyfin_mpv_shim/sync/manager.py
+msgid ""
+"That folder isn't empty. Choose an empty folder — the download folder is "
+"managed by this app and anything else in it can be moved or removed."
 msgstr ""
 
 #: jellyfin_mpv_shim/sync/manager.py
@@ -5244,6 +5368,12 @@ msgstr ""
 
 #: jellyfin_mpv_shim/sync/manager.py
 msgid "A download is still finishing. Wait for it to stop, then try again."
+msgstr ""
+
+#: jellyfin_mpv_shim/sync/manager.py
+msgid ""
+"There isn't enough space on that drive to move the downloads. Free some "
+"space and try again — nothing was moved."
 msgstr ""
 
 #: jellyfin_mpv_shim/sync/manager.py

--- a/jellyfin_mpv_shim/messages/kk/LC_MESSAGES/base.po
+++ b/jellyfin_mpv_shim/messages/kk/LC_MESSAGES/base.po
@@ -6,7 +6,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2026-08-30 22:19-0400\n"
+"POT-Creation-Date: 2026-09-07 17:35-0400\n"
 "PO-Revision-Date: 2022-07-04 21:06+0000\n"
 "Last-Translator: WWWesten <wwwesten@gmail.com>\n"
 "Language-Team: Kazakh <https://translate.jellyfin.org/projects/jellyfin/"
@@ -523,6 +523,11 @@ msgid "Night Mode (Auto Volume Adj)"
 msgstr ""
 
 #: jellyfin_mpv_shim/mpvtk_browser/app.py
+#: jellyfin_mpv_shim/mpvtk_browser/auth.py
+msgid "Locked"
+msgstr ""
+
+#: jellyfin_mpv_shim/mpvtk_browser/app.py
 msgid "Failed to load. Check the connection."
 msgstr ""
 
@@ -802,10 +807,6 @@ msgstr ""
 "Qosylu mälımetterın tekserıñız."
 
 #: jellyfin_mpv_shim/mpvtk_browser/auth.py
-msgid "Locked"
-msgstr ""
-
-#: jellyfin_mpv_shim/mpvtk_browser/auth.py
 #: jellyfin_mpv_shim/mpvtk_browser/pages/home.py
 msgid "Connecting to your server…"
 msgstr ""
@@ -886,6 +887,10 @@ msgstr "Şyğyp qaralmağan retınde belgıleu"
 #: jellyfin_mpv_shim/mpvtk_browser/pages/books.py
 msgid "Favorite"
 msgstr "Tañdauly"
+
+#: jellyfin_mpv_shim/mpvtk_browser/components/detail.py
+msgid "Web"
+msgstr ""
 
 # seeded from jellyfin-web: HeaderVideos
 #: jellyfin_mpv_shim/mpvtk_browser/components/media_info.py
@@ -1490,11 +1495,7 @@ msgid "Jellyfin UI"
 msgstr ""
 
 #: jellyfin_mpv_shim/mpvtk_browser/config.py
-msgid "MPV UI with thumbnails"
-msgstr ""
-
-#: jellyfin_mpv_shim/mpvtk_browser/config.py
-msgid "MPV built-in default"
+msgid "MPV UI"
 msgstr ""
 
 #: jellyfin_mpv_shim/mpvtk_browser/config.py
@@ -1841,7 +1842,19 @@ msgid "Window Buttons in the Top Bar"
 msgstr ""
 
 #: jellyfin_mpv_shim/mpvtk_browser/config.py
+msgid "Keep Window Buttons in Full Screen"
+msgstr ""
+
+#: jellyfin_mpv_shim/mpvtk_browser/config.py
+msgid "Hide the Desktop Title Bar"
+msgstr ""
+
+#: jellyfin_mpv_shim/mpvtk_browser/config.py
 msgid "Player Controls Style"
+msgstr ""
+
+#: jellyfin_mpv_shim/mpvtk_browser/config.py
+msgid "Enable Trickplay Thumbnails"
 msgstr ""
 
 #: jellyfin_mpv_shim/mpvtk_browser/config.py
@@ -1872,6 +1885,10 @@ msgstr ""
 
 #: jellyfin_mpv_shim/mpvtk_browser/config.py
 msgid "Full-Width Backdrops"
+msgstr ""
+
+#: jellyfin_mpv_shim/mpvtk_browser/config.py
+msgid "12-Hour Clock"
 msgstr ""
 
 #: jellyfin_mpv_shim/mpvtk_browser/config.py
@@ -1917,12 +1934,23 @@ msgid "Fullscreen Library Browser"
 msgstr ""
 
 #: jellyfin_mpv_shim/mpvtk_browser/config.py
+msgid "Block Player Keybinds While Browsing"
+msgstr ""
+
+#: jellyfin_mpv_shim/mpvtk_browser/config.py
 msgid "Always Bind Arrow Keys to Player Controls"
 msgstr ""
 
 #: jellyfin_mpv_shim/mpvtk_browser/config.py
 msgid "Player Controls Activation Key"
 msgstr ""
+
+# seeded from jellyfin-web: SelectAll
+#: jellyfin_mpv_shim/mpvtk_browser/config.py
+#, fuzzy
+#| msgid "Select All"
+msgid "Select Key"
+msgstr "Bärin bölekteu"
 
 #: jellyfin_mpv_shim/mpvtk_browser/config.py
 msgid "Shading Behind the Player Controls"
@@ -1934,6 +1962,10 @@ msgstr ""
 
 #: jellyfin_mpv_shim/mpvtk_browser/config.py
 msgid "Hide the Player Controls After (seconds)"
+msgstr ""
+
+#: jellyfin_mpv_shim/mpvtk_browser/config.py
+msgid "Shrink the Player Controls on a Narrow Window"
 msgstr ""
 
 #: jellyfin_mpv_shim/mpvtk_browser/config.py
@@ -2020,6 +2052,21 @@ msgstr ""
 
 #: jellyfin_mpv_shim/mpvtk_browser/config.py
 msgid ""
+"Stops MPV's own shortcuts -- picture adjustment, screenshots, subtitle and "
+"audio switching -- from acting while you are in the library, where there is "
+"no video for them to act on. Turn it off to use your own MPV key bindings "
+"there."
+msgstr ""
+
+#: jellyfin_mpv_shim/mpvtk_browser/config.py
+msgid ""
+"Activates whatever is highlighted, in the library and on the player "
+"controls. An mpv key name; changing it hands Enter back to MPV. The game "
+"controller's Confirm button and a phone's Select follow it."
+msgstr ""
+
+#: jellyfin_mpv_shim/mpvtk_browser/config.py
+msgid ""
 "Leave these blank unless downloads are waking your disks too often. Set both "
 "of the first two together: episodes are then fetched in one batch when a "
 "series runs low, instead of one at a time."
@@ -2033,7 +2080,8 @@ msgstr ""
 #: jellyfin_mpv_shim/mpvtk_browser/config.py
 msgid ""
 "Off gives MPV's own mouse behaviour instead: drag the video to move the "
-"window, and right click to pause. Double click is full screen either way."
+"window, and the right button does whatever your MPV config gives it. Double "
+"click is full screen either way."
 msgstr ""
 
 #: jellyfin_mpv_shim/mpvtk_browser/config.py
@@ -2123,6 +2171,30 @@ msgid ""
 "maximize and close in the top bar instead, and lets you drag the window by "
 "it. On \"Only when the window has no title bar\", MPV is asked whether this "
 "window got one, so desktops that draw a title bar are left alone."
+msgstr ""
+
+#: jellyfin_mpv_shim/mpvtk_browser/config.py
+msgid ""
+"Full screen has no title bar anywhere and nothing to move or maximize, so "
+"the buttons are normally hidden there. Turn this on to keep a way out of "
+"full screen that is not a keyboard shortcut."
+msgstr ""
+
+#: jellyfin_mpv_shim/mpvtk_browser/config.py
+msgid ""
+"Asks the desktop for no title bar on the player window, so the top bar above "
+"is the only one. Pairs with the setting above: on \"Only when the window has "
+"no title bar\" the buttons appear as soon as this is on. Leave both off "
+"unless you want them, since a window with neither can be awkward to move on "
+"some desktops."
+msgstr ""
+
+#: jellyfin_mpv_shim/mpvtk_browser/config.py
+msgid ""
+"Shows a preview frame while you drag the seek bar. Works with every player "
+"control style, including your own OSC script if it supports thumbfast. The "
+"images are fetched from the server per video, which costs disk space and "
+"memory -- tens of MB for an episode, a few hundred for a long film."
 msgstr ""
 
 #: jellyfin_mpv_shim/mpvtk_browser/config.py
@@ -2232,6 +2304,13 @@ msgstr ""
 
 #: jellyfin_mpv_shim/mpvtk_browser/config.py
 msgid ""
+"Show times of day as \"8:30 PM\" rather than \"20:30\" — the Live TV guide "
+"and its air times, and the \"Ends at\" labels on a detail page and the "
+"player controls."
+msgstr ""
+
+#: jellyfin_mpv_shim/mpvtk_browser/config.py
+msgid ""
 "The controls have to stay legible over any frame. \"None\" gives the text a "
 "drop shadow instead of shading the picture behind it."
 msgstr ""
@@ -2246,6 +2325,13 @@ msgstr ""
 msgid ""
 "0 hides them as soon as the pointer is not on them, and forces \"Hide unless "
 "hovered\"."
+msgstr ""
+
+#: jellyfin_mpv_shim/mpvtk_browser/config.py
+msgid ""
+"Narrowing the window shrinks the controls until the smallest button reaches "
+"the accessibility minimum, instead of dropping buttons sooner. Off keeps the "
+"older, larger floor."
 msgstr ""
 
 #: jellyfin_mpv_shim/mpvtk_browser/config.py
@@ -3850,6 +3936,7 @@ msgid "More Like This"
 msgstr "Osy siaqty köbırek"
 
 #: jellyfin_mpv_shim/mpvtk_browser/pages/detail.py
+#: jellyfin_mpv_shim/mpvtk_browser/tiles.py
 msgid "Go to Series"
 msgstr ""
 
@@ -5043,6 +5130,22 @@ msgstr "Serverdı alastau"
 msgid "There is nothing here to queue."
 msgstr ""
 
+#: jellyfin_mpv_shim/mpvtk_browser/timefmt.py
+#, python-brace-format
+msgctxt "12-hour clock"
+msgid "{time} {period}"
+msgstr ""
+
+#: jellyfin_mpv_shim/mpvtk_browser/timefmt.py
+msgctxt "12-hour clock"
+msgid "AM"
+msgstr ""
+
+#: jellyfin_mpv_shim/mpvtk_browser/timefmt.py
+msgctxt "12-hour clock"
+msgid "PM"
+msgstr ""
+
 # seeded from jellyfin-web: Search
 #: jellyfin_mpv_shim/mpvtk_browser/views.py
 #: jellyfin_mpv_shim/mpvtk_browser/window_chrome.py
@@ -5210,13 +5313,32 @@ msgid "Enable SVP"
 msgstr "SVP qosu"
 
 #: jellyfin_mpv_shim/sync/manager.py
+msgid "The downloads are already in that folder."
+msgstr ""
+
+#: jellyfin_mpv_shim/sync/manager.py
 msgid ""
 "Can't change the download folder while a download is in progress. Wait for "
 "it to finish, then try again."
 msgstr ""
 
 #: jellyfin_mpv_shim/sync/manager.py
+msgid ""
+"That folder is inside the current download folder. Choose one outside it."
+msgstr ""
+
+#: jellyfin_mpv_shim/sync/manager.py
+msgid "Can't read that folder. Check the path and its permissions."
+msgstr ""
+
+#: jellyfin_mpv_shim/sync/manager.py
 msgid "That folder already contains downloads. Choose an empty folder."
+msgstr ""
+
+#: jellyfin_mpv_shim/sync/manager.py
+msgid ""
+"That folder isn't empty. Choose an empty folder — the download folder is "
+"managed by this app and anything else in it can be moved or removed."
 msgstr ""
 
 #: jellyfin_mpv_shim/sync/manager.py
@@ -5225,6 +5347,12 @@ msgstr ""
 
 #: jellyfin_mpv_shim/sync/manager.py
 msgid "A download is still finishing. Wait for it to stop, then try again."
+msgstr ""
+
+#: jellyfin_mpv_shim/sync/manager.py
+msgid ""
+"There isn't enough space on that drive to move the downloads. Free some "
+"space and try again — nothing was moved."
 msgstr ""
 
 #: jellyfin_mpv_shim/sync/manager.py

--- a/jellyfin_mpv_shim/messages/km/LC_MESSAGES/base.po
+++ b/jellyfin_mpv_shim/messages/km/LC_MESSAGES/base.po
@@ -6,7 +6,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2026-08-30 22:19-0400\n"
+"POT-Creation-Date: 2026-09-07 17:35-0400\n"
 "PO-Revision-Date: 2024-08-20 19:12+0000\n"
 "Last-Translator: houching <houching.online2@gmail.com>\n"
 "Language-Team: Khmer (Central) <https://translate.jellyfin.org/projects/"
@@ -518,6 +518,11 @@ msgid "Night Mode (Auto Volume Adj)"
 msgstr ""
 
 #: jellyfin_mpv_shim/mpvtk_browser/app.py
+#: jellyfin_mpv_shim/mpvtk_browser/auth.py
+msgid "Locked"
+msgstr ""
+
+#: jellyfin_mpv_shim/mpvtk_browser/app.py
 msgid "Failed to load. Check the connection."
 msgstr ""
 
@@ -791,10 +796,6 @@ msgstr ""
 "សូមពិនិត្យមើលព័ត៌មានការតភ្ជាប់របស់អ្នក."
 
 #: jellyfin_mpv_shim/mpvtk_browser/auth.py
-msgid "Locked"
-msgstr ""
-
-#: jellyfin_mpv_shim/mpvtk_browser/auth.py
 #: jellyfin_mpv_shim/mpvtk_browser/pages/home.py
 msgid "Connecting to your server…"
 msgstr ""
@@ -870,6 +871,10 @@ msgstr "ចាកចេញ ហើយចំណាំទុកក្នុង Unwa
 #: jellyfin_mpv_shim/mpvtk_browser/hud.py
 #: jellyfin_mpv_shim/mpvtk_browser/pages/books.py
 msgid "Favorite"
+msgstr ""
+
+#: jellyfin_mpv_shim/mpvtk_browser/components/detail.py
+msgid "Web"
 msgstr ""
 
 #: jellyfin_mpv_shim/mpvtk_browser/components/media_info.py
@@ -1397,11 +1402,7 @@ msgid "Jellyfin UI"
 msgstr ""
 
 #: jellyfin_mpv_shim/mpvtk_browser/config.py
-msgid "MPV UI with thumbnails"
-msgstr ""
-
-#: jellyfin_mpv_shim/mpvtk_browser/config.py
-msgid "MPV built-in default"
+msgid "MPV UI"
 msgstr ""
 
 #: jellyfin_mpv_shim/mpvtk_browser/config.py
@@ -1742,7 +1743,19 @@ msgid "Window Buttons in the Top Bar"
 msgstr ""
 
 #: jellyfin_mpv_shim/mpvtk_browser/config.py
+msgid "Keep Window Buttons in Full Screen"
+msgstr ""
+
+#: jellyfin_mpv_shim/mpvtk_browser/config.py
+msgid "Hide the Desktop Title Bar"
+msgstr ""
+
+#: jellyfin_mpv_shim/mpvtk_browser/config.py
 msgid "Player Controls Style"
+msgstr ""
+
+#: jellyfin_mpv_shim/mpvtk_browser/config.py
+msgid "Enable Trickplay Thumbnails"
 msgstr ""
 
 #: jellyfin_mpv_shim/mpvtk_browser/config.py
@@ -1772,6 +1785,10 @@ msgstr ""
 
 #: jellyfin_mpv_shim/mpvtk_browser/config.py
 msgid "Full-Width Backdrops"
+msgstr ""
+
+#: jellyfin_mpv_shim/mpvtk_browser/config.py
+msgid "12-Hour Clock"
 msgstr ""
 
 #: jellyfin_mpv_shim/mpvtk_browser/config.py
@@ -1815,11 +1832,19 @@ msgid "Fullscreen Library Browser"
 msgstr ""
 
 #: jellyfin_mpv_shim/mpvtk_browser/config.py
+msgid "Block Player Keybinds While Browsing"
+msgstr ""
+
+#: jellyfin_mpv_shim/mpvtk_browser/config.py
 msgid "Always Bind Arrow Keys to Player Controls"
 msgstr ""
 
 #: jellyfin_mpv_shim/mpvtk_browser/config.py
 msgid "Player Controls Activation Key"
+msgstr ""
+
+#: jellyfin_mpv_shim/mpvtk_browser/config.py
+msgid "Select Key"
 msgstr ""
 
 #: jellyfin_mpv_shim/mpvtk_browser/config.py
@@ -1832,6 +1857,10 @@ msgstr ""
 
 #: jellyfin_mpv_shim/mpvtk_browser/config.py
 msgid "Hide the Player Controls After (seconds)"
+msgstr ""
+
+#: jellyfin_mpv_shim/mpvtk_browser/config.py
+msgid "Shrink the Player Controls on a Narrow Window"
 msgstr ""
 
 #: jellyfin_mpv_shim/mpvtk_browser/config.py
@@ -1916,6 +1945,21 @@ msgstr ""
 
 #: jellyfin_mpv_shim/mpvtk_browser/config.py
 msgid ""
+"Stops MPV's own shortcuts -- picture adjustment, screenshots, subtitle and "
+"audio switching -- from acting while you are in the library, where there is "
+"no video for them to act on. Turn it off to use your own MPV key bindings "
+"there."
+msgstr ""
+
+#: jellyfin_mpv_shim/mpvtk_browser/config.py
+msgid ""
+"Activates whatever is highlighted, in the library and on the player "
+"controls. An mpv key name; changing it hands Enter back to MPV. The game "
+"controller's Confirm button and a phone's Select follow it."
+msgstr ""
+
+#: jellyfin_mpv_shim/mpvtk_browser/config.py
+msgid ""
 "Leave these blank unless downloads are waking your disks too often. Set both "
 "of the first two together: episodes are then fetched in one batch when a "
 "series runs low, instead of one at a time."
@@ -1929,7 +1973,8 @@ msgstr ""
 #: jellyfin_mpv_shim/mpvtk_browser/config.py
 msgid ""
 "Off gives MPV's own mouse behaviour instead: drag the video to move the "
-"window, and right click to pause. Double click is full screen either way."
+"window, and the right button does whatever your MPV config gives it. Double "
+"click is full screen either way."
 msgstr ""
 
 #: jellyfin_mpv_shim/mpvtk_browser/config.py
@@ -2019,6 +2064,30 @@ msgid ""
 "maximize and close in the top bar instead, and lets you drag the window by "
 "it. On \"Only when the window has no title bar\", MPV is asked whether this "
 "window got one, so desktops that draw a title bar are left alone."
+msgstr ""
+
+#: jellyfin_mpv_shim/mpvtk_browser/config.py
+msgid ""
+"Full screen has no title bar anywhere and nothing to move or maximize, so "
+"the buttons are normally hidden there. Turn this on to keep a way out of "
+"full screen that is not a keyboard shortcut."
+msgstr ""
+
+#: jellyfin_mpv_shim/mpvtk_browser/config.py
+msgid ""
+"Asks the desktop for no title bar on the player window, so the top bar above "
+"is the only one. Pairs with the setting above: on \"Only when the window has "
+"no title bar\" the buttons appear as soon as this is on. Leave both off "
+"unless you want them, since a window with neither can be awkward to move on "
+"some desktops."
+msgstr ""
+
+#: jellyfin_mpv_shim/mpvtk_browser/config.py
+msgid ""
+"Shows a preview frame while you drag the seek bar. Works with every player "
+"control style, including your own OSC script if it supports thumbfast. The "
+"images are fetched from the server per video, which costs disk space and "
+"memory -- tens of MB for an episode, a few hundred for a long film."
 msgstr ""
 
 #: jellyfin_mpv_shim/mpvtk_browser/config.py
@@ -2126,6 +2195,13 @@ msgstr ""
 
 #: jellyfin_mpv_shim/mpvtk_browser/config.py
 msgid ""
+"Show times of day as \"8:30 PM\" rather than \"20:30\" — the Live TV guide "
+"and its air times, and the \"Ends at\" labels on a detail page and the "
+"player controls."
+msgstr ""
+
+#: jellyfin_mpv_shim/mpvtk_browser/config.py
+msgid ""
 "The controls have to stay legible over any frame. \"None\" gives the text a "
 "drop shadow instead of shading the picture behind it."
 msgstr ""
@@ -2140,6 +2216,13 @@ msgstr ""
 msgid ""
 "0 hides them as soon as the pointer is not on them, and forces \"Hide unless "
 "hovered\"."
+msgstr ""
+
+#: jellyfin_mpv_shim/mpvtk_browser/config.py
+msgid ""
+"Narrowing the window shrinks the controls until the smallest button reaches "
+"the accessibility minimum, instead of dropping buttons sooner. Off keeps the "
+"older, larger floor."
 msgstr ""
 
 #: jellyfin_mpv_shim/mpvtk_browser/config.py
@@ -3615,6 +3698,7 @@ msgid "More Like This"
 msgstr ""
 
 #: jellyfin_mpv_shim/mpvtk_browser/pages/detail.py
+#: jellyfin_mpv_shim/mpvtk_browser/tiles.py
 msgid "Go to Series"
 msgstr ""
 
@@ -4743,6 +4827,22 @@ msgstr "លុបម៉ាស៊ីនមេ"
 msgid "There is nothing here to queue."
 msgstr ""
 
+#: jellyfin_mpv_shim/mpvtk_browser/timefmt.py
+#, python-brace-format
+msgctxt "12-hour clock"
+msgid "{time} {period}"
+msgstr ""
+
+#: jellyfin_mpv_shim/mpvtk_browser/timefmt.py
+msgctxt "12-hour clock"
+msgid "AM"
+msgstr ""
+
+#: jellyfin_mpv_shim/mpvtk_browser/timefmt.py
+msgctxt "12-hour clock"
+msgid "PM"
+msgstr ""
+
 #: jellyfin_mpv_shim/mpvtk_browser/views.py
 #: jellyfin_mpv_shim/mpvtk_browser/window_chrome.py
 msgid "Search"
@@ -4903,13 +5003,32 @@ msgid "Enable SVP"
 msgstr ""
 
 #: jellyfin_mpv_shim/sync/manager.py
+msgid "The downloads are already in that folder."
+msgstr ""
+
+#: jellyfin_mpv_shim/sync/manager.py
 msgid ""
 "Can't change the download folder while a download is in progress. Wait for "
 "it to finish, then try again."
 msgstr ""
 
 #: jellyfin_mpv_shim/sync/manager.py
+msgid ""
+"That folder is inside the current download folder. Choose one outside it."
+msgstr ""
+
+#: jellyfin_mpv_shim/sync/manager.py
+msgid "Can't read that folder. Check the path and its permissions."
+msgstr ""
+
+#: jellyfin_mpv_shim/sync/manager.py
 msgid "That folder already contains downloads. Choose an empty folder."
+msgstr ""
+
+#: jellyfin_mpv_shim/sync/manager.py
+msgid ""
+"That folder isn't empty. Choose an empty folder — the download folder is "
+"managed by this app and anything else in it can be moved or removed."
 msgstr ""
 
 #: jellyfin_mpv_shim/sync/manager.py
@@ -4918,6 +5037,12 @@ msgstr ""
 
 #: jellyfin_mpv_shim/sync/manager.py
 msgid "A download is still finishing. Wait for it to stop, then try again."
+msgstr ""
+
+#: jellyfin_mpv_shim/sync/manager.py
+msgid ""
+"There isn't enough space on that drive to move the downloads. Free some "
+"space and try again — nothing was moved."
 msgstr ""
 
 #: jellyfin_mpv_shim/sync/manager.py

--- a/jellyfin_mpv_shim/messages/kn/LC_MESSAGES/base.po
+++ b/jellyfin_mpv_shim/messages/kn/LC_MESSAGES/base.po
@@ -6,7 +6,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2026-08-30 22:19-0400\n"
+"POT-Creation-Date: 2026-09-07 17:35-0400\n"
 "PO-Revision-Date: 2022-08-06 12:22+0000\n"
 "Last-Translator: Daniel Papasergio <daniel.papasergio@outlook.com>\n"
 "Language-Team: Kannada <https://translate.jellyfin.org/projects/jellyfin/"
@@ -506,6 +506,11 @@ msgid "Night Mode (Auto Volume Adj)"
 msgstr ""
 
 #: jellyfin_mpv_shim/mpvtk_browser/app.py
+#: jellyfin_mpv_shim/mpvtk_browser/auth.py
+msgid "Locked"
+msgstr ""
+
+#: jellyfin_mpv_shim/mpvtk_browser/app.py
 msgid "Failed to load. Check the connection."
 msgstr ""
 
@@ -746,10 +751,6 @@ msgid "Could not connect. Please check your details."
 msgstr ""
 
 #: jellyfin_mpv_shim/mpvtk_browser/auth.py
-msgid "Locked"
-msgstr ""
-
-#: jellyfin_mpv_shim/mpvtk_browser/auth.py
 #: jellyfin_mpv_shim/mpvtk_browser/pages/home.py
 msgid "Connecting to your server…"
 msgstr ""
@@ -819,6 +820,10 @@ msgstr ""
 #: jellyfin_mpv_shim/mpvtk_browser/hud.py
 #: jellyfin_mpv_shim/mpvtk_browser/pages/books.py
 msgid "Favorite"
+msgstr ""
+
+#: jellyfin_mpv_shim/mpvtk_browser/components/detail.py
+msgid "Web"
 msgstr ""
 
 #: jellyfin_mpv_shim/mpvtk_browser/components/media_info.py
@@ -1329,11 +1334,7 @@ msgid "Jellyfin UI"
 msgstr ""
 
 #: jellyfin_mpv_shim/mpvtk_browser/config.py
-msgid "MPV UI with thumbnails"
-msgstr ""
-
-#: jellyfin_mpv_shim/mpvtk_browser/config.py
-msgid "MPV built-in default"
+msgid "MPV UI"
 msgstr ""
 
 #: jellyfin_mpv_shim/mpvtk_browser/config.py
@@ -1666,7 +1667,19 @@ msgid "Window Buttons in the Top Bar"
 msgstr ""
 
 #: jellyfin_mpv_shim/mpvtk_browser/config.py
+msgid "Keep Window Buttons in Full Screen"
+msgstr ""
+
+#: jellyfin_mpv_shim/mpvtk_browser/config.py
+msgid "Hide the Desktop Title Bar"
+msgstr ""
+
+#: jellyfin_mpv_shim/mpvtk_browser/config.py
 msgid "Player Controls Style"
+msgstr ""
+
+#: jellyfin_mpv_shim/mpvtk_browser/config.py
+msgid "Enable Trickplay Thumbnails"
 msgstr ""
 
 #: jellyfin_mpv_shim/mpvtk_browser/config.py
@@ -1696,6 +1709,10 @@ msgstr ""
 
 #: jellyfin_mpv_shim/mpvtk_browser/config.py
 msgid "Full-Width Backdrops"
+msgstr ""
+
+#: jellyfin_mpv_shim/mpvtk_browser/config.py
+msgid "12-Hour Clock"
 msgstr ""
 
 #: jellyfin_mpv_shim/mpvtk_browser/config.py
@@ -1739,11 +1756,19 @@ msgid "Fullscreen Library Browser"
 msgstr ""
 
 #: jellyfin_mpv_shim/mpvtk_browser/config.py
+msgid "Block Player Keybinds While Browsing"
+msgstr ""
+
+#: jellyfin_mpv_shim/mpvtk_browser/config.py
 msgid "Always Bind Arrow Keys to Player Controls"
 msgstr ""
 
 #: jellyfin_mpv_shim/mpvtk_browser/config.py
 msgid "Player Controls Activation Key"
+msgstr ""
+
+#: jellyfin_mpv_shim/mpvtk_browser/config.py
+msgid "Select Key"
 msgstr ""
 
 #: jellyfin_mpv_shim/mpvtk_browser/config.py
@@ -1756,6 +1781,10 @@ msgstr ""
 
 #: jellyfin_mpv_shim/mpvtk_browser/config.py
 msgid "Hide the Player Controls After (seconds)"
+msgstr ""
+
+#: jellyfin_mpv_shim/mpvtk_browser/config.py
+msgid "Shrink the Player Controls on a Narrow Window"
 msgstr ""
 
 #: jellyfin_mpv_shim/mpvtk_browser/config.py
@@ -1838,6 +1867,21 @@ msgstr ""
 
 #: jellyfin_mpv_shim/mpvtk_browser/config.py
 msgid ""
+"Stops MPV's own shortcuts -- picture adjustment, screenshots, subtitle and "
+"audio switching -- from acting while you are in the library, where there is "
+"no video for them to act on. Turn it off to use your own MPV key bindings "
+"there."
+msgstr ""
+
+#: jellyfin_mpv_shim/mpvtk_browser/config.py
+msgid ""
+"Activates whatever is highlighted, in the library and on the player "
+"controls. An mpv key name; changing it hands Enter back to MPV. The game "
+"controller's Confirm button and a phone's Select follow it."
+msgstr ""
+
+#: jellyfin_mpv_shim/mpvtk_browser/config.py
+msgid ""
 "Leave these blank unless downloads are waking your disks too often. Set both "
 "of the first two together: episodes are then fetched in one batch when a "
 "series runs low, instead of one at a time."
@@ -1851,7 +1895,8 @@ msgstr ""
 #: jellyfin_mpv_shim/mpvtk_browser/config.py
 msgid ""
 "Off gives MPV's own mouse behaviour instead: drag the video to move the "
-"window, and right click to pause. Double click is full screen either way."
+"window, and the right button does whatever your MPV config gives it. Double "
+"click is full screen either way."
 msgstr ""
 
 #: jellyfin_mpv_shim/mpvtk_browser/config.py
@@ -1941,6 +1986,30 @@ msgid ""
 "maximize and close in the top bar instead, and lets you drag the window by "
 "it. On \"Only when the window has no title bar\", MPV is asked whether this "
 "window got one, so desktops that draw a title bar are left alone."
+msgstr ""
+
+#: jellyfin_mpv_shim/mpvtk_browser/config.py
+msgid ""
+"Full screen has no title bar anywhere and nothing to move or maximize, so "
+"the buttons are normally hidden there. Turn this on to keep a way out of "
+"full screen that is not a keyboard shortcut."
+msgstr ""
+
+#: jellyfin_mpv_shim/mpvtk_browser/config.py
+msgid ""
+"Asks the desktop for no title bar on the player window, so the top bar above "
+"is the only one. Pairs with the setting above: on \"Only when the window has "
+"no title bar\" the buttons appear as soon as this is on. Leave both off "
+"unless you want them, since a window with neither can be awkward to move on "
+"some desktops."
+msgstr ""
+
+#: jellyfin_mpv_shim/mpvtk_browser/config.py
+msgid ""
+"Shows a preview frame while you drag the seek bar. Works with every player "
+"control style, including your own OSC script if it supports thumbfast. The "
+"images are fetched from the server per video, which costs disk space and "
+"memory -- tens of MB for an episode, a few hundred for a long film."
 msgstr ""
 
 #: jellyfin_mpv_shim/mpvtk_browser/config.py
@@ -2048,6 +2117,13 @@ msgstr ""
 
 #: jellyfin_mpv_shim/mpvtk_browser/config.py
 msgid ""
+"Show times of day as \"8:30 PM\" rather than \"20:30\" — the Live TV guide "
+"and its air times, and the \"Ends at\" labels on a detail page and the "
+"player controls."
+msgstr ""
+
+#: jellyfin_mpv_shim/mpvtk_browser/config.py
+msgid ""
 "The controls have to stay legible over any frame. \"None\" gives the text a "
 "drop shadow instead of shading the picture behind it."
 msgstr ""
@@ -2062,6 +2138,13 @@ msgstr ""
 msgid ""
 "0 hides them as soon as the pointer is not on them, and forces \"Hide unless "
 "hovered\"."
+msgstr ""
+
+#: jellyfin_mpv_shim/mpvtk_browser/config.py
+msgid ""
+"Narrowing the window shrinks the controls until the smallest button reaches "
+"the accessibility minimum, instead of dropping buttons sooner. Off keeps the "
+"older, larger floor."
 msgstr ""
 
 #: jellyfin_mpv_shim/mpvtk_browser/config.py
@@ -3406,6 +3489,7 @@ msgid "More Like This"
 msgstr ""
 
 #: jellyfin_mpv_shim/mpvtk_browser/pages/detail.py
+#: jellyfin_mpv_shim/mpvtk_browser/tiles.py
 msgid "Go to Series"
 msgstr ""
 
@@ -4413,6 +4497,22 @@ msgstr ""
 msgid "There is nothing here to queue."
 msgstr ""
 
+#: jellyfin_mpv_shim/mpvtk_browser/timefmt.py
+#, python-brace-format
+msgctxt "12-hour clock"
+msgid "{time} {period}"
+msgstr ""
+
+#: jellyfin_mpv_shim/mpvtk_browser/timefmt.py
+msgctxt "12-hour clock"
+msgid "AM"
+msgstr ""
+
+#: jellyfin_mpv_shim/mpvtk_browser/timefmt.py
+msgctxt "12-hour clock"
+msgid "PM"
+msgstr ""
+
 #: jellyfin_mpv_shim/mpvtk_browser/views.py
 #: jellyfin_mpv_shim/mpvtk_browser/window_chrome.py
 msgid "Search"
@@ -4563,13 +4663,32 @@ msgid "Enable SVP"
 msgstr ""
 
 #: jellyfin_mpv_shim/sync/manager.py
+msgid "The downloads are already in that folder."
+msgstr ""
+
+#: jellyfin_mpv_shim/sync/manager.py
 msgid ""
 "Can't change the download folder while a download is in progress. Wait for "
 "it to finish, then try again."
 msgstr ""
 
 #: jellyfin_mpv_shim/sync/manager.py
+msgid ""
+"That folder is inside the current download folder. Choose one outside it."
+msgstr ""
+
+#: jellyfin_mpv_shim/sync/manager.py
+msgid "Can't read that folder. Check the path and its permissions."
+msgstr ""
+
+#: jellyfin_mpv_shim/sync/manager.py
 msgid "That folder already contains downloads. Choose an empty folder."
+msgstr ""
+
+#: jellyfin_mpv_shim/sync/manager.py
+msgid ""
+"That folder isn't empty. Choose an empty folder — the download folder is "
+"managed by this app and anything else in it can be moved or removed."
 msgstr ""
 
 #: jellyfin_mpv_shim/sync/manager.py
@@ -4578,6 +4697,12 @@ msgstr ""
 
 #: jellyfin_mpv_shim/sync/manager.py
 msgid "A download is still finishing. Wait for it to stop, then try again."
+msgstr ""
+
+#: jellyfin_mpv_shim/sync/manager.py
+msgid ""
+"There isn't enough space on that drive to move the downloads. Free some "
+"space and try again — nothing was moved."
 msgstr ""
 
 #: jellyfin_mpv_shim/sync/manager.py

--- a/jellyfin_mpv_shim/messages/ko/LC_MESSAGES/base.po
+++ b/jellyfin_mpv_shim/messages/ko/LC_MESSAGES/base.po
@@ -6,7 +6,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2026-08-30 22:19-0400\n"
+"POT-Creation-Date: 2026-09-07 17:35-0400\n"
 "PO-Revision-Date: 2026-08-11 11:37+0000\n"
 "Last-Translator: 김수명 <admin@sumyeong.kim>\n"
 "Language-Team: Korean <https://translate.jellyfin.org/projects/jellyfin/"
@@ -529,6 +529,11 @@ msgid "Night Mode (Auto Volume Adj)"
 msgstr ""
 
 #: jellyfin_mpv_shim/mpvtk_browser/app.py
+#: jellyfin_mpv_shim/mpvtk_browser/auth.py
+msgid "Locked"
+msgstr ""
+
+#: jellyfin_mpv_shim/mpvtk_browser/app.py
 msgid "Failed to load. Check the connection."
 msgstr ""
 
@@ -806,10 +811,6 @@ msgstr ""
 "연결 정보를 확인하십시오."
 
 #: jellyfin_mpv_shim/mpvtk_browser/auth.py
-msgid "Locked"
-msgstr ""
-
-#: jellyfin_mpv_shim/mpvtk_browser/auth.py
 #: jellyfin_mpv_shim/mpvtk_browser/pages/home.py
 msgid "Connecting to your server…"
 msgstr ""
@@ -890,6 +891,10 @@ msgstr "종료하고 보지 않음으로 표시"
 #: jellyfin_mpv_shim/mpvtk_browser/pages/books.py
 msgid "Favorite"
 msgstr "즐겨찾기"
+
+#: jellyfin_mpv_shim/mpvtk_browser/components/detail.py
+msgid "Web"
+msgstr ""
 
 # seeded from jellyfin-web: Video
 #: jellyfin_mpv_shim/mpvtk_browser/components/media_info.py
@@ -1499,11 +1504,7 @@ msgid "Jellyfin UI"
 msgstr ""
 
 #: jellyfin_mpv_shim/mpvtk_browser/config.py
-msgid "MPV UI with thumbnails"
-msgstr ""
-
-#: jellyfin_mpv_shim/mpvtk_browser/config.py
-msgid "MPV built-in default"
+msgid "MPV UI"
 msgstr ""
 
 #: jellyfin_mpv_shim/mpvtk_browser/config.py
@@ -1852,8 +1853,22 @@ msgid "Window Buttons in the Top Bar"
 msgstr ""
 
 #: jellyfin_mpv_shim/mpvtk_browser/config.py
+msgid "Keep Window Buttons in Full Screen"
+msgstr ""
+
+#: jellyfin_mpv_shim/mpvtk_browser/config.py
+msgid "Hide the Desktop Title Bar"
+msgstr ""
+
+#: jellyfin_mpv_shim/mpvtk_browser/config.py
 msgid "Player Controls Style"
 msgstr ""
+
+#: jellyfin_mpv_shim/mpvtk_browser/config.py
+#, fuzzy
+#| msgid "Enable thumbnail previews"
+msgid "Enable Trickplay Thumbnails"
+msgstr "섬네일 미리보기 활성화하기"
 
 #: jellyfin_mpv_shim/mpvtk_browser/config.py
 msgid "Load All Seek Previews at Once"
@@ -1883,6 +1898,10 @@ msgstr ""
 
 #: jellyfin_mpv_shim/mpvtk_browser/config.py
 msgid "Full-Width Backdrops"
+msgstr ""
+
+#: jellyfin_mpv_shim/mpvtk_browser/config.py
+msgid "12-Hour Clock"
 msgstr ""
 
 #: jellyfin_mpv_shim/mpvtk_browser/config.py
@@ -1928,12 +1947,23 @@ msgid "Fullscreen Library Browser"
 msgstr ""
 
 #: jellyfin_mpv_shim/mpvtk_browser/config.py
+msgid "Block Player Keybinds While Browsing"
+msgstr ""
+
+#: jellyfin_mpv_shim/mpvtk_browser/config.py
 msgid "Always Bind Arrow Keys to Player Controls"
 msgstr ""
 
 #: jellyfin_mpv_shim/mpvtk_browser/config.py
 msgid "Player Controls Activation Key"
 msgstr ""
+
+# seeded from jellyfin-web: SelectAll
+#: jellyfin_mpv_shim/mpvtk_browser/config.py
+#, fuzzy
+#| msgid "Select All"
+msgid "Select Key"
+msgstr "모두 선택"
 
 #: jellyfin_mpv_shim/mpvtk_browser/config.py
 msgid "Shading Behind the Player Controls"
@@ -1945,6 +1975,10 @@ msgstr ""
 
 #: jellyfin_mpv_shim/mpvtk_browser/config.py
 msgid "Hide the Player Controls After (seconds)"
+msgstr ""
+
+#: jellyfin_mpv_shim/mpvtk_browser/config.py
+msgid "Shrink the Player Controls on a Narrow Window"
 msgstr ""
 
 #: jellyfin_mpv_shim/mpvtk_browser/config.py
@@ -2031,6 +2065,21 @@ msgstr ""
 
 #: jellyfin_mpv_shim/mpvtk_browser/config.py
 msgid ""
+"Stops MPV's own shortcuts -- picture adjustment, screenshots, subtitle and "
+"audio switching -- from acting while you are in the library, where there is "
+"no video for them to act on. Turn it off to use your own MPV key bindings "
+"there."
+msgstr ""
+
+#: jellyfin_mpv_shim/mpvtk_browser/config.py
+msgid ""
+"Activates whatever is highlighted, in the library and on the player "
+"controls. An mpv key name; changing it hands Enter back to MPV. The game "
+"controller's Confirm button and a phone's Select follow it."
+msgstr ""
+
+#: jellyfin_mpv_shim/mpvtk_browser/config.py
+msgid ""
 "Leave these blank unless downloads are waking your disks too often. Set both "
 "of the first two together: episodes are then fetched in one batch when a "
 "series runs low, instead of one at a time."
@@ -2044,7 +2093,8 @@ msgstr ""
 #: jellyfin_mpv_shim/mpvtk_browser/config.py
 msgid ""
 "Off gives MPV's own mouse behaviour instead: drag the video to move the "
-"window, and right click to pause. Double click is full screen either way."
+"window, and the right button does whatever your MPV config gives it. Double "
+"click is full screen either way."
 msgstr ""
 
 #: jellyfin_mpv_shim/mpvtk_browser/config.py
@@ -2134,6 +2184,30 @@ msgid ""
 "maximize and close in the top bar instead, and lets you drag the window by "
 "it. On \"Only when the window has no title bar\", MPV is asked whether this "
 "window got one, so desktops that draw a title bar are left alone."
+msgstr ""
+
+#: jellyfin_mpv_shim/mpvtk_browser/config.py
+msgid ""
+"Full screen has no title bar anywhere and nothing to move or maximize, so "
+"the buttons are normally hidden there. Turn this on to keep a way out of "
+"full screen that is not a keyboard shortcut."
+msgstr ""
+
+#: jellyfin_mpv_shim/mpvtk_browser/config.py
+msgid ""
+"Asks the desktop for no title bar on the player window, so the top bar above "
+"is the only one. Pairs with the setting above: on \"Only when the window has "
+"no title bar\" the buttons appear as soon as this is on. Leave both off "
+"unless you want them, since a window with neither can be awkward to move on "
+"some desktops."
+msgstr ""
+
+#: jellyfin_mpv_shim/mpvtk_browser/config.py
+msgid ""
+"Shows a preview frame while you drag the seek bar. Works with every player "
+"control style, including your own OSC script if it supports thumbfast. The "
+"images are fetched from the server per video, which costs disk space and "
+"memory -- tens of MB for an episode, a few hundred for a long film."
 msgstr ""
 
 #: jellyfin_mpv_shim/mpvtk_browser/config.py
@@ -2243,6 +2317,13 @@ msgstr ""
 
 #: jellyfin_mpv_shim/mpvtk_browser/config.py
 msgid ""
+"Show times of day as \"8:30 PM\" rather than \"20:30\" — the Live TV guide "
+"and its air times, and the \"Ends at\" labels on a detail page and the "
+"player controls."
+msgstr ""
+
+#: jellyfin_mpv_shim/mpvtk_browser/config.py
+msgid ""
 "The controls have to stay legible over any frame. \"None\" gives the text a "
 "drop shadow instead of shading the picture behind it."
 msgstr ""
@@ -2257,6 +2338,13 @@ msgstr ""
 msgid ""
 "0 hides them as soon as the pointer is not on them, and forces \"Hide unless "
 "hovered\"."
+msgstr ""
+
+#: jellyfin_mpv_shim/mpvtk_browser/config.py
+msgid ""
+"Narrowing the window shrinks the controls until the smallest button reaches "
+"the accessibility minimum, instead of dropping buttons sooner. Off keeps the "
+"older, larger floor."
 msgstr ""
 
 #: jellyfin_mpv_shim/mpvtk_browser/config.py
@@ -3861,6 +3949,7 @@ msgid "More Like This"
 msgstr "비슷한 작품"
 
 #: jellyfin_mpv_shim/mpvtk_browser/pages/detail.py
+#: jellyfin_mpv_shim/mpvtk_browser/tiles.py
 msgid "Go to Series"
 msgstr ""
 
@@ -5053,6 +5142,22 @@ msgstr "서버 제거"
 msgid "There is nothing here to queue."
 msgstr ""
 
+#: jellyfin_mpv_shim/mpvtk_browser/timefmt.py
+#, python-brace-format
+msgctxt "12-hour clock"
+msgid "{time} {period}"
+msgstr ""
+
+#: jellyfin_mpv_shim/mpvtk_browser/timefmt.py
+msgctxt "12-hour clock"
+msgid "AM"
+msgstr ""
+
+#: jellyfin_mpv_shim/mpvtk_browser/timefmt.py
+msgctxt "12-hour clock"
+msgid "PM"
+msgstr ""
+
 # seeded from jellyfin-web: Search
 #: jellyfin_mpv_shim/mpvtk_browser/views.py
 #: jellyfin_mpv_shim/mpvtk_browser/window_chrome.py
@@ -5220,13 +5325,32 @@ msgid "Enable SVP"
 msgstr "SVP 활성화"
 
 #: jellyfin_mpv_shim/sync/manager.py
+msgid "The downloads are already in that folder."
+msgstr ""
+
+#: jellyfin_mpv_shim/sync/manager.py
 msgid ""
 "Can't change the download folder while a download is in progress. Wait for "
 "it to finish, then try again."
 msgstr ""
 
 #: jellyfin_mpv_shim/sync/manager.py
+msgid ""
+"That folder is inside the current download folder. Choose one outside it."
+msgstr ""
+
+#: jellyfin_mpv_shim/sync/manager.py
+msgid "Can't read that folder. Check the path and its permissions."
+msgstr ""
+
+#: jellyfin_mpv_shim/sync/manager.py
 msgid "That folder already contains downloads. Choose an empty folder."
+msgstr ""
+
+#: jellyfin_mpv_shim/sync/manager.py
+msgid ""
+"That folder isn't empty. Choose an empty folder — the download folder is "
+"managed by this app and anything else in it can be moved or removed."
 msgstr ""
 
 #: jellyfin_mpv_shim/sync/manager.py
@@ -5235,6 +5359,12 @@ msgstr ""
 
 #: jellyfin_mpv_shim/sync/manager.py
 msgid "A download is still finishing. Wait for it to stop, then try again."
+msgstr ""
+
+#: jellyfin_mpv_shim/sync/manager.py
+msgid ""
+"There isn't enough space on that drive to move the downloads. Free some "
+"space and try again — nothing was moved."
 msgstr ""
 
 #: jellyfin_mpv_shim/sync/manager.py

--- a/jellyfin_mpv_shim/messages/kw/LC_MESSAGES/base.po
+++ b/jellyfin_mpv_shim/messages/kw/LC_MESSAGES/base.po
@@ -6,7 +6,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2026-08-30 22:19-0400\n"
+"POT-Creation-Date: 2026-09-07 17:35-0400\n"
 "PO-Revision-Date: 2025-12-22 15:37+0000\n"
 "Last-Translator: shuimu <2246333259@qq.com>\n"
 "Language-Team: Cornish <https://translate.jellyfin.org/projects/jellyfin/"
@@ -512,6 +512,11 @@ msgid "Night Mode (Auto Volume Adj)"
 msgstr ""
 
 #: jellyfin_mpv_shim/mpvtk_browser/app.py
+#: jellyfin_mpv_shim/mpvtk_browser/auth.py
+msgid "Locked"
+msgstr ""
+
+#: jellyfin_mpv_shim/mpvtk_browser/app.py
 msgid "Failed to load. Check the connection."
 msgstr ""
 
@@ -753,10 +758,6 @@ msgid "Could not connect. Please check your details."
 msgstr ""
 
 #: jellyfin_mpv_shim/mpvtk_browser/auth.py
-msgid "Locked"
-msgstr ""
-
-#: jellyfin_mpv_shim/mpvtk_browser/auth.py
 #: jellyfin_mpv_shim/mpvtk_browser/pages/home.py
 msgid "Connecting to your server…"
 msgstr ""
@@ -826,6 +827,10 @@ msgstr ""
 #: jellyfin_mpv_shim/mpvtk_browser/hud.py
 #: jellyfin_mpv_shim/mpvtk_browser/pages/books.py
 msgid "Favorite"
+msgstr ""
+
+#: jellyfin_mpv_shim/mpvtk_browser/components/detail.py
+msgid "Web"
 msgstr ""
 
 #: jellyfin_mpv_shim/mpvtk_browser/components/media_info.py
@@ -1337,11 +1342,7 @@ msgid "Jellyfin UI"
 msgstr ""
 
 #: jellyfin_mpv_shim/mpvtk_browser/config.py
-msgid "MPV UI with thumbnails"
-msgstr ""
-
-#: jellyfin_mpv_shim/mpvtk_browser/config.py
-msgid "MPV built-in default"
+msgid "MPV UI"
 msgstr ""
 
 #: jellyfin_mpv_shim/mpvtk_browser/config.py
@@ -1674,7 +1675,19 @@ msgid "Window Buttons in the Top Bar"
 msgstr ""
 
 #: jellyfin_mpv_shim/mpvtk_browser/config.py
+msgid "Keep Window Buttons in Full Screen"
+msgstr ""
+
+#: jellyfin_mpv_shim/mpvtk_browser/config.py
+msgid "Hide the Desktop Title Bar"
+msgstr ""
+
+#: jellyfin_mpv_shim/mpvtk_browser/config.py
 msgid "Player Controls Style"
+msgstr ""
+
+#: jellyfin_mpv_shim/mpvtk_browser/config.py
+msgid "Enable Trickplay Thumbnails"
 msgstr ""
 
 #: jellyfin_mpv_shim/mpvtk_browser/config.py
@@ -1704,6 +1717,10 @@ msgstr ""
 
 #: jellyfin_mpv_shim/mpvtk_browser/config.py
 msgid "Full-Width Backdrops"
+msgstr ""
+
+#: jellyfin_mpv_shim/mpvtk_browser/config.py
+msgid "12-Hour Clock"
 msgstr ""
 
 #: jellyfin_mpv_shim/mpvtk_browser/config.py
@@ -1747,11 +1764,19 @@ msgid "Fullscreen Library Browser"
 msgstr ""
 
 #: jellyfin_mpv_shim/mpvtk_browser/config.py
+msgid "Block Player Keybinds While Browsing"
+msgstr ""
+
+#: jellyfin_mpv_shim/mpvtk_browser/config.py
 msgid "Always Bind Arrow Keys to Player Controls"
 msgstr ""
 
 #: jellyfin_mpv_shim/mpvtk_browser/config.py
 msgid "Player Controls Activation Key"
+msgstr ""
+
+#: jellyfin_mpv_shim/mpvtk_browser/config.py
+msgid "Select Key"
 msgstr ""
 
 #: jellyfin_mpv_shim/mpvtk_browser/config.py
@@ -1764,6 +1789,10 @@ msgstr ""
 
 #: jellyfin_mpv_shim/mpvtk_browser/config.py
 msgid "Hide the Player Controls After (seconds)"
+msgstr ""
+
+#: jellyfin_mpv_shim/mpvtk_browser/config.py
+msgid "Shrink the Player Controls on a Narrow Window"
 msgstr ""
 
 #: jellyfin_mpv_shim/mpvtk_browser/config.py
@@ -1846,6 +1875,21 @@ msgstr ""
 
 #: jellyfin_mpv_shim/mpvtk_browser/config.py
 msgid ""
+"Stops MPV's own shortcuts -- picture adjustment, screenshots, subtitle and "
+"audio switching -- from acting while you are in the library, where there is "
+"no video for them to act on. Turn it off to use your own MPV key bindings "
+"there."
+msgstr ""
+
+#: jellyfin_mpv_shim/mpvtk_browser/config.py
+msgid ""
+"Activates whatever is highlighted, in the library and on the player "
+"controls. An mpv key name; changing it hands Enter back to MPV. The game "
+"controller's Confirm button and a phone's Select follow it."
+msgstr ""
+
+#: jellyfin_mpv_shim/mpvtk_browser/config.py
+msgid ""
 "Leave these blank unless downloads are waking your disks too often. Set both "
 "of the first two together: episodes are then fetched in one batch when a "
 "series runs low, instead of one at a time."
@@ -1859,7 +1903,8 @@ msgstr ""
 #: jellyfin_mpv_shim/mpvtk_browser/config.py
 msgid ""
 "Off gives MPV's own mouse behaviour instead: drag the video to move the "
-"window, and right click to pause. Double click is full screen either way."
+"window, and the right button does whatever your MPV config gives it. Double "
+"click is full screen either way."
 msgstr ""
 
 #: jellyfin_mpv_shim/mpvtk_browser/config.py
@@ -1949,6 +1994,30 @@ msgid ""
 "maximize and close in the top bar instead, and lets you drag the window by "
 "it. On \"Only when the window has no title bar\", MPV is asked whether this "
 "window got one, so desktops that draw a title bar are left alone."
+msgstr ""
+
+#: jellyfin_mpv_shim/mpvtk_browser/config.py
+msgid ""
+"Full screen has no title bar anywhere and nothing to move or maximize, so "
+"the buttons are normally hidden there. Turn this on to keep a way out of "
+"full screen that is not a keyboard shortcut."
+msgstr ""
+
+#: jellyfin_mpv_shim/mpvtk_browser/config.py
+msgid ""
+"Asks the desktop for no title bar on the player window, so the top bar above "
+"is the only one. Pairs with the setting above: on \"Only when the window has "
+"no title bar\" the buttons appear as soon as this is on. Leave both off "
+"unless you want them, since a window with neither can be awkward to move on "
+"some desktops."
+msgstr ""
+
+#: jellyfin_mpv_shim/mpvtk_browser/config.py
+msgid ""
+"Shows a preview frame while you drag the seek bar. Works with every player "
+"control style, including your own OSC script if it supports thumbfast. The "
+"images are fetched from the server per video, which costs disk space and "
+"memory -- tens of MB for an episode, a few hundred for a long film."
 msgstr ""
 
 #: jellyfin_mpv_shim/mpvtk_browser/config.py
@@ -2056,6 +2125,13 @@ msgstr ""
 
 #: jellyfin_mpv_shim/mpvtk_browser/config.py
 msgid ""
+"Show times of day as \"8:30 PM\" rather than \"20:30\" — the Live TV guide "
+"and its air times, and the \"Ends at\" labels on a detail page and the "
+"player controls."
+msgstr ""
+
+#: jellyfin_mpv_shim/mpvtk_browser/config.py
+msgid ""
 "The controls have to stay legible over any frame. \"None\" gives the text a "
 "drop shadow instead of shading the picture behind it."
 msgstr ""
@@ -2070,6 +2146,13 @@ msgstr ""
 msgid ""
 "0 hides them as soon as the pointer is not on them, and forces \"Hide unless "
 "hovered\"."
+msgstr ""
+
+#: jellyfin_mpv_shim/mpvtk_browser/config.py
+msgid ""
+"Narrowing the window shrinks the controls until the smallest button reaches "
+"the accessibility minimum, instead of dropping buttons sooner. Off keeps the "
+"older, larger floor."
 msgstr ""
 
 #: jellyfin_mpv_shim/mpvtk_browser/config.py
@@ -3419,6 +3502,7 @@ msgid "More Like This"
 msgstr ""
 
 #: jellyfin_mpv_shim/mpvtk_browser/pages/detail.py
+#: jellyfin_mpv_shim/mpvtk_browser/tiles.py
 msgid "Go to Series"
 msgstr ""
 
@@ -4431,6 +4515,22 @@ msgstr ""
 msgid "There is nothing here to queue."
 msgstr ""
 
+#: jellyfin_mpv_shim/mpvtk_browser/timefmt.py
+#, python-brace-format
+msgctxt "12-hour clock"
+msgid "{time} {period}"
+msgstr ""
+
+#: jellyfin_mpv_shim/mpvtk_browser/timefmt.py
+msgctxt "12-hour clock"
+msgid "AM"
+msgstr ""
+
+#: jellyfin_mpv_shim/mpvtk_browser/timefmt.py
+msgctxt "12-hour clock"
+msgid "PM"
+msgstr ""
+
 #: jellyfin_mpv_shim/mpvtk_browser/views.py
 #: jellyfin_mpv_shim/mpvtk_browser/window_chrome.py
 msgid "Search"
@@ -4581,13 +4681,32 @@ msgid "Enable SVP"
 msgstr ""
 
 #: jellyfin_mpv_shim/sync/manager.py
+msgid "The downloads are already in that folder."
+msgstr ""
+
+#: jellyfin_mpv_shim/sync/manager.py
 msgid ""
 "Can't change the download folder while a download is in progress. Wait for "
 "it to finish, then try again."
 msgstr ""
 
 #: jellyfin_mpv_shim/sync/manager.py
+msgid ""
+"That folder is inside the current download folder. Choose one outside it."
+msgstr ""
+
+#: jellyfin_mpv_shim/sync/manager.py
+msgid "Can't read that folder. Check the path and its permissions."
+msgstr ""
+
+#: jellyfin_mpv_shim/sync/manager.py
 msgid "That folder already contains downloads. Choose an empty folder."
+msgstr ""
+
+#: jellyfin_mpv_shim/sync/manager.py
+msgid ""
+"That folder isn't empty. Choose an empty folder — the download folder is "
+"managed by this app and anything else in it can be moved or removed."
 msgstr ""
 
 #: jellyfin_mpv_shim/sync/manager.py
@@ -4596,6 +4715,12 @@ msgstr ""
 
 #: jellyfin_mpv_shim/sync/manager.py
 msgid "A download is still finishing. Wait for it to stop, then try again."
+msgstr ""
+
+#: jellyfin_mpv_shim/sync/manager.py
+msgid ""
+"There isn't enough space on that drive to move the downloads. Free some "
+"space and try again — nothing was moved."
 msgstr ""
 
 #: jellyfin_mpv_shim/sync/manager.py

--- a/jellyfin_mpv_shim/messages/lb/LC_MESSAGES/base.po
+++ b/jellyfin_mpv_shim/messages/lb/LC_MESSAGES/base.po
@@ -6,7 +6,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2026-08-30 22:19-0400\n"
+"POT-Creation-Date: 2026-09-07 17:35-0400\n"
 "PO-Revision-Date: 2026-07-30 14:13+0000\n"
 "Last-Translator: David Wagener <david.wagener@pm.me>\n"
 "Language-Team: Luxembourgish <https://translate.jellyfin.org/projects/"
@@ -513,6 +513,11 @@ msgid "Night Mode (Auto Volume Adj)"
 msgstr ""
 
 #: jellyfin_mpv_shim/mpvtk_browser/app.py
+#: jellyfin_mpv_shim/mpvtk_browser/auth.py
+msgid "Locked"
+msgstr ""
+
+#: jellyfin_mpv_shim/mpvtk_browser/app.py
 msgid "Failed to load. Check the connection."
 msgstr ""
 
@@ -761,10 +766,6 @@ msgid "Could not connect. Please check your details."
 msgstr ""
 
 #: jellyfin_mpv_shim/mpvtk_browser/auth.py
-msgid "Locked"
-msgstr ""
-
-#: jellyfin_mpv_shim/mpvtk_browser/auth.py
 #: jellyfin_mpv_shim/mpvtk_browser/pages/home.py
 msgid "Connecting to your server…"
 msgstr ""
@@ -840,6 +841,10 @@ msgstr "Gekuckt"
 #: jellyfin_mpv_shim/mpvtk_browser/pages/books.py
 msgid "Favorite"
 msgstr "Favorit"
+
+#: jellyfin_mpv_shim/mpvtk_browser/components/detail.py
+msgid "Web"
+msgstr ""
 
 # seeded from jellyfin-web: HeaderVideos
 #: jellyfin_mpv_shim/mpvtk_browser/components/media_info.py
@@ -1446,11 +1451,7 @@ msgid "Jellyfin UI"
 msgstr ""
 
 #: jellyfin_mpv_shim/mpvtk_browser/config.py
-msgid "MPV UI with thumbnails"
-msgstr ""
-
-#: jellyfin_mpv_shim/mpvtk_browser/config.py
-msgid "MPV built-in default"
+msgid "MPV UI"
 msgstr ""
 
 #: jellyfin_mpv_shim/mpvtk_browser/config.py
@@ -1792,7 +1793,19 @@ msgid "Window Buttons in the Top Bar"
 msgstr ""
 
 #: jellyfin_mpv_shim/mpvtk_browser/config.py
+msgid "Keep Window Buttons in Full Screen"
+msgstr ""
+
+#: jellyfin_mpv_shim/mpvtk_browser/config.py
+msgid "Hide the Desktop Title Bar"
+msgstr ""
+
+#: jellyfin_mpv_shim/mpvtk_browser/config.py
 msgid "Player Controls Style"
+msgstr ""
+
+#: jellyfin_mpv_shim/mpvtk_browser/config.py
+msgid "Enable Trickplay Thumbnails"
 msgstr ""
 
 #: jellyfin_mpv_shim/mpvtk_browser/config.py
@@ -1823,6 +1836,10 @@ msgstr ""
 
 #: jellyfin_mpv_shim/mpvtk_browser/config.py
 msgid "Full-Width Backdrops"
+msgstr ""
+
+#: jellyfin_mpv_shim/mpvtk_browser/config.py
+msgid "12-Hour Clock"
 msgstr ""
 
 #: jellyfin_mpv_shim/mpvtk_browser/config.py
@@ -1868,12 +1885,23 @@ msgid "Fullscreen Library Browser"
 msgstr ""
 
 #: jellyfin_mpv_shim/mpvtk_browser/config.py
+msgid "Block Player Keybinds While Browsing"
+msgstr ""
+
+#: jellyfin_mpv_shim/mpvtk_browser/config.py
 msgid "Always Bind Arrow Keys to Player Controls"
 msgstr ""
 
 #: jellyfin_mpv_shim/mpvtk_browser/config.py
 msgid "Player Controls Activation Key"
 msgstr ""
+
+# seeded from jellyfin-web: SelectAll
+#: jellyfin_mpv_shim/mpvtk_browser/config.py
+#, fuzzy
+#| msgid "Select All"
+msgid "Select Key"
+msgstr "Alles auswielen"
 
 #: jellyfin_mpv_shim/mpvtk_browser/config.py
 msgid "Shading Behind the Player Controls"
@@ -1885,6 +1913,10 @@ msgstr ""
 
 #: jellyfin_mpv_shim/mpvtk_browser/config.py
 msgid "Hide the Player Controls After (seconds)"
+msgstr ""
+
+#: jellyfin_mpv_shim/mpvtk_browser/config.py
+msgid "Shrink the Player Controls on a Narrow Window"
 msgstr ""
 
 #: jellyfin_mpv_shim/mpvtk_browser/config.py
@@ -1967,6 +1999,21 @@ msgstr ""
 
 #: jellyfin_mpv_shim/mpvtk_browser/config.py
 msgid ""
+"Stops MPV's own shortcuts -- picture adjustment, screenshots, subtitle and "
+"audio switching -- from acting while you are in the library, where there is "
+"no video for them to act on. Turn it off to use your own MPV key bindings "
+"there."
+msgstr ""
+
+#: jellyfin_mpv_shim/mpvtk_browser/config.py
+msgid ""
+"Activates whatever is highlighted, in the library and on the player "
+"controls. An mpv key name; changing it hands Enter back to MPV. The game "
+"controller's Confirm button and a phone's Select follow it."
+msgstr ""
+
+#: jellyfin_mpv_shim/mpvtk_browser/config.py
+msgid ""
 "Leave these blank unless downloads are waking your disks too often. Set both "
 "of the first two together: episodes are then fetched in one batch when a "
 "series runs low, instead of one at a time."
@@ -1980,7 +2027,8 @@ msgstr ""
 #: jellyfin_mpv_shim/mpvtk_browser/config.py
 msgid ""
 "Off gives MPV's own mouse behaviour instead: drag the video to move the "
-"window, and right click to pause. Double click is full screen either way."
+"window, and the right button does whatever your MPV config gives it. Double "
+"click is full screen either way."
 msgstr ""
 
 #: jellyfin_mpv_shim/mpvtk_browser/config.py
@@ -2070,6 +2118,30 @@ msgid ""
 "maximize and close in the top bar instead, and lets you drag the window by "
 "it. On \"Only when the window has no title bar\", MPV is asked whether this "
 "window got one, so desktops that draw a title bar are left alone."
+msgstr ""
+
+#: jellyfin_mpv_shim/mpvtk_browser/config.py
+msgid ""
+"Full screen has no title bar anywhere and nothing to move or maximize, so "
+"the buttons are normally hidden there. Turn this on to keep a way out of "
+"full screen that is not a keyboard shortcut."
+msgstr ""
+
+#: jellyfin_mpv_shim/mpvtk_browser/config.py
+msgid ""
+"Asks the desktop for no title bar on the player window, so the top bar above "
+"is the only one. Pairs with the setting above: on \"Only when the window has "
+"no title bar\" the buttons appear as soon as this is on. Leave both off "
+"unless you want them, since a window with neither can be awkward to move on "
+"some desktops."
+msgstr ""
+
+#: jellyfin_mpv_shim/mpvtk_browser/config.py
+msgid ""
+"Shows a preview frame while you drag the seek bar. Works with every player "
+"control style, including your own OSC script if it supports thumbfast. The "
+"images are fetched from the server per video, which costs disk space and "
+"memory -- tens of MB for an episode, a few hundred for a long film."
 msgstr ""
 
 #: jellyfin_mpv_shim/mpvtk_browser/config.py
@@ -2177,6 +2249,13 @@ msgstr ""
 
 #: jellyfin_mpv_shim/mpvtk_browser/config.py
 msgid ""
+"Show times of day as \"8:30 PM\" rather than \"20:30\" — the Live TV guide "
+"and its air times, and the \"Ends at\" labels on a detail page and the "
+"player controls."
+msgstr ""
+
+#: jellyfin_mpv_shim/mpvtk_browser/config.py
+msgid ""
 "The controls have to stay legible over any frame. \"None\" gives the text a "
 "drop shadow instead of shading the picture behind it."
 msgstr ""
@@ -2191,6 +2270,13 @@ msgstr ""
 msgid ""
 "0 hides them as soon as the pointer is not on them, and forces \"Hide unless "
 "hovered\"."
+msgstr ""
+
+#: jellyfin_mpv_shim/mpvtk_browser/config.py
+msgid ""
+"Narrowing the window shrinks the controls until the smallest button reaches "
+"the accessibility minimum, instead of dropping buttons sooner. Off keeps the "
+"older, larger floor."
 msgstr ""
 
 #: jellyfin_mpv_shim/mpvtk_browser/config.py
@@ -3704,6 +3790,7 @@ msgid "More Like This"
 msgstr "Méi wéi dëst"
 
 #: jellyfin_mpv_shim/mpvtk_browser/pages/detail.py
+#: jellyfin_mpv_shim/mpvtk_browser/tiles.py
 msgid "Go to Series"
 msgstr ""
 
@@ -4795,6 +4882,22 @@ msgstr ""
 msgid "There is nothing here to queue."
 msgstr ""
 
+#: jellyfin_mpv_shim/mpvtk_browser/timefmt.py
+#, python-brace-format
+msgctxt "12-hour clock"
+msgid "{time} {period}"
+msgstr ""
+
+#: jellyfin_mpv_shim/mpvtk_browser/timefmt.py
+msgctxt "12-hour clock"
+msgid "AM"
+msgstr ""
+
+#: jellyfin_mpv_shim/mpvtk_browser/timefmt.py
+msgctxt "12-hour clock"
+msgid "PM"
+msgstr ""
+
 # seeded from jellyfin-web: Search
 #: jellyfin_mpv_shim/mpvtk_browser/views.py
 #: jellyfin_mpv_shim/mpvtk_browser/window_chrome.py
@@ -4956,13 +5059,32 @@ msgid "Enable SVP"
 msgstr ""
 
 #: jellyfin_mpv_shim/sync/manager.py
+msgid "The downloads are already in that folder."
+msgstr ""
+
+#: jellyfin_mpv_shim/sync/manager.py
 msgid ""
 "Can't change the download folder while a download is in progress. Wait for "
 "it to finish, then try again."
 msgstr ""
 
 #: jellyfin_mpv_shim/sync/manager.py
+msgid ""
+"That folder is inside the current download folder. Choose one outside it."
+msgstr ""
+
+#: jellyfin_mpv_shim/sync/manager.py
+msgid "Can't read that folder. Check the path and its permissions."
+msgstr ""
+
+#: jellyfin_mpv_shim/sync/manager.py
 msgid "That folder already contains downloads. Choose an empty folder."
+msgstr ""
+
+#: jellyfin_mpv_shim/sync/manager.py
+msgid ""
+"That folder isn't empty. Choose an empty folder — the download folder is "
+"managed by this app and anything else in it can be moved or removed."
 msgstr ""
 
 #: jellyfin_mpv_shim/sync/manager.py
@@ -4971,6 +5093,12 @@ msgstr ""
 
 #: jellyfin_mpv_shim/sync/manager.py
 msgid "A download is still finishing. Wait for it to stop, then try again."
+msgstr ""
+
+#: jellyfin_mpv_shim/sync/manager.py
+msgid ""
+"There isn't enough space on that drive to move the downloads. Free some "
+"space and try again — nothing was moved."
 msgstr ""
 
 #: jellyfin_mpv_shim/sync/manager.py

--- a/jellyfin_mpv_shim/messages/lt/LC_MESSAGES/base.po
+++ b/jellyfin_mpv_shim/messages/lt/LC_MESSAGES/base.po
@@ -6,7 +6,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2026-08-30 22:19-0400\n"
+"POT-Creation-Date: 2026-09-07 17:35-0400\n"
 "PO-Revision-Date: 2026-09-06 21:17+0000\n"
 "Last-Translator: Vitalijus <vitalijus.n@gmail.com>\n"
 "Language-Team: Lithuanian <https://translate.jellyfin.org/projects/jellyfin/"
@@ -510,6 +510,11 @@ msgid "Night Mode (Auto Volume Adj)"
 msgstr "Naktinis režimas (automatinis garsumo reguliavimas)"
 
 #: jellyfin_mpv_shim/mpvtk_browser/app.py
+#: jellyfin_mpv_shim/mpvtk_browser/auth.py
+msgid "Locked"
+msgstr "Užrakinta"
+
+#: jellyfin_mpv_shim/mpvtk_browser/app.py
 msgid "Failed to load. Check the connection."
 msgstr "Nepavyko įkelti. Patikrinkite ryšį."
 
@@ -750,10 +755,6 @@ msgid "Could not connect. Please check your details."
 msgstr "Nepavyko prisijungti. Patikrinkite savo duomenis."
 
 #: jellyfin_mpv_shim/mpvtk_browser/auth.py
-msgid "Locked"
-msgstr "Užrakinta"
-
-#: jellyfin_mpv_shim/mpvtk_browser/auth.py
 #: jellyfin_mpv_shim/mpvtk_browser/pages/home.py
 msgid "Connecting to your server…"
 msgstr "Jungiamasi prie jūsų serverio…"
@@ -824,6 +825,10 @@ msgstr "Žiūrėtas"
 #: jellyfin_mpv_shim/mpvtk_browser/pages/books.py
 msgid "Favorite"
 msgstr "Mėgstamas"
+
+#: jellyfin_mpv_shim/mpvtk_browser/components/detail.py
+msgid "Web"
+msgstr ""
 
 #: jellyfin_mpv_shim/mpvtk_browser/components/media_info.py
 msgid "Video"
@@ -1328,12 +1333,8 @@ msgid "Jellyfin UI"
 msgstr "Jellyfin vartotojo sąsaja"
 
 #: jellyfin_mpv_shim/mpvtk_browser/config.py
-msgid "MPV UI with thumbnails"
-msgstr "MPV vartotojo sąsaja su miniatiūromis"
-
-#: jellyfin_mpv_shim/mpvtk_browser/config.py
-msgid "MPV built-in default"
-msgstr "MPV integruotas numatytasis nustatymas"
+msgid "MPV UI"
+msgstr ""
 
 #: jellyfin_mpv_shim/mpvtk_browser/config.py
 msgid "Custom OSC"
@@ -1665,8 +1666,22 @@ msgid "Window Buttons in the Top Bar"
 msgstr ""
 
 #: jellyfin_mpv_shim/mpvtk_browser/config.py
+msgid "Keep Window Buttons in Full Screen"
+msgstr ""
+
+#: jellyfin_mpv_shim/mpvtk_browser/config.py
+msgid "Hide the Desktop Title Bar"
+msgstr ""
+
+#: jellyfin_mpv_shim/mpvtk_browser/config.py
 msgid "Player Controls Style"
 msgstr "Grotuvo valdiklių stilius"
+
+#: jellyfin_mpv_shim/mpvtk_browser/config.py
+#, fuzzy
+#| msgid "Enable thumbnail previews"
+msgid "Enable Trickplay Thumbnails"
+msgstr "Įjungti miniatūrų peržiūrą"
 
 #: jellyfin_mpv_shim/mpvtk_browser/config.py
 msgid "Load All Seek Previews at Once"
@@ -1695,6 +1710,10 @@ msgstr "Viršelio dydis"
 
 #: jellyfin_mpv_shim/mpvtk_browser/config.py
 msgid "Full-Width Backdrops"
+msgstr ""
+
+#: jellyfin_mpv_shim/mpvtk_browser/config.py
+msgid "12-Hour Clock"
 msgstr ""
 
 #: jellyfin_mpv_shim/mpvtk_browser/config.py
@@ -1738,12 +1757,22 @@ msgid "Fullscreen Library Browser"
 msgstr ""
 
 #: jellyfin_mpv_shim/mpvtk_browser/config.py
+msgid "Block Player Keybinds While Browsing"
+msgstr ""
+
+#: jellyfin_mpv_shim/mpvtk_browser/config.py
 msgid "Always Bind Arrow Keys to Player Controls"
 msgstr ""
 
 #: jellyfin_mpv_shim/mpvtk_browser/config.py
 msgid "Player Controls Activation Key"
 msgstr ""
+
+#: jellyfin_mpv_shim/mpvtk_browser/config.py
+#, fuzzy
+#| msgid "Selected: %s"
+msgid "Select Key"
+msgstr "Pasirinkta: %s"
 
 #: jellyfin_mpv_shim/mpvtk_browser/config.py
 msgid "Shading Behind the Player Controls"
@@ -1755,6 +1784,10 @@ msgstr ""
 
 #: jellyfin_mpv_shim/mpvtk_browser/config.py
 msgid "Hide the Player Controls After (seconds)"
+msgstr ""
+
+#: jellyfin_mpv_shim/mpvtk_browser/config.py
+msgid "Shrink the Player Controls on a Narrow Window"
 msgstr ""
 
 #: jellyfin_mpv_shim/mpvtk_browser/config.py
@@ -1837,6 +1870,21 @@ msgstr ""
 
 #: jellyfin_mpv_shim/mpvtk_browser/config.py
 msgid ""
+"Stops MPV's own shortcuts -- picture adjustment, screenshots, subtitle and "
+"audio switching -- from acting while you are in the library, where there is "
+"no video for them to act on. Turn it off to use your own MPV key bindings "
+"there."
+msgstr ""
+
+#: jellyfin_mpv_shim/mpvtk_browser/config.py
+msgid ""
+"Activates whatever is highlighted, in the library and on the player "
+"controls. An mpv key name; changing it hands Enter back to MPV. The game "
+"controller's Confirm button and a phone's Select follow it."
+msgstr ""
+
+#: jellyfin_mpv_shim/mpvtk_browser/config.py
+msgid ""
 "Leave these blank unless downloads are waking your disks too often. Set both "
 "of the first two together: episodes are then fetched in one batch when a "
 "series runs low, instead of one at a time."
@@ -1850,7 +1898,8 @@ msgstr ""
 #: jellyfin_mpv_shim/mpvtk_browser/config.py
 msgid ""
 "Off gives MPV's own mouse behaviour instead: drag the video to move the "
-"window, and right click to pause. Double click is full screen either way."
+"window, and the right button does whatever your MPV config gives it. Double "
+"click is full screen either way."
 msgstr ""
 
 #: jellyfin_mpv_shim/mpvtk_browser/config.py
@@ -1940,6 +1989,30 @@ msgid ""
 "maximize and close in the top bar instead, and lets you drag the window by "
 "it. On \"Only when the window has no title bar\", MPV is asked whether this "
 "window got one, so desktops that draw a title bar are left alone."
+msgstr ""
+
+#: jellyfin_mpv_shim/mpvtk_browser/config.py
+msgid ""
+"Full screen has no title bar anywhere and nothing to move or maximize, so "
+"the buttons are normally hidden there. Turn this on to keep a way out of "
+"full screen that is not a keyboard shortcut."
+msgstr ""
+
+#: jellyfin_mpv_shim/mpvtk_browser/config.py
+msgid ""
+"Asks the desktop for no title bar on the player window, so the top bar above "
+"is the only one. Pairs with the setting above: on \"Only when the window has "
+"no title bar\" the buttons appear as soon as this is on. Leave both off "
+"unless you want them, since a window with neither can be awkward to move on "
+"some desktops."
+msgstr ""
+
+#: jellyfin_mpv_shim/mpvtk_browser/config.py
+msgid ""
+"Shows a preview frame while you drag the seek bar. Works with every player "
+"control style, including your own OSC script if it supports thumbfast. The "
+"images are fetched from the server per video, which costs disk space and "
+"memory -- tens of MB for an episode, a few hundred for a long film."
 msgstr ""
 
 #: jellyfin_mpv_shim/mpvtk_browser/config.py
@@ -2047,6 +2120,13 @@ msgstr ""
 
 #: jellyfin_mpv_shim/mpvtk_browser/config.py
 msgid ""
+"Show times of day as \"8:30 PM\" rather than \"20:30\" — the Live TV guide "
+"and its air times, and the \"Ends at\" labels on a detail page and the "
+"player controls."
+msgstr ""
+
+#: jellyfin_mpv_shim/mpvtk_browser/config.py
+msgid ""
 "The controls have to stay legible over any frame. \"None\" gives the text a "
 "drop shadow instead of shading the picture behind it."
 msgstr ""
@@ -2061,6 +2141,13 @@ msgstr ""
 msgid ""
 "0 hides them as soon as the pointer is not on them, and forces \"Hide unless "
 "hovered\"."
+msgstr ""
+
+#: jellyfin_mpv_shim/mpvtk_browser/config.py
+msgid ""
+"Narrowing the window shrinks the controls until the smallest button reaches "
+"the accessibility minimum, instead of dropping buttons sooner. Off keeps the "
+"older, larger floor."
 msgstr ""
 
 #: jellyfin_mpv_shim/mpvtk_browser/config.py
@@ -3387,6 +3474,7 @@ msgid "More Like This"
 msgstr ""
 
 #: jellyfin_mpv_shim/mpvtk_browser/pages/detail.py
+#: jellyfin_mpv_shim/mpvtk_browser/tiles.py
 msgid "Go to Series"
 msgstr ""
 
@@ -4381,6 +4469,22 @@ msgstr "Pašalinti %s iš šis kolekcijos?"
 msgid "There is nothing here to queue."
 msgstr ""
 
+#: jellyfin_mpv_shim/mpvtk_browser/timefmt.py
+#, python-brace-format
+msgctxt "12-hour clock"
+msgid "{time} {period}"
+msgstr ""
+
+#: jellyfin_mpv_shim/mpvtk_browser/timefmt.py
+msgctxt "12-hour clock"
+msgid "AM"
+msgstr ""
+
+#: jellyfin_mpv_shim/mpvtk_browser/timefmt.py
+msgctxt "12-hour clock"
+msgid "PM"
+msgstr ""
+
 #: jellyfin_mpv_shim/mpvtk_browser/views.py
 #: jellyfin_mpv_shim/mpvtk_browser/window_chrome.py
 msgid "Search"
@@ -4533,13 +4637,32 @@ msgid "Enable SVP"
 msgstr "Įjungti SVP"
 
 #: jellyfin_mpv_shim/sync/manager.py
+msgid "The downloads are already in that folder."
+msgstr ""
+
+#: jellyfin_mpv_shim/sync/manager.py
 msgid ""
 "Can't change the download folder while a download is in progress. Wait for "
 "it to finish, then try again."
 msgstr ""
 
 #: jellyfin_mpv_shim/sync/manager.py
+msgid ""
+"That folder is inside the current download folder. Choose one outside it."
+msgstr ""
+
+#: jellyfin_mpv_shim/sync/manager.py
+msgid "Can't read that folder. Check the path and its permissions."
+msgstr ""
+
+#: jellyfin_mpv_shim/sync/manager.py
 msgid "That folder already contains downloads. Choose an empty folder."
+msgstr ""
+
+#: jellyfin_mpv_shim/sync/manager.py
+msgid ""
+"That folder isn't empty. Choose an empty folder — the download folder is "
+"managed by this app and anything else in it can be moved or removed."
 msgstr ""
 
 #: jellyfin_mpv_shim/sync/manager.py
@@ -4548,6 +4671,12 @@ msgstr ""
 
 #: jellyfin_mpv_shim/sync/manager.py
 msgid "A download is still finishing. Wait for it to stop, then try again."
+msgstr ""
+
+#: jellyfin_mpv_shim/sync/manager.py
+msgid ""
+"There isn't enough space on that drive to move the downloads. Free some "
+"space and try again — nothing was moved."
 msgstr ""
 
 #: jellyfin_mpv_shim/sync/manager.py
@@ -4744,6 +4873,12 @@ msgstr "Vaizdo atkūrimo profilis"
 #: jellyfin_mpv_shim/video_profile.py
 msgid "Select Shader Profile"
 msgstr "Pasirinkite Shader profilį"
+
+#~ msgid "MPV UI with thumbnails"
+#~ msgstr "MPV vartotojo sąsaja su miniatiūromis"
+
+#~ msgid "MPV built-in default"
+#~ msgstr "MPV integruotas numatytasis nustatymas"
 
 #~ msgid "Could not copy the text."
 #~ msgstr "Nepavyko nukopijuoti teksto."

--- a/jellyfin_mpv_shim/messages/lv/LC_MESSAGES/base.po
+++ b/jellyfin_mpv_shim/messages/lv/LC_MESSAGES/base.po
@@ -6,7 +6,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2026-08-30 22:19-0400\n"
+"POT-Creation-Date: 2026-09-07 17:35-0400\n"
 "PO-Revision-Date: 2026-09-07 08:34+0000\n"
 "Last-Translator: \"ℂ𝕠𝕠𝕠𝕝 (𝕘𝕚𝕥𝕙𝕦𝕓.𝕔𝕠𝕞/ℂ𝕠𝕠𝕠𝕝)\" "
 "<translate.jellyfin.org@coool.id.lv>\n"
@@ -538,6 +538,11 @@ msgid "Night Mode (Auto Volume Adj)"
 msgstr ""
 
 #: jellyfin_mpv_shim/mpvtk_browser/app.py
+#: jellyfin_mpv_shim/mpvtk_browser/auth.py
+msgid "Locked"
+msgstr ""
+
+#: jellyfin_mpv_shim/mpvtk_browser/app.py
 msgid "Failed to load. Check the connection."
 msgstr ""
 
@@ -814,10 +819,6 @@ msgstr ""
 "Lūdzu, pārbaudiet savienojuma informāciju."
 
 #: jellyfin_mpv_shim/mpvtk_browser/auth.py
-msgid "Locked"
-msgstr ""
-
-#: jellyfin_mpv_shim/mpvtk_browser/auth.py
 #: jellyfin_mpv_shim/mpvtk_browser/pages/home.py
 msgid "Connecting to your server…"
 msgstr ""
@@ -898,6 +899,10 @@ msgstr "Iziet un atzīmēt kā neskatītu"
 #: jellyfin_mpv_shim/mpvtk_browser/pages/books.py
 msgid "Favorite"
 msgstr "Izlasē"
+
+#: jellyfin_mpv_shim/mpvtk_browser/components/detail.py
+msgid "Web"
+msgstr ""
 
 # seeded from jellyfin-web: Video
 #: jellyfin_mpv_shim/mpvtk_browser/components/media_info.py
@@ -1507,11 +1512,7 @@ msgid "Jellyfin UI"
 msgstr ""
 
 #: jellyfin_mpv_shim/mpvtk_browser/config.py
-msgid "MPV UI with thumbnails"
-msgstr ""
-
-#: jellyfin_mpv_shim/mpvtk_browser/config.py
-msgid "MPV built-in default"
+msgid "MPV UI"
 msgstr ""
 
 #: jellyfin_mpv_shim/mpvtk_browser/config.py
@@ -1860,8 +1861,22 @@ msgid "Window Buttons in the Top Bar"
 msgstr ""
 
 #: jellyfin_mpv_shim/mpvtk_browser/config.py
+msgid "Keep Window Buttons in Full Screen"
+msgstr ""
+
+#: jellyfin_mpv_shim/mpvtk_browser/config.py
+msgid "Hide the Desktop Title Bar"
+msgstr ""
+
+#: jellyfin_mpv_shim/mpvtk_browser/config.py
 msgid "Player Controls Style"
 msgstr ""
+
+#: jellyfin_mpv_shim/mpvtk_browser/config.py
+#, fuzzy
+#| msgid "Enable thumbnail previews"
+msgid "Enable Trickplay Thumbnails"
+msgstr "Ieslēgt sīktēlu priekšskatījumus"
 
 #: jellyfin_mpv_shim/mpvtk_browser/config.py
 msgid "Load All Seek Previews at Once"
@@ -1892,6 +1907,10 @@ msgstr ""
 
 #: jellyfin_mpv_shim/mpvtk_browser/config.py
 msgid "Full-Width Backdrops"
+msgstr ""
+
+#: jellyfin_mpv_shim/mpvtk_browser/config.py
+msgid "12-Hour Clock"
 msgstr ""
 
 #: jellyfin_mpv_shim/mpvtk_browser/config.py
@@ -1937,12 +1956,23 @@ msgid "Fullscreen Library Browser"
 msgstr ""
 
 #: jellyfin_mpv_shim/mpvtk_browser/config.py
+msgid "Block Player Keybinds While Browsing"
+msgstr ""
+
+#: jellyfin_mpv_shim/mpvtk_browser/config.py
 msgid "Always Bind Arrow Keys to Player Controls"
 msgstr ""
 
 #: jellyfin_mpv_shim/mpvtk_browser/config.py
 msgid "Player Controls Activation Key"
 msgstr ""
+
+# seeded from jellyfin-web: SelectAll
+#: jellyfin_mpv_shim/mpvtk_browser/config.py
+#, fuzzy
+#| msgid "Select All"
+msgid "Select Key"
+msgstr "Izvēlēties visu"
 
 #: jellyfin_mpv_shim/mpvtk_browser/config.py
 msgid "Shading Behind the Player Controls"
@@ -1954,6 +1984,10 @@ msgstr ""
 
 #: jellyfin_mpv_shim/mpvtk_browser/config.py
 msgid "Hide the Player Controls After (seconds)"
+msgstr ""
+
+#: jellyfin_mpv_shim/mpvtk_browser/config.py
+msgid "Shrink the Player Controls on a Narrow Window"
 msgstr ""
 
 #: jellyfin_mpv_shim/mpvtk_browser/config.py
@@ -2040,6 +2074,21 @@ msgstr ""
 
 #: jellyfin_mpv_shim/mpvtk_browser/config.py
 msgid ""
+"Stops MPV's own shortcuts -- picture adjustment, screenshots, subtitle and "
+"audio switching -- from acting while you are in the library, where there is "
+"no video for them to act on. Turn it off to use your own MPV key bindings "
+"there."
+msgstr ""
+
+#: jellyfin_mpv_shim/mpvtk_browser/config.py
+msgid ""
+"Activates whatever is highlighted, in the library and on the player "
+"controls. An mpv key name; changing it hands Enter back to MPV. The game "
+"controller's Confirm button and a phone's Select follow it."
+msgstr ""
+
+#: jellyfin_mpv_shim/mpvtk_browser/config.py
+msgid ""
 "Leave these blank unless downloads are waking your disks too often. Set both "
 "of the first two together: episodes are then fetched in one batch when a "
 "series runs low, instead of one at a time."
@@ -2053,7 +2102,8 @@ msgstr ""
 #: jellyfin_mpv_shim/mpvtk_browser/config.py
 msgid ""
 "Off gives MPV's own mouse behaviour instead: drag the video to move the "
-"window, and right click to pause. Double click is full screen either way."
+"window, and the right button does whatever your MPV config gives it. Double "
+"click is full screen either way."
 msgstr ""
 
 #: jellyfin_mpv_shim/mpvtk_browser/config.py
@@ -2143,6 +2193,30 @@ msgid ""
 "maximize and close in the top bar instead, and lets you drag the window by "
 "it. On \"Only when the window has no title bar\", MPV is asked whether this "
 "window got one, so desktops that draw a title bar are left alone."
+msgstr ""
+
+#: jellyfin_mpv_shim/mpvtk_browser/config.py
+msgid ""
+"Full screen has no title bar anywhere and nothing to move or maximize, so "
+"the buttons are normally hidden there. Turn this on to keep a way out of "
+"full screen that is not a keyboard shortcut."
+msgstr ""
+
+#: jellyfin_mpv_shim/mpvtk_browser/config.py
+msgid ""
+"Asks the desktop for no title bar on the player window, so the top bar above "
+"is the only one. Pairs with the setting above: on \"Only when the window has "
+"no title bar\" the buttons appear as soon as this is on. Leave both off "
+"unless you want them, since a window with neither can be awkward to move on "
+"some desktops."
+msgstr ""
+
+#: jellyfin_mpv_shim/mpvtk_browser/config.py
+msgid ""
+"Shows a preview frame while you drag the seek bar. Works with every player "
+"control style, including your own OSC script if it supports thumbfast. The "
+"images are fetched from the server per video, which costs disk space and "
+"memory -- tens of MB for an episode, a few hundred for a long film."
 msgstr ""
 
 #: jellyfin_mpv_shim/mpvtk_browser/config.py
@@ -2252,6 +2326,13 @@ msgstr ""
 
 #: jellyfin_mpv_shim/mpvtk_browser/config.py
 msgid ""
+"Show times of day as \"8:30 PM\" rather than \"20:30\" — the Live TV guide "
+"and its air times, and the \"Ends at\" labels on a detail page and the "
+"player controls."
+msgstr ""
+
+#: jellyfin_mpv_shim/mpvtk_browser/config.py
+msgid ""
 "The controls have to stay legible over any frame. \"None\" gives the text a "
 "drop shadow instead of shading the picture behind it."
 msgstr ""
@@ -2266,6 +2347,13 @@ msgstr ""
 msgid ""
 "0 hides them as soon as the pointer is not on them, and forces \"Hide unless "
 "hovered\"."
+msgstr ""
+
+#: jellyfin_mpv_shim/mpvtk_browser/config.py
+msgid ""
+"Narrowing the window shrinks the controls until the smallest button reaches "
+"the accessibility minimum, instead of dropping buttons sooner. Off keeps the "
+"older, larger floor."
 msgstr ""
 
 #: jellyfin_mpv_shim/mpvtk_browser/config.py
@@ -3835,6 +3923,7 @@ msgid "More Like This"
 msgstr "Līdzīgs saturs"
 
 #: jellyfin_mpv_shim/mpvtk_browser/pages/detail.py
+#: jellyfin_mpv_shim/mpvtk_browser/tiles.py
 msgid "Go to Series"
 msgstr ""
 
@@ -5007,6 +5096,22 @@ msgstr "Noņemt serveri"
 msgid "There is nothing here to queue."
 msgstr ""
 
+#: jellyfin_mpv_shim/mpvtk_browser/timefmt.py
+#, python-brace-format
+msgctxt "12-hour clock"
+msgid "{time} {period}"
+msgstr ""
+
+#: jellyfin_mpv_shim/mpvtk_browser/timefmt.py
+msgctxt "12-hour clock"
+msgid "AM"
+msgstr ""
+
+#: jellyfin_mpv_shim/mpvtk_browser/timefmt.py
+msgctxt "12-hour clock"
+msgid "PM"
+msgstr ""
+
 # seeded from jellyfin-web: Search
 #: jellyfin_mpv_shim/mpvtk_browser/views.py
 #: jellyfin_mpv_shim/mpvtk_browser/window_chrome.py
@@ -5173,13 +5278,32 @@ msgid "Enable SVP"
 msgstr "Iestatīt SVP"
 
 #: jellyfin_mpv_shim/sync/manager.py
+msgid "The downloads are already in that folder."
+msgstr ""
+
+#: jellyfin_mpv_shim/sync/manager.py
 msgid ""
 "Can't change the download folder while a download is in progress. Wait for "
 "it to finish, then try again."
 msgstr ""
 
 #: jellyfin_mpv_shim/sync/manager.py
+msgid ""
+"That folder is inside the current download folder. Choose one outside it."
+msgstr ""
+
+#: jellyfin_mpv_shim/sync/manager.py
+msgid "Can't read that folder. Check the path and its permissions."
+msgstr ""
+
+#: jellyfin_mpv_shim/sync/manager.py
 msgid "That folder already contains downloads. Choose an empty folder."
+msgstr ""
+
+#: jellyfin_mpv_shim/sync/manager.py
+msgid ""
+"That folder isn't empty. Choose an empty folder — the download folder is "
+"managed by this app and anything else in it can be moved or removed."
 msgstr ""
 
 #: jellyfin_mpv_shim/sync/manager.py
@@ -5188,6 +5312,12 @@ msgstr ""
 
 #: jellyfin_mpv_shim/sync/manager.py
 msgid "A download is still finishing. Wait for it to stop, then try again."
+msgstr ""
+
+#: jellyfin_mpv_shim/sync/manager.py
+msgid ""
+"There isn't enough space on that drive to move the downloads. Free some "
+"space and try again — nothing was moved."
 msgstr ""
 
 #: jellyfin_mpv_shim/sync/manager.py

--- a/jellyfin_mpv_shim/messages/lzh/LC_MESSAGES/base.po
+++ b/jellyfin_mpv_shim/messages/lzh/LC_MESSAGES/base.po
@@ -6,7 +6,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2026-08-30 22:19-0400\n"
+"POT-Creation-Date: 2026-09-07 17:35-0400\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: Automatically generated\n"
 "Language-Team: none\n"
@@ -503,6 +503,11 @@ msgid "Night Mode (Auto Volume Adj)"
 msgstr ""
 
 #: jellyfin_mpv_shim/mpvtk_browser/app.py
+#: jellyfin_mpv_shim/mpvtk_browser/auth.py
+msgid "Locked"
+msgstr ""
+
+#: jellyfin_mpv_shim/mpvtk_browser/app.py
 msgid "Failed to load. Check the connection."
 msgstr ""
 
@@ -743,10 +748,6 @@ msgid "Could not connect. Please check your details."
 msgstr ""
 
 #: jellyfin_mpv_shim/mpvtk_browser/auth.py
-msgid "Locked"
-msgstr ""
-
-#: jellyfin_mpv_shim/mpvtk_browser/auth.py
 #: jellyfin_mpv_shim/mpvtk_browser/pages/home.py
 msgid "Connecting to your server…"
 msgstr ""
@@ -816,6 +817,10 @@ msgstr ""
 #: jellyfin_mpv_shim/mpvtk_browser/hud.py
 #: jellyfin_mpv_shim/mpvtk_browser/pages/books.py
 msgid "Favorite"
+msgstr ""
+
+#: jellyfin_mpv_shim/mpvtk_browser/components/detail.py
+msgid "Web"
 msgstr ""
 
 #: jellyfin_mpv_shim/mpvtk_browser/components/media_info.py
@@ -1321,11 +1326,7 @@ msgid "Jellyfin UI"
 msgstr ""
 
 #: jellyfin_mpv_shim/mpvtk_browser/config.py
-msgid "MPV UI with thumbnails"
-msgstr ""
-
-#: jellyfin_mpv_shim/mpvtk_browser/config.py
-msgid "MPV built-in default"
+msgid "MPV UI"
 msgstr ""
 
 #: jellyfin_mpv_shim/mpvtk_browser/config.py
@@ -1658,7 +1659,19 @@ msgid "Window Buttons in the Top Bar"
 msgstr ""
 
 #: jellyfin_mpv_shim/mpvtk_browser/config.py
+msgid "Keep Window Buttons in Full Screen"
+msgstr ""
+
+#: jellyfin_mpv_shim/mpvtk_browser/config.py
+msgid "Hide the Desktop Title Bar"
+msgstr ""
+
+#: jellyfin_mpv_shim/mpvtk_browser/config.py
 msgid "Player Controls Style"
+msgstr ""
+
+#: jellyfin_mpv_shim/mpvtk_browser/config.py
+msgid "Enable Trickplay Thumbnails"
 msgstr ""
 
 #: jellyfin_mpv_shim/mpvtk_browser/config.py
@@ -1688,6 +1701,10 @@ msgstr ""
 
 #: jellyfin_mpv_shim/mpvtk_browser/config.py
 msgid "Full-Width Backdrops"
+msgstr ""
+
+#: jellyfin_mpv_shim/mpvtk_browser/config.py
+msgid "12-Hour Clock"
 msgstr ""
 
 #: jellyfin_mpv_shim/mpvtk_browser/config.py
@@ -1731,11 +1748,19 @@ msgid "Fullscreen Library Browser"
 msgstr ""
 
 #: jellyfin_mpv_shim/mpvtk_browser/config.py
+msgid "Block Player Keybinds While Browsing"
+msgstr ""
+
+#: jellyfin_mpv_shim/mpvtk_browser/config.py
 msgid "Always Bind Arrow Keys to Player Controls"
 msgstr ""
 
 #: jellyfin_mpv_shim/mpvtk_browser/config.py
 msgid "Player Controls Activation Key"
+msgstr ""
+
+#: jellyfin_mpv_shim/mpvtk_browser/config.py
+msgid "Select Key"
 msgstr ""
 
 #: jellyfin_mpv_shim/mpvtk_browser/config.py
@@ -1748,6 +1773,10 @@ msgstr ""
 
 #: jellyfin_mpv_shim/mpvtk_browser/config.py
 msgid "Hide the Player Controls After (seconds)"
+msgstr ""
+
+#: jellyfin_mpv_shim/mpvtk_browser/config.py
+msgid "Shrink the Player Controls on a Narrow Window"
 msgstr ""
 
 #: jellyfin_mpv_shim/mpvtk_browser/config.py
@@ -1830,6 +1859,21 @@ msgstr ""
 
 #: jellyfin_mpv_shim/mpvtk_browser/config.py
 msgid ""
+"Stops MPV's own shortcuts -- picture adjustment, screenshots, subtitle and "
+"audio switching -- from acting while you are in the library, where there is "
+"no video for them to act on. Turn it off to use your own MPV key bindings "
+"there."
+msgstr ""
+
+#: jellyfin_mpv_shim/mpvtk_browser/config.py
+msgid ""
+"Activates whatever is highlighted, in the library and on the player "
+"controls. An mpv key name; changing it hands Enter back to MPV. The game "
+"controller's Confirm button and a phone's Select follow it."
+msgstr ""
+
+#: jellyfin_mpv_shim/mpvtk_browser/config.py
+msgid ""
 "Leave these blank unless downloads are waking your disks too often. Set both "
 "of the first two together: episodes are then fetched in one batch when a "
 "series runs low, instead of one at a time."
@@ -1843,7 +1887,8 @@ msgstr ""
 #: jellyfin_mpv_shim/mpvtk_browser/config.py
 msgid ""
 "Off gives MPV's own mouse behaviour instead: drag the video to move the "
-"window, and right click to pause. Double click is full screen either way."
+"window, and the right button does whatever your MPV config gives it. Double "
+"click is full screen either way."
 msgstr ""
 
 #: jellyfin_mpv_shim/mpvtk_browser/config.py
@@ -1933,6 +1978,30 @@ msgid ""
 "maximize and close in the top bar instead, and lets you drag the window by "
 "it. On \"Only when the window has no title bar\", MPV is asked whether this "
 "window got one, so desktops that draw a title bar are left alone."
+msgstr ""
+
+#: jellyfin_mpv_shim/mpvtk_browser/config.py
+msgid ""
+"Full screen has no title bar anywhere and nothing to move or maximize, so "
+"the buttons are normally hidden there. Turn this on to keep a way out of "
+"full screen that is not a keyboard shortcut."
+msgstr ""
+
+#: jellyfin_mpv_shim/mpvtk_browser/config.py
+msgid ""
+"Asks the desktop for no title bar on the player window, so the top bar above "
+"is the only one. Pairs with the setting above: on \"Only when the window has "
+"no title bar\" the buttons appear as soon as this is on. Leave both off "
+"unless you want them, since a window with neither can be awkward to move on "
+"some desktops."
+msgstr ""
+
+#: jellyfin_mpv_shim/mpvtk_browser/config.py
+msgid ""
+"Shows a preview frame while you drag the seek bar. Works with every player "
+"control style, including your own OSC script if it supports thumbfast. The "
+"images are fetched from the server per video, which costs disk space and "
+"memory -- tens of MB for an episode, a few hundred for a long film."
 msgstr ""
 
 #: jellyfin_mpv_shim/mpvtk_browser/config.py
@@ -2040,6 +2109,13 @@ msgstr ""
 
 #: jellyfin_mpv_shim/mpvtk_browser/config.py
 msgid ""
+"Show times of day as \"8:30 PM\" rather than \"20:30\" — the Live TV guide "
+"and its air times, and the \"Ends at\" labels on a detail page and the "
+"player controls."
+msgstr ""
+
+#: jellyfin_mpv_shim/mpvtk_browser/config.py
+msgid ""
 "The controls have to stay legible over any frame. \"None\" gives the text a "
 "drop shadow instead of shading the picture behind it."
 msgstr ""
@@ -2054,6 +2130,13 @@ msgstr ""
 msgid ""
 "0 hides them as soon as the pointer is not on them, and forces \"Hide unless "
 "hovered\"."
+msgstr ""
+
+#: jellyfin_mpv_shim/mpvtk_browser/config.py
+msgid ""
+"Narrowing the window shrinks the controls until the smallest button reaches "
+"the accessibility minimum, instead of dropping buttons sooner. Off keeps the "
+"older, larger floor."
 msgstr ""
 
 #: jellyfin_mpv_shim/mpvtk_browser/config.py
@@ -3380,6 +3463,7 @@ msgid "More Like This"
 msgstr ""
 
 #: jellyfin_mpv_shim/mpvtk_browser/pages/detail.py
+#: jellyfin_mpv_shim/mpvtk_browser/tiles.py
 msgid "Go to Series"
 msgstr ""
 
@@ -4374,6 +4458,22 @@ msgstr ""
 msgid "There is nothing here to queue."
 msgstr ""
 
+#: jellyfin_mpv_shim/mpvtk_browser/timefmt.py
+#, python-brace-format
+msgctxt "12-hour clock"
+msgid "{time} {period}"
+msgstr ""
+
+#: jellyfin_mpv_shim/mpvtk_browser/timefmt.py
+msgctxt "12-hour clock"
+msgid "AM"
+msgstr ""
+
+#: jellyfin_mpv_shim/mpvtk_browser/timefmt.py
+msgctxt "12-hour clock"
+msgid "PM"
+msgstr ""
+
 #: jellyfin_mpv_shim/mpvtk_browser/views.py
 #: jellyfin_mpv_shim/mpvtk_browser/window_chrome.py
 msgid "Search"
@@ -4524,13 +4624,32 @@ msgid "Enable SVP"
 msgstr ""
 
 #: jellyfin_mpv_shim/sync/manager.py
+msgid "The downloads are already in that folder."
+msgstr ""
+
+#: jellyfin_mpv_shim/sync/manager.py
 msgid ""
 "Can't change the download folder while a download is in progress. Wait for "
 "it to finish, then try again."
 msgstr ""
 
 #: jellyfin_mpv_shim/sync/manager.py
+msgid ""
+"That folder is inside the current download folder. Choose one outside it."
+msgstr ""
+
+#: jellyfin_mpv_shim/sync/manager.py
+msgid "Can't read that folder. Check the path and its permissions."
+msgstr ""
+
+#: jellyfin_mpv_shim/sync/manager.py
 msgid "That folder already contains downloads. Choose an empty folder."
+msgstr ""
+
+#: jellyfin_mpv_shim/sync/manager.py
+msgid ""
+"That folder isn't empty. Choose an empty folder — the download folder is "
+"managed by this app and anything else in it can be moved or removed."
 msgstr ""
 
 #: jellyfin_mpv_shim/sync/manager.py
@@ -4539,6 +4658,12 @@ msgstr ""
 
 #: jellyfin_mpv_shim/sync/manager.py
 msgid "A download is still finishing. Wait for it to stop, then try again."
+msgstr ""
+
+#: jellyfin_mpv_shim/sync/manager.py
+msgid ""
+"There isn't enough space on that drive to move the downloads. Free some "
+"space and try again — nothing was moved."
 msgstr ""
 
 #: jellyfin_mpv_shim/sync/manager.py

--- a/jellyfin_mpv_shim/messages/mi/LC_MESSAGES/base.po
+++ b/jellyfin_mpv_shim/messages/mi/LC_MESSAGES/base.po
@@ -6,7 +6,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2026-08-30 22:19-0400\n"
+"POT-Creation-Date: 2026-09-07 17:35-0400\n"
 "PO-Revision-Date: 2025-12-10 05:20+0000\n"
 "Last-Translator: Veldermon-rbg <burtjayden3@gmail.com>\n"
 "Language-Team: Maori <https://translate.jellyfin.org/projects/jellyfin/"
@@ -506,6 +506,11 @@ msgid "Night Mode (Auto Volume Adj)"
 msgstr ""
 
 #: jellyfin_mpv_shim/mpvtk_browser/app.py
+#: jellyfin_mpv_shim/mpvtk_browser/auth.py
+msgid "Locked"
+msgstr ""
+
+#: jellyfin_mpv_shim/mpvtk_browser/app.py
 msgid "Failed to load. Check the connection."
 msgstr ""
 
@@ -746,10 +751,6 @@ msgid "Could not connect. Please check your details."
 msgstr ""
 
 #: jellyfin_mpv_shim/mpvtk_browser/auth.py
-msgid "Locked"
-msgstr ""
-
-#: jellyfin_mpv_shim/mpvtk_browser/auth.py
 #: jellyfin_mpv_shim/mpvtk_browser/pages/home.py
 msgid "Connecting to your server…"
 msgstr ""
@@ -819,6 +820,10 @@ msgstr ""
 #: jellyfin_mpv_shim/mpvtk_browser/hud.py
 #: jellyfin_mpv_shim/mpvtk_browser/pages/books.py
 msgid "Favorite"
+msgstr ""
+
+#: jellyfin_mpv_shim/mpvtk_browser/components/detail.py
+msgid "Web"
 msgstr ""
 
 #: jellyfin_mpv_shim/mpvtk_browser/components/media_info.py
@@ -1332,11 +1337,7 @@ msgid "Jellyfin UI"
 msgstr ""
 
 #: jellyfin_mpv_shim/mpvtk_browser/config.py
-msgid "MPV UI with thumbnails"
-msgstr ""
-
-#: jellyfin_mpv_shim/mpvtk_browser/config.py
-msgid "MPV built-in default"
+msgid "MPV UI"
 msgstr ""
 
 #: jellyfin_mpv_shim/mpvtk_browser/config.py
@@ -1669,7 +1670,19 @@ msgid "Window Buttons in the Top Bar"
 msgstr ""
 
 #: jellyfin_mpv_shim/mpvtk_browser/config.py
+msgid "Keep Window Buttons in Full Screen"
+msgstr ""
+
+#: jellyfin_mpv_shim/mpvtk_browser/config.py
+msgid "Hide the Desktop Title Bar"
+msgstr ""
+
+#: jellyfin_mpv_shim/mpvtk_browser/config.py
 msgid "Player Controls Style"
+msgstr ""
+
+#: jellyfin_mpv_shim/mpvtk_browser/config.py
+msgid "Enable Trickplay Thumbnails"
 msgstr ""
 
 #: jellyfin_mpv_shim/mpvtk_browser/config.py
@@ -1699,6 +1712,10 @@ msgstr ""
 
 #: jellyfin_mpv_shim/mpvtk_browser/config.py
 msgid "Full-Width Backdrops"
+msgstr ""
+
+#: jellyfin_mpv_shim/mpvtk_browser/config.py
+msgid "12-Hour Clock"
 msgstr ""
 
 #: jellyfin_mpv_shim/mpvtk_browser/config.py
@@ -1742,11 +1759,19 @@ msgid "Fullscreen Library Browser"
 msgstr ""
 
 #: jellyfin_mpv_shim/mpvtk_browser/config.py
+msgid "Block Player Keybinds While Browsing"
+msgstr ""
+
+#: jellyfin_mpv_shim/mpvtk_browser/config.py
 msgid "Always Bind Arrow Keys to Player Controls"
 msgstr ""
 
 #: jellyfin_mpv_shim/mpvtk_browser/config.py
 msgid "Player Controls Activation Key"
+msgstr ""
+
+#: jellyfin_mpv_shim/mpvtk_browser/config.py
+msgid "Select Key"
 msgstr ""
 
 #: jellyfin_mpv_shim/mpvtk_browser/config.py
@@ -1759,6 +1784,10 @@ msgstr ""
 
 #: jellyfin_mpv_shim/mpvtk_browser/config.py
 msgid "Hide the Player Controls After (seconds)"
+msgstr ""
+
+#: jellyfin_mpv_shim/mpvtk_browser/config.py
+msgid "Shrink the Player Controls on a Narrow Window"
 msgstr ""
 
 #: jellyfin_mpv_shim/mpvtk_browser/config.py
@@ -1841,6 +1870,21 @@ msgstr ""
 
 #: jellyfin_mpv_shim/mpvtk_browser/config.py
 msgid ""
+"Stops MPV's own shortcuts -- picture adjustment, screenshots, subtitle and "
+"audio switching -- from acting while you are in the library, where there is "
+"no video for them to act on. Turn it off to use your own MPV key bindings "
+"there."
+msgstr ""
+
+#: jellyfin_mpv_shim/mpvtk_browser/config.py
+msgid ""
+"Activates whatever is highlighted, in the library and on the player "
+"controls. An mpv key name; changing it hands Enter back to MPV. The game "
+"controller's Confirm button and a phone's Select follow it."
+msgstr ""
+
+#: jellyfin_mpv_shim/mpvtk_browser/config.py
+msgid ""
 "Leave these blank unless downloads are waking your disks too often. Set both "
 "of the first two together: episodes are then fetched in one batch when a "
 "series runs low, instead of one at a time."
@@ -1854,7 +1898,8 @@ msgstr ""
 #: jellyfin_mpv_shim/mpvtk_browser/config.py
 msgid ""
 "Off gives MPV's own mouse behaviour instead: drag the video to move the "
-"window, and right click to pause. Double click is full screen either way."
+"window, and the right button does whatever your MPV config gives it. Double "
+"click is full screen either way."
 msgstr ""
 
 #: jellyfin_mpv_shim/mpvtk_browser/config.py
@@ -1944,6 +1989,30 @@ msgid ""
 "maximize and close in the top bar instead, and lets you drag the window by "
 "it. On \"Only when the window has no title bar\", MPV is asked whether this "
 "window got one, so desktops that draw a title bar are left alone."
+msgstr ""
+
+#: jellyfin_mpv_shim/mpvtk_browser/config.py
+msgid ""
+"Full screen has no title bar anywhere and nothing to move or maximize, so "
+"the buttons are normally hidden there. Turn this on to keep a way out of "
+"full screen that is not a keyboard shortcut."
+msgstr ""
+
+#: jellyfin_mpv_shim/mpvtk_browser/config.py
+msgid ""
+"Asks the desktop for no title bar on the player window, so the top bar above "
+"is the only one. Pairs with the setting above: on \"Only when the window has "
+"no title bar\" the buttons appear as soon as this is on. Leave both off "
+"unless you want them, since a window with neither can be awkward to move on "
+"some desktops."
+msgstr ""
+
+#: jellyfin_mpv_shim/mpvtk_browser/config.py
+msgid ""
+"Shows a preview frame while you drag the seek bar. Works with every player "
+"control style, including your own OSC script if it supports thumbfast. The "
+"images are fetched from the server per video, which costs disk space and "
+"memory -- tens of MB for an episode, a few hundred for a long film."
 msgstr ""
 
 #: jellyfin_mpv_shim/mpvtk_browser/config.py
@@ -2051,6 +2120,13 @@ msgstr ""
 
 #: jellyfin_mpv_shim/mpvtk_browser/config.py
 msgid ""
+"Show times of day as \"8:30 PM\" rather than \"20:30\" — the Live TV guide "
+"and its air times, and the \"Ends at\" labels on a detail page and the "
+"player controls."
+msgstr ""
+
+#: jellyfin_mpv_shim/mpvtk_browser/config.py
+msgid ""
 "The controls have to stay legible over any frame. \"None\" gives the text a "
 "drop shadow instead of shading the picture behind it."
 msgstr ""
@@ -2065,6 +2141,13 @@ msgstr ""
 msgid ""
 "0 hides them as soon as the pointer is not on them, and forces \"Hide unless "
 "hovered\"."
+msgstr ""
+
+#: jellyfin_mpv_shim/mpvtk_browser/config.py
+msgid ""
+"Narrowing the window shrinks the controls until the smallest button reaches "
+"the accessibility minimum, instead of dropping buttons sooner. Off keeps the "
+"older, larger floor."
 msgstr ""
 
 #: jellyfin_mpv_shim/mpvtk_browser/config.py
@@ -3409,6 +3492,7 @@ msgid "More Like This"
 msgstr ""
 
 #: jellyfin_mpv_shim/mpvtk_browser/pages/detail.py
+#: jellyfin_mpv_shim/mpvtk_browser/tiles.py
 msgid "Go to Series"
 msgstr ""
 
@@ -4411,6 +4495,22 @@ msgstr ""
 msgid "There is nothing here to queue."
 msgstr ""
 
+#: jellyfin_mpv_shim/mpvtk_browser/timefmt.py
+#, python-brace-format
+msgctxt "12-hour clock"
+msgid "{time} {period}"
+msgstr ""
+
+#: jellyfin_mpv_shim/mpvtk_browser/timefmt.py
+msgctxt "12-hour clock"
+msgid "AM"
+msgstr ""
+
+#: jellyfin_mpv_shim/mpvtk_browser/timefmt.py
+msgctxt "12-hour clock"
+msgid "PM"
+msgstr ""
+
 #: jellyfin_mpv_shim/mpvtk_browser/views.py
 #: jellyfin_mpv_shim/mpvtk_browser/window_chrome.py
 msgid "Search"
@@ -4561,13 +4661,32 @@ msgid "Enable SVP"
 msgstr ""
 
 #: jellyfin_mpv_shim/sync/manager.py
+msgid "The downloads are already in that folder."
+msgstr ""
+
+#: jellyfin_mpv_shim/sync/manager.py
 msgid ""
 "Can't change the download folder while a download is in progress. Wait for "
 "it to finish, then try again."
 msgstr ""
 
 #: jellyfin_mpv_shim/sync/manager.py
+msgid ""
+"That folder is inside the current download folder. Choose one outside it."
+msgstr ""
+
+#: jellyfin_mpv_shim/sync/manager.py
+msgid "Can't read that folder. Check the path and its permissions."
+msgstr ""
+
+#: jellyfin_mpv_shim/sync/manager.py
 msgid "That folder already contains downloads. Choose an empty folder."
+msgstr ""
+
+#: jellyfin_mpv_shim/sync/manager.py
+msgid ""
+"That folder isn't empty. Choose an empty folder — the download folder is "
+"managed by this app and anything else in it can be moved or removed."
 msgstr ""
 
 #: jellyfin_mpv_shim/sync/manager.py
@@ -4576,6 +4695,12 @@ msgstr ""
 
 #: jellyfin_mpv_shim/sync/manager.py
 msgid "A download is still finishing. Wait for it to stop, then try again."
+msgstr ""
+
+#: jellyfin_mpv_shim/sync/manager.py
+msgid ""
+"There isn't enough space on that drive to move the downloads. Free some "
+"space and try again — nothing was moved."
 msgstr ""
 
 #: jellyfin_mpv_shim/sync/manager.py

--- a/jellyfin_mpv_shim/messages/ml/LC_MESSAGES/base.po
+++ b/jellyfin_mpv_shim/messages/ml/LC_MESSAGES/base.po
@@ -6,7 +6,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2026-08-30 22:19-0400\n"
+"POT-Creation-Date: 2026-09-07 17:35-0400\n"
 "PO-Revision-Date: 2026-08-14 22:50+0000\n"
 "Last-Translator: XtronXI Debloated <x2thehacker@outlook.com>\n"
 "Language-Team: Malayalam <https://translate.jellyfin.org/projects/jellyfin/"
@@ -520,6 +520,11 @@ msgid "Night Mode (Auto Volume Adj)"
 msgstr ""
 
 #: jellyfin_mpv_shim/mpvtk_browser/app.py
+#: jellyfin_mpv_shim/mpvtk_browser/auth.py
+msgid "Locked"
+msgstr ""
+
+#: jellyfin_mpv_shim/mpvtk_browser/app.py
 msgid "Failed to load. Check the connection."
 msgstr ""
 
@@ -795,10 +800,6 @@ msgstr ""
 "ദയവായി നിങ്ങളുടെ ഇന്റർനെറ്റുമായി ബന്ധപ്പെട്ട വിവരങ്ങൾ പരിശോധിക്കുക."
 
 #: jellyfin_mpv_shim/mpvtk_browser/auth.py
-msgid "Locked"
-msgstr ""
-
-#: jellyfin_mpv_shim/mpvtk_browser/auth.py
 #: jellyfin_mpv_shim/mpvtk_browser/pages/home.py
 msgid "Connecting to your server…"
 msgstr ""
@@ -877,6 +878,10 @@ msgstr "കണ്ടു"
 #: jellyfin_mpv_shim/mpvtk_browser/pages/books.py
 msgid "Favorite"
 msgstr "പ്രിയപ്പെട്ടവ"
+
+#: jellyfin_mpv_shim/mpvtk_browser/components/detail.py
+msgid "Web"
+msgstr ""
 
 # seeded from jellyfin-web: HeaderVideos
 #: jellyfin_mpv_shim/mpvtk_browser/components/media_info.py
@@ -1471,11 +1476,7 @@ msgid "Jellyfin UI"
 msgstr ""
 
 #: jellyfin_mpv_shim/mpvtk_browser/config.py
-msgid "MPV UI with thumbnails"
-msgstr ""
-
-#: jellyfin_mpv_shim/mpvtk_browser/config.py
-msgid "MPV built-in default"
+msgid "MPV UI"
 msgstr ""
 
 #: jellyfin_mpv_shim/mpvtk_browser/config.py
@@ -1818,7 +1819,19 @@ msgid "Window Buttons in the Top Bar"
 msgstr ""
 
 #: jellyfin_mpv_shim/mpvtk_browser/config.py
+msgid "Keep Window Buttons in Full Screen"
+msgstr ""
+
+#: jellyfin_mpv_shim/mpvtk_browser/config.py
+msgid "Hide the Desktop Title Bar"
+msgstr ""
+
+#: jellyfin_mpv_shim/mpvtk_browser/config.py
 msgid "Player Controls Style"
+msgstr ""
+
+#: jellyfin_mpv_shim/mpvtk_browser/config.py
+msgid "Enable Trickplay Thumbnails"
 msgstr ""
 
 #: jellyfin_mpv_shim/mpvtk_browser/config.py
@@ -1849,6 +1862,10 @@ msgstr ""
 
 #: jellyfin_mpv_shim/mpvtk_browser/config.py
 msgid "Full-Width Backdrops"
+msgstr ""
+
+#: jellyfin_mpv_shim/mpvtk_browser/config.py
+msgid "12-Hour Clock"
 msgstr ""
 
 #: jellyfin_mpv_shim/mpvtk_browser/config.py
@@ -1894,11 +1911,19 @@ msgid "Fullscreen Library Browser"
 msgstr ""
 
 #: jellyfin_mpv_shim/mpvtk_browser/config.py
+msgid "Block Player Keybinds While Browsing"
+msgstr ""
+
+#: jellyfin_mpv_shim/mpvtk_browser/config.py
 msgid "Always Bind Arrow Keys to Player Controls"
 msgstr ""
 
 #: jellyfin_mpv_shim/mpvtk_browser/config.py
 msgid "Player Controls Activation Key"
+msgstr ""
+
+#: jellyfin_mpv_shim/mpvtk_browser/config.py
+msgid "Select Key"
 msgstr ""
 
 #: jellyfin_mpv_shim/mpvtk_browser/config.py
@@ -1911,6 +1936,10 @@ msgstr ""
 
 #: jellyfin_mpv_shim/mpvtk_browser/config.py
 msgid "Hide the Player Controls After (seconds)"
+msgstr ""
+
+#: jellyfin_mpv_shim/mpvtk_browser/config.py
+msgid "Shrink the Player Controls on a Narrow Window"
 msgstr ""
 
 #: jellyfin_mpv_shim/mpvtk_browser/config.py
@@ -1993,6 +2022,21 @@ msgstr ""
 
 #: jellyfin_mpv_shim/mpvtk_browser/config.py
 msgid ""
+"Stops MPV's own shortcuts -- picture adjustment, screenshots, subtitle and "
+"audio switching -- from acting while you are in the library, where there is "
+"no video for them to act on. Turn it off to use your own MPV key bindings "
+"there."
+msgstr ""
+
+#: jellyfin_mpv_shim/mpvtk_browser/config.py
+msgid ""
+"Activates whatever is highlighted, in the library and on the player "
+"controls. An mpv key name; changing it hands Enter back to MPV. The game "
+"controller's Confirm button and a phone's Select follow it."
+msgstr ""
+
+#: jellyfin_mpv_shim/mpvtk_browser/config.py
+msgid ""
 "Leave these blank unless downloads are waking your disks too often. Set both "
 "of the first two together: episodes are then fetched in one batch when a "
 "series runs low, instead of one at a time."
@@ -2006,7 +2050,8 @@ msgstr ""
 #: jellyfin_mpv_shim/mpvtk_browser/config.py
 msgid ""
 "Off gives MPV's own mouse behaviour instead: drag the video to move the "
-"window, and right click to pause. Double click is full screen either way."
+"window, and the right button does whatever your MPV config gives it. Double "
+"click is full screen either way."
 msgstr ""
 
 #: jellyfin_mpv_shim/mpvtk_browser/config.py
@@ -2096,6 +2141,30 @@ msgid ""
 "maximize and close in the top bar instead, and lets you drag the window by "
 "it. On \"Only when the window has no title bar\", MPV is asked whether this "
 "window got one, so desktops that draw a title bar are left alone."
+msgstr ""
+
+#: jellyfin_mpv_shim/mpvtk_browser/config.py
+msgid ""
+"Full screen has no title bar anywhere and nothing to move or maximize, so "
+"the buttons are normally hidden there. Turn this on to keep a way out of "
+"full screen that is not a keyboard shortcut."
+msgstr ""
+
+#: jellyfin_mpv_shim/mpvtk_browser/config.py
+msgid ""
+"Asks the desktop for no title bar on the player window, so the top bar above "
+"is the only one. Pairs with the setting above: on \"Only when the window has "
+"no title bar\" the buttons appear as soon as this is on. Leave both off "
+"unless you want them, since a window with neither can be awkward to move on "
+"some desktops."
+msgstr ""
+
+#: jellyfin_mpv_shim/mpvtk_browser/config.py
+msgid ""
+"Shows a preview frame while you drag the seek bar. Works with every player "
+"control style, including your own OSC script if it supports thumbfast. The "
+"images are fetched from the server per video, which costs disk space and "
+"memory -- tens of MB for an episode, a few hundred for a long film."
 msgstr ""
 
 #: jellyfin_mpv_shim/mpvtk_browser/config.py
@@ -2203,6 +2272,13 @@ msgstr ""
 
 #: jellyfin_mpv_shim/mpvtk_browser/config.py
 msgid ""
+"Show times of day as \"8:30 PM\" rather than \"20:30\" — the Live TV guide "
+"and its air times, and the \"Ends at\" labels on a detail page and the "
+"player controls."
+msgstr ""
+
+#: jellyfin_mpv_shim/mpvtk_browser/config.py
+msgid ""
 "The controls have to stay legible over any frame. \"None\" gives the text a "
 "drop shadow instead of shading the picture behind it."
 msgstr ""
@@ -2217,6 +2293,13 @@ msgstr ""
 msgid ""
 "0 hides them as soon as the pointer is not on them, and forces \"Hide unless "
 "hovered\"."
+msgstr ""
+
+#: jellyfin_mpv_shim/mpvtk_browser/config.py
+msgid ""
+"Narrowing the window shrinks the controls until the smallest button reaches "
+"the accessibility minimum, instead of dropping buttons sooner. Off keeps the "
+"older, larger floor."
 msgstr ""
 
 #: jellyfin_mpv_shim/mpvtk_browser/config.py
@@ -3777,6 +3860,7 @@ msgid "More Like This"
 msgstr "ഇത് കൂടുതൽ ഇഷ്ടപ്പെടുന്നു"
 
 #: jellyfin_mpv_shim/mpvtk_browser/pages/detail.py
+#: jellyfin_mpv_shim/mpvtk_browser/tiles.py
 msgid "Go to Series"
 msgstr ""
 
@@ -4948,6 +5032,22 @@ msgstr ""
 msgid "There is nothing here to queue."
 msgstr ""
 
+#: jellyfin_mpv_shim/mpvtk_browser/timefmt.py
+#, python-brace-format
+msgctxt "12-hour clock"
+msgid "{time} {period}"
+msgstr ""
+
+#: jellyfin_mpv_shim/mpvtk_browser/timefmt.py
+msgctxt "12-hour clock"
+msgid "AM"
+msgstr ""
+
+#: jellyfin_mpv_shim/mpvtk_browser/timefmt.py
+msgctxt "12-hour clock"
+msgid "PM"
+msgstr ""
+
 # seeded from jellyfin-web: Search
 #: jellyfin_mpv_shim/mpvtk_browser/views.py
 #: jellyfin_mpv_shim/mpvtk_browser/window_chrome.py
@@ -5109,13 +5209,32 @@ msgid "Enable SVP"
 msgstr ""
 
 #: jellyfin_mpv_shim/sync/manager.py
+msgid "The downloads are already in that folder."
+msgstr ""
+
+#: jellyfin_mpv_shim/sync/manager.py
 msgid ""
 "Can't change the download folder while a download is in progress. Wait for "
 "it to finish, then try again."
 msgstr ""
 
 #: jellyfin_mpv_shim/sync/manager.py
+msgid ""
+"That folder is inside the current download folder. Choose one outside it."
+msgstr ""
+
+#: jellyfin_mpv_shim/sync/manager.py
+msgid "Can't read that folder. Check the path and its permissions."
+msgstr ""
+
+#: jellyfin_mpv_shim/sync/manager.py
 msgid "That folder already contains downloads. Choose an empty folder."
+msgstr ""
+
+#: jellyfin_mpv_shim/sync/manager.py
+msgid ""
+"That folder isn't empty. Choose an empty folder — the download folder is "
+"managed by this app and anything else in it can be moved or removed."
 msgstr ""
 
 #: jellyfin_mpv_shim/sync/manager.py
@@ -5124,6 +5243,12 @@ msgstr ""
 
 #: jellyfin_mpv_shim/sync/manager.py
 msgid "A download is still finishing. Wait for it to stop, then try again."
+msgstr ""
+
+#: jellyfin_mpv_shim/sync/manager.py
+msgid ""
+"There isn't enough space on that drive to move the downloads. Free some "
+"space and try again — nothing was moved."
 msgstr ""
 
 #: jellyfin_mpv_shim/sync/manager.py

--- a/jellyfin_mpv_shim/messages/mn/LC_MESSAGES/base.po
+++ b/jellyfin_mpv_shim/messages/mn/LC_MESSAGES/base.po
@@ -6,7 +6,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2026-08-30 22:19-0400\n"
+"POT-Creation-Date: 2026-09-07 17:35-0400\n"
 "PO-Revision-Date: 2025-10-29 22:47+0000\n"
 "Last-Translator: Battseren Badral <bbattseren88@gmail.com>\n"
 "Language-Team: Mongolian <https://translate.jellyfin.org/projects/jellyfin/"
@@ -547,6 +547,11 @@ msgid "Night Mode (Auto Volume Adj)"
 msgstr ""
 
 #: jellyfin_mpv_shim/mpvtk_browser/app.py
+#: jellyfin_mpv_shim/mpvtk_browser/auth.py
+msgid "Locked"
+msgstr ""
+
+#: jellyfin_mpv_shim/mpvtk_browser/app.py
 msgid "Failed to load. Check the connection."
 msgstr ""
 
@@ -826,10 +831,6 @@ msgstr ""
 "Холболтоо шалгана уу."
 
 #: jellyfin_mpv_shim/mpvtk_browser/auth.py
-msgid "Locked"
-msgstr ""
-
-#: jellyfin_mpv_shim/mpvtk_browser/auth.py
 #: jellyfin_mpv_shim/mpvtk_browser/pages/home.py
 msgid "Connecting to your server…"
 msgstr ""
@@ -910,6 +911,10 @@ msgstr "Гараад, Үзээгүй гэж тэмдэглэх"
 #: jellyfin_mpv_shim/mpvtk_browser/pages/books.py
 msgid "Favorite"
 msgstr "Дуртай"
+
+#: jellyfin_mpv_shim/mpvtk_browser/components/detail.py
+msgid "Web"
+msgstr ""
 
 # seeded from jellyfin-web: HeaderVideos
 #: jellyfin_mpv_shim/mpvtk_browser/components/media_info.py
@@ -1523,11 +1528,7 @@ msgid "Jellyfin UI"
 msgstr ""
 
 #: jellyfin_mpv_shim/mpvtk_browser/config.py
-msgid "MPV UI with thumbnails"
-msgstr ""
-
-#: jellyfin_mpv_shim/mpvtk_browser/config.py
-msgid "MPV built-in default"
+msgid "MPV UI"
 msgstr ""
 
 #: jellyfin_mpv_shim/mpvtk_browser/config.py
@@ -1876,8 +1877,22 @@ msgid "Window Buttons in the Top Bar"
 msgstr ""
 
 #: jellyfin_mpv_shim/mpvtk_browser/config.py
+msgid "Keep Window Buttons in Full Screen"
+msgstr ""
+
+#: jellyfin_mpv_shim/mpvtk_browser/config.py
+msgid "Hide the Desktop Title Bar"
+msgstr ""
+
+#: jellyfin_mpv_shim/mpvtk_browser/config.py
 msgid "Player Controls Style"
 msgstr ""
+
+#: jellyfin_mpv_shim/mpvtk_browser/config.py
+#, fuzzy
+#| msgid "Enable thumbnail previews"
+msgid "Enable Trickplay Thumbnails"
+msgstr "Жижиг зургуудын урьдчилсан харагдац идэвхжүүлэх"
 
 #: jellyfin_mpv_shim/mpvtk_browser/config.py
 msgid "Load All Seek Previews at Once"
@@ -1907,6 +1922,10 @@ msgstr ""
 
 #: jellyfin_mpv_shim/mpvtk_browser/config.py
 msgid "Full-Width Backdrops"
+msgstr ""
+
+#: jellyfin_mpv_shim/mpvtk_browser/config.py
+msgid "12-Hour Clock"
 msgstr ""
 
 #: jellyfin_mpv_shim/mpvtk_browser/config.py
@@ -1952,12 +1971,23 @@ msgid "Fullscreen Library Browser"
 msgstr ""
 
 #: jellyfin_mpv_shim/mpvtk_browser/config.py
+msgid "Block Player Keybinds While Browsing"
+msgstr ""
+
+#: jellyfin_mpv_shim/mpvtk_browser/config.py
 msgid "Always Bind Arrow Keys to Player Controls"
 msgstr ""
 
 #: jellyfin_mpv_shim/mpvtk_browser/config.py
 msgid "Player Controls Activation Key"
 msgstr ""
+
+# seeded from jellyfin-web: SelectAll
+#: jellyfin_mpv_shim/mpvtk_browser/config.py
+#, fuzzy
+#| msgid "Select All"
+msgid "Select Key"
+msgstr "Бүгдийг сонгох"
 
 #: jellyfin_mpv_shim/mpvtk_browser/config.py
 msgid "Shading Behind the Player Controls"
@@ -1969,6 +1999,10 @@ msgstr ""
 
 #: jellyfin_mpv_shim/mpvtk_browser/config.py
 msgid "Hide the Player Controls After (seconds)"
+msgstr ""
+
+#: jellyfin_mpv_shim/mpvtk_browser/config.py
+msgid "Shrink the Player Controls on a Narrow Window"
 msgstr ""
 
 #: jellyfin_mpv_shim/mpvtk_browser/config.py
@@ -2055,6 +2089,21 @@ msgstr ""
 
 #: jellyfin_mpv_shim/mpvtk_browser/config.py
 msgid ""
+"Stops MPV's own shortcuts -- picture adjustment, screenshots, subtitle and "
+"audio switching -- from acting while you are in the library, where there is "
+"no video for them to act on. Turn it off to use your own MPV key bindings "
+"there."
+msgstr ""
+
+#: jellyfin_mpv_shim/mpvtk_browser/config.py
+msgid ""
+"Activates whatever is highlighted, in the library and on the player "
+"controls. An mpv key name; changing it hands Enter back to MPV. The game "
+"controller's Confirm button and a phone's Select follow it."
+msgstr ""
+
+#: jellyfin_mpv_shim/mpvtk_browser/config.py
+msgid ""
 "Leave these blank unless downloads are waking your disks too often. Set both "
 "of the first two together: episodes are then fetched in one batch when a "
 "series runs low, instead of one at a time."
@@ -2068,7 +2117,8 @@ msgstr ""
 #: jellyfin_mpv_shim/mpvtk_browser/config.py
 msgid ""
 "Off gives MPV's own mouse behaviour instead: drag the video to move the "
-"window, and right click to pause. Double click is full screen either way."
+"window, and the right button does whatever your MPV config gives it. Double "
+"click is full screen either way."
 msgstr ""
 
 #: jellyfin_mpv_shim/mpvtk_browser/config.py
@@ -2158,6 +2208,30 @@ msgid ""
 "maximize and close in the top bar instead, and lets you drag the window by "
 "it. On \"Only when the window has no title bar\", MPV is asked whether this "
 "window got one, so desktops that draw a title bar are left alone."
+msgstr ""
+
+#: jellyfin_mpv_shim/mpvtk_browser/config.py
+msgid ""
+"Full screen has no title bar anywhere and nothing to move or maximize, so "
+"the buttons are normally hidden there. Turn this on to keep a way out of "
+"full screen that is not a keyboard shortcut."
+msgstr ""
+
+#: jellyfin_mpv_shim/mpvtk_browser/config.py
+msgid ""
+"Asks the desktop for no title bar on the player window, so the top bar above "
+"is the only one. Pairs with the setting above: on \"Only when the window has "
+"no title bar\" the buttons appear as soon as this is on. Leave both off "
+"unless you want them, since a window with neither can be awkward to move on "
+"some desktops."
+msgstr ""
+
+#: jellyfin_mpv_shim/mpvtk_browser/config.py
+msgid ""
+"Shows a preview frame while you drag the seek bar. Works with every player "
+"control style, including your own OSC script if it supports thumbfast. The "
+"images are fetched from the server per video, which costs disk space and "
+"memory -- tens of MB for an episode, a few hundred for a long film."
 msgstr ""
 
 #: jellyfin_mpv_shim/mpvtk_browser/config.py
@@ -2267,6 +2341,13 @@ msgstr ""
 
 #: jellyfin_mpv_shim/mpvtk_browser/config.py
 msgid ""
+"Show times of day as \"8:30 PM\" rather than \"20:30\" — the Live TV guide "
+"and its air times, and the \"Ends at\" labels on a detail page and the "
+"player controls."
+msgstr ""
+
+#: jellyfin_mpv_shim/mpvtk_browser/config.py
+msgid ""
 "The controls have to stay legible over any frame. \"None\" gives the text a "
 "drop shadow instead of shading the picture behind it."
 msgstr ""
@@ -2281,6 +2362,13 @@ msgstr ""
 msgid ""
 "0 hides them as soon as the pointer is not on them, and forces \"Hide unless "
 "hovered\"."
+msgstr ""
+
+#: jellyfin_mpv_shim/mpvtk_browser/config.py
+msgid ""
+"Narrowing the window shrinks the controls until the smallest button reaches "
+"the accessibility minimum, instead of dropping buttons sooner. Off keeps the "
+"older, larger floor."
 msgstr ""
 
 #: jellyfin_mpv_shim/mpvtk_browser/config.py
@@ -3882,6 +3970,7 @@ msgid "More Like This"
 msgstr "Үүнтэй төстэй"
 
 #: jellyfin_mpv_shim/mpvtk_browser/pages/detail.py
+#: jellyfin_mpv_shim/mpvtk_browser/tiles.py
 msgid "Go to Series"
 msgstr ""
 
@@ -5071,6 +5160,22 @@ msgstr "Серверийг устгах"
 msgid "There is nothing here to queue."
 msgstr ""
 
+#: jellyfin_mpv_shim/mpvtk_browser/timefmt.py
+#, python-brace-format
+msgctxt "12-hour clock"
+msgid "{time} {period}"
+msgstr ""
+
+#: jellyfin_mpv_shim/mpvtk_browser/timefmt.py
+msgctxt "12-hour clock"
+msgid "AM"
+msgstr ""
+
+#: jellyfin_mpv_shim/mpvtk_browser/timefmt.py
+msgctxt "12-hour clock"
+msgid "PM"
+msgstr ""
+
 # seeded from jellyfin-web: Search
 #: jellyfin_mpv_shim/mpvtk_browser/views.py
 #: jellyfin_mpv_shim/mpvtk_browser/window_chrome.py
@@ -5239,13 +5344,32 @@ msgid "Enable SVP"
 msgstr "SVP-г идэвхжүүлэх"
 
 #: jellyfin_mpv_shim/sync/manager.py
+msgid "The downloads are already in that folder."
+msgstr ""
+
+#: jellyfin_mpv_shim/sync/manager.py
 msgid ""
 "Can't change the download folder while a download is in progress. Wait for "
 "it to finish, then try again."
 msgstr ""
 
 #: jellyfin_mpv_shim/sync/manager.py
+msgid ""
+"That folder is inside the current download folder. Choose one outside it."
+msgstr ""
+
+#: jellyfin_mpv_shim/sync/manager.py
+msgid "Can't read that folder. Check the path and its permissions."
+msgstr ""
+
+#: jellyfin_mpv_shim/sync/manager.py
 msgid "That folder already contains downloads. Choose an empty folder."
+msgstr ""
+
+#: jellyfin_mpv_shim/sync/manager.py
+msgid ""
+"That folder isn't empty. Choose an empty folder — the download folder is "
+"managed by this app and anything else in it can be moved or removed."
 msgstr ""
 
 #: jellyfin_mpv_shim/sync/manager.py
@@ -5254,6 +5378,12 @@ msgstr ""
 
 #: jellyfin_mpv_shim/sync/manager.py
 msgid "A download is still finishing. Wait for it to stop, then try again."
+msgstr ""
+
+#: jellyfin_mpv_shim/sync/manager.py
+msgid ""
+"There isn't enough space on that drive to move the downloads. Free some "
+"space and try again — nothing was moved."
 msgstr ""
 
 #: jellyfin_mpv_shim/sync/manager.py

--- a/jellyfin_mpv_shim/messages/mr/LC_MESSAGES/base.po
+++ b/jellyfin_mpv_shim/messages/mr/LC_MESSAGES/base.po
@@ -6,7 +6,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2026-08-30 22:19-0400\n"
+"POT-Creation-Date: 2026-09-07 17:35-0400\n"
 "PO-Revision-Date: 2025-12-16 05:55+0000\n"
 "Last-Translator: sabretou <sabretou@gmail.com>\n"
 "Language-Team: Marathi <https://translate.jellyfin.org/projects/jellyfin/"
@@ -511,6 +511,11 @@ msgid "Night Mode (Auto Volume Adj)"
 msgstr ""
 
 #: jellyfin_mpv_shim/mpvtk_browser/app.py
+#: jellyfin_mpv_shim/mpvtk_browser/auth.py
+msgid "Locked"
+msgstr ""
+
+#: jellyfin_mpv_shim/mpvtk_browser/app.py
 msgid "Failed to load. Check the connection."
 msgstr ""
 
@@ -761,10 +766,6 @@ msgid "Could not connect. Please check your details."
 msgstr ""
 
 #: jellyfin_mpv_shim/mpvtk_browser/auth.py
-msgid "Locked"
-msgstr ""
-
-#: jellyfin_mpv_shim/mpvtk_browser/auth.py
 #: jellyfin_mpv_shim/mpvtk_browser/pages/home.py
 msgid "Connecting to your server…"
 msgstr ""
@@ -841,6 +842,10 @@ msgstr "बघितले"
 #: jellyfin_mpv_shim/mpvtk_browser/pages/books.py
 msgid "Favorite"
 msgstr "आवडीचे"
+
+#: jellyfin_mpv_shim/mpvtk_browser/components/detail.py
+msgid "Web"
+msgstr ""
 
 # seeded from jellyfin-web: HeaderVideos
 #: jellyfin_mpv_shim/mpvtk_browser/components/media_info.py
@@ -1421,11 +1426,7 @@ msgid "Jellyfin UI"
 msgstr ""
 
 #: jellyfin_mpv_shim/mpvtk_browser/config.py
-msgid "MPV UI with thumbnails"
-msgstr ""
-
-#: jellyfin_mpv_shim/mpvtk_browser/config.py
-msgid "MPV built-in default"
+msgid "MPV UI"
 msgstr ""
 
 #: jellyfin_mpv_shim/mpvtk_browser/config.py
@@ -1770,7 +1771,19 @@ msgid "Window Buttons in the Top Bar"
 msgstr ""
 
 #: jellyfin_mpv_shim/mpvtk_browser/config.py
+msgid "Keep Window Buttons in Full Screen"
+msgstr ""
+
+#: jellyfin_mpv_shim/mpvtk_browser/config.py
+msgid "Hide the Desktop Title Bar"
+msgstr ""
+
+#: jellyfin_mpv_shim/mpvtk_browser/config.py
 msgid "Player Controls Style"
+msgstr ""
+
+#: jellyfin_mpv_shim/mpvtk_browser/config.py
+msgid "Enable Trickplay Thumbnails"
 msgstr ""
 
 #: jellyfin_mpv_shim/mpvtk_browser/config.py
@@ -1800,6 +1813,10 @@ msgstr ""
 
 #: jellyfin_mpv_shim/mpvtk_browser/config.py
 msgid "Full-Width Backdrops"
+msgstr ""
+
+#: jellyfin_mpv_shim/mpvtk_browser/config.py
+msgid "12-Hour Clock"
 msgstr ""
 
 #: jellyfin_mpv_shim/mpvtk_browser/config.py
@@ -1843,12 +1860,23 @@ msgid "Fullscreen Library Browser"
 msgstr ""
 
 #: jellyfin_mpv_shim/mpvtk_browser/config.py
+msgid "Block Player Keybinds While Browsing"
+msgstr ""
+
+#: jellyfin_mpv_shim/mpvtk_browser/config.py
 msgid "Always Bind Arrow Keys to Player Controls"
 msgstr ""
 
 #: jellyfin_mpv_shim/mpvtk_browser/config.py
 msgid "Player Controls Activation Key"
 msgstr ""
+
+# seeded from jellyfin-web: SelectAll
+#: jellyfin_mpv_shim/mpvtk_browser/config.py
+#, fuzzy
+#| msgid "Select All"
+msgid "Select Key"
+msgstr "सर्व निवडा"
 
 #: jellyfin_mpv_shim/mpvtk_browser/config.py
 msgid "Shading Behind the Player Controls"
@@ -1860,6 +1888,10 @@ msgstr ""
 
 #: jellyfin_mpv_shim/mpvtk_browser/config.py
 msgid "Hide the Player Controls After (seconds)"
+msgstr ""
+
+#: jellyfin_mpv_shim/mpvtk_browser/config.py
+msgid "Shrink the Player Controls on a Narrow Window"
 msgstr ""
 
 #: jellyfin_mpv_shim/mpvtk_browser/config.py
@@ -1944,6 +1976,21 @@ msgstr ""
 
 #: jellyfin_mpv_shim/mpvtk_browser/config.py
 msgid ""
+"Stops MPV's own shortcuts -- picture adjustment, screenshots, subtitle and "
+"audio switching -- from acting while you are in the library, where there is "
+"no video for them to act on. Turn it off to use your own MPV key bindings "
+"there."
+msgstr ""
+
+#: jellyfin_mpv_shim/mpvtk_browser/config.py
+msgid ""
+"Activates whatever is highlighted, in the library and on the player "
+"controls. An mpv key name; changing it hands Enter back to MPV. The game "
+"controller's Confirm button and a phone's Select follow it."
+msgstr ""
+
+#: jellyfin_mpv_shim/mpvtk_browser/config.py
+msgid ""
 "Leave these blank unless downloads are waking your disks too often. Set both "
 "of the first two together: episodes are then fetched in one batch when a "
 "series runs low, instead of one at a time."
@@ -1957,7 +2004,8 @@ msgstr ""
 #: jellyfin_mpv_shim/mpvtk_browser/config.py
 msgid ""
 "Off gives MPV's own mouse behaviour instead: drag the video to move the "
-"window, and right click to pause. Double click is full screen either way."
+"window, and the right button does whatever your MPV config gives it. Double "
+"click is full screen either way."
 msgstr ""
 
 #: jellyfin_mpv_shim/mpvtk_browser/config.py
@@ -2047,6 +2095,30 @@ msgid ""
 "maximize and close in the top bar instead, and lets you drag the window by "
 "it. On \"Only when the window has no title bar\", MPV is asked whether this "
 "window got one, so desktops that draw a title bar are left alone."
+msgstr ""
+
+#: jellyfin_mpv_shim/mpvtk_browser/config.py
+msgid ""
+"Full screen has no title bar anywhere and nothing to move or maximize, so "
+"the buttons are normally hidden there. Turn this on to keep a way out of "
+"full screen that is not a keyboard shortcut."
+msgstr ""
+
+#: jellyfin_mpv_shim/mpvtk_browser/config.py
+msgid ""
+"Asks the desktop for no title bar on the player window, so the top bar above "
+"is the only one. Pairs with the setting above: on \"Only when the window has "
+"no title bar\" the buttons appear as soon as this is on. Leave both off "
+"unless you want them, since a window with neither can be awkward to move on "
+"some desktops."
+msgstr ""
+
+#: jellyfin_mpv_shim/mpvtk_browser/config.py
+msgid ""
+"Shows a preview frame while you drag the seek bar. Works with every player "
+"control style, including your own OSC script if it supports thumbfast. The "
+"images are fetched from the server per video, which costs disk space and "
+"memory -- tens of MB for an episode, a few hundred for a long film."
 msgstr ""
 
 #: jellyfin_mpv_shim/mpvtk_browser/config.py
@@ -2156,6 +2228,13 @@ msgstr ""
 
 #: jellyfin_mpv_shim/mpvtk_browser/config.py
 msgid ""
+"Show times of day as \"8:30 PM\" rather than \"20:30\" — the Live TV guide "
+"and its air times, and the \"Ends at\" labels on a detail page and the "
+"player controls."
+msgstr ""
+
+#: jellyfin_mpv_shim/mpvtk_browser/config.py
+msgid ""
 "The controls have to stay legible over any frame. \"None\" gives the text a "
 "drop shadow instead of shading the picture behind it."
 msgstr ""
@@ -2170,6 +2249,13 @@ msgstr ""
 msgid ""
 "0 hides them as soon as the pointer is not on them, and forces \"Hide unless "
 "hovered\"."
+msgstr ""
+
+#: jellyfin_mpv_shim/mpvtk_browser/config.py
+msgid ""
+"Narrowing the window shrinks the controls until the smallest button reaches "
+"the accessibility minimum, instead of dropping buttons sooner. Off keeps the "
+"older, larger floor."
 msgstr ""
 
 #: jellyfin_mpv_shim/mpvtk_browser/config.py
@@ -3684,6 +3770,7 @@ msgid "More Like This"
 msgstr "यासारखे अजून"
 
 #: jellyfin_mpv_shim/mpvtk_browser/pages/detail.py
+#: jellyfin_mpv_shim/mpvtk_browser/tiles.py
 msgid "Go to Series"
 msgstr ""
 
@@ -4796,6 +4883,22 @@ msgstr "सर्व्हर काढून टाका"
 msgid "There is nothing here to queue."
 msgstr ""
 
+#: jellyfin_mpv_shim/mpvtk_browser/timefmt.py
+#, python-brace-format
+msgctxt "12-hour clock"
+msgid "{time} {period}"
+msgstr ""
+
+#: jellyfin_mpv_shim/mpvtk_browser/timefmt.py
+msgctxt "12-hour clock"
+msgid "AM"
+msgstr ""
+
+#: jellyfin_mpv_shim/mpvtk_browser/timefmt.py
+msgctxt "12-hour clock"
+msgid "PM"
+msgstr ""
+
 # seeded from jellyfin-web: Search
 #: jellyfin_mpv_shim/mpvtk_browser/views.py
 #: jellyfin_mpv_shim/mpvtk_browser/window_chrome.py
@@ -4961,13 +5064,32 @@ msgid "Enable SVP"
 msgstr ""
 
 #: jellyfin_mpv_shim/sync/manager.py
+msgid "The downloads are already in that folder."
+msgstr ""
+
+#: jellyfin_mpv_shim/sync/manager.py
 msgid ""
 "Can't change the download folder while a download is in progress. Wait for "
 "it to finish, then try again."
 msgstr ""
 
 #: jellyfin_mpv_shim/sync/manager.py
+msgid ""
+"That folder is inside the current download folder. Choose one outside it."
+msgstr ""
+
+#: jellyfin_mpv_shim/sync/manager.py
+msgid "Can't read that folder. Check the path and its permissions."
+msgstr ""
+
+#: jellyfin_mpv_shim/sync/manager.py
 msgid "That folder already contains downloads. Choose an empty folder."
+msgstr ""
+
+#: jellyfin_mpv_shim/sync/manager.py
+msgid ""
+"That folder isn't empty. Choose an empty folder — the download folder is "
+"managed by this app and anything else in it can be moved or removed."
 msgstr ""
 
 #: jellyfin_mpv_shim/sync/manager.py
@@ -4976,6 +5098,12 @@ msgstr ""
 
 #: jellyfin_mpv_shim/sync/manager.py
 msgid "A download is still finishing. Wait for it to stop, then try again."
+msgstr ""
+
+#: jellyfin_mpv_shim/sync/manager.py
+msgid ""
+"There isn't enough space on that drive to move the downloads. Free some "
+"space and try again — nothing was moved."
 msgstr ""
 
 #: jellyfin_mpv_shim/sync/manager.py

--- a/jellyfin_mpv_shim/messages/ms/LC_MESSAGES/base.po
+++ b/jellyfin_mpv_shim/messages/ms/LC_MESSAGES/base.po
@@ -6,7 +6,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2026-08-30 22:19-0400\n"
+"POT-Creation-Date: 2026-09-07 17:35-0400\n"
 "PO-Revision-Date: 2026-09-01 04:42+0000\n"
 "Last-Translator: fredsimon <fredoline.simon@gmail.com>\n"
 "Language-Team: Malay <https://translate.jellyfin.org/projects/jellyfin/"
@@ -521,6 +521,11 @@ msgid "Night Mode (Auto Volume Adj)"
 msgstr ""
 
 #: jellyfin_mpv_shim/mpvtk_browser/app.py
+#: jellyfin_mpv_shim/mpvtk_browser/auth.py
+msgid "Locked"
+msgstr ""
+
+#: jellyfin_mpv_shim/mpvtk_browser/app.py
 msgid "Failed to load. Check the connection."
 msgstr ""
 
@@ -791,10 +796,6 @@ msgstr ""
 "Sila semak maklumat sambungan anda."
 
 #: jellyfin_mpv_shim/mpvtk_browser/auth.py
-msgid "Locked"
-msgstr ""
-
-#: jellyfin_mpv_shim/mpvtk_browser/auth.py
 #: jellyfin_mpv_shim/mpvtk_browser/pages/home.py
 msgid "Connecting to your server…"
 msgstr ""
@@ -872,6 +873,10 @@ msgstr ""
 #: jellyfin_mpv_shim/mpvtk_browser/pages/books.py
 msgid "Favorite"
 msgstr "Kegemaran"
+
+#: jellyfin_mpv_shim/mpvtk_browser/components/detail.py
+msgid "Web"
+msgstr ""
 
 #: jellyfin_mpv_shim/mpvtk_browser/components/media_info.py
 msgid "Video"
@@ -1407,11 +1412,7 @@ msgid "Jellyfin UI"
 msgstr ""
 
 #: jellyfin_mpv_shim/mpvtk_browser/config.py
-msgid "MPV UI with thumbnails"
-msgstr ""
-
-#: jellyfin_mpv_shim/mpvtk_browser/config.py
-msgid "MPV built-in default"
+msgid "MPV UI"
 msgstr ""
 
 #: jellyfin_mpv_shim/mpvtk_browser/config.py
@@ -1752,7 +1753,19 @@ msgid "Window Buttons in the Top Bar"
 msgstr ""
 
 #: jellyfin_mpv_shim/mpvtk_browser/config.py
+msgid "Keep Window Buttons in Full Screen"
+msgstr ""
+
+#: jellyfin_mpv_shim/mpvtk_browser/config.py
+msgid "Hide the Desktop Title Bar"
+msgstr ""
+
+#: jellyfin_mpv_shim/mpvtk_browser/config.py
 msgid "Player Controls Style"
+msgstr ""
+
+#: jellyfin_mpv_shim/mpvtk_browser/config.py
+msgid "Enable Trickplay Thumbnails"
 msgstr ""
 
 #: jellyfin_mpv_shim/mpvtk_browser/config.py
@@ -1782,6 +1795,10 @@ msgstr ""
 
 #: jellyfin_mpv_shim/mpvtk_browser/config.py
 msgid "Full-Width Backdrops"
+msgstr ""
+
+#: jellyfin_mpv_shim/mpvtk_browser/config.py
+msgid "12-Hour Clock"
 msgstr ""
 
 #: jellyfin_mpv_shim/mpvtk_browser/config.py
@@ -1825,12 +1842,22 @@ msgid "Fullscreen Library Browser"
 msgstr ""
 
 #: jellyfin_mpv_shim/mpvtk_browser/config.py
+msgid "Block Player Keybinds While Browsing"
+msgstr ""
+
+#: jellyfin_mpv_shim/mpvtk_browser/config.py
 msgid "Always Bind Arrow Keys to Player Controls"
 msgstr ""
 
 #: jellyfin_mpv_shim/mpvtk_browser/config.py
 msgid "Player Controls Activation Key"
 msgstr ""
+
+#: jellyfin_mpv_shim/mpvtk_browser/config.py
+#, fuzzy
+#| msgid "Selected: %s"
+msgid "Select Key"
+msgstr "Jumlah dipilih: %s"
 
 #: jellyfin_mpv_shim/mpvtk_browser/config.py
 msgid "Shading Behind the Player Controls"
@@ -1842,6 +1869,10 @@ msgstr ""
 
 #: jellyfin_mpv_shim/mpvtk_browser/config.py
 msgid "Hide the Player Controls After (seconds)"
+msgstr ""
+
+#: jellyfin_mpv_shim/mpvtk_browser/config.py
+msgid "Shrink the Player Controls on a Narrow Window"
 msgstr ""
 
 #: jellyfin_mpv_shim/mpvtk_browser/config.py
@@ -1924,6 +1955,21 @@ msgstr ""
 
 #: jellyfin_mpv_shim/mpvtk_browser/config.py
 msgid ""
+"Stops MPV's own shortcuts -- picture adjustment, screenshots, subtitle and "
+"audio switching -- from acting while you are in the library, where there is "
+"no video for them to act on. Turn it off to use your own MPV key bindings "
+"there."
+msgstr ""
+
+#: jellyfin_mpv_shim/mpvtk_browser/config.py
+msgid ""
+"Activates whatever is highlighted, in the library and on the player "
+"controls. An mpv key name; changing it hands Enter back to MPV. The game "
+"controller's Confirm button and a phone's Select follow it."
+msgstr ""
+
+#: jellyfin_mpv_shim/mpvtk_browser/config.py
+msgid ""
 "Leave these blank unless downloads are waking your disks too often. Set both "
 "of the first two together: episodes are then fetched in one batch when a "
 "series runs low, instead of one at a time."
@@ -1937,7 +1983,8 @@ msgstr ""
 #: jellyfin_mpv_shim/mpvtk_browser/config.py
 msgid ""
 "Off gives MPV's own mouse behaviour instead: drag the video to move the "
-"window, and right click to pause. Double click is full screen either way."
+"window, and the right button does whatever your MPV config gives it. Double "
+"click is full screen either way."
 msgstr ""
 
 #: jellyfin_mpv_shim/mpvtk_browser/config.py
@@ -2027,6 +2074,30 @@ msgid ""
 "maximize and close in the top bar instead, and lets you drag the window by "
 "it. On \"Only when the window has no title bar\", MPV is asked whether this "
 "window got one, so desktops that draw a title bar are left alone."
+msgstr ""
+
+#: jellyfin_mpv_shim/mpvtk_browser/config.py
+msgid ""
+"Full screen has no title bar anywhere and nothing to move or maximize, so "
+"the buttons are normally hidden there. Turn this on to keep a way out of "
+"full screen that is not a keyboard shortcut."
+msgstr ""
+
+#: jellyfin_mpv_shim/mpvtk_browser/config.py
+msgid ""
+"Asks the desktop for no title bar on the player window, so the top bar above "
+"is the only one. Pairs with the setting above: on \"Only when the window has "
+"no title bar\" the buttons appear as soon as this is on. Leave both off "
+"unless you want them, since a window with neither can be awkward to move on "
+"some desktops."
+msgstr ""
+
+#: jellyfin_mpv_shim/mpvtk_browser/config.py
+msgid ""
+"Shows a preview frame while you drag the seek bar. Works with every player "
+"control style, including your own OSC script if it supports thumbfast. The "
+"images are fetched from the server per video, which costs disk space and "
+"memory -- tens of MB for an episode, a few hundred for a long film."
 msgstr ""
 
 #: jellyfin_mpv_shim/mpvtk_browser/config.py
@@ -2134,6 +2205,13 @@ msgstr ""
 
 #: jellyfin_mpv_shim/mpvtk_browser/config.py
 msgid ""
+"Show times of day as \"8:30 PM\" rather than \"20:30\" — the Live TV guide "
+"and its air times, and the \"Ends at\" labels on a detail page and the "
+"player controls."
+msgstr ""
+
+#: jellyfin_mpv_shim/mpvtk_browser/config.py
+msgid ""
 "The controls have to stay legible over any frame. \"None\" gives the text a "
 "drop shadow instead of shading the picture behind it."
 msgstr ""
@@ -2148,6 +2226,13 @@ msgstr ""
 msgid ""
 "0 hides them as soon as the pointer is not on them, and forces \"Hide unless "
 "hovered\"."
+msgstr ""
+
+#: jellyfin_mpv_shim/mpvtk_browser/config.py
+msgid ""
+"Narrowing the window shrinks the controls until the smallest button reaches "
+"the accessibility minimum, instead of dropping buttons sooner. Off keeps the "
+"older, larger floor."
 msgstr ""
 
 #: jellyfin_mpv_shim/mpvtk_browser/config.py
@@ -3654,6 +3739,7 @@ msgid "More Like This"
 msgstr ""
 
 #: jellyfin_mpv_shim/mpvtk_browser/pages/detail.py
+#: jellyfin_mpv_shim/mpvtk_browser/tiles.py
 msgid "Go to Series"
 msgstr ""
 
@@ -4792,6 +4878,22 @@ msgstr "Buang Pelayan"
 msgid "There is nothing here to queue."
 msgstr ""
 
+#: jellyfin_mpv_shim/mpvtk_browser/timefmt.py
+#, python-brace-format
+msgctxt "12-hour clock"
+msgid "{time} {period}"
+msgstr ""
+
+#: jellyfin_mpv_shim/mpvtk_browser/timefmt.py
+msgctxt "12-hour clock"
+msgid "AM"
+msgstr ""
+
+#: jellyfin_mpv_shim/mpvtk_browser/timefmt.py
+msgctxt "12-hour clock"
+msgid "PM"
+msgstr ""
+
 #: jellyfin_mpv_shim/mpvtk_browser/views.py
 #: jellyfin_mpv_shim/mpvtk_browser/window_chrome.py
 msgid "Search"
@@ -4951,13 +5053,32 @@ msgid "Enable SVP"
 msgstr ""
 
 #: jellyfin_mpv_shim/sync/manager.py
+msgid "The downloads are already in that folder."
+msgstr ""
+
+#: jellyfin_mpv_shim/sync/manager.py
 msgid ""
 "Can't change the download folder while a download is in progress. Wait for "
 "it to finish, then try again."
 msgstr ""
 
 #: jellyfin_mpv_shim/sync/manager.py
+msgid ""
+"That folder is inside the current download folder. Choose one outside it."
+msgstr ""
+
+#: jellyfin_mpv_shim/sync/manager.py
+msgid "Can't read that folder. Check the path and its permissions."
+msgstr ""
+
+#: jellyfin_mpv_shim/sync/manager.py
 msgid "That folder already contains downloads. Choose an empty folder."
+msgstr ""
+
+#: jellyfin_mpv_shim/sync/manager.py
+msgid ""
+"That folder isn't empty. Choose an empty folder — the download folder is "
+"managed by this app and anything else in it can be moved or removed."
 msgstr ""
 
 #: jellyfin_mpv_shim/sync/manager.py
@@ -4966,6 +5087,12 @@ msgstr ""
 
 #: jellyfin_mpv_shim/sync/manager.py
 msgid "A download is still finishing. Wait for it to stop, then try again."
+msgstr ""
+
+#: jellyfin_mpv_shim/sync/manager.py
+msgid ""
+"There isn't enough space on that drive to move the downloads. Free some "
+"space and try again — nothing was moved."
 msgstr ""
 
 #: jellyfin_mpv_shim/sync/manager.py

--- a/jellyfin_mpv_shim/messages/nb_NO/LC_MESSAGES/base.po
+++ b/jellyfin_mpv_shim/messages/nb_NO/LC_MESSAGES/base.po
@@ -6,7 +6,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2026-08-30 22:19-0400\n"
+"POT-Creation-Date: 2026-09-07 17:35-0400\n"
 "PO-Revision-Date: 2024-10-11 07:53+0000\n"
 "Last-Translator: BromTeque <github@bromteque.com>\n"
 "Language-Team: Norwegian Bokmål <https://translate.jellyfin.org/projects/"
@@ -547,6 +547,11 @@ msgid "Night Mode (Auto Volume Adj)"
 msgstr ""
 
 #: jellyfin_mpv_shim/mpvtk_browser/app.py
+#: jellyfin_mpv_shim/mpvtk_browser/auth.py
+msgid "Locked"
+msgstr ""
+
+#: jellyfin_mpv_shim/mpvtk_browser/app.py
 msgid "Failed to load. Check the connection."
 msgstr ""
 
@@ -826,10 +831,6 @@ msgstr ""
 "Vennligst sjekk tilkoblingsinformasjonen din."
 
 #: jellyfin_mpv_shim/mpvtk_browser/auth.py
-msgid "Locked"
-msgstr ""
-
-#: jellyfin_mpv_shim/mpvtk_browser/auth.py
 #: jellyfin_mpv_shim/mpvtk_browser/pages/home.py
 msgid "Connecting to your server…"
 msgstr ""
@@ -910,6 +911,10 @@ msgstr "Avslutt og marker som usett"
 #: jellyfin_mpv_shim/mpvtk_browser/pages/books.py
 msgid "Favorite"
 msgstr "Favoritt"
+
+#: jellyfin_mpv_shim/mpvtk_browser/components/detail.py
+msgid "Web"
+msgstr ""
 
 # seeded from jellyfin-web: Video
 #: jellyfin_mpv_shim/mpvtk_browser/components/media_info.py
@@ -1526,11 +1531,7 @@ msgid "Jellyfin UI"
 msgstr ""
 
 #: jellyfin_mpv_shim/mpvtk_browser/config.py
-msgid "MPV UI with thumbnails"
-msgstr ""
-
-#: jellyfin_mpv_shim/mpvtk_browser/config.py
-msgid "MPV built-in default"
+msgid "MPV UI"
 msgstr ""
 
 #: jellyfin_mpv_shim/mpvtk_browser/config.py
@@ -1879,8 +1880,22 @@ msgid "Window Buttons in the Top Bar"
 msgstr ""
 
 #: jellyfin_mpv_shim/mpvtk_browser/config.py
+msgid "Keep Window Buttons in Full Screen"
+msgstr ""
+
+#: jellyfin_mpv_shim/mpvtk_browser/config.py
+msgid "Hide the Desktop Title Bar"
+msgstr ""
+
+#: jellyfin_mpv_shim/mpvtk_browser/config.py
 msgid "Player Controls Style"
 msgstr ""
+
+#: jellyfin_mpv_shim/mpvtk_browser/config.py
+#, fuzzy
+#| msgid "Enable thumbnail previews"
+msgid "Enable Trickplay Thumbnails"
+msgstr "Aktiver forhåndsvisning av miniatyrbilder"
 
 #: jellyfin_mpv_shim/mpvtk_browser/config.py
 msgid "Load All Seek Previews at Once"
@@ -1910,6 +1925,10 @@ msgstr ""
 
 #: jellyfin_mpv_shim/mpvtk_browser/config.py
 msgid "Full-Width Backdrops"
+msgstr ""
+
+#: jellyfin_mpv_shim/mpvtk_browser/config.py
+msgid "12-Hour Clock"
 msgstr ""
 
 #: jellyfin_mpv_shim/mpvtk_browser/config.py
@@ -1955,12 +1974,23 @@ msgid "Fullscreen Library Browser"
 msgstr ""
 
 #: jellyfin_mpv_shim/mpvtk_browser/config.py
+msgid "Block Player Keybinds While Browsing"
+msgstr ""
+
+#: jellyfin_mpv_shim/mpvtk_browser/config.py
 msgid "Always Bind Arrow Keys to Player Controls"
 msgstr ""
 
 #: jellyfin_mpv_shim/mpvtk_browser/config.py
 msgid "Player Controls Activation Key"
 msgstr ""
+
+# seeded from jellyfin-web: SelectAll
+#: jellyfin_mpv_shim/mpvtk_browser/config.py
+#, fuzzy
+#| msgid "Select All"
+msgid "Select Key"
+msgstr "Merk alle"
 
 #: jellyfin_mpv_shim/mpvtk_browser/config.py
 msgid "Shading Behind the Player Controls"
@@ -1972,6 +2002,10 @@ msgstr ""
 
 #: jellyfin_mpv_shim/mpvtk_browser/config.py
 msgid "Hide the Player Controls After (seconds)"
+msgstr ""
+
+#: jellyfin_mpv_shim/mpvtk_browser/config.py
+msgid "Shrink the Player Controls on a Narrow Window"
 msgstr ""
 
 #: jellyfin_mpv_shim/mpvtk_browser/config.py
@@ -2058,6 +2092,21 @@ msgstr ""
 
 #: jellyfin_mpv_shim/mpvtk_browser/config.py
 msgid ""
+"Stops MPV's own shortcuts -- picture adjustment, screenshots, subtitle and "
+"audio switching -- from acting while you are in the library, where there is "
+"no video for them to act on. Turn it off to use your own MPV key bindings "
+"there."
+msgstr ""
+
+#: jellyfin_mpv_shim/mpvtk_browser/config.py
+msgid ""
+"Activates whatever is highlighted, in the library and on the player "
+"controls. An mpv key name; changing it hands Enter back to MPV. The game "
+"controller's Confirm button and a phone's Select follow it."
+msgstr ""
+
+#: jellyfin_mpv_shim/mpvtk_browser/config.py
+msgid ""
 "Leave these blank unless downloads are waking your disks too often. Set both "
 "of the first two together: episodes are then fetched in one batch when a "
 "series runs low, instead of one at a time."
@@ -2071,7 +2120,8 @@ msgstr ""
 #: jellyfin_mpv_shim/mpvtk_browser/config.py
 msgid ""
 "Off gives MPV's own mouse behaviour instead: drag the video to move the "
-"window, and right click to pause. Double click is full screen either way."
+"window, and the right button does whatever your MPV config gives it. Double "
+"click is full screen either way."
 msgstr ""
 
 #: jellyfin_mpv_shim/mpvtk_browser/config.py
@@ -2161,6 +2211,30 @@ msgid ""
 "maximize and close in the top bar instead, and lets you drag the window by "
 "it. On \"Only when the window has no title bar\", MPV is asked whether this "
 "window got one, so desktops that draw a title bar are left alone."
+msgstr ""
+
+#: jellyfin_mpv_shim/mpvtk_browser/config.py
+msgid ""
+"Full screen has no title bar anywhere and nothing to move or maximize, so "
+"the buttons are normally hidden there. Turn this on to keep a way out of "
+"full screen that is not a keyboard shortcut."
+msgstr ""
+
+#: jellyfin_mpv_shim/mpvtk_browser/config.py
+msgid ""
+"Asks the desktop for no title bar on the player window, so the top bar above "
+"is the only one. Pairs with the setting above: on \"Only when the window has "
+"no title bar\" the buttons appear as soon as this is on. Leave both off "
+"unless you want them, since a window with neither can be awkward to move on "
+"some desktops."
+msgstr ""
+
+#: jellyfin_mpv_shim/mpvtk_browser/config.py
+msgid ""
+"Shows a preview frame while you drag the seek bar. Works with every player "
+"control style, including your own OSC script if it supports thumbfast. The "
+"images are fetched from the server per video, which costs disk space and "
+"memory -- tens of MB for an episode, a few hundred for a long film."
 msgstr ""
 
 #: jellyfin_mpv_shim/mpvtk_browser/config.py
@@ -2270,6 +2344,13 @@ msgstr ""
 
 #: jellyfin_mpv_shim/mpvtk_browser/config.py
 msgid ""
+"Show times of day as \"8:30 PM\" rather than \"20:30\" — the Live TV guide "
+"and its air times, and the \"Ends at\" labels on a detail page and the "
+"player controls."
+msgstr ""
+
+#: jellyfin_mpv_shim/mpvtk_browser/config.py
+msgid ""
 "The controls have to stay legible over any frame. \"None\" gives the text a "
 "drop shadow instead of shading the picture behind it."
 msgstr ""
@@ -2284,6 +2365,13 @@ msgstr ""
 msgid ""
 "0 hides them as soon as the pointer is not on them, and forces \"Hide unless "
 "hovered\"."
+msgstr ""
+
+#: jellyfin_mpv_shim/mpvtk_browser/config.py
+msgid ""
+"Narrowing the window shrinks the controls until the smallest button reaches "
+"the accessibility minimum, instead of dropping buttons sooner. Off keeps the "
+"older, larger floor."
 msgstr ""
 
 #: jellyfin_mpv_shim/mpvtk_browser/config.py
@@ -3890,6 +3978,7 @@ msgid "More Like This"
 msgstr "Flere som dette"
 
 #: jellyfin_mpv_shim/mpvtk_browser/pages/detail.py
+#: jellyfin_mpv_shim/mpvtk_browser/tiles.py
 msgid "Go to Series"
 msgstr ""
 
@@ -5082,6 +5171,22 @@ msgstr "Fjern server"
 msgid "There is nothing here to queue."
 msgstr ""
 
+#: jellyfin_mpv_shim/mpvtk_browser/timefmt.py
+#, python-brace-format
+msgctxt "12-hour clock"
+msgid "{time} {period}"
+msgstr ""
+
+#: jellyfin_mpv_shim/mpvtk_browser/timefmt.py
+msgctxt "12-hour clock"
+msgid "AM"
+msgstr ""
+
+#: jellyfin_mpv_shim/mpvtk_browser/timefmt.py
+msgctxt "12-hour clock"
+msgid "PM"
+msgstr ""
+
 # seeded from jellyfin-web: Search
 #: jellyfin_mpv_shim/mpvtk_browser/views.py
 #: jellyfin_mpv_shim/mpvtk_browser/window_chrome.py
@@ -5250,13 +5355,32 @@ msgid "Enable SVP"
 msgstr "Aktiver SVP"
 
 #: jellyfin_mpv_shim/sync/manager.py
+msgid "The downloads are already in that folder."
+msgstr ""
+
+#: jellyfin_mpv_shim/sync/manager.py
 msgid ""
 "Can't change the download folder while a download is in progress. Wait for "
 "it to finish, then try again."
 msgstr ""
 
 #: jellyfin_mpv_shim/sync/manager.py
+msgid ""
+"That folder is inside the current download folder. Choose one outside it."
+msgstr ""
+
+#: jellyfin_mpv_shim/sync/manager.py
+msgid "Can't read that folder. Check the path and its permissions."
+msgstr ""
+
+#: jellyfin_mpv_shim/sync/manager.py
 msgid "That folder already contains downloads. Choose an empty folder."
+msgstr ""
+
+#: jellyfin_mpv_shim/sync/manager.py
+msgid ""
+"That folder isn't empty. Choose an empty folder — the download folder is "
+"managed by this app and anything else in it can be moved or removed."
 msgstr ""
 
 #: jellyfin_mpv_shim/sync/manager.py
@@ -5265,6 +5389,12 @@ msgstr ""
 
 #: jellyfin_mpv_shim/sync/manager.py
 msgid "A download is still finishing. Wait for it to stop, then try again."
+msgstr ""
+
+#: jellyfin_mpv_shim/sync/manager.py
+msgid ""
+"There isn't enough space on that drive to move the downloads. Free some "
+"space and try again — nothing was moved."
 msgstr ""
 
 #: jellyfin_mpv_shim/sync/manager.py

--- a/jellyfin_mpv_shim/messages/nds/LC_MESSAGES/base.po
+++ b/jellyfin_mpv_shim/messages/nds/LC_MESSAGES/base.po
@@ -6,7 +6,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2026-08-30 22:19-0400\n"
+"POT-Creation-Date: 2026-09-07 17:35-0400\n"
 "PO-Revision-Date: 2026-05-01 09:29+0000\n"
 "Last-Translator: \"@reco-tec\" <mods_vincas_2s@icloud.com>\n"
 "Language-Team: German (Low) <https://translate.jellyfin.org/projects/"
@@ -546,6 +546,11 @@ msgid "Night Mode (Auto Volume Adj)"
 msgstr ""
 
 #: jellyfin_mpv_shim/mpvtk_browser/app.py
+#: jellyfin_mpv_shim/mpvtk_browser/auth.py
+msgid "Locked"
+msgstr ""
+
+#: jellyfin_mpv_shim/mpvtk_browser/app.py
 msgid "Failed to load. Check the connection."
 msgstr ""
 
@@ -808,10 +813,6 @@ msgstr ""
 "Bitte überprüfe deine Verbindungsinformationen."
 
 #: jellyfin_mpv_shim/mpvtk_browser/auth.py
-msgid "Locked"
-msgstr ""
-
-#: jellyfin_mpv_shim/mpvtk_browser/auth.py
 #: jellyfin_mpv_shim/mpvtk_browser/pages/home.py
 msgid "Connecting to your server…"
 msgstr ""
@@ -886,6 +887,10 @@ msgstr "Beenden und als ungesehen markieren"
 #: jellyfin_mpv_shim/mpvtk_browser/hud.py
 #: jellyfin_mpv_shim/mpvtk_browser/pages/books.py
 msgid "Favorite"
+msgstr ""
+
+#: jellyfin_mpv_shim/mpvtk_browser/components/detail.py
+msgid "Web"
 msgstr ""
 
 #: jellyfin_mpv_shim/mpvtk_browser/components/media_info.py
@@ -1421,11 +1426,7 @@ msgid "Jellyfin UI"
 msgstr ""
 
 #: jellyfin_mpv_shim/mpvtk_browser/config.py
-msgid "MPV UI with thumbnails"
-msgstr ""
-
-#: jellyfin_mpv_shim/mpvtk_browser/config.py
-msgid "MPV built-in default"
+msgid "MPV UI"
 msgstr ""
 
 #: jellyfin_mpv_shim/mpvtk_browser/config.py
@@ -1768,8 +1769,21 @@ msgid "Window Buttons in the Top Bar"
 msgstr ""
 
 #: jellyfin_mpv_shim/mpvtk_browser/config.py
+msgid "Keep Window Buttons in Full Screen"
+msgstr ""
+
+#: jellyfin_mpv_shim/mpvtk_browser/config.py
+msgid "Hide the Desktop Title Bar"
+msgstr ""
+
+#: jellyfin_mpv_shim/mpvtk_browser/config.py
 msgid "Player Controls Style"
 msgstr ""
+
+#: jellyfin_mpv_shim/mpvtk_browser/config.py
+#, fuzzy
+msgid "Enable Trickplay Thumbnails"
+msgstr "Thumbnail-Vorschau aktivieren"
 
 #: jellyfin_mpv_shim/mpvtk_browser/config.py
 msgid "Load All Seek Previews at Once"
@@ -1798,6 +1812,10 @@ msgstr ""
 
 #: jellyfin_mpv_shim/mpvtk_browser/config.py
 msgid "Full-Width Backdrops"
+msgstr ""
+
+#: jellyfin_mpv_shim/mpvtk_browser/config.py
+msgid "12-Hour Clock"
 msgstr ""
 
 #: jellyfin_mpv_shim/mpvtk_browser/config.py
@@ -1841,11 +1859,19 @@ msgid "Fullscreen Library Browser"
 msgstr ""
 
 #: jellyfin_mpv_shim/mpvtk_browser/config.py
+msgid "Block Player Keybinds While Browsing"
+msgstr ""
+
+#: jellyfin_mpv_shim/mpvtk_browser/config.py
 msgid "Always Bind Arrow Keys to Player Controls"
 msgstr ""
 
 #: jellyfin_mpv_shim/mpvtk_browser/config.py
 msgid "Player Controls Activation Key"
+msgstr ""
+
+#: jellyfin_mpv_shim/mpvtk_browser/config.py
+msgid "Select Key"
 msgstr ""
 
 #: jellyfin_mpv_shim/mpvtk_browser/config.py
@@ -1858,6 +1884,10 @@ msgstr ""
 
 #: jellyfin_mpv_shim/mpvtk_browser/config.py
 msgid "Hide the Player Controls After (seconds)"
+msgstr ""
+
+#: jellyfin_mpv_shim/mpvtk_browser/config.py
+msgid "Shrink the Player Controls on a Narrow Window"
 msgstr ""
 
 #: jellyfin_mpv_shim/mpvtk_browser/config.py
@@ -1944,6 +1974,21 @@ msgstr ""
 
 #: jellyfin_mpv_shim/mpvtk_browser/config.py
 msgid ""
+"Stops MPV's own shortcuts -- picture adjustment, screenshots, subtitle and "
+"audio switching -- from acting while you are in the library, where there is "
+"no video for them to act on. Turn it off to use your own MPV key bindings "
+"there."
+msgstr ""
+
+#: jellyfin_mpv_shim/mpvtk_browser/config.py
+msgid ""
+"Activates whatever is highlighted, in the library and on the player "
+"controls. An mpv key name; changing it hands Enter back to MPV. The game "
+"controller's Confirm button and a phone's Select follow it."
+msgstr ""
+
+#: jellyfin_mpv_shim/mpvtk_browser/config.py
+msgid ""
 "Leave these blank unless downloads are waking your disks too often. Set both "
 "of the first two together: episodes are then fetched in one batch when a "
 "series runs low, instead of one at a time."
@@ -1957,7 +2002,8 @@ msgstr ""
 #: jellyfin_mpv_shim/mpvtk_browser/config.py
 msgid ""
 "Off gives MPV's own mouse behaviour instead: drag the video to move the "
-"window, and right click to pause. Double click is full screen either way."
+"window, and the right button does whatever your MPV config gives it. Double "
+"click is full screen either way."
 msgstr ""
 
 #: jellyfin_mpv_shim/mpvtk_browser/config.py
@@ -2047,6 +2093,30 @@ msgid ""
 "maximize and close in the top bar instead, and lets you drag the window by "
 "it. On \"Only when the window has no title bar\", MPV is asked whether this "
 "window got one, so desktops that draw a title bar are left alone."
+msgstr ""
+
+#: jellyfin_mpv_shim/mpvtk_browser/config.py
+msgid ""
+"Full screen has no title bar anywhere and nothing to move or maximize, so "
+"the buttons are normally hidden there. Turn this on to keep a way out of "
+"full screen that is not a keyboard shortcut."
+msgstr ""
+
+#: jellyfin_mpv_shim/mpvtk_browser/config.py
+msgid ""
+"Asks the desktop for no title bar on the player window, so the top bar above "
+"is the only one. Pairs with the setting above: on \"Only when the window has "
+"no title bar\" the buttons appear as soon as this is on. Leave both off "
+"unless you want them, since a window with neither can be awkward to move on "
+"some desktops."
+msgstr ""
+
+#: jellyfin_mpv_shim/mpvtk_browser/config.py
+msgid ""
+"Shows a preview frame while you drag the seek bar. Works with every player "
+"control style, including your own OSC script if it supports thumbfast. The "
+"images are fetched from the server per video, which costs disk space and "
+"memory -- tens of MB for an episode, a few hundred for a long film."
 msgstr ""
 
 #: jellyfin_mpv_shim/mpvtk_browser/config.py
@@ -2156,6 +2226,13 @@ msgstr ""
 
 #: jellyfin_mpv_shim/mpvtk_browser/config.py
 msgid ""
+"Show times of day as \"8:30 PM\" rather than \"20:30\" — the Live TV guide "
+"and its air times, and the \"Ends at\" labels on a detail page and the "
+"player controls."
+msgstr ""
+
+#: jellyfin_mpv_shim/mpvtk_browser/config.py
+msgid ""
 "The controls have to stay legible over any frame. \"None\" gives the text a "
 "drop shadow instead of shading the picture behind it."
 msgstr ""
@@ -2170,6 +2247,13 @@ msgstr ""
 msgid ""
 "0 hides them as soon as the pointer is not on them, and forces \"Hide unless "
 "hovered\"."
+msgstr ""
+
+#: jellyfin_mpv_shim/mpvtk_browser/config.py
+msgid ""
+"Narrowing the window shrinks the controls until the smallest button reaches "
+"the accessibility minimum, instead of dropping buttons sooner. Off keeps the "
+"older, larger floor."
 msgstr ""
 
 #: jellyfin_mpv_shim/mpvtk_browser/config.py
@@ -3622,6 +3706,7 @@ msgid "More Like This"
 msgstr ""
 
 #: jellyfin_mpv_shim/mpvtk_browser/pages/detail.py
+#: jellyfin_mpv_shim/mpvtk_browser/tiles.py
 msgid "Go to Series"
 msgstr ""
 
@@ -4715,6 +4800,22 @@ msgstr "Server entfernen"
 msgid "There is nothing here to queue."
 msgstr ""
 
+#: jellyfin_mpv_shim/mpvtk_browser/timefmt.py
+#, python-brace-format
+msgctxt "12-hour clock"
+msgid "{time} {period}"
+msgstr ""
+
+#: jellyfin_mpv_shim/mpvtk_browser/timefmt.py
+msgctxt "12-hour clock"
+msgid "AM"
+msgstr ""
+
+#: jellyfin_mpv_shim/mpvtk_browser/timefmt.py
+msgctxt "12-hour clock"
+msgid "PM"
+msgstr ""
+
 #: jellyfin_mpv_shim/mpvtk_browser/views.py
 #: jellyfin_mpv_shim/mpvtk_browser/window_chrome.py
 msgid "Search"
@@ -4877,13 +4978,32 @@ msgid "Enable SVP"
 msgstr "SVP aktivieren"
 
 #: jellyfin_mpv_shim/sync/manager.py
+msgid "The downloads are already in that folder."
+msgstr ""
+
+#: jellyfin_mpv_shim/sync/manager.py
 msgid ""
 "Can't change the download folder while a download is in progress. Wait for "
 "it to finish, then try again."
 msgstr ""
 
 #: jellyfin_mpv_shim/sync/manager.py
+msgid ""
+"That folder is inside the current download folder. Choose one outside it."
+msgstr ""
+
+#: jellyfin_mpv_shim/sync/manager.py
+msgid "Can't read that folder. Check the path and its permissions."
+msgstr ""
+
+#: jellyfin_mpv_shim/sync/manager.py
 msgid "That folder already contains downloads. Choose an empty folder."
+msgstr ""
+
+#: jellyfin_mpv_shim/sync/manager.py
+msgid ""
+"That folder isn't empty. Choose an empty folder — the download folder is "
+"managed by this app and anything else in it can be moved or removed."
 msgstr ""
 
 #: jellyfin_mpv_shim/sync/manager.py
@@ -4892,6 +5012,12 @@ msgstr ""
 
 #: jellyfin_mpv_shim/sync/manager.py
 msgid "A download is still finishing. Wait for it to stop, then try again."
+msgstr ""
+
+#: jellyfin_mpv_shim/sync/manager.py
+msgid ""
+"There isn't enough space on that drive to move the downloads. Free some "
+"space and try again — nothing was moved."
 msgstr ""
 
 #: jellyfin_mpv_shim/sync/manager.py

--- a/jellyfin_mpv_shim/messages/ne/LC_MESSAGES/base.po
+++ b/jellyfin_mpv_shim/messages/ne/LC_MESSAGES/base.po
@@ -6,7 +6,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2026-08-30 22:19-0400\n"
+"POT-Creation-Date: 2026-09-07 17:35-0400\n"
 "PO-Revision-Date: 2023-12-04 03:30+0000\n"
 "Last-Translator: Kristopher Roller <akjroller@gmail.com>\n"
 "Language-Team: Nepali <https://translate.jellyfin.org/projects/jellyfin/"
@@ -550,6 +550,11 @@ msgid "Night Mode (Auto Volume Adj)"
 msgstr ""
 
 #: jellyfin_mpv_shim/mpvtk_browser/app.py
+#: jellyfin_mpv_shim/mpvtk_browser/auth.py
+msgid "Locked"
+msgstr ""
+
+#: jellyfin_mpv_shim/mpvtk_browser/app.py
 msgid "Failed to load. Check the connection."
 msgstr ""
 
@@ -825,10 +830,6 @@ msgstr ""
 "कृपया आफ्नो जडान जानकारी जाँच गर्नुहोस्।"
 
 #: jellyfin_mpv_shim/mpvtk_browser/auth.py
-msgid "Locked"
-msgstr ""
-
-#: jellyfin_mpv_shim/mpvtk_browser/auth.py
 #: jellyfin_mpv_shim/mpvtk_browser/pages/home.py
 msgid "Connecting to your server…"
 msgstr ""
@@ -904,6 +905,10 @@ msgstr "छोड्नुहोस् र नहेरेको चिन्ह
 #: jellyfin_mpv_shim/mpvtk_browser/hud.py
 #: jellyfin_mpv_shim/mpvtk_browser/pages/books.py
 msgid "Favorite"
+msgstr ""
+
+#: jellyfin_mpv_shim/mpvtk_browser/components/detail.py
+msgid "Web"
 msgstr ""
 
 #: jellyfin_mpv_shim/mpvtk_browser/components/media_info.py
@@ -1446,11 +1451,7 @@ msgid "Jellyfin UI"
 msgstr ""
 
 #: jellyfin_mpv_shim/mpvtk_browser/config.py
-msgid "MPV UI with thumbnails"
-msgstr ""
-
-#: jellyfin_mpv_shim/mpvtk_browser/config.py
-msgid "MPV built-in default"
+msgid "MPV UI"
 msgstr ""
 
 #: jellyfin_mpv_shim/mpvtk_browser/config.py
@@ -1795,8 +1796,22 @@ msgid "Window Buttons in the Top Bar"
 msgstr ""
 
 #: jellyfin_mpv_shim/mpvtk_browser/config.py
+msgid "Keep Window Buttons in Full Screen"
+msgstr ""
+
+#: jellyfin_mpv_shim/mpvtk_browser/config.py
+msgid "Hide the Desktop Title Bar"
+msgstr ""
+
+#: jellyfin_mpv_shim/mpvtk_browser/config.py
 msgid "Player Controls Style"
 msgstr ""
+
+#: jellyfin_mpv_shim/mpvtk_browser/config.py
+#, fuzzy
+#| msgid "Enable thumbnail previews"
+msgid "Enable Trickplay Thumbnails"
+msgstr "थम्बनेल पूर्वावलोकन सक्षम गर्नुहोस्"
 
 #: jellyfin_mpv_shim/mpvtk_browser/config.py
 msgid "Load All Seek Previews at Once"
@@ -1826,6 +1841,10 @@ msgstr ""
 
 #: jellyfin_mpv_shim/mpvtk_browser/config.py
 msgid "Full-Width Backdrops"
+msgstr ""
+
+#: jellyfin_mpv_shim/mpvtk_browser/config.py
+msgid "12-Hour Clock"
 msgstr ""
 
 #: jellyfin_mpv_shim/mpvtk_browser/config.py
@@ -1869,11 +1888,19 @@ msgid "Fullscreen Library Browser"
 msgstr ""
 
 #: jellyfin_mpv_shim/mpvtk_browser/config.py
+msgid "Block Player Keybinds While Browsing"
+msgstr ""
+
+#: jellyfin_mpv_shim/mpvtk_browser/config.py
 msgid "Always Bind Arrow Keys to Player Controls"
 msgstr ""
 
 #: jellyfin_mpv_shim/mpvtk_browser/config.py
 msgid "Player Controls Activation Key"
+msgstr ""
+
+#: jellyfin_mpv_shim/mpvtk_browser/config.py
+msgid "Select Key"
 msgstr ""
 
 #: jellyfin_mpv_shim/mpvtk_browser/config.py
@@ -1886,6 +1913,10 @@ msgstr ""
 
 #: jellyfin_mpv_shim/mpvtk_browser/config.py
 msgid "Hide the Player Controls After (seconds)"
+msgstr ""
+
+#: jellyfin_mpv_shim/mpvtk_browser/config.py
+msgid "Shrink the Player Controls on a Narrow Window"
 msgstr ""
 
 #: jellyfin_mpv_shim/mpvtk_browser/config.py
@@ -1972,6 +2003,21 @@ msgstr ""
 
 #: jellyfin_mpv_shim/mpvtk_browser/config.py
 msgid ""
+"Stops MPV's own shortcuts -- picture adjustment, screenshots, subtitle and "
+"audio switching -- from acting while you are in the library, where there is "
+"no video for them to act on. Turn it off to use your own MPV key bindings "
+"there."
+msgstr ""
+
+#: jellyfin_mpv_shim/mpvtk_browser/config.py
+msgid ""
+"Activates whatever is highlighted, in the library and on the player "
+"controls. An mpv key name; changing it hands Enter back to MPV. The game "
+"controller's Confirm button and a phone's Select follow it."
+msgstr ""
+
+#: jellyfin_mpv_shim/mpvtk_browser/config.py
+msgid ""
 "Leave these blank unless downloads are waking your disks too often. Set both "
 "of the first two together: episodes are then fetched in one batch when a "
 "series runs low, instead of one at a time."
@@ -1985,7 +2031,8 @@ msgstr ""
 #: jellyfin_mpv_shim/mpvtk_browser/config.py
 msgid ""
 "Off gives MPV's own mouse behaviour instead: drag the video to move the "
-"window, and right click to pause. Double click is full screen either way."
+"window, and the right button does whatever your MPV config gives it. Double "
+"click is full screen either way."
 msgstr ""
 
 #: jellyfin_mpv_shim/mpvtk_browser/config.py
@@ -2075,6 +2122,30 @@ msgid ""
 "maximize and close in the top bar instead, and lets you drag the window by "
 "it. On \"Only when the window has no title bar\", MPV is asked whether this "
 "window got one, so desktops that draw a title bar are left alone."
+msgstr ""
+
+#: jellyfin_mpv_shim/mpvtk_browser/config.py
+msgid ""
+"Full screen has no title bar anywhere and nothing to move or maximize, so "
+"the buttons are normally hidden there. Turn this on to keep a way out of "
+"full screen that is not a keyboard shortcut."
+msgstr ""
+
+#: jellyfin_mpv_shim/mpvtk_browser/config.py
+msgid ""
+"Asks the desktop for no title bar on the player window, so the top bar above "
+"is the only one. Pairs with the setting above: on \"Only when the window has "
+"no title bar\" the buttons appear as soon as this is on. Leave both off "
+"unless you want them, since a window with neither can be awkward to move on "
+"some desktops."
+msgstr ""
+
+#: jellyfin_mpv_shim/mpvtk_browser/config.py
+msgid ""
+"Shows a preview frame while you drag the seek bar. Works with every player "
+"control style, including your own OSC script if it supports thumbfast. The "
+"images are fetched from the server per video, which costs disk space and "
+"memory -- tens of MB for an episode, a few hundred for a long film."
 msgstr ""
 
 #: jellyfin_mpv_shim/mpvtk_browser/config.py
@@ -2184,6 +2255,13 @@ msgstr ""
 
 #: jellyfin_mpv_shim/mpvtk_browser/config.py
 msgid ""
+"Show times of day as \"8:30 PM\" rather than \"20:30\" — the Live TV guide "
+"and its air times, and the \"Ends at\" labels on a detail page and the "
+"player controls."
+msgstr ""
+
+#: jellyfin_mpv_shim/mpvtk_browser/config.py
+msgid ""
 "The controls have to stay legible over any frame. \"None\" gives the text a "
 "drop shadow instead of shading the picture behind it."
 msgstr ""
@@ -2198,6 +2276,13 @@ msgstr ""
 msgid ""
 "0 hides them as soon as the pointer is not on them, and forces \"Hide unless "
 "hovered\"."
+msgstr ""
+
+#: jellyfin_mpv_shim/mpvtk_browser/config.py
+msgid ""
+"Narrowing the window shrinks the controls until the smallest button reaches "
+"the accessibility minimum, instead of dropping buttons sooner. Off keeps the "
+"older, larger floor."
 msgstr ""
 
 #: jellyfin_mpv_shim/mpvtk_browser/config.py
@@ -3714,6 +3799,7 @@ msgid "More Like This"
 msgstr ""
 
 #: jellyfin_mpv_shim/mpvtk_browser/pages/detail.py
+#: jellyfin_mpv_shim/mpvtk_browser/tiles.py
 msgid "Go to Series"
 msgstr ""
 
@@ -4857,6 +4943,22 @@ msgstr "सर्भर हटाउनुहोस्"
 msgid "There is nothing here to queue."
 msgstr ""
 
+#: jellyfin_mpv_shim/mpvtk_browser/timefmt.py
+#, python-brace-format
+msgctxt "12-hour clock"
+msgid "{time} {period}"
+msgstr ""
+
+#: jellyfin_mpv_shim/mpvtk_browser/timefmt.py
+msgctxt "12-hour clock"
+msgid "AM"
+msgstr ""
+
+#: jellyfin_mpv_shim/mpvtk_browser/timefmt.py
+msgctxt "12-hour clock"
+msgid "PM"
+msgstr ""
+
 #: jellyfin_mpv_shim/mpvtk_browser/views.py
 #: jellyfin_mpv_shim/mpvtk_browser/window_chrome.py
 msgid "Search"
@@ -5019,13 +5121,32 @@ msgid "Enable SVP"
 msgstr "SVP सक्षम गर्नुहोस्"
 
 #: jellyfin_mpv_shim/sync/manager.py
+msgid "The downloads are already in that folder."
+msgstr ""
+
+#: jellyfin_mpv_shim/sync/manager.py
 msgid ""
 "Can't change the download folder while a download is in progress. Wait for "
 "it to finish, then try again."
 msgstr ""
 
 #: jellyfin_mpv_shim/sync/manager.py
+msgid ""
+"That folder is inside the current download folder. Choose one outside it."
+msgstr ""
+
+#: jellyfin_mpv_shim/sync/manager.py
+msgid "Can't read that folder. Check the path and its permissions."
+msgstr ""
+
+#: jellyfin_mpv_shim/sync/manager.py
 msgid "That folder already contains downloads. Choose an empty folder."
+msgstr ""
+
+#: jellyfin_mpv_shim/sync/manager.py
+msgid ""
+"That folder isn't empty. Choose an empty folder — the download folder is "
+"managed by this app and anything else in it can be moved or removed."
 msgstr ""
 
 #: jellyfin_mpv_shim/sync/manager.py
@@ -5034,6 +5155,12 @@ msgstr ""
 
 #: jellyfin_mpv_shim/sync/manager.py
 msgid "A download is still finishing. Wait for it to stop, then try again."
+msgstr ""
+
+#: jellyfin_mpv_shim/sync/manager.py
+msgid ""
+"There isn't enough space on that drive to move the downloads. Free some "
+"space and try again — nothing was moved."
 msgstr ""
 
 #: jellyfin_mpv_shim/sync/manager.py

--- a/jellyfin_mpv_shim/messages/nl/LC_MESSAGES/base.po
+++ b/jellyfin_mpv_shim/messages/nl/LC_MESSAGES/base.po
@@ -6,7 +6,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2026-08-30 22:19-0400\n"
+"POT-Creation-Date: 2026-09-07 17:35-0400\n"
 "PO-Revision-Date: 2026-09-03 09:00+0000\n"
 "Last-Translator: Kas <kasjunk@proton.me>\n"
 "Language-Team: Dutch <https://translate.jellyfin.org/projects/jellyfin/"
@@ -513,6 +513,11 @@ msgid "Night Mode (Auto Volume Adj)"
 msgstr "Nachtmodus (volume aut. aanp.)"
 
 #: jellyfin_mpv_shim/mpvtk_browser/app.py
+#: jellyfin_mpv_shim/mpvtk_browser/auth.py
+msgid "Locked"
+msgstr "Vergrendeld"
+
+#: jellyfin_mpv_shim/mpvtk_browser/app.py
 msgid "Failed to load. Check the connection."
 msgstr "Laden mislukt. Controleer de verbinding."
 
@@ -756,10 +761,6 @@ msgid "Could not connect. Please check your details."
 msgstr "Kon niet verbinden. Controleer je gegevens."
 
 #: jellyfin_mpv_shim/mpvtk_browser/auth.py
-msgid "Locked"
-msgstr "Vergrendeld"
-
-#: jellyfin_mpv_shim/mpvtk_browser/auth.py
 #: jellyfin_mpv_shim/mpvtk_browser/pages/home.py
 msgid "Connecting to your server…"
 msgstr "Verbinden met je server…"
@@ -833,6 +834,10 @@ msgstr "Gekeken"
 #: jellyfin_mpv_shim/mpvtk_browser/pages/books.py
 msgid "Favorite"
 msgstr "Favoriet"
+
+#: jellyfin_mpv_shim/mpvtk_browser/components/detail.py
+msgid "Web"
+msgstr ""
 
 # seeded from jellyfin-web: HeaderVideos
 #: jellyfin_mpv_shim/mpvtk_browser/components/media_info.py
@@ -1446,12 +1451,8 @@ msgid "Jellyfin UI"
 msgstr "Jellyfin-interface"
 
 #: jellyfin_mpv_shim/mpvtk_browser/config.py
-msgid "MPV UI with thumbnails"
-msgstr "MPV-interface met miniaturen"
-
-#: jellyfin_mpv_shim/mpvtk_browser/config.py
-msgid "MPV built-in default"
-msgstr "Ingebouwde standaard MPV"
+msgid "MPV UI"
+msgstr ""
 
 #: jellyfin_mpv_shim/mpvtk_browser/config.py
 msgid "Custom OSC"
@@ -1800,8 +1801,22 @@ msgid "Window Buttons in the Top Bar"
 msgstr ""
 
 #: jellyfin_mpv_shim/mpvtk_browser/config.py
+msgid "Keep Window Buttons in Full Screen"
+msgstr ""
+
+#: jellyfin_mpv_shim/mpvtk_browser/config.py
+msgid "Hide the Desktop Title Bar"
+msgstr ""
+
+#: jellyfin_mpv_shim/mpvtk_browser/config.py
 msgid "Player Controls Style"
 msgstr "Stijl spelerbediening"
+
+#: jellyfin_mpv_shim/mpvtk_browser/config.py
+#, fuzzy
+#| msgid "Enable thumbnail previews"
+msgid "Enable Trickplay Thumbnails"
+msgstr "Miniatuurvoorbeelden inschakelen"
 
 #: jellyfin_mpv_shim/mpvtk_browser/config.py
 msgid "Load All Seek Previews at Once"
@@ -1831,6 +1846,10 @@ msgstr ""
 
 #: jellyfin_mpv_shim/mpvtk_browser/config.py
 msgid "Full-Width Backdrops"
+msgstr ""
+
+#: jellyfin_mpv_shim/mpvtk_browser/config.py
+msgid "12-Hour Clock"
 msgstr ""
 
 #: jellyfin_mpv_shim/mpvtk_browser/config.py
@@ -1876,12 +1895,23 @@ msgid "Fullscreen Library Browser"
 msgstr "Bibliotheekbrowser op volledig scherm"
 
 #: jellyfin_mpv_shim/mpvtk_browser/config.py
+msgid "Block Player Keybinds While Browsing"
+msgstr ""
+
+#: jellyfin_mpv_shim/mpvtk_browser/config.py
 msgid "Always Bind Arrow Keys to Player Controls"
 msgstr ""
 
 #: jellyfin_mpv_shim/mpvtk_browser/config.py
 msgid "Player Controls Activation Key"
 msgstr "Activatietoets spelerbediening"
+
+# seeded from jellyfin-web: SelectAll
+#: jellyfin_mpv_shim/mpvtk_browser/config.py
+#, fuzzy
+#| msgid "Select All"
+msgid "Select Key"
+msgstr "Alles selecteren"
 
 #: jellyfin_mpv_shim/mpvtk_browser/config.py
 msgid "Shading Behind the Player Controls"
@@ -1896,6 +1926,12 @@ msgstr "Stijl spelerbediening"
 #: jellyfin_mpv_shim/mpvtk_browser/config.py
 msgid "Hide the Player Controls After (seconds)"
 msgstr ""
+
+#: jellyfin_mpv_shim/mpvtk_browser/config.py
+#, fuzzy
+#| msgid "Player Controls Style"
+msgid "Shrink the Player Controls on a Narrow Window"
+msgstr "Stijl spelerbediening"
 
 #: jellyfin_mpv_shim/mpvtk_browser/config.py
 msgid "Mouse Back/Forward Buttons Skip Chapters"
@@ -1981,6 +2017,21 @@ msgstr ""
 
 #: jellyfin_mpv_shim/mpvtk_browser/config.py
 msgid ""
+"Stops MPV's own shortcuts -- picture adjustment, screenshots, subtitle and "
+"audio switching -- from acting while you are in the library, where there is "
+"no video for them to act on. Turn it off to use your own MPV key bindings "
+"there."
+msgstr ""
+
+#: jellyfin_mpv_shim/mpvtk_browser/config.py
+msgid ""
+"Activates whatever is highlighted, in the library and on the player "
+"controls. An mpv key name; changing it hands Enter back to MPV. The game "
+"controller's Confirm button and a phone's Select follow it."
+msgstr ""
+
+#: jellyfin_mpv_shim/mpvtk_browser/config.py
+msgid ""
 "Leave these blank unless downloads are waking your disks too often. Set both "
 "of the first two together: episodes are then fetched in one batch when a "
 "series runs low, instead of one at a time."
@@ -1994,7 +2045,8 @@ msgstr ""
 #: jellyfin_mpv_shim/mpvtk_browser/config.py
 msgid ""
 "Off gives MPV's own mouse behaviour instead: drag the video to move the "
-"window, and right click to pause. Double click is full screen either way."
+"window, and the right button does whatever your MPV config gives it. Double "
+"click is full screen either way."
 msgstr ""
 
 #: jellyfin_mpv_shim/mpvtk_browser/config.py
@@ -2113,6 +2165,30 @@ msgstr ""
 
 #: jellyfin_mpv_shim/mpvtk_browser/config.py
 msgid ""
+"Full screen has no title bar anywhere and nothing to move or maximize, so "
+"the buttons are normally hidden there. Turn this on to keep a way out of "
+"full screen that is not a keyboard shortcut."
+msgstr ""
+
+#: jellyfin_mpv_shim/mpvtk_browser/config.py
+msgid ""
+"Asks the desktop for no title bar on the player window, so the top bar above "
+"is the only one. Pairs with the setting above: on \"Only when the window has "
+"no title bar\" the buttons appear as soon as this is on. Leave both off "
+"unless you want them, since a window with neither can be awkward to move on "
+"some desktops."
+msgstr ""
+
+#: jellyfin_mpv_shim/mpvtk_browser/config.py
+msgid ""
+"Shows a preview frame while you drag the seek bar. Works with every player "
+"control style, including your own OSC script if it supports thumbfast. The "
+"images are fetched from the server per video, which costs disk space and "
+"memory -- tens of MB for an episode, a few hundred for a long film."
+msgstr ""
+
+#: jellyfin_mpv_shim/mpvtk_browser/config.py
+msgid ""
 "Seek previews are normally fetched a few minutes at a time around where you "
 "are seeking, so scrubbing somewhere new waits briefly. Turn this on to load "
 "them all up front instead: nothing ever waits, but a long film can cost "
@@ -2218,6 +2294,13 @@ msgstr ""
 
 #: jellyfin_mpv_shim/mpvtk_browser/config.py
 msgid ""
+"Show times of day as \"8:30 PM\" rather than \"20:30\" — the Live TV guide "
+"and its air times, and the \"Ends at\" labels on a detail page and the "
+"player controls."
+msgstr ""
+
+#: jellyfin_mpv_shim/mpvtk_browser/config.py
+msgid ""
 "The controls have to stay legible over any frame. \"None\" gives the text a "
 "drop shadow instead of shading the picture behind it."
 msgstr ""
@@ -2232,6 +2315,13 @@ msgstr ""
 msgid ""
 "0 hides them as soon as the pointer is not on them, and forces \"Hide unless "
 "hovered\"."
+msgstr ""
+
+#: jellyfin_mpv_shim/mpvtk_browser/config.py
+msgid ""
+"Narrowing the window shrinks the controls until the smallest button reaches "
+"the accessibility minimum, instead of dropping buttons sooner. Off keeps the "
+"older, larger floor."
 msgstr ""
 
 #: jellyfin_mpv_shim/mpvtk_browser/config.py
@@ -3812,6 +3902,7 @@ msgid "More Like This"
 msgstr "Meer zoals dit"
 
 #: jellyfin_mpv_shim/mpvtk_browser/pages/detail.py
+#: jellyfin_mpv_shim/mpvtk_browser/tiles.py
 msgid "Go to Series"
 msgstr ""
 
@@ -5013,6 +5104,22 @@ msgstr "Server verwijderen"
 msgid "There is nothing here to queue."
 msgstr "Er is niets om aan de wachtrij toe te voegen."
 
+#: jellyfin_mpv_shim/mpvtk_browser/timefmt.py
+#, python-brace-format
+msgctxt "12-hour clock"
+msgid "{time} {period}"
+msgstr ""
+
+#: jellyfin_mpv_shim/mpvtk_browser/timefmt.py
+msgctxt "12-hour clock"
+msgid "AM"
+msgstr ""
+
+#: jellyfin_mpv_shim/mpvtk_browser/timefmt.py
+msgctxt "12-hour clock"
+msgid "PM"
+msgstr ""
+
 # seeded from jellyfin-web: Search
 #: jellyfin_mpv_shim/mpvtk_browser/views.py
 #: jellyfin_mpv_shim/mpvtk_browser/window_chrome.py
@@ -5182,6 +5289,12 @@ msgid "Enable SVP"
 msgstr "SVP activeren"
 
 #: jellyfin_mpv_shim/sync/manager.py
+#, fuzzy
+#| msgid "The download could not be started."
+msgid "The downloads are already in that folder."
+msgstr "De download kon niet worden gestart."
+
+#: jellyfin_mpv_shim/sync/manager.py
 msgid ""
 "Can't change the download folder while a download is in progress. Wait for "
 "it to finish, then try again."
@@ -5190,8 +5303,27 @@ msgstr ""
 "Wacht tot deze is voltooid en probeer het opnieuw."
 
 #: jellyfin_mpv_shim/sync/manager.py
+#, fuzzy
+#| msgid "That folder already contains downloads. Choose an empty folder."
+msgid ""
+"That folder is inside the current download folder. Choose one outside it."
+msgstr "Die map bevat al downloads. Kies een lege map."
+
+#: jellyfin_mpv_shim/sync/manager.py
+#, fuzzy
+#| msgid "Can't create that folder. Check the path and its permissions."
+msgid "Can't read that folder. Check the path and its permissions."
+msgstr "Kan die map niet aanmaken. Controleer het pad en de machtigingen."
+
+#: jellyfin_mpv_shim/sync/manager.py
 msgid "That folder already contains downloads. Choose an empty folder."
 msgstr "Die map bevat al downloads. Kies een lege map."
+
+#: jellyfin_mpv_shim/sync/manager.py
+msgid ""
+"That folder isn't empty. Choose an empty folder — the download folder is "
+"managed by this app and anything else in it can be moved or removed."
+msgstr ""
 
 #: jellyfin_mpv_shim/sync/manager.py
 msgid "Can't create that folder. Check the path and its permissions."
@@ -5202,6 +5334,12 @@ msgid "A download is still finishing. Wait for it to stop, then try again."
 msgstr ""
 "Een download wordt nog afgerond. Wacht tot deze klaar is en probeer het "
 "opnieuw."
+
+#: jellyfin_mpv_shim/sync/manager.py
+msgid ""
+"There isn't enough space on that drive to move the downloads. Free some "
+"space and try again — nothing was moved."
+msgstr ""
 
 #: jellyfin_mpv_shim/sync/manager.py
 msgid ""
@@ -5407,6 +5545,12 @@ msgstr "Video-afspeelprofielen"
 #: jellyfin_mpv_shim/video_profile.py
 msgid "Select Shader Profile"
 msgstr "Selecteer Shader profiel"
+
+#~ msgid "MPV UI with thumbnails"
+#~ msgstr "MPV-interface met miniaturen"
+
+#~ msgid "MPV built-in default"
+#~ msgstr "Ingebouwde standaard MPV"
 
 #, fuzzy
 #~| msgid ""

--- a/jellyfin_mpv_shim/messages/nn/LC_MESSAGES/base.po
+++ b/jellyfin_mpv_shim/messages/nn/LC_MESSAGES/base.po
@@ -6,7 +6,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2026-08-30 22:19-0400\n"
+"POT-Creation-Date: 2026-09-07 17:35-0400\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: Automatically generated\n"
 "Language-Team: none\n"
@@ -521,6 +521,11 @@ msgid "Night Mode (Auto Volume Adj)"
 msgstr ""
 
 #: jellyfin_mpv_shim/mpvtk_browser/app.py
+#: jellyfin_mpv_shim/mpvtk_browser/auth.py
+msgid "Locked"
+msgstr ""
+
+#: jellyfin_mpv_shim/mpvtk_browser/app.py
 msgid "Failed to load. Check the connection."
 msgstr ""
 
@@ -771,10 +776,6 @@ msgid "Could not connect. Please check your details."
 msgstr ""
 
 #: jellyfin_mpv_shim/mpvtk_browser/auth.py
-msgid "Locked"
-msgstr ""
-
-#: jellyfin_mpv_shim/mpvtk_browser/auth.py
 #: jellyfin_mpv_shim/mpvtk_browser/pages/home.py
 msgid "Connecting to your server…"
 msgstr ""
@@ -850,6 +851,10 @@ msgstr "Sett"
 #: jellyfin_mpv_shim/mpvtk_browser/pages/books.py
 msgid "Favorite"
 msgstr "Favoritt"
+
+#: jellyfin_mpv_shim/mpvtk_browser/components/detail.py
+msgid "Web"
+msgstr ""
 
 # seeded from jellyfin-web: HeaderVideos
 #: jellyfin_mpv_shim/mpvtk_browser/components/media_info.py
@@ -1458,11 +1463,7 @@ msgid "Jellyfin UI"
 msgstr ""
 
 #: jellyfin_mpv_shim/mpvtk_browser/config.py
-msgid "MPV UI with thumbnails"
-msgstr ""
-
-#: jellyfin_mpv_shim/mpvtk_browser/config.py
-msgid "MPV built-in default"
+msgid "MPV UI"
 msgstr ""
 
 #: jellyfin_mpv_shim/mpvtk_browser/config.py
@@ -1804,7 +1805,19 @@ msgid "Window Buttons in the Top Bar"
 msgstr ""
 
 #: jellyfin_mpv_shim/mpvtk_browser/config.py
+msgid "Keep Window Buttons in Full Screen"
+msgstr ""
+
+#: jellyfin_mpv_shim/mpvtk_browser/config.py
+msgid "Hide the Desktop Title Bar"
+msgstr ""
+
+#: jellyfin_mpv_shim/mpvtk_browser/config.py
 msgid "Player Controls Style"
+msgstr ""
+
+#: jellyfin_mpv_shim/mpvtk_browser/config.py
+msgid "Enable Trickplay Thumbnails"
 msgstr ""
 
 #: jellyfin_mpv_shim/mpvtk_browser/config.py
@@ -1835,6 +1848,10 @@ msgstr ""
 
 #: jellyfin_mpv_shim/mpvtk_browser/config.py
 msgid "Full-Width Backdrops"
+msgstr ""
+
+#: jellyfin_mpv_shim/mpvtk_browser/config.py
+msgid "12-Hour Clock"
 msgstr ""
 
 #: jellyfin_mpv_shim/mpvtk_browser/config.py
@@ -1880,12 +1897,23 @@ msgid "Fullscreen Library Browser"
 msgstr ""
 
 #: jellyfin_mpv_shim/mpvtk_browser/config.py
+msgid "Block Player Keybinds While Browsing"
+msgstr ""
+
+#: jellyfin_mpv_shim/mpvtk_browser/config.py
 msgid "Always Bind Arrow Keys to Player Controls"
 msgstr ""
 
 #: jellyfin_mpv_shim/mpvtk_browser/config.py
 msgid "Player Controls Activation Key"
 msgstr ""
+
+# seeded from jellyfin-web: SelectAll
+#: jellyfin_mpv_shim/mpvtk_browser/config.py
+#, fuzzy
+#| msgid "Select All"
+msgid "Select Key"
+msgstr "Vel alle"
 
 #: jellyfin_mpv_shim/mpvtk_browser/config.py
 msgid "Shading Behind the Player Controls"
@@ -1897,6 +1925,10 @@ msgstr ""
 
 #: jellyfin_mpv_shim/mpvtk_browser/config.py
 msgid "Hide the Player Controls After (seconds)"
+msgstr ""
+
+#: jellyfin_mpv_shim/mpvtk_browser/config.py
+msgid "Shrink the Player Controls on a Narrow Window"
 msgstr ""
 
 #: jellyfin_mpv_shim/mpvtk_browser/config.py
@@ -1979,6 +2011,21 @@ msgstr ""
 
 #: jellyfin_mpv_shim/mpvtk_browser/config.py
 msgid ""
+"Stops MPV's own shortcuts -- picture adjustment, screenshots, subtitle and "
+"audio switching -- from acting while you are in the library, where there is "
+"no video for them to act on. Turn it off to use your own MPV key bindings "
+"there."
+msgstr ""
+
+#: jellyfin_mpv_shim/mpvtk_browser/config.py
+msgid ""
+"Activates whatever is highlighted, in the library and on the player "
+"controls. An mpv key name; changing it hands Enter back to MPV. The game "
+"controller's Confirm button and a phone's Select follow it."
+msgstr ""
+
+#: jellyfin_mpv_shim/mpvtk_browser/config.py
+msgid ""
 "Leave these blank unless downloads are waking your disks too often. Set both "
 "of the first two together: episodes are then fetched in one batch when a "
 "series runs low, instead of one at a time."
@@ -1992,7 +2039,8 @@ msgstr ""
 #: jellyfin_mpv_shim/mpvtk_browser/config.py
 msgid ""
 "Off gives MPV's own mouse behaviour instead: drag the video to move the "
-"window, and right click to pause. Double click is full screen either way."
+"window, and the right button does whatever your MPV config gives it. Double "
+"click is full screen either way."
 msgstr ""
 
 #: jellyfin_mpv_shim/mpvtk_browser/config.py
@@ -2082,6 +2130,30 @@ msgid ""
 "maximize and close in the top bar instead, and lets you drag the window by "
 "it. On \"Only when the window has no title bar\", MPV is asked whether this "
 "window got one, so desktops that draw a title bar are left alone."
+msgstr ""
+
+#: jellyfin_mpv_shim/mpvtk_browser/config.py
+msgid ""
+"Full screen has no title bar anywhere and nothing to move or maximize, so "
+"the buttons are normally hidden there. Turn this on to keep a way out of "
+"full screen that is not a keyboard shortcut."
+msgstr ""
+
+#: jellyfin_mpv_shim/mpvtk_browser/config.py
+msgid ""
+"Asks the desktop for no title bar on the player window, so the top bar above "
+"is the only one. Pairs with the setting above: on \"Only when the window has "
+"no title bar\" the buttons appear as soon as this is on. Leave both off "
+"unless you want them, since a window with neither can be awkward to move on "
+"some desktops."
+msgstr ""
+
+#: jellyfin_mpv_shim/mpvtk_browser/config.py
+msgid ""
+"Shows a preview frame while you drag the seek bar. Works with every player "
+"control style, including your own OSC script if it supports thumbfast. The "
+"images are fetched from the server per video, which costs disk space and "
+"memory -- tens of MB for an episode, a few hundred for a long film."
 msgstr ""
 
 #: jellyfin_mpv_shim/mpvtk_browser/config.py
@@ -2189,6 +2261,13 @@ msgstr ""
 
 #: jellyfin_mpv_shim/mpvtk_browser/config.py
 msgid ""
+"Show times of day as \"8:30 PM\" rather than \"20:30\" — the Live TV guide "
+"and its air times, and the \"Ends at\" labels on a detail page and the "
+"player controls."
+msgstr ""
+
+#: jellyfin_mpv_shim/mpvtk_browser/config.py
+msgid ""
 "The controls have to stay legible over any frame. \"None\" gives the text a "
 "drop shadow instead of shading the picture behind it."
 msgstr ""
@@ -2203,6 +2282,13 @@ msgstr ""
 msgid ""
 "0 hides them as soon as the pointer is not on them, and forces \"Hide unless "
 "hovered\"."
+msgstr ""
+
+#: jellyfin_mpv_shim/mpvtk_browser/config.py
+msgid ""
+"Narrowing the window shrinks the controls until the smallest button reaches "
+"the accessibility minimum, instead of dropping buttons sooner. Off keeps the "
+"older, larger floor."
 msgstr ""
 
 #: jellyfin_mpv_shim/mpvtk_browser/config.py
@@ -3701,6 +3787,7 @@ msgid "More Like This"
 msgstr "Meir som dette"
 
 #: jellyfin_mpv_shim/mpvtk_browser/pages/detail.py
+#: jellyfin_mpv_shim/mpvtk_browser/tiles.py
 msgid "Go to Series"
 msgstr ""
 
@@ -4789,6 +4876,22 @@ msgstr ""
 msgid "There is nothing here to queue."
 msgstr ""
 
+#: jellyfin_mpv_shim/mpvtk_browser/timefmt.py
+#, python-brace-format
+msgctxt "12-hour clock"
+msgid "{time} {period}"
+msgstr ""
+
+#: jellyfin_mpv_shim/mpvtk_browser/timefmt.py
+msgctxt "12-hour clock"
+msgid "AM"
+msgstr ""
+
+#: jellyfin_mpv_shim/mpvtk_browser/timefmt.py
+msgctxt "12-hour clock"
+msgid "PM"
+msgstr ""
+
 # seeded from jellyfin-web: Search
 #: jellyfin_mpv_shim/mpvtk_browser/views.py
 #: jellyfin_mpv_shim/mpvtk_browser/window_chrome.py
@@ -4949,13 +5052,32 @@ msgid "Enable SVP"
 msgstr ""
 
 #: jellyfin_mpv_shim/sync/manager.py
+msgid "The downloads are already in that folder."
+msgstr ""
+
+#: jellyfin_mpv_shim/sync/manager.py
 msgid ""
 "Can't change the download folder while a download is in progress. Wait for "
 "it to finish, then try again."
 msgstr ""
 
 #: jellyfin_mpv_shim/sync/manager.py
+msgid ""
+"That folder is inside the current download folder. Choose one outside it."
+msgstr ""
+
+#: jellyfin_mpv_shim/sync/manager.py
+msgid "Can't read that folder. Check the path and its permissions."
+msgstr ""
+
+#: jellyfin_mpv_shim/sync/manager.py
 msgid "That folder already contains downloads. Choose an empty folder."
+msgstr ""
+
+#: jellyfin_mpv_shim/sync/manager.py
+msgid ""
+"That folder isn't empty. Choose an empty folder — the download folder is "
+"managed by this app and anything else in it can be moved or removed."
 msgstr ""
 
 #: jellyfin_mpv_shim/sync/manager.py
@@ -4964,6 +5086,12 @@ msgstr ""
 
 #: jellyfin_mpv_shim/sync/manager.py
 msgid "A download is still finishing. Wait for it to stop, then try again."
+msgstr ""
+
+#: jellyfin_mpv_shim/sync/manager.py
+msgid ""
+"There isn't enough space on that drive to move the downloads. Free some "
+"space and try again — nothing was moved."
 msgstr ""
 
 #: jellyfin_mpv_shim/sync/manager.py

--- a/jellyfin_mpv_shim/messages/oc/LC_MESSAGES/base.po
+++ b/jellyfin_mpv_shim/messages/oc/LC_MESSAGES/base.po
@@ -6,7 +6,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2026-08-30 22:19-0400\n"
+"POT-Creation-Date: 2026-09-07 17:35-0400\n"
 "PO-Revision-Date: 2026-07-29 00:32+0000\n"
 "Last-Translator: Paroc <a.puel@proton.me>\n"
 "Language-Team: Occitan <https://translate.jellyfin.org/projects/jellyfin/"
@@ -506,6 +506,11 @@ msgid "Night Mode (Auto Volume Adj)"
 msgstr ""
 
 #: jellyfin_mpv_shim/mpvtk_browser/app.py
+#: jellyfin_mpv_shim/mpvtk_browser/auth.py
+msgid "Locked"
+msgstr ""
+
+#: jellyfin_mpv_shim/mpvtk_browser/app.py
 msgid "Failed to load. Check the connection."
 msgstr ""
 
@@ -746,10 +751,6 @@ msgid "Could not connect. Please check your details."
 msgstr ""
 
 #: jellyfin_mpv_shim/mpvtk_browser/auth.py
-msgid "Locked"
-msgstr ""
-
-#: jellyfin_mpv_shim/mpvtk_browser/auth.py
 #: jellyfin_mpv_shim/mpvtk_browser/pages/home.py
 msgid "Connecting to your server…"
 msgstr ""
@@ -819,6 +820,10 @@ msgstr ""
 #: jellyfin_mpv_shim/mpvtk_browser/hud.py
 #: jellyfin_mpv_shim/mpvtk_browser/pages/books.py
 msgid "Favorite"
+msgstr ""
+
+#: jellyfin_mpv_shim/mpvtk_browser/components/detail.py
+msgid "Web"
 msgstr ""
 
 #: jellyfin_mpv_shim/mpvtk_browser/components/media_info.py
@@ -1327,11 +1332,7 @@ msgid "Jellyfin UI"
 msgstr ""
 
 #: jellyfin_mpv_shim/mpvtk_browser/config.py
-msgid "MPV UI with thumbnails"
-msgstr ""
-
-#: jellyfin_mpv_shim/mpvtk_browser/config.py
-msgid "MPV built-in default"
+msgid "MPV UI"
 msgstr ""
 
 #: jellyfin_mpv_shim/mpvtk_browser/config.py
@@ -1664,7 +1665,19 @@ msgid "Window Buttons in the Top Bar"
 msgstr ""
 
 #: jellyfin_mpv_shim/mpvtk_browser/config.py
+msgid "Keep Window Buttons in Full Screen"
+msgstr ""
+
+#: jellyfin_mpv_shim/mpvtk_browser/config.py
+msgid "Hide the Desktop Title Bar"
+msgstr ""
+
+#: jellyfin_mpv_shim/mpvtk_browser/config.py
 msgid "Player Controls Style"
+msgstr ""
+
+#: jellyfin_mpv_shim/mpvtk_browser/config.py
+msgid "Enable Trickplay Thumbnails"
 msgstr ""
 
 #: jellyfin_mpv_shim/mpvtk_browser/config.py
@@ -1694,6 +1707,10 @@ msgstr ""
 
 #: jellyfin_mpv_shim/mpvtk_browser/config.py
 msgid "Full-Width Backdrops"
+msgstr ""
+
+#: jellyfin_mpv_shim/mpvtk_browser/config.py
+msgid "12-Hour Clock"
 msgstr ""
 
 #: jellyfin_mpv_shim/mpvtk_browser/config.py
@@ -1737,11 +1754,19 @@ msgid "Fullscreen Library Browser"
 msgstr ""
 
 #: jellyfin_mpv_shim/mpvtk_browser/config.py
+msgid "Block Player Keybinds While Browsing"
+msgstr ""
+
+#: jellyfin_mpv_shim/mpvtk_browser/config.py
 msgid "Always Bind Arrow Keys to Player Controls"
 msgstr ""
 
 #: jellyfin_mpv_shim/mpvtk_browser/config.py
 msgid "Player Controls Activation Key"
+msgstr ""
+
+#: jellyfin_mpv_shim/mpvtk_browser/config.py
+msgid "Select Key"
 msgstr ""
 
 #: jellyfin_mpv_shim/mpvtk_browser/config.py
@@ -1754,6 +1779,10 @@ msgstr ""
 
 #: jellyfin_mpv_shim/mpvtk_browser/config.py
 msgid "Hide the Player Controls After (seconds)"
+msgstr ""
+
+#: jellyfin_mpv_shim/mpvtk_browser/config.py
+msgid "Shrink the Player Controls on a Narrow Window"
 msgstr ""
 
 #: jellyfin_mpv_shim/mpvtk_browser/config.py
@@ -1836,6 +1865,21 @@ msgstr ""
 
 #: jellyfin_mpv_shim/mpvtk_browser/config.py
 msgid ""
+"Stops MPV's own shortcuts -- picture adjustment, screenshots, subtitle and "
+"audio switching -- from acting while you are in the library, where there is "
+"no video for them to act on. Turn it off to use your own MPV key bindings "
+"there."
+msgstr ""
+
+#: jellyfin_mpv_shim/mpvtk_browser/config.py
+msgid ""
+"Activates whatever is highlighted, in the library and on the player "
+"controls. An mpv key name; changing it hands Enter back to MPV. The game "
+"controller's Confirm button and a phone's Select follow it."
+msgstr ""
+
+#: jellyfin_mpv_shim/mpvtk_browser/config.py
+msgid ""
 "Leave these blank unless downloads are waking your disks too often. Set both "
 "of the first two together: episodes are then fetched in one batch when a "
 "series runs low, instead of one at a time."
@@ -1849,7 +1893,8 @@ msgstr ""
 #: jellyfin_mpv_shim/mpvtk_browser/config.py
 msgid ""
 "Off gives MPV's own mouse behaviour instead: drag the video to move the "
-"window, and right click to pause. Double click is full screen either way."
+"window, and the right button does whatever your MPV config gives it. Double "
+"click is full screen either way."
 msgstr ""
 
 #: jellyfin_mpv_shim/mpvtk_browser/config.py
@@ -1939,6 +1984,30 @@ msgid ""
 "maximize and close in the top bar instead, and lets you drag the window by "
 "it. On \"Only when the window has no title bar\", MPV is asked whether this "
 "window got one, so desktops that draw a title bar are left alone."
+msgstr ""
+
+#: jellyfin_mpv_shim/mpvtk_browser/config.py
+msgid ""
+"Full screen has no title bar anywhere and nothing to move or maximize, so "
+"the buttons are normally hidden there. Turn this on to keep a way out of "
+"full screen that is not a keyboard shortcut."
+msgstr ""
+
+#: jellyfin_mpv_shim/mpvtk_browser/config.py
+msgid ""
+"Asks the desktop for no title bar on the player window, so the top bar above "
+"is the only one. Pairs with the setting above: on \"Only when the window has "
+"no title bar\" the buttons appear as soon as this is on. Leave both off "
+"unless you want them, since a window with neither can be awkward to move on "
+"some desktops."
+msgstr ""
+
+#: jellyfin_mpv_shim/mpvtk_browser/config.py
+msgid ""
+"Shows a preview frame while you drag the seek bar. Works with every player "
+"control style, including your own OSC script if it supports thumbfast. The "
+"images are fetched from the server per video, which costs disk space and "
+"memory -- tens of MB for an episode, a few hundred for a long film."
 msgstr ""
 
 #: jellyfin_mpv_shim/mpvtk_browser/config.py
@@ -2046,6 +2115,13 @@ msgstr ""
 
 #: jellyfin_mpv_shim/mpvtk_browser/config.py
 msgid ""
+"Show times of day as \"8:30 PM\" rather than \"20:30\" — the Live TV guide "
+"and its air times, and the \"Ends at\" labels on a detail page and the "
+"player controls."
+msgstr ""
+
+#: jellyfin_mpv_shim/mpvtk_browser/config.py
+msgid ""
 "The controls have to stay legible over any frame. \"None\" gives the text a "
 "drop shadow instead of shading the picture behind it."
 msgstr ""
@@ -2060,6 +2136,13 @@ msgstr ""
 msgid ""
 "0 hides them as soon as the pointer is not on them, and forces \"Hide unless "
 "hovered\"."
+msgstr ""
+
+#: jellyfin_mpv_shim/mpvtk_browser/config.py
+msgid ""
+"Narrowing the window shrinks the controls until the smallest button reaches "
+"the accessibility minimum, instead of dropping buttons sooner. Off keeps the "
+"older, larger floor."
 msgstr ""
 
 #: jellyfin_mpv_shim/mpvtk_browser/config.py
@@ -3397,6 +3480,7 @@ msgid "More Like This"
 msgstr ""
 
 #: jellyfin_mpv_shim/mpvtk_browser/pages/detail.py
+#: jellyfin_mpv_shim/mpvtk_browser/tiles.py
 msgid "Go to Series"
 msgstr ""
 
@@ -4397,6 +4481,22 @@ msgstr ""
 msgid "There is nothing here to queue."
 msgstr ""
 
+#: jellyfin_mpv_shim/mpvtk_browser/timefmt.py
+#, python-brace-format
+msgctxt "12-hour clock"
+msgid "{time} {period}"
+msgstr ""
+
+#: jellyfin_mpv_shim/mpvtk_browser/timefmt.py
+msgctxt "12-hour clock"
+msgid "AM"
+msgstr ""
+
+#: jellyfin_mpv_shim/mpvtk_browser/timefmt.py
+msgctxt "12-hour clock"
+msgid "PM"
+msgstr ""
+
 #: jellyfin_mpv_shim/mpvtk_browser/views.py
 #: jellyfin_mpv_shim/mpvtk_browser/window_chrome.py
 msgid "Search"
@@ -4547,13 +4647,32 @@ msgid "Enable SVP"
 msgstr ""
 
 #: jellyfin_mpv_shim/sync/manager.py
+msgid "The downloads are already in that folder."
+msgstr ""
+
+#: jellyfin_mpv_shim/sync/manager.py
 msgid ""
 "Can't change the download folder while a download is in progress. Wait for "
 "it to finish, then try again."
 msgstr ""
 
 #: jellyfin_mpv_shim/sync/manager.py
+msgid ""
+"That folder is inside the current download folder. Choose one outside it."
+msgstr ""
+
+#: jellyfin_mpv_shim/sync/manager.py
+msgid "Can't read that folder. Check the path and its permissions."
+msgstr ""
+
+#: jellyfin_mpv_shim/sync/manager.py
 msgid "That folder already contains downloads. Choose an empty folder."
+msgstr ""
+
+#: jellyfin_mpv_shim/sync/manager.py
+msgid ""
+"That folder isn't empty. Choose an empty folder — the download folder is "
+"managed by this app and anything else in it can be moved or removed."
 msgstr ""
 
 #: jellyfin_mpv_shim/sync/manager.py
@@ -4562,6 +4681,12 @@ msgstr ""
 
 #: jellyfin_mpv_shim/sync/manager.py
 msgid "A download is still finishing. Wait for it to stop, then try again."
+msgstr ""
+
+#: jellyfin_mpv_shim/sync/manager.py
+msgid ""
+"There isn't enough space on that drive to move the downloads. Free some "
+"space and try again — nothing was moved."
 msgstr ""
 
 #: jellyfin_mpv_shim/sync/manager.py

--- a/jellyfin_mpv_shim/messages/pl/LC_MESSAGES/base.po
+++ b/jellyfin_mpv_shim/messages/pl/LC_MESSAGES/base.po
@@ -6,7 +6,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2026-08-30 22:19-0400\n"
+"POT-Creation-Date: 2026-09-07 17:35-0400\n"
 "PO-Revision-Date: 2026-08-25 21:29+0000\n"
 "Last-Translator: Rogal <progalin55@gmail.com>\n"
 "Language-Team: Polish <https://translate.jellyfin.org/projects/jellyfin/"
@@ -522,6 +522,11 @@ msgid "Night Mode (Auto Volume Adj)"
 msgstr "Tryb nocny (automatyczna regulacja głośności)"
 
 #: jellyfin_mpv_shim/mpvtk_browser/app.py
+#: jellyfin_mpv_shim/mpvtk_browser/auth.py
+msgid "Locked"
+msgstr "Zablokowane"
+
+#: jellyfin_mpv_shim/mpvtk_browser/app.py
 msgid "Failed to load. Check the connection."
 msgstr "Nie udało się załadować. Sprawdź połączenie."
 
@@ -765,10 +770,6 @@ msgid "Could not connect. Please check your details."
 msgstr "Nie udało się połączyć. Sprawdź swoje dane."
 
 #: jellyfin_mpv_shim/mpvtk_browser/auth.py
-msgid "Locked"
-msgstr "Zablokowane"
-
-#: jellyfin_mpv_shim/mpvtk_browser/auth.py
 #: jellyfin_mpv_shim/mpvtk_browser/pages/home.py
 msgid "Connecting to your server…"
 msgstr "Łączenie z Twoim serwerem…"
@@ -842,6 +843,10 @@ msgstr "Obejrzane"
 #: jellyfin_mpv_shim/mpvtk_browser/pages/books.py
 msgid "Favorite"
 msgstr "Ulubione"
+
+#: jellyfin_mpv_shim/mpvtk_browser/components/detail.py
+msgid "Web"
+msgstr ""
 
 # seeded from jellyfin-web: Video
 #: jellyfin_mpv_shim/mpvtk_browser/components/media_info.py
@@ -1436,12 +1441,8 @@ msgid "Jellyfin UI"
 msgstr "Interfejs Jellyfin"
 
 #: jellyfin_mpv_shim/mpvtk_browser/config.py
-msgid "MPV UI with thumbnails"
-msgstr "Interfejs MPV z miniaturami"
-
-#: jellyfin_mpv_shim/mpvtk_browser/config.py
-msgid "MPV built-in default"
-msgstr "Domyślnie wbudowany MPV"
+msgid "MPV UI"
+msgstr ""
 
 #: jellyfin_mpv_shim/mpvtk_browser/config.py
 msgid "Custom OSC"
@@ -1789,8 +1790,22 @@ msgid "Window Buttons in the Top Bar"
 msgstr ""
 
 #: jellyfin_mpv_shim/mpvtk_browser/config.py
+msgid "Keep Window Buttons in Full Screen"
+msgstr ""
+
+#: jellyfin_mpv_shim/mpvtk_browser/config.py
+msgid "Hide the Desktop Title Bar"
+msgstr ""
+
+#: jellyfin_mpv_shim/mpvtk_browser/config.py
 msgid "Player Controls Style"
 msgstr "Styl kontrolek odtwarzacza"
+
+#: jellyfin_mpv_shim/mpvtk_browser/config.py
+#, fuzzy
+#| msgid "Enable thumbnail previews"
+msgid "Enable Trickplay Thumbnails"
+msgstr "Włącz podgląd miniatur"
 
 #: jellyfin_mpv_shim/mpvtk_browser/config.py
 msgid "Load All Seek Previews at Once"
@@ -1820,6 +1835,10 @@ msgstr ""
 
 #: jellyfin_mpv_shim/mpvtk_browser/config.py
 msgid "Full-Width Backdrops"
+msgstr ""
+
+#: jellyfin_mpv_shim/mpvtk_browser/config.py
+msgid "12-Hour Clock"
 msgstr ""
 
 #: jellyfin_mpv_shim/mpvtk_browser/config.py
@@ -1865,12 +1884,23 @@ msgid "Fullscreen Library Browser"
 msgstr ""
 
 #: jellyfin_mpv_shim/mpvtk_browser/config.py
+msgid "Block Player Keybinds While Browsing"
+msgstr ""
+
+#: jellyfin_mpv_shim/mpvtk_browser/config.py
 msgid "Always Bind Arrow Keys to Player Controls"
 msgstr ""
 
 #: jellyfin_mpv_shim/mpvtk_browser/config.py
 msgid "Player Controls Activation Key"
 msgstr ""
+
+# seeded from jellyfin-web: SelectAll
+#: jellyfin_mpv_shim/mpvtk_browser/config.py
+#, fuzzy
+#| msgid "Select All"
+msgid "Select Key"
+msgstr "Wybierz wszystkie"
 
 #: jellyfin_mpv_shim/mpvtk_browser/config.py
 msgid "Shading Behind the Player Controls"
@@ -1885,6 +1915,12 @@ msgstr "Styl kontrolek odtwarzacza"
 #: jellyfin_mpv_shim/mpvtk_browser/config.py
 msgid "Hide the Player Controls After (seconds)"
 msgstr ""
+
+#: jellyfin_mpv_shim/mpvtk_browser/config.py
+#, fuzzy
+#| msgid "Player Controls Style"
+msgid "Shrink the Player Controls on a Narrow Window"
+msgstr "Styl kontrolek odtwarzacza"
 
 #: jellyfin_mpv_shim/mpvtk_browser/config.py
 msgid "Mouse Back/Forward Buttons Skip Chapters"
@@ -1970,6 +2006,21 @@ msgstr ""
 
 #: jellyfin_mpv_shim/mpvtk_browser/config.py
 msgid ""
+"Stops MPV's own shortcuts -- picture adjustment, screenshots, subtitle and "
+"audio switching -- from acting while you are in the library, where there is "
+"no video for them to act on. Turn it off to use your own MPV key bindings "
+"there."
+msgstr ""
+
+#: jellyfin_mpv_shim/mpvtk_browser/config.py
+msgid ""
+"Activates whatever is highlighted, in the library and on the player "
+"controls. An mpv key name; changing it hands Enter back to MPV. The game "
+"controller's Confirm button and a phone's Select follow it."
+msgstr ""
+
+#: jellyfin_mpv_shim/mpvtk_browser/config.py
+msgid ""
 "Leave these blank unless downloads are waking your disks too often. Set both "
 "of the first two together: episodes are then fetched in one batch when a "
 "series runs low, instead of one at a time."
@@ -1983,7 +2034,8 @@ msgstr ""
 #: jellyfin_mpv_shim/mpvtk_browser/config.py
 msgid ""
 "Off gives MPV's own mouse behaviour instead: drag the video to move the "
-"window, and right click to pause. Double click is full screen either way."
+"window, and the right button does whatever your MPV config gives it. Double "
+"click is full screen either way."
 msgstr ""
 
 #: jellyfin_mpv_shim/mpvtk_browser/config.py
@@ -2073,6 +2125,30 @@ msgid ""
 "maximize and close in the top bar instead, and lets you drag the window by "
 "it. On \"Only when the window has no title bar\", MPV is asked whether this "
 "window got one, so desktops that draw a title bar are left alone."
+msgstr ""
+
+#: jellyfin_mpv_shim/mpvtk_browser/config.py
+msgid ""
+"Full screen has no title bar anywhere and nothing to move or maximize, so "
+"the buttons are normally hidden there. Turn this on to keep a way out of "
+"full screen that is not a keyboard shortcut."
+msgstr ""
+
+#: jellyfin_mpv_shim/mpvtk_browser/config.py
+msgid ""
+"Asks the desktop for no title bar on the player window, so the top bar above "
+"is the only one. Pairs with the setting above: on \"Only when the window has "
+"no title bar\" the buttons appear as soon as this is on. Leave both off "
+"unless you want them, since a window with neither can be awkward to move on "
+"some desktops."
+msgstr ""
+
+#: jellyfin_mpv_shim/mpvtk_browser/config.py
+msgid ""
+"Shows a preview frame while you drag the seek bar. Works with every player "
+"control style, including your own OSC script if it supports thumbfast. The "
+"images are fetched from the server per video, which costs disk space and "
+"memory -- tens of MB for an episode, a few hundred for a long film."
 msgstr ""
 
 #: jellyfin_mpv_shim/mpvtk_browser/config.py
@@ -2182,6 +2258,13 @@ msgstr ""
 
 #: jellyfin_mpv_shim/mpvtk_browser/config.py
 msgid ""
+"Show times of day as \"8:30 PM\" rather than \"20:30\" — the Live TV guide "
+"and its air times, and the \"Ends at\" labels on a detail page and the "
+"player controls."
+msgstr ""
+
+#: jellyfin_mpv_shim/mpvtk_browser/config.py
+msgid ""
 "The controls have to stay legible over any frame. \"None\" gives the text a "
 "drop shadow instead of shading the picture behind it."
 msgstr ""
@@ -2196,6 +2279,13 @@ msgstr ""
 msgid ""
 "0 hides them as soon as the pointer is not on them, and forces \"Hide unless "
 "hovered\"."
+msgstr ""
+
+#: jellyfin_mpv_shim/mpvtk_browser/config.py
+msgid ""
+"Narrowing the window shrinks the controls until the smallest button reaches "
+"the accessibility minimum, instead of dropping buttons sooner. Off keeps the "
+"older, larger floor."
 msgstr ""
 
 #: jellyfin_mpv_shim/mpvtk_browser/config.py
@@ -3798,6 +3888,7 @@ msgid "More Like This"
 msgstr "Więcej podobnych"
 
 #: jellyfin_mpv_shim/mpvtk_browser/pages/detail.py
+#: jellyfin_mpv_shim/mpvtk_browser/tiles.py
 msgid "Go to Series"
 msgstr ""
 
@@ -4973,6 +5064,22 @@ msgstr "Usunąć %s z tej kolekcji?"
 msgid "There is nothing here to queue."
 msgstr ""
 
+#: jellyfin_mpv_shim/mpvtk_browser/timefmt.py
+#, python-brace-format
+msgctxt "12-hour clock"
+msgid "{time} {period}"
+msgstr ""
+
+#: jellyfin_mpv_shim/mpvtk_browser/timefmt.py
+msgctxt "12-hour clock"
+msgid "AM"
+msgstr ""
+
+#: jellyfin_mpv_shim/mpvtk_browser/timefmt.py
+msgctxt "12-hour clock"
+msgid "PM"
+msgstr ""
+
 # seeded from jellyfin-web: Search
 #: jellyfin_mpv_shim/mpvtk_browser/views.py
 #: jellyfin_mpv_shim/mpvtk_browser/window_chrome.py
@@ -5137,13 +5244,32 @@ msgid "Enable SVP"
 msgstr "Włącz SVP"
 
 #: jellyfin_mpv_shim/sync/manager.py
+msgid "The downloads are already in that folder."
+msgstr ""
+
+#: jellyfin_mpv_shim/sync/manager.py
 msgid ""
 "Can't change the download folder while a download is in progress. Wait for "
 "it to finish, then try again."
 msgstr ""
 
 #: jellyfin_mpv_shim/sync/manager.py
+msgid ""
+"That folder is inside the current download folder. Choose one outside it."
+msgstr ""
+
+#: jellyfin_mpv_shim/sync/manager.py
+msgid "Can't read that folder. Check the path and its permissions."
+msgstr ""
+
+#: jellyfin_mpv_shim/sync/manager.py
 msgid "That folder already contains downloads. Choose an empty folder."
+msgstr ""
+
+#: jellyfin_mpv_shim/sync/manager.py
+msgid ""
+"That folder isn't empty. Choose an empty folder — the download folder is "
+"managed by this app and anything else in it can be moved or removed."
 msgstr ""
 
 #: jellyfin_mpv_shim/sync/manager.py
@@ -5152,6 +5278,12 @@ msgstr ""
 
 #: jellyfin_mpv_shim/sync/manager.py
 msgid "A download is still finishing. Wait for it to stop, then try again."
+msgstr ""
+
+#: jellyfin_mpv_shim/sync/manager.py
+msgid ""
+"There isn't enough space on that drive to move the downloads. Free some "
+"space and try again — nothing was moved."
 msgstr ""
 
 #: jellyfin_mpv_shim/sync/manager.py
@@ -5356,6 +5488,12 @@ msgstr "Profile odtwarzania wideo"
 #: jellyfin_mpv_shim/video_profile.py
 msgid "Select Shader Profile"
 msgstr "Wybierz profil shadera"
+
+#~ msgid "MPV UI with thumbnails"
+#~ msgstr "Interfejs MPV z miniaturami"
+
+#~ msgid "MPV built-in default"
+#~ msgstr "Domyślnie wbudowany MPV"
 
 #, fuzzy
 #~| msgid ""

--- a/jellyfin_mpv_shim/messages/pon/LC_MESSAGES/base.po
+++ b/jellyfin_mpv_shim/messages/pon/LC_MESSAGES/base.po
@@ -6,7 +6,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2026-08-30 22:19-0400\n"
+"POT-Creation-Date: 2026-09-07 17:35-0400\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: Automatically generated\n"
 "Language-Team: none\n"
@@ -503,6 +503,11 @@ msgid "Night Mode (Auto Volume Adj)"
 msgstr ""
 
 #: jellyfin_mpv_shim/mpvtk_browser/app.py
+#: jellyfin_mpv_shim/mpvtk_browser/auth.py
+msgid "Locked"
+msgstr ""
+
+#: jellyfin_mpv_shim/mpvtk_browser/app.py
 msgid "Failed to load. Check the connection."
 msgstr ""
 
@@ -743,10 +748,6 @@ msgid "Could not connect. Please check your details."
 msgstr ""
 
 #: jellyfin_mpv_shim/mpvtk_browser/auth.py
-msgid "Locked"
-msgstr ""
-
-#: jellyfin_mpv_shim/mpvtk_browser/auth.py
 #: jellyfin_mpv_shim/mpvtk_browser/pages/home.py
 msgid "Connecting to your server…"
 msgstr ""
@@ -816,6 +817,10 @@ msgstr ""
 #: jellyfin_mpv_shim/mpvtk_browser/hud.py
 #: jellyfin_mpv_shim/mpvtk_browser/pages/books.py
 msgid "Favorite"
+msgstr ""
+
+#: jellyfin_mpv_shim/mpvtk_browser/components/detail.py
+msgid "Web"
 msgstr ""
 
 #: jellyfin_mpv_shim/mpvtk_browser/components/media_info.py
@@ -1321,11 +1326,7 @@ msgid "Jellyfin UI"
 msgstr ""
 
 #: jellyfin_mpv_shim/mpvtk_browser/config.py
-msgid "MPV UI with thumbnails"
-msgstr ""
-
-#: jellyfin_mpv_shim/mpvtk_browser/config.py
-msgid "MPV built-in default"
+msgid "MPV UI"
 msgstr ""
 
 #: jellyfin_mpv_shim/mpvtk_browser/config.py
@@ -1658,7 +1659,19 @@ msgid "Window Buttons in the Top Bar"
 msgstr ""
 
 #: jellyfin_mpv_shim/mpvtk_browser/config.py
+msgid "Keep Window Buttons in Full Screen"
+msgstr ""
+
+#: jellyfin_mpv_shim/mpvtk_browser/config.py
+msgid "Hide the Desktop Title Bar"
+msgstr ""
+
+#: jellyfin_mpv_shim/mpvtk_browser/config.py
 msgid "Player Controls Style"
+msgstr ""
+
+#: jellyfin_mpv_shim/mpvtk_browser/config.py
+msgid "Enable Trickplay Thumbnails"
 msgstr ""
 
 #: jellyfin_mpv_shim/mpvtk_browser/config.py
@@ -1688,6 +1701,10 @@ msgstr ""
 
 #: jellyfin_mpv_shim/mpvtk_browser/config.py
 msgid "Full-Width Backdrops"
+msgstr ""
+
+#: jellyfin_mpv_shim/mpvtk_browser/config.py
+msgid "12-Hour Clock"
 msgstr ""
 
 #: jellyfin_mpv_shim/mpvtk_browser/config.py
@@ -1731,11 +1748,19 @@ msgid "Fullscreen Library Browser"
 msgstr ""
 
 #: jellyfin_mpv_shim/mpvtk_browser/config.py
+msgid "Block Player Keybinds While Browsing"
+msgstr ""
+
+#: jellyfin_mpv_shim/mpvtk_browser/config.py
 msgid "Always Bind Arrow Keys to Player Controls"
 msgstr ""
 
 #: jellyfin_mpv_shim/mpvtk_browser/config.py
 msgid "Player Controls Activation Key"
+msgstr ""
+
+#: jellyfin_mpv_shim/mpvtk_browser/config.py
+msgid "Select Key"
 msgstr ""
 
 #: jellyfin_mpv_shim/mpvtk_browser/config.py
@@ -1748,6 +1773,10 @@ msgstr ""
 
 #: jellyfin_mpv_shim/mpvtk_browser/config.py
 msgid "Hide the Player Controls After (seconds)"
+msgstr ""
+
+#: jellyfin_mpv_shim/mpvtk_browser/config.py
+msgid "Shrink the Player Controls on a Narrow Window"
 msgstr ""
 
 #: jellyfin_mpv_shim/mpvtk_browser/config.py
@@ -1830,6 +1859,21 @@ msgstr ""
 
 #: jellyfin_mpv_shim/mpvtk_browser/config.py
 msgid ""
+"Stops MPV's own shortcuts -- picture adjustment, screenshots, subtitle and "
+"audio switching -- from acting while you are in the library, where there is "
+"no video for them to act on. Turn it off to use your own MPV key bindings "
+"there."
+msgstr ""
+
+#: jellyfin_mpv_shim/mpvtk_browser/config.py
+msgid ""
+"Activates whatever is highlighted, in the library and on the player "
+"controls. An mpv key name; changing it hands Enter back to MPV. The game "
+"controller's Confirm button and a phone's Select follow it."
+msgstr ""
+
+#: jellyfin_mpv_shim/mpvtk_browser/config.py
+msgid ""
 "Leave these blank unless downloads are waking your disks too often. Set both "
 "of the first two together: episodes are then fetched in one batch when a "
 "series runs low, instead of one at a time."
@@ -1843,7 +1887,8 @@ msgstr ""
 #: jellyfin_mpv_shim/mpvtk_browser/config.py
 msgid ""
 "Off gives MPV's own mouse behaviour instead: drag the video to move the "
-"window, and right click to pause. Double click is full screen either way."
+"window, and the right button does whatever your MPV config gives it. Double "
+"click is full screen either way."
 msgstr ""
 
 #: jellyfin_mpv_shim/mpvtk_browser/config.py
@@ -1933,6 +1978,30 @@ msgid ""
 "maximize and close in the top bar instead, and lets you drag the window by "
 "it. On \"Only when the window has no title bar\", MPV is asked whether this "
 "window got one, so desktops that draw a title bar are left alone."
+msgstr ""
+
+#: jellyfin_mpv_shim/mpvtk_browser/config.py
+msgid ""
+"Full screen has no title bar anywhere and nothing to move or maximize, so "
+"the buttons are normally hidden there. Turn this on to keep a way out of "
+"full screen that is not a keyboard shortcut."
+msgstr ""
+
+#: jellyfin_mpv_shim/mpvtk_browser/config.py
+msgid ""
+"Asks the desktop for no title bar on the player window, so the top bar above "
+"is the only one. Pairs with the setting above: on \"Only when the window has "
+"no title bar\" the buttons appear as soon as this is on. Leave both off "
+"unless you want them, since a window with neither can be awkward to move on "
+"some desktops."
+msgstr ""
+
+#: jellyfin_mpv_shim/mpvtk_browser/config.py
+msgid ""
+"Shows a preview frame while you drag the seek bar. Works with every player "
+"control style, including your own OSC script if it supports thumbfast. The "
+"images are fetched from the server per video, which costs disk space and "
+"memory -- tens of MB for an episode, a few hundred for a long film."
 msgstr ""
 
 #: jellyfin_mpv_shim/mpvtk_browser/config.py
@@ -2040,6 +2109,13 @@ msgstr ""
 
 #: jellyfin_mpv_shim/mpvtk_browser/config.py
 msgid ""
+"Show times of day as \"8:30 PM\" rather than \"20:30\" — the Live TV guide "
+"and its air times, and the \"Ends at\" labels on a detail page and the "
+"player controls."
+msgstr ""
+
+#: jellyfin_mpv_shim/mpvtk_browser/config.py
+msgid ""
 "The controls have to stay legible over any frame. \"None\" gives the text a "
 "drop shadow instead of shading the picture behind it."
 msgstr ""
@@ -2054,6 +2130,13 @@ msgstr ""
 msgid ""
 "0 hides them as soon as the pointer is not on them, and forces \"Hide unless "
 "hovered\"."
+msgstr ""
+
+#: jellyfin_mpv_shim/mpvtk_browser/config.py
+msgid ""
+"Narrowing the window shrinks the controls until the smallest button reaches "
+"the accessibility minimum, instead of dropping buttons sooner. Off keeps the "
+"older, larger floor."
 msgstr ""
 
 #: jellyfin_mpv_shim/mpvtk_browser/config.py
@@ -3380,6 +3463,7 @@ msgid "More Like This"
 msgstr ""
 
 #: jellyfin_mpv_shim/mpvtk_browser/pages/detail.py
+#: jellyfin_mpv_shim/mpvtk_browser/tiles.py
 msgid "Go to Series"
 msgstr ""
 
@@ -4374,6 +4458,22 @@ msgstr ""
 msgid "There is nothing here to queue."
 msgstr ""
 
+#: jellyfin_mpv_shim/mpvtk_browser/timefmt.py
+#, python-brace-format
+msgctxt "12-hour clock"
+msgid "{time} {period}"
+msgstr ""
+
+#: jellyfin_mpv_shim/mpvtk_browser/timefmt.py
+msgctxt "12-hour clock"
+msgid "AM"
+msgstr ""
+
+#: jellyfin_mpv_shim/mpvtk_browser/timefmt.py
+msgctxt "12-hour clock"
+msgid "PM"
+msgstr ""
+
 #: jellyfin_mpv_shim/mpvtk_browser/views.py
 #: jellyfin_mpv_shim/mpvtk_browser/window_chrome.py
 msgid "Search"
@@ -4524,13 +4624,32 @@ msgid "Enable SVP"
 msgstr ""
 
 #: jellyfin_mpv_shim/sync/manager.py
+msgid "The downloads are already in that folder."
+msgstr ""
+
+#: jellyfin_mpv_shim/sync/manager.py
 msgid ""
 "Can't change the download folder while a download is in progress. Wait for "
 "it to finish, then try again."
 msgstr ""
 
 #: jellyfin_mpv_shim/sync/manager.py
+msgid ""
+"That folder is inside the current download folder. Choose one outside it."
+msgstr ""
+
+#: jellyfin_mpv_shim/sync/manager.py
+msgid "Can't read that folder. Check the path and its permissions."
+msgstr ""
+
+#: jellyfin_mpv_shim/sync/manager.py
 msgid "That folder already contains downloads. Choose an empty folder."
+msgstr ""
+
+#: jellyfin_mpv_shim/sync/manager.py
+msgid ""
+"That folder isn't empty. Choose an empty folder — the download folder is "
+"managed by this app and anything else in it can be moved or removed."
 msgstr ""
 
 #: jellyfin_mpv_shim/sync/manager.py
@@ -4539,6 +4658,12 @@ msgstr ""
 
 #: jellyfin_mpv_shim/sync/manager.py
 msgid "A download is still finishing. Wait for it to stop, then try again."
+msgstr ""
+
+#: jellyfin_mpv_shim/sync/manager.py
+msgid ""
+"There isn't enough space on that drive to move the downloads. Free some "
+"space and try again — nothing was moved."
 msgstr ""
 
 #: jellyfin_mpv_shim/sync/manager.py

--- a/jellyfin_mpv_shim/messages/pt/LC_MESSAGES/base.po
+++ b/jellyfin_mpv_shim/messages/pt/LC_MESSAGES/base.po
@@ -6,7 +6,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2026-08-30 22:19-0400\n"
+"POT-Creation-Date: 2026-09-07 17:35-0400\n"
 "PO-Revision-Date: 2026-08-19 22:07+0000\n"
 "Last-Translator: Blackspirits <blackspirits@gmail.com>\n"
 "Language-Team: Portuguese <https://translate.jellyfin.org/projects/jellyfin/"
@@ -511,6 +511,11 @@ msgid "Night Mode (Auto Volume Adj)"
 msgstr "Modo noturno (ajuste automático do volume)"
 
 #: jellyfin_mpv_shim/mpvtk_browser/app.py
+#: jellyfin_mpv_shim/mpvtk_browser/auth.py
+msgid "Locked"
+msgstr "Bloqueado"
+
+#: jellyfin_mpv_shim/mpvtk_browser/app.py
 msgid "Failed to load. Check the connection."
 msgstr "Falha ao carregar. Verifica a ligação."
 
@@ -757,10 +762,6 @@ msgid "Could not connect. Please check your details."
 msgstr "Não foi possível ligar. Verifica os dados introduzidos."
 
 #: jellyfin_mpv_shim/mpvtk_browser/auth.py
-msgid "Locked"
-msgstr "Bloqueado"
-
-#: jellyfin_mpv_shim/mpvtk_browser/auth.py
 #: jellyfin_mpv_shim/mpvtk_browser/pages/home.py
 msgid "Connecting to your server…"
 msgstr "A ligar ao teu servidor…"
@@ -835,6 +836,10 @@ msgstr "Visto"
 #: jellyfin_mpv_shim/mpvtk_browser/pages/books.py
 msgid "Favorite"
 msgstr "Favorito"
+
+#: jellyfin_mpv_shim/mpvtk_browser/components/detail.py
+msgid "Web"
+msgstr ""
 
 # seeded from jellyfin-web: HeaderVideos
 #: jellyfin_mpv_shim/mpvtk_browser/components/media_info.py
@@ -1427,12 +1432,8 @@ msgid "Jellyfin UI"
 msgstr "Interface do Jellyfin"
 
 #: jellyfin_mpv_shim/mpvtk_browser/config.py
-msgid "MPV UI with thumbnails"
-msgstr "Interface do MPV com miniaturas"
-
-#: jellyfin_mpv_shim/mpvtk_browser/config.py
-msgid "MPV built-in default"
-msgstr "Predefinição integrada do MPV"
+msgid "MPV UI"
+msgstr ""
 
 #: jellyfin_mpv_shim/mpvtk_browser/config.py
 msgid "Custom OSC"
@@ -1774,8 +1775,24 @@ msgid "Window Buttons in the Top Bar"
 msgstr "Botões da janela na barra superior"
 
 #: jellyfin_mpv_shim/mpvtk_browser/config.py
+#, fuzzy
+#| msgid "Window Buttons in the Top Bar"
+msgid "Keep Window Buttons in Full Screen"
+msgstr "Botões da janela na barra superior"
+
+#: jellyfin_mpv_shim/mpvtk_browser/config.py
+msgid "Hide the Desktop Title Bar"
+msgstr ""
+
+#: jellyfin_mpv_shim/mpvtk_browser/config.py
 msgid "Player Controls Style"
 msgstr "Estilo dos controlos do leitor"
+
+#: jellyfin_mpv_shim/mpvtk_browser/config.py
+#, fuzzy
+#| msgid "Enable thumbnail previews"
+msgid "Enable Trickplay Thumbnails"
+msgstr "Ativar pré-visualizações em miniatura"
 
 #: jellyfin_mpv_shim/mpvtk_browser/config.py
 msgid "Load All Seek Previews at Once"
@@ -1806,6 +1823,10 @@ msgstr "Tamanho da capa"
 
 #: jellyfin_mpv_shim/mpvtk_browser/config.py
 msgid "Full-Width Backdrops"
+msgstr ""
+
+#: jellyfin_mpv_shim/mpvtk_browser/config.py
+msgid "12-Hour Clock"
 msgstr ""
 
 #: jellyfin_mpv_shim/mpvtk_browser/config.py
@@ -1850,12 +1871,23 @@ msgid "Fullscreen Library Browser"
 msgstr "Navegador da biblioteca em ecrã inteiro"
 
 #: jellyfin_mpv_shim/mpvtk_browser/config.py
+msgid "Block Player Keybinds While Browsing"
+msgstr ""
+
+#: jellyfin_mpv_shim/mpvtk_browser/config.py
 msgid "Always Bind Arrow Keys to Player Controls"
 msgstr "Associar sempre as teclas de seta aos controlos do leitor"
 
 #: jellyfin_mpv_shim/mpvtk_browser/config.py
 msgid "Player Controls Activation Key"
 msgstr "Tecla de ativação dos controlos do leitor"
+
+# seeded from jellyfin-web: SelectAll
+#: jellyfin_mpv_shim/mpvtk_browser/config.py
+#, fuzzy
+#| msgid "Select All"
+msgid "Select Key"
+msgstr "Selecionar tudo"
 
 #: jellyfin_mpv_shim/mpvtk_browser/config.py
 msgid "Shading Behind the Player Controls"
@@ -1868,6 +1900,12 @@ msgstr "Quando ocultar os controlos do leitor"
 #: jellyfin_mpv_shim/mpvtk_browser/config.py
 msgid "Hide the Player Controls After (seconds)"
 msgstr "Ocultar os controlos do leitor após (segundos)"
+
+#: jellyfin_mpv_shim/mpvtk_browser/config.py
+#, fuzzy
+#| msgid "When the Player Controls Hide"
+msgid "Shrink the Player Controls on a Narrow Window"
+msgstr "Quando ocultar os controlos do leitor"
 
 #: jellyfin_mpv_shim/mpvtk_browser/config.py
 msgid "Mouse Back/Forward Buttons Skip Chapters"
@@ -1953,6 +1991,21 @@ msgstr ""
 
 #: jellyfin_mpv_shim/mpvtk_browser/config.py
 msgid ""
+"Stops MPV's own shortcuts -- picture adjustment, screenshots, subtitle and "
+"audio switching -- from acting while you are in the library, where there is "
+"no video for them to act on. Turn it off to use your own MPV key bindings "
+"there."
+msgstr ""
+
+#: jellyfin_mpv_shim/mpvtk_browser/config.py
+msgid ""
+"Activates whatever is highlighted, in the library and on the player "
+"controls. An mpv key name; changing it hands Enter back to MPV. The game "
+"controller's Confirm button and a phone's Select follow it."
+msgstr ""
+
+#: jellyfin_mpv_shim/mpvtk_browser/config.py
+msgid ""
 "Leave these blank unless downloads are waking your disks too often. Set both "
 "of the first two together: episodes are then fetched in one batch when a "
 "series runs low, instead of one at a time."
@@ -1970,9 +2023,14 @@ msgstr ""
 "não tenhas visto."
 
 #: jellyfin_mpv_shim/mpvtk_browser/config.py
+#, fuzzy
+#| msgid ""
+#| "Off gives MPV's own mouse behaviour instead: drag the video to move the "
+#| "window, and right click to pause. Double click is full screen either way."
 msgid ""
 "Off gives MPV's own mouse behaviour instead: drag the video to move the "
-"window, and right click to pause. Double click is full screen either way."
+"window, and the right button does whatever your MPV config gives it. Double "
+"click is full screen either way."
 msgstr ""
 "Desativado utiliza o comportamento do rato do próprio MPV: arrasta o vídeo "
 "para mover a janela e clica com o botão direito para pausar. Em ambos os "
@@ -2109,6 +2167,30 @@ msgstr ""
 "barra superior e permite arrastar a janela por essa barra. Com «Apenas "
 "quando a janela não tem barra de título», o MPV verifica se a janela recebeu "
 "uma, deixando inalterados os ambientes que já a apresentam."
+
+#: jellyfin_mpv_shim/mpvtk_browser/config.py
+msgid ""
+"Full screen has no title bar anywhere and nothing to move or maximize, so "
+"the buttons are normally hidden there. Turn this on to keep a way out of "
+"full screen that is not a keyboard shortcut."
+msgstr ""
+
+#: jellyfin_mpv_shim/mpvtk_browser/config.py
+msgid ""
+"Asks the desktop for no title bar on the player window, so the top bar above "
+"is the only one. Pairs with the setting above: on \"Only when the window has "
+"no title bar\" the buttons appear as soon as this is on. Leave both off "
+"unless you want them, since a window with neither can be awkward to move on "
+"some desktops."
+msgstr ""
+
+#: jellyfin_mpv_shim/mpvtk_browser/config.py
+msgid ""
+"Shows a preview frame while you drag the seek bar. Works with every player "
+"control style, including your own OSC script if it supports thumbfast. The "
+"images are fetched from the server per video, which costs disk space and "
+"memory -- tens of MB for an episode, a few hundred for a long film."
+msgstr ""
 
 #: jellyfin_mpv_shim/mpvtk_browser/config.py
 msgid ""
@@ -2294,6 +2376,13 @@ msgstr ""
 
 #: jellyfin_mpv_shim/mpvtk_browser/config.py
 msgid ""
+"Show times of day as \"8:30 PM\" rather than \"20:30\" — the Live TV guide "
+"and its air times, and the \"Ends at\" labels on a detail page and the "
+"player controls."
+msgstr ""
+
+#: jellyfin_mpv_shim/mpvtk_browser/config.py
+msgid ""
 "The controls have to stay legible over any frame. \"None\" gives the text a "
 "drop shadow instead of shading the picture behind it."
 msgstr ""
@@ -2315,6 +2404,13 @@ msgid ""
 msgstr ""
 "0 oculta-os assim que o ponteiro deixa de estar sobre eles e força «Ocultar "
 "exceto ao passar o cursor»."
+
+#: jellyfin_mpv_shim/mpvtk_browser/config.py
+msgid ""
+"Narrowing the window shrinks the controls until the smallest button reaches "
+"the accessibility minimum, instead of dropping buttons sooner. Off keeps the "
+"older, larger floor."
+msgstr ""
 
 #: jellyfin_mpv_shim/mpvtk_browser/config.py
 #, fuzzy
@@ -3840,6 +3936,7 @@ msgid "More Like This"
 msgstr "Títulos semelhantes"
 
 #: jellyfin_mpv_shim/mpvtk_browser/pages/detail.py
+#: jellyfin_mpv_shim/mpvtk_browser/tiles.py
 msgid "Go to Series"
 msgstr "Ir para a série"
 
@@ -4937,6 +5034,22 @@ msgstr "Remover %s desta coleção?"
 msgid "There is nothing here to queue."
 msgstr "Não há nada aqui para adicionar à fila."
 
+#: jellyfin_mpv_shim/mpvtk_browser/timefmt.py
+#, python-brace-format
+msgctxt "12-hour clock"
+msgid "{time} {period}"
+msgstr ""
+
+#: jellyfin_mpv_shim/mpvtk_browser/timefmt.py
+msgctxt "12-hour clock"
+msgid "AM"
+msgstr ""
+
+#: jellyfin_mpv_shim/mpvtk_browser/timefmt.py
+msgctxt "12-hour clock"
+msgid "PM"
+msgstr ""
+
 # seeded from jellyfin-web: Search
 #: jellyfin_mpv_shim/mpvtk_browser/views.py
 #: jellyfin_mpv_shim/mpvtk_browser/window_chrome.py
@@ -5100,6 +5213,12 @@ msgid "Enable SVP"
 msgstr "Ativar SVP"
 
 #: jellyfin_mpv_shim/sync/manager.py
+#, fuzzy
+#| msgid "Move the downloads back to the default folder?"
+msgid "The downloads are already in that folder."
+msgstr "Mover as transferências de volta para a pasta predefinida?"
+
+#: jellyfin_mpv_shim/sync/manager.py
 msgid ""
 "Can't change the download folder while a download is in progress. Wait for "
 "it to finish, then try again."
@@ -5108,8 +5227,29 @@ msgstr ""
 "transferência em curso. Aguarda até terminar e tenta novamente."
 
 #: jellyfin_mpv_shim/sync/manager.py
+#, fuzzy
+#| msgid "That folder already contains downloads. Choose an empty folder."
+msgid ""
+"That folder is inside the current download folder. Choose one outside it."
+msgstr "Essa pasta já contém transferências. Escolhe uma pasta vazia."
+
+#: jellyfin_mpv_shim/sync/manager.py
+#, fuzzy
+#| msgid "Can't create that folder. Check the path and its permissions."
+msgid "Can't read that folder. Check the path and its permissions."
+msgstr ""
+"Não foi possível criar essa pasta. Verifica o caminho e as respetivas "
+"permissões."
+
+#: jellyfin_mpv_shim/sync/manager.py
 msgid "That folder already contains downloads. Choose an empty folder."
 msgstr "Essa pasta já contém transferências. Escolhe uma pasta vazia."
+
+#: jellyfin_mpv_shim/sync/manager.py
+msgid ""
+"That folder isn't empty. Choose an empty folder — the download folder is "
+"managed by this app and anything else in it can be moved or removed."
+msgstr ""
 
 #: jellyfin_mpv_shim/sync/manager.py
 msgid "Can't create that folder. Check the path and its permissions."
@@ -5121,6 +5261,12 @@ msgstr ""
 msgid "A download is still finishing. Wait for it to stop, then try again."
 msgstr ""
 "Ainda está uma transferência a terminar. Aguarda até parar e tenta novamente."
+
+#: jellyfin_mpv_shim/sync/manager.py
+msgid ""
+"There isn't enough space on that drive to move the downloads. Free some "
+"space and try again — nothing was moved."
+msgstr ""
 
 #: jellyfin_mpv_shim/sync/manager.py
 msgid ""
@@ -5328,6 +5474,12 @@ msgstr "Perfil de reprodução de vídeo"
 #: jellyfin_mpv_shim/video_profile.py
 msgid "Select Shader Profile"
 msgstr "Selecionar perfil de shader"
+
+#~ msgid "MPV UI with thumbnails"
+#~ msgstr "Interface do MPV com miniaturas"
+
+#~ msgid "MPV built-in default"
+#~ msgstr "Predefinição integrada do MPV"
 
 #~ msgid "Discord Rich Presence. Takes effect after a restart."
 #~ msgstr "Discord Rich Presence. Produz efeito após reiniciar."

--- a/jellyfin_mpv_shim/messages/pt_BR/LC_MESSAGES/base.po
+++ b/jellyfin_mpv_shim/messages/pt_BR/LC_MESSAGES/base.po
@@ -6,7 +6,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2026-08-30 22:19-0400\n"
+"POT-Creation-Date: 2026-09-07 17:35-0400\n"
 "PO-Revision-Date: 2026-08-31 01:08+0000\n"
 "Last-Translator: alison2033 <a23030485@gmail.com>\n"
 "Language-Team: Portuguese (Brazil) <https://translate.jellyfin.org/projects/"
@@ -529,6 +529,11 @@ msgid "Night Mode (Auto Volume Adj)"
 msgstr "Modo noturno (ajuste automático de volume)"
 
 #: jellyfin_mpv_shim/mpvtk_browser/app.py
+#: jellyfin_mpv_shim/mpvtk_browser/auth.py
+msgid "Locked"
+msgstr ""
+
+#: jellyfin_mpv_shim/mpvtk_browser/app.py
 msgid "Failed to load. Check the connection."
 msgstr "Falha ao carregar. Verifique a conexão."
 
@@ -792,10 +797,6 @@ msgstr ""
 "Por favor verifique os dados da conexão."
 
 #: jellyfin_mpv_shim/mpvtk_browser/auth.py
-msgid "Locked"
-msgstr ""
-
-#: jellyfin_mpv_shim/mpvtk_browser/auth.py
 #: jellyfin_mpv_shim/mpvtk_browser/pages/home.py
 msgid "Connecting to your server…"
 msgstr ""
@@ -874,6 +875,10 @@ msgstr "Sair e marcar como não visto"
 #: jellyfin_mpv_shim/mpvtk_browser/pages/books.py
 msgid "Favorite"
 msgstr "Favorito"
+
+#: jellyfin_mpv_shim/mpvtk_browser/components/detail.py
+msgid "Web"
+msgstr ""
 
 # seeded from jellyfin-web: HeaderVideos
 #: jellyfin_mpv_shim/mpvtk_browser/components/media_info.py
@@ -1490,11 +1495,7 @@ msgid "Jellyfin UI"
 msgstr ""
 
 #: jellyfin_mpv_shim/mpvtk_browser/config.py
-msgid "MPV UI with thumbnails"
-msgstr ""
-
-#: jellyfin_mpv_shim/mpvtk_browser/config.py
-msgid "MPV built-in default"
+msgid "MPV UI"
 msgstr ""
 
 #: jellyfin_mpv_shim/mpvtk_browser/config.py
@@ -1843,8 +1844,22 @@ msgid "Window Buttons in the Top Bar"
 msgstr ""
 
 #: jellyfin_mpv_shim/mpvtk_browser/config.py
+msgid "Keep Window Buttons in Full Screen"
+msgstr ""
+
+#: jellyfin_mpv_shim/mpvtk_browser/config.py
+msgid "Hide the Desktop Title Bar"
+msgstr ""
+
+#: jellyfin_mpv_shim/mpvtk_browser/config.py
 msgid "Player Controls Style"
 msgstr ""
+
+#: jellyfin_mpv_shim/mpvtk_browser/config.py
+#, fuzzy
+#| msgid "Enable thumbnail previews"
+msgid "Enable Trickplay Thumbnails"
+msgstr "Habilitar miniaturas de imagens"
 
 #: jellyfin_mpv_shim/mpvtk_browser/config.py
 msgid "Load All Seek Previews at Once"
@@ -1874,6 +1889,10 @@ msgstr ""
 
 #: jellyfin_mpv_shim/mpvtk_browser/config.py
 msgid "Full-Width Backdrops"
+msgstr ""
+
+#: jellyfin_mpv_shim/mpvtk_browser/config.py
+msgid "12-Hour Clock"
 msgstr ""
 
 #: jellyfin_mpv_shim/mpvtk_browser/config.py
@@ -1919,12 +1938,23 @@ msgid "Fullscreen Library Browser"
 msgstr ""
 
 #: jellyfin_mpv_shim/mpvtk_browser/config.py
+msgid "Block Player Keybinds While Browsing"
+msgstr ""
+
+#: jellyfin_mpv_shim/mpvtk_browser/config.py
 msgid "Always Bind Arrow Keys to Player Controls"
 msgstr ""
 
 #: jellyfin_mpv_shim/mpvtk_browser/config.py
 msgid "Player Controls Activation Key"
 msgstr ""
+
+# seeded from jellyfin-web: SelectAll
+#: jellyfin_mpv_shim/mpvtk_browser/config.py
+#, fuzzy
+#| msgid "Select All"
+msgid "Select Key"
+msgstr "Selecionar Tudo"
 
 #: jellyfin_mpv_shim/mpvtk_browser/config.py
 msgid "Shading Behind the Player Controls"
@@ -1936,6 +1966,10 @@ msgstr ""
 
 #: jellyfin_mpv_shim/mpvtk_browser/config.py
 msgid "Hide the Player Controls After (seconds)"
+msgstr ""
+
+#: jellyfin_mpv_shim/mpvtk_browser/config.py
+msgid "Shrink the Player Controls on a Narrow Window"
 msgstr ""
 
 #: jellyfin_mpv_shim/mpvtk_browser/config.py
@@ -2022,6 +2056,21 @@ msgstr ""
 
 #: jellyfin_mpv_shim/mpvtk_browser/config.py
 msgid ""
+"Stops MPV's own shortcuts -- picture adjustment, screenshots, subtitle and "
+"audio switching -- from acting while you are in the library, where there is "
+"no video for them to act on. Turn it off to use your own MPV key bindings "
+"there."
+msgstr ""
+
+#: jellyfin_mpv_shim/mpvtk_browser/config.py
+msgid ""
+"Activates whatever is highlighted, in the library and on the player "
+"controls. An mpv key name; changing it hands Enter back to MPV. The game "
+"controller's Confirm button and a phone's Select follow it."
+msgstr ""
+
+#: jellyfin_mpv_shim/mpvtk_browser/config.py
+msgid ""
 "Leave these blank unless downloads are waking your disks too often. Set both "
 "of the first two together: episodes are then fetched in one batch when a "
 "series runs low, instead of one at a time."
@@ -2035,7 +2084,8 @@ msgstr ""
 #: jellyfin_mpv_shim/mpvtk_browser/config.py
 msgid ""
 "Off gives MPV's own mouse behaviour instead: drag the video to move the "
-"window, and right click to pause. Double click is full screen either way."
+"window, and the right button does whatever your MPV config gives it. Double "
+"click is full screen either way."
 msgstr ""
 
 #: jellyfin_mpv_shim/mpvtk_browser/config.py
@@ -2125,6 +2175,30 @@ msgid ""
 "maximize and close in the top bar instead, and lets you drag the window by "
 "it. On \"Only when the window has no title bar\", MPV is asked whether this "
 "window got one, so desktops that draw a title bar are left alone."
+msgstr ""
+
+#: jellyfin_mpv_shim/mpvtk_browser/config.py
+msgid ""
+"Full screen has no title bar anywhere and nothing to move or maximize, so "
+"the buttons are normally hidden there. Turn this on to keep a way out of "
+"full screen that is not a keyboard shortcut."
+msgstr ""
+
+#: jellyfin_mpv_shim/mpvtk_browser/config.py
+msgid ""
+"Asks the desktop for no title bar on the player window, so the top bar above "
+"is the only one. Pairs with the setting above: on \"Only when the window has "
+"no title bar\" the buttons appear as soon as this is on. Leave both off "
+"unless you want them, since a window with neither can be awkward to move on "
+"some desktops."
+msgstr ""
+
+#: jellyfin_mpv_shim/mpvtk_browser/config.py
+msgid ""
+"Shows a preview frame while you drag the seek bar. Works with every player "
+"control style, including your own OSC script if it supports thumbfast. The "
+"images are fetched from the server per video, which costs disk space and "
+"memory -- tens of MB for an episode, a few hundred for a long film."
 msgstr ""
 
 #: jellyfin_mpv_shim/mpvtk_browser/config.py
@@ -2234,6 +2308,13 @@ msgstr ""
 
 #: jellyfin_mpv_shim/mpvtk_browser/config.py
 msgid ""
+"Show times of day as \"8:30 PM\" rather than \"20:30\" — the Live TV guide "
+"and its air times, and the \"Ends at\" labels on a detail page and the "
+"player controls."
+msgstr ""
+
+#: jellyfin_mpv_shim/mpvtk_browser/config.py
+msgid ""
 "The controls have to stay legible over any frame. \"None\" gives the text a "
 "drop shadow instead of shading the picture behind it."
 msgstr ""
@@ -2248,6 +2329,13 @@ msgstr ""
 msgid ""
 "0 hides them as soon as the pointer is not on them, and forces \"Hide unless "
 "hovered\"."
+msgstr ""
+
+#: jellyfin_mpv_shim/mpvtk_browser/config.py
+msgid ""
+"Narrowing the window shrinks the controls until the smallest button reaches "
+"the accessibility minimum, instead of dropping buttons sooner. Off keeps the "
+"older, larger floor."
 msgstr ""
 
 #: jellyfin_mpv_shim/mpvtk_browser/config.py
@@ -3835,6 +3923,7 @@ msgid "More Like This"
 msgstr "Mais Disso"
 
 #: jellyfin_mpv_shim/mpvtk_browser/pages/detail.py
+#: jellyfin_mpv_shim/mpvtk_browser/tiles.py
 msgid "Go to Series"
 msgstr ""
 
@@ -5016,6 +5105,22 @@ msgstr "Remover servidor"
 msgid "There is nothing here to queue."
 msgstr ""
 
+#: jellyfin_mpv_shim/mpvtk_browser/timefmt.py
+#, python-brace-format
+msgctxt "12-hour clock"
+msgid "{time} {period}"
+msgstr ""
+
+#: jellyfin_mpv_shim/mpvtk_browser/timefmt.py
+msgctxt "12-hour clock"
+msgid "AM"
+msgstr ""
+
+#: jellyfin_mpv_shim/mpvtk_browser/timefmt.py
+msgctxt "12-hour clock"
+msgid "PM"
+msgstr ""
+
 # seeded from jellyfin-web: Search
 #: jellyfin_mpv_shim/mpvtk_browser/views.py
 #: jellyfin_mpv_shim/mpvtk_browser/window_chrome.py
@@ -5181,13 +5286,32 @@ msgid "Enable SVP"
 msgstr "Habilitar SVP"
 
 #: jellyfin_mpv_shim/sync/manager.py
+msgid "The downloads are already in that folder."
+msgstr ""
+
+#: jellyfin_mpv_shim/sync/manager.py
 msgid ""
 "Can't change the download folder while a download is in progress. Wait for "
 "it to finish, then try again."
 msgstr ""
 
 #: jellyfin_mpv_shim/sync/manager.py
+msgid ""
+"That folder is inside the current download folder. Choose one outside it."
+msgstr ""
+
+#: jellyfin_mpv_shim/sync/manager.py
+msgid "Can't read that folder. Check the path and its permissions."
+msgstr ""
+
+#: jellyfin_mpv_shim/sync/manager.py
 msgid "That folder already contains downloads. Choose an empty folder."
+msgstr ""
+
+#: jellyfin_mpv_shim/sync/manager.py
+msgid ""
+"That folder isn't empty. Choose an empty folder — the download folder is "
+"managed by this app and anything else in it can be moved or removed."
 msgstr ""
 
 #: jellyfin_mpv_shim/sync/manager.py
@@ -5196,6 +5320,12 @@ msgstr ""
 
 #: jellyfin_mpv_shim/sync/manager.py
 msgid "A download is still finishing. Wait for it to stop, then try again."
+msgstr ""
+
+#: jellyfin_mpv_shim/sync/manager.py
+msgid ""
+"There isn't enough space on that drive to move the downloads. Free some "
+"space and try again — nothing was moved."
 msgstr ""
 
 #: jellyfin_mpv_shim/sync/manager.py

--- a/jellyfin_mpv_shim/messages/pt_PT/LC_MESSAGES/base.po
+++ b/jellyfin_mpv_shim/messages/pt_PT/LC_MESSAGES/base.po
@@ -6,7 +6,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2026-08-30 22:19-0400\n"
+"POT-Creation-Date: 2026-09-07 17:35-0400\n"
 "PO-Revision-Date: 2026-08-25 12:09+0000\n"
 "Last-Translator: João Pedro Fontes <github@jpedrofontes.com>\n"
 "Language-Team: Portuguese (Portugal) <https://translate.jellyfin.org/"
@@ -511,6 +511,11 @@ msgid "Night Mode (Auto Volume Adj)"
 msgstr "Modo noturno (ajuste automático do volume)"
 
 #: jellyfin_mpv_shim/mpvtk_browser/app.py
+#: jellyfin_mpv_shim/mpvtk_browser/auth.py
+msgid "Locked"
+msgstr "Bloqueado"
+
+#: jellyfin_mpv_shim/mpvtk_browser/app.py
 msgid "Failed to load. Check the connection."
 msgstr "Falha ao carregar. Verifica a ligação."
 
@@ -759,10 +764,6 @@ msgid "Could not connect. Please check your details."
 msgstr "Não foi possível ligar. Verifica os dados introduzidos."
 
 #: jellyfin_mpv_shim/mpvtk_browser/auth.py
-msgid "Locked"
-msgstr "Bloqueado"
-
-#: jellyfin_mpv_shim/mpvtk_browser/auth.py
 #: jellyfin_mpv_shim/mpvtk_browser/pages/home.py
 msgid "Connecting to your server…"
 msgstr "A ligar ao teu servidor…"
@@ -837,6 +838,10 @@ msgstr "Visto"
 #: jellyfin_mpv_shim/mpvtk_browser/pages/books.py
 msgid "Favorite"
 msgstr "Favorito"
+
+#: jellyfin_mpv_shim/mpvtk_browser/components/detail.py
+msgid "Web"
+msgstr ""
 
 # seeded from jellyfin-web: HeaderVideos
 #: jellyfin_mpv_shim/mpvtk_browser/components/media_info.py
@@ -1415,12 +1420,8 @@ msgid "Jellyfin UI"
 msgstr "Interface do Jellyfin"
 
 #: jellyfin_mpv_shim/mpvtk_browser/config.py
-msgid "MPV UI with thumbnails"
-msgstr "Interface do MPV com miniaturas"
-
-#: jellyfin_mpv_shim/mpvtk_browser/config.py
-msgid "MPV built-in default"
-msgstr "Predefinição integrada do MPV"
+msgid "MPV UI"
+msgstr ""
 
 #: jellyfin_mpv_shim/mpvtk_browser/config.py
 msgid "Custom OSC"
@@ -1762,8 +1763,24 @@ msgid "Window Buttons in the Top Bar"
 msgstr "Botões da janela na barra superior"
 
 #: jellyfin_mpv_shim/mpvtk_browser/config.py
+#, fuzzy
+#| msgid "Window Buttons in the Top Bar"
+msgid "Keep Window Buttons in Full Screen"
+msgstr "Botões da janela na barra superior"
+
+#: jellyfin_mpv_shim/mpvtk_browser/config.py
+msgid "Hide the Desktop Title Bar"
+msgstr ""
+
+#: jellyfin_mpv_shim/mpvtk_browser/config.py
 msgid "Player Controls Style"
 msgstr "Estilo dos controlos do leitor"
+
+#: jellyfin_mpv_shim/mpvtk_browser/config.py
+#, fuzzy
+#| msgid "Enable thumbnail previews"
+msgid "Enable Trickplay Thumbnails"
+msgstr "Ativar pré-visualizações em miniatura"
 
 #: jellyfin_mpv_shim/mpvtk_browser/config.py
 msgid "Load All Seek Previews at Once"
@@ -1794,6 +1811,10 @@ msgstr "Tamanho da capa"
 
 #: jellyfin_mpv_shim/mpvtk_browser/config.py
 msgid "Full-Width Backdrops"
+msgstr ""
+
+#: jellyfin_mpv_shim/mpvtk_browser/config.py
+msgid "12-Hour Clock"
 msgstr ""
 
 #: jellyfin_mpv_shim/mpvtk_browser/config.py
@@ -1838,12 +1859,23 @@ msgid "Fullscreen Library Browser"
 msgstr "Navegador da biblioteca em ecrã inteiro"
 
 #: jellyfin_mpv_shim/mpvtk_browser/config.py
+msgid "Block Player Keybinds While Browsing"
+msgstr ""
+
+#: jellyfin_mpv_shim/mpvtk_browser/config.py
 msgid "Always Bind Arrow Keys to Player Controls"
 msgstr "Associar sempre as teclas de seta aos controlos do leitor"
 
 #: jellyfin_mpv_shim/mpvtk_browser/config.py
 msgid "Player Controls Activation Key"
 msgstr "Tecla de ativação dos controlos do leitor"
+
+# seeded from jellyfin-web: SelectAll
+#: jellyfin_mpv_shim/mpvtk_browser/config.py
+#, fuzzy
+#| msgid "Select All"
+msgid "Select Key"
+msgstr "Selecionar tudo"
 
 #: jellyfin_mpv_shim/mpvtk_browser/config.py
 msgid "Shading Behind the Player Controls"
@@ -1856,6 +1888,12 @@ msgstr "Quando ocultar os controlos do leitor"
 #: jellyfin_mpv_shim/mpvtk_browser/config.py
 msgid "Hide the Player Controls After (seconds)"
 msgstr "Ocultar os controlos do leitor após (segundos)"
+
+#: jellyfin_mpv_shim/mpvtk_browser/config.py
+#, fuzzy
+#| msgid "When the Player Controls Hide"
+msgid "Shrink the Player Controls on a Narrow Window"
+msgstr "Quando ocultar os controlos do leitor"
 
 #: jellyfin_mpv_shim/mpvtk_browser/config.py
 msgid "Mouse Back/Forward Buttons Skip Chapters"
@@ -1941,6 +1979,21 @@ msgstr ""
 
 #: jellyfin_mpv_shim/mpvtk_browser/config.py
 msgid ""
+"Stops MPV's own shortcuts -- picture adjustment, screenshots, subtitle and "
+"audio switching -- from acting while you are in the library, where there is "
+"no video for them to act on. Turn it off to use your own MPV key bindings "
+"there."
+msgstr ""
+
+#: jellyfin_mpv_shim/mpvtk_browser/config.py
+msgid ""
+"Activates whatever is highlighted, in the library and on the player "
+"controls. An mpv key name; changing it hands Enter back to MPV. The game "
+"controller's Confirm button and a phone's Select follow it."
+msgstr ""
+
+#: jellyfin_mpv_shim/mpvtk_browser/config.py
+msgid ""
 "Leave these blank unless downloads are waking your disks too often. Set both "
 "of the first two together: episodes are then fetched in one batch when a "
 "series runs low, instead of one at a time."
@@ -1958,9 +2011,14 @@ msgstr ""
 "não tenhas visto."
 
 #: jellyfin_mpv_shim/mpvtk_browser/config.py
+#, fuzzy
+#| msgid ""
+#| "Off gives MPV's own mouse behaviour instead: drag the video to move the "
+#| "window, and right click to pause. Double click is full screen either way."
 msgid ""
 "Off gives MPV's own mouse behaviour instead: drag the video to move the "
-"window, and right click to pause. Double click is full screen either way."
+"window, and the right button does whatever your MPV config gives it. Double "
+"click is full screen either way."
 msgstr ""
 "Desativado utiliza o comportamento do rato do próprio MPV: arrasta o vídeo "
 "para mover a janela e clica com o botão direito para pausar. Em ambos os "
@@ -2097,6 +2155,30 @@ msgstr ""
 "barra superior e permite arrastar a janela por essa barra. Com «Apenas "
 "quando a janela não tem barra de título», o MPV verifica se a janela recebeu "
 "uma, deixando inalterados os ambientes que já a apresentam."
+
+#: jellyfin_mpv_shim/mpvtk_browser/config.py
+msgid ""
+"Full screen has no title bar anywhere and nothing to move or maximize, so "
+"the buttons are normally hidden there. Turn this on to keep a way out of "
+"full screen that is not a keyboard shortcut."
+msgstr ""
+
+#: jellyfin_mpv_shim/mpvtk_browser/config.py
+msgid ""
+"Asks the desktop for no title bar on the player window, so the top bar above "
+"is the only one. Pairs with the setting above: on \"Only when the window has "
+"no title bar\" the buttons appear as soon as this is on. Leave both off "
+"unless you want them, since a window with neither can be awkward to move on "
+"some desktops."
+msgstr ""
+
+#: jellyfin_mpv_shim/mpvtk_browser/config.py
+msgid ""
+"Shows a preview frame while you drag the seek bar. Works with every player "
+"control style, including your own OSC script if it supports thumbfast. The "
+"images are fetched from the server per video, which costs disk space and "
+"memory -- tens of MB for an episode, a few hundred for a long film."
+msgstr ""
 
 #: jellyfin_mpv_shim/mpvtk_browser/config.py
 msgid ""
@@ -2282,6 +2364,13 @@ msgstr ""
 
 #: jellyfin_mpv_shim/mpvtk_browser/config.py
 msgid ""
+"Show times of day as \"8:30 PM\" rather than \"20:30\" — the Live TV guide "
+"and its air times, and the \"Ends at\" labels on a detail page and the "
+"player controls."
+msgstr ""
+
+#: jellyfin_mpv_shim/mpvtk_browser/config.py
+msgid ""
 "The controls have to stay legible over any frame. \"None\" gives the text a "
 "drop shadow instead of shading the picture behind it."
 msgstr ""
@@ -2303,6 +2392,13 @@ msgid ""
 msgstr ""
 "0 oculta-os assim que o ponteiro deixa de estar sobre eles e força «Ocultar "
 "exceto ao passar o cursor»."
+
+#: jellyfin_mpv_shim/mpvtk_browser/config.py
+msgid ""
+"Narrowing the window shrinks the controls until the smallest button reaches "
+"the accessibility minimum, instead of dropping buttons sooner. Off keeps the "
+"older, larger floor."
+msgstr ""
 
 #: jellyfin_mpv_shim/mpvtk_browser/config.py
 #, fuzzy
@@ -3829,6 +3925,7 @@ msgid "More Like This"
 msgstr "Títulos semelhantes"
 
 #: jellyfin_mpv_shim/mpvtk_browser/pages/detail.py
+#: jellyfin_mpv_shim/mpvtk_browser/tiles.py
 msgid "Go to Series"
 msgstr "Ir para a série"
 
@@ -4927,6 +5024,22 @@ msgstr "Remover %s desta coleção?"
 msgid "There is nothing here to queue."
 msgstr "Não há nada aqui para adicionar à fila."
 
+#: jellyfin_mpv_shim/mpvtk_browser/timefmt.py
+#, python-brace-format
+msgctxt "12-hour clock"
+msgid "{time} {period}"
+msgstr ""
+
+#: jellyfin_mpv_shim/mpvtk_browser/timefmt.py
+msgctxt "12-hour clock"
+msgid "AM"
+msgstr ""
+
+#: jellyfin_mpv_shim/mpvtk_browser/timefmt.py
+msgctxt "12-hour clock"
+msgid "PM"
+msgstr ""
+
 # seeded from jellyfin-web: Search
 #: jellyfin_mpv_shim/mpvtk_browser/views.py
 #: jellyfin_mpv_shim/mpvtk_browser/window_chrome.py
@@ -5090,6 +5203,12 @@ msgid "Enable SVP"
 msgstr "Ativar SVP"
 
 #: jellyfin_mpv_shim/sync/manager.py
+#, fuzzy
+#| msgid "Move the downloads back to the default folder?"
+msgid "The downloads are already in that folder."
+msgstr "Mover as transferências de volta para a pasta predefinida?"
+
+#: jellyfin_mpv_shim/sync/manager.py
 msgid ""
 "Can't change the download folder while a download is in progress. Wait for "
 "it to finish, then try again."
@@ -5098,8 +5217,29 @@ msgstr ""
 "transferência em curso. Aguarda até terminar e tenta novamente."
 
 #: jellyfin_mpv_shim/sync/manager.py
+#, fuzzy
+#| msgid "That folder already contains downloads. Choose an empty folder."
+msgid ""
+"That folder is inside the current download folder. Choose one outside it."
+msgstr "Essa pasta já contém transferências. Escolhe uma pasta vazia."
+
+#: jellyfin_mpv_shim/sync/manager.py
+#, fuzzy
+#| msgid "Can't create that folder. Check the path and its permissions."
+msgid "Can't read that folder. Check the path and its permissions."
+msgstr ""
+"Não foi possível criar essa pasta. Verifica o caminho e as respetivas "
+"permissões."
+
+#: jellyfin_mpv_shim/sync/manager.py
 msgid "That folder already contains downloads. Choose an empty folder."
 msgstr "Essa pasta já contém transferências. Escolhe uma pasta vazia."
+
+#: jellyfin_mpv_shim/sync/manager.py
+msgid ""
+"That folder isn't empty. Choose an empty folder — the download folder is "
+"managed by this app and anything else in it can be moved or removed."
+msgstr ""
 
 #: jellyfin_mpv_shim/sync/manager.py
 msgid "Can't create that folder. Check the path and its permissions."
@@ -5111,6 +5251,12 @@ msgstr ""
 msgid "A download is still finishing. Wait for it to stop, then try again."
 msgstr ""
 "Ainda está uma transferência a terminar. Aguarda até parar e tenta novamente."
+
+#: jellyfin_mpv_shim/sync/manager.py
+msgid ""
+"There isn't enough space on that drive to move the downloads. Free some "
+"space and try again — nothing was moved."
+msgstr ""
 
 #: jellyfin_mpv_shim/sync/manager.py
 msgid ""
@@ -5318,6 +5464,12 @@ msgstr "Perfil de reprodução de vídeo"
 #: jellyfin_mpv_shim/video_profile.py
 msgid "Select Shader Profile"
 msgstr "Selecionar perfil de shader"
+
+#~ msgid "MPV UI with thumbnails"
+#~ msgstr "Interface do MPV com miniaturas"
+
+#~ msgid "MPV built-in default"
+#~ msgstr "Predefinição integrada do MPV"
 
 #~ msgid "Discord Rich Presence. Takes effect after a restart."
 #~ msgstr "Discord Rich Presence. Produz efeito após reiniciar."

--- a/jellyfin_mpv_shim/messages/ro/LC_MESSAGES/base.po
+++ b/jellyfin_mpv_shim/messages/ro/LC_MESSAGES/base.po
@@ -6,7 +6,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2026-08-30 22:19-0400\n"
+"POT-Creation-Date: 2026-09-07 17:35-0400\n"
 "PO-Revision-Date: 2024-09-16 00:41+0000\n"
 "Last-Translator: sand14 <sand.avrigeanu@yahoo.com>\n"
 "Language-Team: Romanian <https://translate.jellyfin.org/projects/jellyfin/"
@@ -548,6 +548,11 @@ msgid "Night Mode (Auto Volume Adj)"
 msgstr ""
 
 #: jellyfin_mpv_shim/mpvtk_browser/app.py
+#: jellyfin_mpv_shim/mpvtk_browser/auth.py
+msgid "Locked"
+msgstr ""
+
+#: jellyfin_mpv_shim/mpvtk_browser/app.py
 msgid "Failed to load. Check the connection."
 msgstr ""
 
@@ -827,10 +832,6 @@ msgstr ""
 "Vă rugăm să verificați informațiile conexiunii."
 
 #: jellyfin_mpv_shim/mpvtk_browser/auth.py
-msgid "Locked"
-msgstr ""
-
-#: jellyfin_mpv_shim/mpvtk_browser/auth.py
 #: jellyfin_mpv_shim/mpvtk_browser/pages/home.py
 msgid "Connecting to your server…"
 msgstr ""
@@ -911,6 +912,10 @@ msgstr "Renunță și Marchează ca Nevăzut"
 #: jellyfin_mpv_shim/mpvtk_browser/pages/books.py
 msgid "Favorite"
 msgstr "Favorit"
+
+#: jellyfin_mpv_shim/mpvtk_browser/components/detail.py
+msgid "Web"
+msgstr ""
 
 # seeded from jellyfin-web: HeaderVideos
 #: jellyfin_mpv_shim/mpvtk_browser/components/media_info.py
@@ -1526,11 +1531,7 @@ msgid "Jellyfin UI"
 msgstr ""
 
 #: jellyfin_mpv_shim/mpvtk_browser/config.py
-msgid "MPV UI with thumbnails"
-msgstr ""
-
-#: jellyfin_mpv_shim/mpvtk_browser/config.py
-msgid "MPV built-in default"
+msgid "MPV UI"
 msgstr ""
 
 #: jellyfin_mpv_shim/mpvtk_browser/config.py
@@ -1879,8 +1880,22 @@ msgid "Window Buttons in the Top Bar"
 msgstr ""
 
 #: jellyfin_mpv_shim/mpvtk_browser/config.py
+msgid "Keep Window Buttons in Full Screen"
+msgstr ""
+
+#: jellyfin_mpv_shim/mpvtk_browser/config.py
+msgid "Hide the Desktop Title Bar"
+msgstr ""
+
+#: jellyfin_mpv_shim/mpvtk_browser/config.py
 msgid "Player Controls Style"
 msgstr ""
+
+#: jellyfin_mpv_shim/mpvtk_browser/config.py
+#, fuzzy
+#| msgid "Enable thumbnail previews"
+msgid "Enable Trickplay Thumbnails"
+msgstr "Activați previzualizările în miniatură"
 
 #: jellyfin_mpv_shim/mpvtk_browser/config.py
 msgid "Load All Seek Previews at Once"
@@ -1910,6 +1925,10 @@ msgstr ""
 
 #: jellyfin_mpv_shim/mpvtk_browser/config.py
 msgid "Full-Width Backdrops"
+msgstr ""
+
+#: jellyfin_mpv_shim/mpvtk_browser/config.py
+msgid "12-Hour Clock"
 msgstr ""
 
 #: jellyfin_mpv_shim/mpvtk_browser/config.py
@@ -1955,12 +1974,23 @@ msgid "Fullscreen Library Browser"
 msgstr ""
 
 #: jellyfin_mpv_shim/mpvtk_browser/config.py
+msgid "Block Player Keybinds While Browsing"
+msgstr ""
+
+#: jellyfin_mpv_shim/mpvtk_browser/config.py
 msgid "Always Bind Arrow Keys to Player Controls"
 msgstr ""
 
 #: jellyfin_mpv_shim/mpvtk_browser/config.py
 msgid "Player Controls Activation Key"
 msgstr ""
+
+# seeded from jellyfin-web: SelectAll
+#: jellyfin_mpv_shim/mpvtk_browser/config.py
+#, fuzzy
+#| msgid "Select All"
+msgid "Select Key"
+msgstr "Selectează Tot"
 
 #: jellyfin_mpv_shim/mpvtk_browser/config.py
 msgid "Shading Behind the Player Controls"
@@ -1972,6 +2002,10 @@ msgstr ""
 
 #: jellyfin_mpv_shim/mpvtk_browser/config.py
 msgid "Hide the Player Controls After (seconds)"
+msgstr ""
+
+#: jellyfin_mpv_shim/mpvtk_browser/config.py
+msgid "Shrink the Player Controls on a Narrow Window"
 msgstr ""
 
 #: jellyfin_mpv_shim/mpvtk_browser/config.py
@@ -2058,6 +2092,21 @@ msgstr ""
 
 #: jellyfin_mpv_shim/mpvtk_browser/config.py
 msgid ""
+"Stops MPV's own shortcuts -- picture adjustment, screenshots, subtitle and "
+"audio switching -- from acting while you are in the library, where there is "
+"no video for them to act on. Turn it off to use your own MPV key bindings "
+"there."
+msgstr ""
+
+#: jellyfin_mpv_shim/mpvtk_browser/config.py
+msgid ""
+"Activates whatever is highlighted, in the library and on the player "
+"controls. An mpv key name; changing it hands Enter back to MPV. The game "
+"controller's Confirm button and a phone's Select follow it."
+msgstr ""
+
+#: jellyfin_mpv_shim/mpvtk_browser/config.py
+msgid ""
 "Leave these blank unless downloads are waking your disks too often. Set both "
 "of the first two together: episodes are then fetched in one batch when a "
 "series runs low, instead of one at a time."
@@ -2071,7 +2120,8 @@ msgstr ""
 #: jellyfin_mpv_shim/mpvtk_browser/config.py
 msgid ""
 "Off gives MPV's own mouse behaviour instead: drag the video to move the "
-"window, and right click to pause. Double click is full screen either way."
+"window, and the right button does whatever your MPV config gives it. Double "
+"click is full screen either way."
 msgstr ""
 
 #: jellyfin_mpv_shim/mpvtk_browser/config.py
@@ -2161,6 +2211,30 @@ msgid ""
 "maximize and close in the top bar instead, and lets you drag the window by "
 "it. On \"Only when the window has no title bar\", MPV is asked whether this "
 "window got one, so desktops that draw a title bar are left alone."
+msgstr ""
+
+#: jellyfin_mpv_shim/mpvtk_browser/config.py
+msgid ""
+"Full screen has no title bar anywhere and nothing to move or maximize, so "
+"the buttons are normally hidden there. Turn this on to keep a way out of "
+"full screen that is not a keyboard shortcut."
+msgstr ""
+
+#: jellyfin_mpv_shim/mpvtk_browser/config.py
+msgid ""
+"Asks the desktop for no title bar on the player window, so the top bar above "
+"is the only one. Pairs with the setting above: on \"Only when the window has "
+"no title bar\" the buttons appear as soon as this is on. Leave both off "
+"unless you want them, since a window with neither can be awkward to move on "
+"some desktops."
+msgstr ""
+
+#: jellyfin_mpv_shim/mpvtk_browser/config.py
+msgid ""
+"Shows a preview frame while you drag the seek bar. Works with every player "
+"control style, including your own OSC script if it supports thumbfast. The "
+"images are fetched from the server per video, which costs disk space and "
+"memory -- tens of MB for an episode, a few hundred for a long film."
 msgstr ""
 
 #: jellyfin_mpv_shim/mpvtk_browser/config.py
@@ -2270,6 +2344,13 @@ msgstr ""
 
 #: jellyfin_mpv_shim/mpvtk_browser/config.py
 msgid ""
+"Show times of day as \"8:30 PM\" rather than \"20:30\" — the Live TV guide "
+"and its air times, and the \"Ends at\" labels on a detail page and the "
+"player controls."
+msgstr ""
+
+#: jellyfin_mpv_shim/mpvtk_browser/config.py
+msgid ""
 "The controls have to stay legible over any frame. \"None\" gives the text a "
 "drop shadow instead of shading the picture behind it."
 msgstr ""
@@ -2284,6 +2365,13 @@ msgstr ""
 msgid ""
 "0 hides them as soon as the pointer is not on them, and forces \"Hide unless "
 "hovered\"."
+msgstr ""
+
+#: jellyfin_mpv_shim/mpvtk_browser/config.py
+msgid ""
+"Narrowing the window shrinks the controls until the smallest button reaches "
+"the accessibility minimum, instead of dropping buttons sooner. Off keeps the "
+"older, larger floor."
 msgstr ""
 
 #: jellyfin_mpv_shim/mpvtk_browser/config.py
@@ -3891,6 +3979,7 @@ msgid "More Like This"
 msgstr "Mai multe ca acesta"
 
 #: jellyfin_mpv_shim/mpvtk_browser/pages/detail.py
+#: jellyfin_mpv_shim/mpvtk_browser/tiles.py
 msgid "Go to Series"
 msgstr ""
 
@@ -5083,6 +5172,22 @@ msgstr "Eliminați Serverul"
 msgid "There is nothing here to queue."
 msgstr ""
 
+#: jellyfin_mpv_shim/mpvtk_browser/timefmt.py
+#, python-brace-format
+msgctxt "12-hour clock"
+msgid "{time} {period}"
+msgstr ""
+
+#: jellyfin_mpv_shim/mpvtk_browser/timefmt.py
+msgctxt "12-hour clock"
+msgid "AM"
+msgstr ""
+
+#: jellyfin_mpv_shim/mpvtk_browser/timefmt.py
+msgctxt "12-hour clock"
+msgid "PM"
+msgstr ""
+
 # seeded from jellyfin-web: Search
 #: jellyfin_mpv_shim/mpvtk_browser/views.py
 #: jellyfin_mpv_shim/mpvtk_browser/window_chrome.py
@@ -5250,13 +5355,32 @@ msgid "Enable SVP"
 msgstr "Activează SVP"
 
 #: jellyfin_mpv_shim/sync/manager.py
+msgid "The downloads are already in that folder."
+msgstr ""
+
+#: jellyfin_mpv_shim/sync/manager.py
 msgid ""
 "Can't change the download folder while a download is in progress. Wait for "
 "it to finish, then try again."
 msgstr ""
 
 #: jellyfin_mpv_shim/sync/manager.py
+msgid ""
+"That folder is inside the current download folder. Choose one outside it."
+msgstr ""
+
+#: jellyfin_mpv_shim/sync/manager.py
+msgid "Can't read that folder. Check the path and its permissions."
+msgstr ""
+
+#: jellyfin_mpv_shim/sync/manager.py
 msgid "That folder already contains downloads. Choose an empty folder."
+msgstr ""
+
+#: jellyfin_mpv_shim/sync/manager.py
+msgid ""
+"That folder isn't empty. Choose an empty folder — the download folder is "
+"managed by this app and anything else in it can be moved or removed."
 msgstr ""
 
 #: jellyfin_mpv_shim/sync/manager.py
@@ -5265,6 +5389,12 @@ msgstr ""
 
 #: jellyfin_mpv_shim/sync/manager.py
 msgid "A download is still finishing. Wait for it to stop, then try again."
+msgstr ""
+
+#: jellyfin_mpv_shim/sync/manager.py
+msgid ""
+"There isn't enough space on that drive to move the downloads. Free some "
+"space and try again — nothing was moved."
 msgstr ""
 
 #: jellyfin_mpv_shim/sync/manager.py

--- a/jellyfin_mpv_shim/messages/ru/LC_MESSAGES/base.po
+++ b/jellyfin_mpv_shim/messages/ru/LC_MESSAGES/base.po
@@ -6,7 +6,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2026-08-30 22:19-0400\n"
+"POT-Creation-Date: 2026-09-07 17:35-0400\n"
 "PO-Revision-Date: 2026-09-04 23:27+0000\n"
 "Last-Translator: TaPaCuK69 <doctorfreeman14@gmail.com>\n"
 "Language-Team: Russian <https://translate.jellyfin.org/projects/jellyfin/"
@@ -534,6 +534,11 @@ msgid "Night Mode (Auto Volume Adj)"
 msgstr "Ночной режим (Авто регулировка громкости)"
 
 #: jellyfin_mpv_shim/mpvtk_browser/app.py
+#: jellyfin_mpv_shim/mpvtk_browser/auth.py
+msgid "Locked"
+msgstr ""
+
+#: jellyfin_mpv_shim/mpvtk_browser/app.py
 msgid "Failed to load. Check the connection."
 msgstr "Ошибка загрузки. Проверьте соединение."
 
@@ -791,10 +796,6 @@ msgstr ""
 "Проверьте информацию о подключении."
 
 #: jellyfin_mpv_shim/mpvtk_browser/auth.py
-msgid "Locked"
-msgstr ""
-
-#: jellyfin_mpv_shim/mpvtk_browser/auth.py
 #: jellyfin_mpv_shim/mpvtk_browser/pages/home.py
 msgid "Connecting to your server…"
 msgstr "Подключаюсь к вашему серверу…"
@@ -871,6 +872,10 @@ msgstr "Просмотренное"
 #: jellyfin_mpv_shim/mpvtk_browser/pages/books.py
 msgid "Favorite"
 msgstr "Избранный"
+
+#: jellyfin_mpv_shim/mpvtk_browser/components/detail.py
+msgid "Web"
+msgstr ""
 
 # seeded from jellyfin-web: Video
 #: jellyfin_mpv_shim/mpvtk_browser/components/media_info.py
@@ -1486,11 +1491,7 @@ msgid "Jellyfin UI"
 msgstr ""
 
 #: jellyfin_mpv_shim/mpvtk_browser/config.py
-msgid "MPV UI with thumbnails"
-msgstr ""
-
-#: jellyfin_mpv_shim/mpvtk_browser/config.py
-msgid "MPV built-in default"
+msgid "MPV UI"
 msgstr ""
 
 #: jellyfin_mpv_shim/mpvtk_browser/config.py
@@ -1841,8 +1842,22 @@ msgid "Window Buttons in the Top Bar"
 msgstr ""
 
 #: jellyfin_mpv_shim/mpvtk_browser/config.py
+msgid "Keep Window Buttons in Full Screen"
+msgstr ""
+
+#: jellyfin_mpv_shim/mpvtk_browser/config.py
+msgid "Hide the Desktop Title Bar"
+msgstr ""
+
+#: jellyfin_mpv_shim/mpvtk_browser/config.py
 msgid "Player Controls Style"
 msgstr ""
+
+#: jellyfin_mpv_shim/mpvtk_browser/config.py
+#, fuzzy
+#| msgid "Enable thumbnail previews"
+msgid "Enable Trickplay Thumbnails"
+msgstr "Включить предварительный просмотр миниатюр"
 
 #: jellyfin_mpv_shim/mpvtk_browser/config.py
 msgid "Load All Seek Previews at Once"
@@ -1872,6 +1887,10 @@ msgstr ""
 
 #: jellyfin_mpv_shim/mpvtk_browser/config.py
 msgid "Full-Width Backdrops"
+msgstr ""
+
+#: jellyfin_mpv_shim/mpvtk_browser/config.py
+msgid "12-Hour Clock"
 msgstr ""
 
 #: jellyfin_mpv_shim/mpvtk_browser/config.py
@@ -1917,12 +1936,23 @@ msgid "Fullscreen Library Browser"
 msgstr ""
 
 #: jellyfin_mpv_shim/mpvtk_browser/config.py
+msgid "Block Player Keybinds While Browsing"
+msgstr ""
+
+#: jellyfin_mpv_shim/mpvtk_browser/config.py
 msgid "Always Bind Arrow Keys to Player Controls"
 msgstr ""
 
 #: jellyfin_mpv_shim/mpvtk_browser/config.py
 msgid "Player Controls Activation Key"
 msgstr ""
+
+# seeded from jellyfin-web: SelectAll
+#: jellyfin_mpv_shim/mpvtk_browser/config.py
+#, fuzzy
+#| msgid "Select All"
+msgid "Select Key"
+msgstr "Выбрать все"
 
 #: jellyfin_mpv_shim/mpvtk_browser/config.py
 msgid "Shading Behind the Player Controls"
@@ -1934,6 +1964,10 @@ msgstr ""
 
 #: jellyfin_mpv_shim/mpvtk_browser/config.py
 msgid "Hide the Player Controls After (seconds)"
+msgstr ""
+
+#: jellyfin_mpv_shim/mpvtk_browser/config.py
+msgid "Shrink the Player Controls on a Narrow Window"
 msgstr ""
 
 #: jellyfin_mpv_shim/mpvtk_browser/config.py
@@ -2020,6 +2054,21 @@ msgstr ""
 
 #: jellyfin_mpv_shim/mpvtk_browser/config.py
 msgid ""
+"Stops MPV's own shortcuts -- picture adjustment, screenshots, subtitle and "
+"audio switching -- from acting while you are in the library, where there is "
+"no video for them to act on. Turn it off to use your own MPV key bindings "
+"there."
+msgstr ""
+
+#: jellyfin_mpv_shim/mpvtk_browser/config.py
+msgid ""
+"Activates whatever is highlighted, in the library and on the player "
+"controls. An mpv key name; changing it hands Enter back to MPV. The game "
+"controller's Confirm button and a phone's Select follow it."
+msgstr ""
+
+#: jellyfin_mpv_shim/mpvtk_browser/config.py
+msgid ""
 "Leave these blank unless downloads are waking your disks too often. Set both "
 "of the first two together: episodes are then fetched in one batch when a "
 "series runs low, instead of one at a time."
@@ -2033,7 +2082,8 @@ msgstr ""
 #: jellyfin_mpv_shim/mpvtk_browser/config.py
 msgid ""
 "Off gives MPV's own mouse behaviour instead: drag the video to move the "
-"window, and right click to pause. Double click is full screen either way."
+"window, and the right button does whatever your MPV config gives it. Double "
+"click is full screen either way."
 msgstr ""
 
 #: jellyfin_mpv_shim/mpvtk_browser/config.py
@@ -2123,6 +2173,30 @@ msgid ""
 "maximize and close in the top bar instead, and lets you drag the window by "
 "it. On \"Only when the window has no title bar\", MPV is asked whether this "
 "window got one, so desktops that draw a title bar are left alone."
+msgstr ""
+
+#: jellyfin_mpv_shim/mpvtk_browser/config.py
+msgid ""
+"Full screen has no title bar anywhere and nothing to move or maximize, so "
+"the buttons are normally hidden there. Turn this on to keep a way out of "
+"full screen that is not a keyboard shortcut."
+msgstr ""
+
+#: jellyfin_mpv_shim/mpvtk_browser/config.py
+msgid ""
+"Asks the desktop for no title bar on the player window, so the top bar above "
+"is the only one. Pairs with the setting above: on \"Only when the window has "
+"no title bar\" the buttons appear as soon as this is on. Leave both off "
+"unless you want them, since a window with neither can be awkward to move on "
+"some desktops."
+msgstr ""
+
+#: jellyfin_mpv_shim/mpvtk_browser/config.py
+msgid ""
+"Shows a preview frame while you drag the seek bar. Works with every player "
+"control style, including your own OSC script if it supports thumbfast. The "
+"images are fetched from the server per video, which costs disk space and "
+"memory -- tens of MB for an episode, a few hundred for a long film."
 msgstr ""
 
 #: jellyfin_mpv_shim/mpvtk_browser/config.py
@@ -2232,6 +2306,13 @@ msgstr ""
 
 #: jellyfin_mpv_shim/mpvtk_browser/config.py
 msgid ""
+"Show times of day as \"8:30 PM\" rather than \"20:30\" — the Live TV guide "
+"and its air times, and the \"Ends at\" labels on a detail page and the "
+"player controls."
+msgstr ""
+
+#: jellyfin_mpv_shim/mpvtk_browser/config.py
+msgid ""
 "The controls have to stay legible over any frame. \"None\" gives the text a "
 "drop shadow instead of shading the picture behind it."
 msgstr ""
@@ -2246,6 +2327,13 @@ msgstr ""
 msgid ""
 "0 hides them as soon as the pointer is not on them, and forces \"Hide unless "
 "hovered\"."
+msgstr ""
+
+#: jellyfin_mpv_shim/mpvtk_browser/config.py
+msgid ""
+"Narrowing the window shrinks the controls until the smallest button reaches "
+"the accessibility minimum, instead of dropping buttons sooner. Off keeps the "
+"older, larger floor."
 msgstr ""
 
 #: jellyfin_mpv_shim/mpvtk_browser/config.py
@@ -3856,6 +3944,7 @@ msgid "More Like This"
 msgstr "Похожее"
 
 #: jellyfin_mpv_shim/mpvtk_browser/pages/detail.py
+#: jellyfin_mpv_shim/mpvtk_browser/tiles.py
 msgid "Go to Series"
 msgstr ""
 
@@ -5049,6 +5138,22 @@ msgstr "Убрать сервер"
 msgid "There is nothing here to queue."
 msgstr ""
 
+#: jellyfin_mpv_shim/mpvtk_browser/timefmt.py
+#, python-brace-format
+msgctxt "12-hour clock"
+msgid "{time} {period}"
+msgstr ""
+
+#: jellyfin_mpv_shim/mpvtk_browser/timefmt.py
+msgctxt "12-hour clock"
+msgid "AM"
+msgstr ""
+
+#: jellyfin_mpv_shim/mpvtk_browser/timefmt.py
+msgctxt "12-hour clock"
+msgid "PM"
+msgstr ""
+
 # seeded from jellyfin-web: Search
 #: jellyfin_mpv_shim/mpvtk_browser/views.py
 #: jellyfin_mpv_shim/mpvtk_browser/window_chrome.py
@@ -5216,13 +5321,32 @@ msgid "Enable SVP"
 msgstr "Включить SVP"
 
 #: jellyfin_mpv_shim/sync/manager.py
+msgid "The downloads are already in that folder."
+msgstr ""
+
+#: jellyfin_mpv_shim/sync/manager.py
 msgid ""
 "Can't change the download folder while a download is in progress. Wait for "
 "it to finish, then try again."
 msgstr ""
 
 #: jellyfin_mpv_shim/sync/manager.py
+msgid ""
+"That folder is inside the current download folder. Choose one outside it."
+msgstr ""
+
+#: jellyfin_mpv_shim/sync/manager.py
+msgid "Can't read that folder. Check the path and its permissions."
+msgstr ""
+
+#: jellyfin_mpv_shim/sync/manager.py
 msgid "That folder already contains downloads. Choose an empty folder."
+msgstr ""
+
+#: jellyfin_mpv_shim/sync/manager.py
+msgid ""
+"That folder isn't empty. Choose an empty folder — the download folder is "
+"managed by this app and anything else in it can be moved or removed."
 msgstr ""
 
 #: jellyfin_mpv_shim/sync/manager.py
@@ -5231,6 +5355,12 @@ msgstr ""
 
 #: jellyfin_mpv_shim/sync/manager.py
 msgid "A download is still finishing. Wait for it to stop, then try again."
+msgstr ""
+
+#: jellyfin_mpv_shim/sync/manager.py
+msgid ""
+"There isn't enough space on that drive to move the downloads. Free some "
+"space and try again — nothing was moved."
 msgstr ""
 
 #: jellyfin_mpv_shim/sync/manager.py

--- a/jellyfin_mpv_shim/messages/sdh/LC_MESSAGES/base.po
+++ b/jellyfin_mpv_shim/messages/sdh/LC_MESSAGES/base.po
@@ -6,7 +6,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2026-08-30 22:19-0400\n"
+"POT-Creation-Date: 2026-09-07 17:35-0400\n"
 "PO-Revision-Date: 2025-07-26 19:59+0000\n"
 "Last-Translator: Djwarf <djwar.fettah@outlook.com>\n"
 "Language-Team: Kurdish (Southern) <https://translate.jellyfin.org/projects/"
@@ -516,6 +516,11 @@ msgid "Night Mode (Auto Volume Adj)"
 msgstr ""
 
 #: jellyfin_mpv_shim/mpvtk_browser/app.py
+#: jellyfin_mpv_shim/mpvtk_browser/auth.py
+msgid "Locked"
+msgstr ""
+
+#: jellyfin_mpv_shim/mpvtk_browser/app.py
 msgid "Failed to load. Check the connection."
 msgstr ""
 
@@ -785,10 +790,6 @@ msgstr ""
 "Ji kerema xwe agahiyên girêdana xwe kontrol bikin."
 
 #: jellyfin_mpv_shim/mpvtk_browser/auth.py
-msgid "Locked"
-msgstr ""
-
-#: jellyfin_mpv_shim/mpvtk_browser/auth.py
 #: jellyfin_mpv_shim/mpvtk_browser/pages/home.py
 msgid "Connecting to your server…"
 msgstr ""
@@ -860,6 +861,10 @@ msgstr ""
 #: jellyfin_mpv_shim/mpvtk_browser/hud.py
 #: jellyfin_mpv_shim/mpvtk_browser/pages/books.py
 msgid "Favorite"
+msgstr ""
+
+#: jellyfin_mpv_shim/mpvtk_browser/components/detail.py
+msgid "Web"
 msgstr ""
 
 #: jellyfin_mpv_shim/mpvtk_browser/components/media_info.py
@@ -1371,11 +1376,7 @@ msgid "Jellyfin UI"
 msgstr ""
 
 #: jellyfin_mpv_shim/mpvtk_browser/config.py
-msgid "MPV UI with thumbnails"
-msgstr ""
-
-#: jellyfin_mpv_shim/mpvtk_browser/config.py
-msgid "MPV built-in default"
+msgid "MPV UI"
 msgstr ""
 
 #: jellyfin_mpv_shim/mpvtk_browser/config.py
@@ -1708,7 +1709,19 @@ msgid "Window Buttons in the Top Bar"
 msgstr ""
 
 #: jellyfin_mpv_shim/mpvtk_browser/config.py
+msgid "Keep Window Buttons in Full Screen"
+msgstr ""
+
+#: jellyfin_mpv_shim/mpvtk_browser/config.py
+msgid "Hide the Desktop Title Bar"
+msgstr ""
+
+#: jellyfin_mpv_shim/mpvtk_browser/config.py
 msgid "Player Controls Style"
+msgstr ""
+
+#: jellyfin_mpv_shim/mpvtk_browser/config.py
+msgid "Enable Trickplay Thumbnails"
 msgstr ""
 
 #: jellyfin_mpv_shim/mpvtk_browser/config.py
@@ -1738,6 +1751,10 @@ msgstr ""
 
 #: jellyfin_mpv_shim/mpvtk_browser/config.py
 msgid "Full-Width Backdrops"
+msgstr ""
+
+#: jellyfin_mpv_shim/mpvtk_browser/config.py
+msgid "12-Hour Clock"
 msgstr ""
 
 #: jellyfin_mpv_shim/mpvtk_browser/config.py
@@ -1781,11 +1798,19 @@ msgid "Fullscreen Library Browser"
 msgstr ""
 
 #: jellyfin_mpv_shim/mpvtk_browser/config.py
+msgid "Block Player Keybinds While Browsing"
+msgstr ""
+
+#: jellyfin_mpv_shim/mpvtk_browser/config.py
 msgid "Always Bind Arrow Keys to Player Controls"
 msgstr ""
 
 #: jellyfin_mpv_shim/mpvtk_browser/config.py
 msgid "Player Controls Activation Key"
+msgstr ""
+
+#: jellyfin_mpv_shim/mpvtk_browser/config.py
+msgid "Select Key"
 msgstr ""
 
 #: jellyfin_mpv_shim/mpvtk_browser/config.py
@@ -1798,6 +1823,10 @@ msgstr ""
 
 #: jellyfin_mpv_shim/mpvtk_browser/config.py
 msgid "Hide the Player Controls After (seconds)"
+msgstr ""
+
+#: jellyfin_mpv_shim/mpvtk_browser/config.py
+msgid "Shrink the Player Controls on a Narrow Window"
 msgstr ""
 
 #: jellyfin_mpv_shim/mpvtk_browser/config.py
@@ -1880,6 +1909,21 @@ msgstr ""
 
 #: jellyfin_mpv_shim/mpvtk_browser/config.py
 msgid ""
+"Stops MPV's own shortcuts -- picture adjustment, screenshots, subtitle and "
+"audio switching -- from acting while you are in the library, where there is "
+"no video for them to act on. Turn it off to use your own MPV key bindings "
+"there."
+msgstr ""
+
+#: jellyfin_mpv_shim/mpvtk_browser/config.py
+msgid ""
+"Activates whatever is highlighted, in the library and on the player "
+"controls. An mpv key name; changing it hands Enter back to MPV. The game "
+"controller's Confirm button and a phone's Select follow it."
+msgstr ""
+
+#: jellyfin_mpv_shim/mpvtk_browser/config.py
+msgid ""
 "Leave these blank unless downloads are waking your disks too often. Set both "
 "of the first two together: episodes are then fetched in one batch when a "
 "series runs low, instead of one at a time."
@@ -1893,7 +1937,8 @@ msgstr ""
 #: jellyfin_mpv_shim/mpvtk_browser/config.py
 msgid ""
 "Off gives MPV's own mouse behaviour instead: drag the video to move the "
-"window, and right click to pause. Double click is full screen either way."
+"window, and the right button does whatever your MPV config gives it. Double "
+"click is full screen either way."
 msgstr ""
 
 #: jellyfin_mpv_shim/mpvtk_browser/config.py
@@ -1983,6 +2028,30 @@ msgid ""
 "maximize and close in the top bar instead, and lets you drag the window by "
 "it. On \"Only when the window has no title bar\", MPV is asked whether this "
 "window got one, so desktops that draw a title bar are left alone."
+msgstr ""
+
+#: jellyfin_mpv_shim/mpvtk_browser/config.py
+msgid ""
+"Full screen has no title bar anywhere and nothing to move or maximize, so "
+"the buttons are normally hidden there. Turn this on to keep a way out of "
+"full screen that is not a keyboard shortcut."
+msgstr ""
+
+#: jellyfin_mpv_shim/mpvtk_browser/config.py
+msgid ""
+"Asks the desktop for no title bar on the player window, so the top bar above "
+"is the only one. Pairs with the setting above: on \"Only when the window has "
+"no title bar\" the buttons appear as soon as this is on. Leave both off "
+"unless you want them, since a window with neither can be awkward to move on "
+"some desktops."
+msgstr ""
+
+#: jellyfin_mpv_shim/mpvtk_browser/config.py
+msgid ""
+"Shows a preview frame while you drag the seek bar. Works with every player "
+"control style, including your own OSC script if it supports thumbfast. The "
+"images are fetched from the server per video, which costs disk space and "
+"memory -- tens of MB for an episode, a few hundred for a long film."
 msgstr ""
 
 #: jellyfin_mpv_shim/mpvtk_browser/config.py
@@ -2090,6 +2159,13 @@ msgstr ""
 
 #: jellyfin_mpv_shim/mpvtk_browser/config.py
 msgid ""
+"Show times of day as \"8:30 PM\" rather than \"20:30\" — the Live TV guide "
+"and its air times, and the \"Ends at\" labels on a detail page and the "
+"player controls."
+msgstr ""
+
+#: jellyfin_mpv_shim/mpvtk_browser/config.py
+msgid ""
 "The controls have to stay legible over any frame. \"None\" gives the text a "
 "drop shadow instead of shading the picture behind it."
 msgstr ""
@@ -2104,6 +2180,13 @@ msgstr ""
 msgid ""
 "0 hides them as soon as the pointer is not on them, and forces \"Hide unless "
 "hovered\"."
+msgstr ""
+
+#: jellyfin_mpv_shim/mpvtk_browser/config.py
+msgid ""
+"Narrowing the window shrinks the controls until the smallest button reaches "
+"the accessibility minimum, instead of dropping buttons sooner. Off keeps the "
+"older, larger floor."
 msgstr ""
 
 #: jellyfin_mpv_shim/mpvtk_browser/config.py
@@ -3505,6 +3588,7 @@ msgid "More Like This"
 msgstr ""
 
 #: jellyfin_mpv_shim/mpvtk_browser/pages/detail.py
+#: jellyfin_mpv_shim/mpvtk_browser/tiles.py
 msgid "Go to Series"
 msgstr ""
 
@@ -4585,6 +4669,22 @@ msgstr ""
 msgid "There is nothing here to queue."
 msgstr ""
 
+#: jellyfin_mpv_shim/mpvtk_browser/timefmt.py
+#, python-brace-format
+msgctxt "12-hour clock"
+msgid "{time} {period}"
+msgstr ""
+
+#: jellyfin_mpv_shim/mpvtk_browser/timefmt.py
+msgctxt "12-hour clock"
+msgid "AM"
+msgstr ""
+
+#: jellyfin_mpv_shim/mpvtk_browser/timefmt.py
+msgctxt "12-hour clock"
+msgid "PM"
+msgstr ""
+
 #: jellyfin_mpv_shim/mpvtk_browser/views.py
 #: jellyfin_mpv_shim/mpvtk_browser/window_chrome.py
 msgid "Search"
@@ -4739,13 +4839,32 @@ msgid "Enable SVP"
 msgstr ""
 
 #: jellyfin_mpv_shim/sync/manager.py
+msgid "The downloads are already in that folder."
+msgstr ""
+
+#: jellyfin_mpv_shim/sync/manager.py
 msgid ""
 "Can't change the download folder while a download is in progress. Wait for "
 "it to finish, then try again."
 msgstr ""
 
 #: jellyfin_mpv_shim/sync/manager.py
+msgid ""
+"That folder is inside the current download folder. Choose one outside it."
+msgstr ""
+
+#: jellyfin_mpv_shim/sync/manager.py
+msgid "Can't read that folder. Check the path and its permissions."
+msgstr ""
+
+#: jellyfin_mpv_shim/sync/manager.py
 msgid "That folder already contains downloads. Choose an empty folder."
+msgstr ""
+
+#: jellyfin_mpv_shim/sync/manager.py
+msgid ""
+"That folder isn't empty. Choose an empty folder — the download folder is "
+"managed by this app and anything else in it can be moved or removed."
 msgstr ""
 
 #: jellyfin_mpv_shim/sync/manager.py
@@ -4754,6 +4873,12 @@ msgstr ""
 
 #: jellyfin_mpv_shim/sync/manager.py
 msgid "A download is still finishing. Wait for it to stop, then try again."
+msgstr ""
+
+#: jellyfin_mpv_shim/sync/manager.py
+msgid ""
+"There isn't enough space on that drive to move the downloads. Free some "
+"space and try again — nothing was moved."
 msgstr ""
 
 #: jellyfin_mpv_shim/sync/manager.py

--- a/jellyfin_mpv_shim/messages/sk/LC_MESSAGES/base.po
+++ b/jellyfin_mpv_shim/messages/sk/LC_MESSAGES/base.po
@@ -6,7 +6,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2026-08-30 22:19-0400\n"
+"POT-Creation-Date: 2026-09-07 17:35-0400\n"
 "PO-Revision-Date: 2026-08-15 01:00+0000\n"
 "Last-Translator: dodog <preklady@mayday.sk>\n"
 "Language-Team: Slovak <https://translate.jellyfin.org/projects/jellyfin/"
@@ -545,6 +545,11 @@ msgid "Night Mode (Auto Volume Adj)"
 msgstr ""
 
 #: jellyfin_mpv_shim/mpvtk_browser/app.py
+#: jellyfin_mpv_shim/mpvtk_browser/auth.py
+msgid "Locked"
+msgstr ""
+
+#: jellyfin_mpv_shim/mpvtk_browser/app.py
 msgid "Failed to load. Check the connection."
 msgstr ""
 
@@ -807,10 +812,6 @@ msgstr ""
 "Skontrolujte prosím informácie o pripojení."
 
 #: jellyfin_mpv_shim/mpvtk_browser/auth.py
-msgid "Locked"
-msgstr ""
-
-#: jellyfin_mpv_shim/mpvtk_browser/auth.py
 #: jellyfin_mpv_shim/mpvtk_browser/pages/home.py
 msgid "Connecting to your server…"
 msgstr ""
@@ -889,6 +890,10 @@ msgstr "Ukončiť a označiť ako nepozreté"
 #: jellyfin_mpv_shim/mpvtk_browser/pages/books.py
 msgid "Favorite"
 msgstr "Obľúbené"
+
+#: jellyfin_mpv_shim/mpvtk_browser/components/detail.py
+msgid "Web"
+msgstr ""
 
 # seeded from jellyfin-web: HeaderVideos
 #: jellyfin_mpv_shim/mpvtk_browser/components/media_info.py
@@ -1503,11 +1508,7 @@ msgid "Jellyfin UI"
 msgstr ""
 
 #: jellyfin_mpv_shim/mpvtk_browser/config.py
-msgid "MPV UI with thumbnails"
-msgstr ""
-
-#: jellyfin_mpv_shim/mpvtk_browser/config.py
-msgid "MPV built-in default"
+msgid "MPV UI"
 msgstr ""
 
 #: jellyfin_mpv_shim/mpvtk_browser/config.py
@@ -1856,8 +1857,22 @@ msgid "Window Buttons in the Top Bar"
 msgstr ""
 
 #: jellyfin_mpv_shim/mpvtk_browser/config.py
+msgid "Keep Window Buttons in Full Screen"
+msgstr ""
+
+#: jellyfin_mpv_shim/mpvtk_browser/config.py
+msgid "Hide the Desktop Title Bar"
+msgstr ""
+
+#: jellyfin_mpv_shim/mpvtk_browser/config.py
 msgid "Player Controls Style"
 msgstr ""
+
+#: jellyfin_mpv_shim/mpvtk_browser/config.py
+#, fuzzy
+#| msgid "Enable thumbnail previews"
+msgid "Enable Trickplay Thumbnails"
+msgstr "Zapnúť zobrazenie miniatúr"
 
 #: jellyfin_mpv_shim/mpvtk_browser/config.py
 msgid "Load All Seek Previews at Once"
@@ -1887,6 +1902,10 @@ msgstr ""
 
 #: jellyfin_mpv_shim/mpvtk_browser/config.py
 msgid "Full-Width Backdrops"
+msgstr ""
+
+#: jellyfin_mpv_shim/mpvtk_browser/config.py
+msgid "12-Hour Clock"
 msgstr ""
 
 #: jellyfin_mpv_shim/mpvtk_browser/config.py
@@ -1932,12 +1951,23 @@ msgid "Fullscreen Library Browser"
 msgstr ""
 
 #: jellyfin_mpv_shim/mpvtk_browser/config.py
+msgid "Block Player Keybinds While Browsing"
+msgstr ""
+
+#: jellyfin_mpv_shim/mpvtk_browser/config.py
 msgid "Always Bind Arrow Keys to Player Controls"
 msgstr ""
 
 #: jellyfin_mpv_shim/mpvtk_browser/config.py
 msgid "Player Controls Activation Key"
 msgstr ""
+
+# seeded from jellyfin-web: SelectAll
+#: jellyfin_mpv_shim/mpvtk_browser/config.py
+#, fuzzy
+#| msgid "Select All"
+msgid "Select Key"
+msgstr "Vybrať všetko"
 
 #: jellyfin_mpv_shim/mpvtk_browser/config.py
 msgid "Shading Behind the Player Controls"
@@ -1949,6 +1979,10 @@ msgstr ""
 
 #: jellyfin_mpv_shim/mpvtk_browser/config.py
 msgid "Hide the Player Controls After (seconds)"
+msgstr ""
+
+#: jellyfin_mpv_shim/mpvtk_browser/config.py
+msgid "Shrink the Player Controls on a Narrow Window"
 msgstr ""
 
 #: jellyfin_mpv_shim/mpvtk_browser/config.py
@@ -2035,6 +2069,21 @@ msgstr ""
 
 #: jellyfin_mpv_shim/mpvtk_browser/config.py
 msgid ""
+"Stops MPV's own shortcuts -- picture adjustment, screenshots, subtitle and "
+"audio switching -- from acting while you are in the library, where there is "
+"no video for them to act on. Turn it off to use your own MPV key bindings "
+"there."
+msgstr ""
+
+#: jellyfin_mpv_shim/mpvtk_browser/config.py
+msgid ""
+"Activates whatever is highlighted, in the library and on the player "
+"controls. An mpv key name; changing it hands Enter back to MPV. The game "
+"controller's Confirm button and a phone's Select follow it."
+msgstr ""
+
+#: jellyfin_mpv_shim/mpvtk_browser/config.py
+msgid ""
 "Leave these blank unless downloads are waking your disks too often. Set both "
 "of the first two together: episodes are then fetched in one batch when a "
 "series runs low, instead of one at a time."
@@ -2048,7 +2097,8 @@ msgstr ""
 #: jellyfin_mpv_shim/mpvtk_browser/config.py
 msgid ""
 "Off gives MPV's own mouse behaviour instead: drag the video to move the "
-"window, and right click to pause. Double click is full screen either way."
+"window, and the right button does whatever your MPV config gives it. Double "
+"click is full screen either way."
 msgstr ""
 
 #: jellyfin_mpv_shim/mpvtk_browser/config.py
@@ -2138,6 +2188,30 @@ msgid ""
 "maximize and close in the top bar instead, and lets you drag the window by "
 "it. On \"Only when the window has no title bar\", MPV is asked whether this "
 "window got one, so desktops that draw a title bar are left alone."
+msgstr ""
+
+#: jellyfin_mpv_shim/mpvtk_browser/config.py
+msgid ""
+"Full screen has no title bar anywhere and nothing to move or maximize, so "
+"the buttons are normally hidden there. Turn this on to keep a way out of "
+"full screen that is not a keyboard shortcut."
+msgstr ""
+
+#: jellyfin_mpv_shim/mpvtk_browser/config.py
+msgid ""
+"Asks the desktop for no title bar on the player window, so the top bar above "
+"is the only one. Pairs with the setting above: on \"Only when the window has "
+"no title bar\" the buttons appear as soon as this is on. Leave both off "
+"unless you want them, since a window with neither can be awkward to move on "
+"some desktops."
+msgstr ""
+
+#: jellyfin_mpv_shim/mpvtk_browser/config.py
+msgid ""
+"Shows a preview frame while you drag the seek bar. Works with every player "
+"control style, including your own OSC script if it supports thumbfast. The "
+"images are fetched from the server per video, which costs disk space and "
+"memory -- tens of MB for an episode, a few hundred for a long film."
 msgstr ""
 
 #: jellyfin_mpv_shim/mpvtk_browser/config.py
@@ -2247,6 +2321,13 @@ msgstr ""
 
 #: jellyfin_mpv_shim/mpvtk_browser/config.py
 msgid ""
+"Show times of day as \"8:30 PM\" rather than \"20:30\" — the Live TV guide "
+"and its air times, and the \"Ends at\" labels on a detail page and the "
+"player controls."
+msgstr ""
+
+#: jellyfin_mpv_shim/mpvtk_browser/config.py
+msgid ""
 "The controls have to stay legible over any frame. \"None\" gives the text a "
 "drop shadow instead of shading the picture behind it."
 msgstr ""
@@ -2261,6 +2342,13 @@ msgstr ""
 msgid ""
 "0 hides them as soon as the pointer is not on them, and forces \"Hide unless "
 "hovered\"."
+msgstr ""
+
+#: jellyfin_mpv_shim/mpvtk_browser/config.py
+msgid ""
+"Narrowing the window shrinks the controls until the smallest button reaches "
+"the accessibility minimum, instead of dropping buttons sooner. Off keeps the "
+"older, larger floor."
 msgstr ""
 
 #: jellyfin_mpv_shim/mpvtk_browser/config.py
@@ -3855,6 +3943,7 @@ msgid "More Like This"
 msgstr "Navrhované"
 
 #: jellyfin_mpv_shim/mpvtk_browser/pages/detail.py
+#: jellyfin_mpv_shim/mpvtk_browser/tiles.py
 msgid "Go to Series"
 msgstr ""
 
@@ -5019,6 +5108,22 @@ msgstr "Odstrániť server"
 msgid "There is nothing here to queue."
 msgstr ""
 
+#: jellyfin_mpv_shim/mpvtk_browser/timefmt.py
+#, python-brace-format
+msgctxt "12-hour clock"
+msgid "{time} {period}"
+msgstr ""
+
+#: jellyfin_mpv_shim/mpvtk_browser/timefmt.py
+msgctxt "12-hour clock"
+msgid "AM"
+msgstr ""
+
+#: jellyfin_mpv_shim/mpvtk_browser/timefmt.py
+msgctxt "12-hour clock"
+msgid "PM"
+msgstr ""
+
 # seeded from jellyfin-web: Search
 #: jellyfin_mpv_shim/mpvtk_browser/views.py
 #: jellyfin_mpv_shim/mpvtk_browser/window_chrome.py
@@ -5180,13 +5285,32 @@ msgid "Enable SVP"
 msgstr "Povoliť SVP"
 
 #: jellyfin_mpv_shim/sync/manager.py
+msgid "The downloads are already in that folder."
+msgstr ""
+
+#: jellyfin_mpv_shim/sync/manager.py
 msgid ""
 "Can't change the download folder while a download is in progress. Wait for "
 "it to finish, then try again."
 msgstr ""
 
 #: jellyfin_mpv_shim/sync/manager.py
+msgid ""
+"That folder is inside the current download folder. Choose one outside it."
+msgstr ""
+
+#: jellyfin_mpv_shim/sync/manager.py
+msgid "Can't read that folder. Check the path and its permissions."
+msgstr ""
+
+#: jellyfin_mpv_shim/sync/manager.py
 msgid "That folder already contains downloads. Choose an empty folder."
+msgstr ""
+
+#: jellyfin_mpv_shim/sync/manager.py
+msgid ""
+"That folder isn't empty. Choose an empty folder — the download folder is "
+"managed by this app and anything else in it can be moved or removed."
 msgstr ""
 
 #: jellyfin_mpv_shim/sync/manager.py
@@ -5195,6 +5319,12 @@ msgstr ""
 
 #: jellyfin_mpv_shim/sync/manager.py
 msgid "A download is still finishing. Wait for it to stop, then try again."
+msgstr ""
+
+#: jellyfin_mpv_shim/sync/manager.py
+msgid ""
+"There isn't enough space on that drive to move the downloads. Free some "
+"space and try again — nothing was moved."
 msgstr ""
 
 #: jellyfin_mpv_shim/sync/manager.py

--- a/jellyfin_mpv_shim/messages/sl/LC_MESSAGES/base.po
+++ b/jellyfin_mpv_shim/messages/sl/LC_MESSAGES/base.po
@@ -6,7 +6,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2026-08-30 22:19-0400\n"
+"POT-Creation-Date: 2026-09-07 17:35-0400\n"
 "PO-Revision-Date: 2026-08-01 17:49+0000\n"
 "Last-Translator: FenomenaGaga <fenomenalna.gaga@gmail.com>\n"
 "Language-Team: Slovenian <https://translate.jellyfin.org/projects/jellyfin/"
@@ -539,6 +539,11 @@ msgid "Night Mode (Auto Volume Adj)"
 msgstr ""
 
 #: jellyfin_mpv_shim/mpvtk_browser/app.py
+#: jellyfin_mpv_shim/mpvtk_browser/auth.py
+msgid "Locked"
+msgstr ""
+
+#: jellyfin_mpv_shim/mpvtk_browser/app.py
 msgid "Failed to load. Check the connection."
 msgstr ""
 
@@ -781,10 +786,6 @@ msgid "Could not connect. Please check your details."
 msgstr "Ni se bilo mogoče povezati. Prosim preverite svoje podatke."
 
 #: jellyfin_mpv_shim/mpvtk_browser/auth.py
-msgid "Locked"
-msgstr ""
-
-#: jellyfin_mpv_shim/mpvtk_browser/auth.py
 #: jellyfin_mpv_shim/mpvtk_browser/pages/home.py
 msgid "Connecting to your server…"
 msgstr ""
@@ -858,6 +859,10 @@ msgstr "Izhod in označi neogledano"
 #: jellyfin_mpv_shim/mpvtk_browser/hud.py
 #: jellyfin_mpv_shim/mpvtk_browser/pages/books.py
 msgid "Favorite"
+msgstr ""
+
+#: jellyfin_mpv_shim/mpvtk_browser/components/detail.py
+msgid "Web"
 msgstr ""
 
 #: jellyfin_mpv_shim/mpvtk_browser/components/media_info.py
@@ -1393,11 +1398,7 @@ msgid "Jellyfin UI"
 msgstr ""
 
 #: jellyfin_mpv_shim/mpvtk_browser/config.py
-msgid "MPV UI with thumbnails"
-msgstr ""
-
-#: jellyfin_mpv_shim/mpvtk_browser/config.py
-msgid "MPV built-in default"
+msgid "MPV UI"
 msgstr ""
 
 #: jellyfin_mpv_shim/mpvtk_browser/config.py
@@ -1742,8 +1743,22 @@ msgid "Window Buttons in the Top Bar"
 msgstr ""
 
 #: jellyfin_mpv_shim/mpvtk_browser/config.py
+msgid "Keep Window Buttons in Full Screen"
+msgstr ""
+
+#: jellyfin_mpv_shim/mpvtk_browser/config.py
+msgid "Hide the Desktop Title Bar"
+msgstr ""
+
+#: jellyfin_mpv_shim/mpvtk_browser/config.py
 msgid "Player Controls Style"
 msgstr ""
+
+#: jellyfin_mpv_shim/mpvtk_browser/config.py
+#, fuzzy
+#| msgid "Enable thumbnail previews"
+msgid "Enable Trickplay Thumbnails"
+msgstr "Omogoči predogledne sličice"
 
 #: jellyfin_mpv_shim/mpvtk_browser/config.py
 msgid "Load All Seek Previews at Once"
@@ -1772,6 +1787,10 @@ msgstr ""
 
 #: jellyfin_mpv_shim/mpvtk_browser/config.py
 msgid "Full-Width Backdrops"
+msgstr ""
+
+#: jellyfin_mpv_shim/mpvtk_browser/config.py
+msgid "12-Hour Clock"
 msgstr ""
 
 #: jellyfin_mpv_shim/mpvtk_browser/config.py
@@ -1815,11 +1834,19 @@ msgid "Fullscreen Library Browser"
 msgstr ""
 
 #: jellyfin_mpv_shim/mpvtk_browser/config.py
+msgid "Block Player Keybinds While Browsing"
+msgstr ""
+
+#: jellyfin_mpv_shim/mpvtk_browser/config.py
 msgid "Always Bind Arrow Keys to Player Controls"
 msgstr ""
 
 #: jellyfin_mpv_shim/mpvtk_browser/config.py
 msgid "Player Controls Activation Key"
+msgstr ""
+
+#: jellyfin_mpv_shim/mpvtk_browser/config.py
+msgid "Select Key"
 msgstr ""
 
 #: jellyfin_mpv_shim/mpvtk_browser/config.py
@@ -1832,6 +1859,10 @@ msgstr ""
 
 #: jellyfin_mpv_shim/mpvtk_browser/config.py
 msgid "Hide the Player Controls After (seconds)"
+msgstr ""
+
+#: jellyfin_mpv_shim/mpvtk_browser/config.py
+msgid "Shrink the Player Controls on a Narrow Window"
 msgstr ""
 
 #: jellyfin_mpv_shim/mpvtk_browser/config.py
@@ -1918,6 +1949,21 @@ msgstr ""
 
 #: jellyfin_mpv_shim/mpvtk_browser/config.py
 msgid ""
+"Stops MPV's own shortcuts -- picture adjustment, screenshots, subtitle and "
+"audio switching -- from acting while you are in the library, where there is "
+"no video for them to act on. Turn it off to use your own MPV key bindings "
+"there."
+msgstr ""
+
+#: jellyfin_mpv_shim/mpvtk_browser/config.py
+msgid ""
+"Activates whatever is highlighted, in the library and on the player "
+"controls. An mpv key name; changing it hands Enter back to MPV. The game "
+"controller's Confirm button and a phone's Select follow it."
+msgstr ""
+
+#: jellyfin_mpv_shim/mpvtk_browser/config.py
+msgid ""
 "Leave these blank unless downloads are waking your disks too often. Set both "
 "of the first two together: episodes are then fetched in one batch when a "
 "series runs low, instead of one at a time."
@@ -1931,7 +1977,8 @@ msgstr ""
 #: jellyfin_mpv_shim/mpvtk_browser/config.py
 msgid ""
 "Off gives MPV's own mouse behaviour instead: drag the video to move the "
-"window, and right click to pause. Double click is full screen either way."
+"window, and the right button does whatever your MPV config gives it. Double "
+"click is full screen either way."
 msgstr ""
 
 #: jellyfin_mpv_shim/mpvtk_browser/config.py
@@ -2021,6 +2068,30 @@ msgid ""
 "maximize and close in the top bar instead, and lets you drag the window by "
 "it. On \"Only when the window has no title bar\", MPV is asked whether this "
 "window got one, so desktops that draw a title bar are left alone."
+msgstr ""
+
+#: jellyfin_mpv_shim/mpvtk_browser/config.py
+msgid ""
+"Full screen has no title bar anywhere and nothing to move or maximize, so "
+"the buttons are normally hidden there. Turn this on to keep a way out of "
+"full screen that is not a keyboard shortcut."
+msgstr ""
+
+#: jellyfin_mpv_shim/mpvtk_browser/config.py
+msgid ""
+"Asks the desktop for no title bar on the player window, so the top bar above "
+"is the only one. Pairs with the setting above: on \"Only when the window has "
+"no title bar\" the buttons appear as soon as this is on. Leave both off "
+"unless you want them, since a window with neither can be awkward to move on "
+"some desktops."
+msgstr ""
+
+#: jellyfin_mpv_shim/mpvtk_browser/config.py
+msgid ""
+"Shows a preview frame while you drag the seek bar. Works with every player "
+"control style, including your own OSC script if it supports thumbfast. The "
+"images are fetched from the server per video, which costs disk space and "
+"memory -- tens of MB for an episode, a few hundred for a long film."
 msgstr ""
 
 #: jellyfin_mpv_shim/mpvtk_browser/config.py
@@ -2130,6 +2201,13 @@ msgstr ""
 
 #: jellyfin_mpv_shim/mpvtk_browser/config.py
 msgid ""
+"Show times of day as \"8:30 PM\" rather than \"20:30\" — the Live TV guide "
+"and its air times, and the \"Ends at\" labels on a detail page and the "
+"player controls."
+msgstr ""
+
+#: jellyfin_mpv_shim/mpvtk_browser/config.py
+msgid ""
 "The controls have to stay legible over any frame. \"None\" gives the text a "
 "drop shadow instead of shading the picture behind it."
 msgstr ""
@@ -2144,6 +2222,13 @@ msgstr ""
 msgid ""
 "0 hides them as soon as the pointer is not on them, and forces \"Hide unless "
 "hovered\"."
+msgstr ""
+
+#: jellyfin_mpv_shim/mpvtk_browser/config.py
+msgid ""
+"Narrowing the window shrinks the controls until the smallest button reaches "
+"the accessibility minimum, instead of dropping buttons sooner. Off keeps the "
+"older, larger floor."
 msgstr ""
 
 #: jellyfin_mpv_shim/mpvtk_browser/config.py
@@ -3641,6 +3726,7 @@ msgid "More Like This"
 msgstr ""
 
 #: jellyfin_mpv_shim/mpvtk_browser/pages/detail.py
+#: jellyfin_mpv_shim/mpvtk_browser/tiles.py
 msgid "Go to Series"
 msgstr ""
 
@@ -4767,6 +4853,22 @@ msgstr "Odstrani strežnik"
 msgid "There is nothing here to queue."
 msgstr ""
 
+#: jellyfin_mpv_shim/mpvtk_browser/timefmt.py
+#, python-brace-format
+msgctxt "12-hour clock"
+msgid "{time} {period}"
+msgstr ""
+
+#: jellyfin_mpv_shim/mpvtk_browser/timefmt.py
+msgctxt "12-hour clock"
+msgid "AM"
+msgstr ""
+
+#: jellyfin_mpv_shim/mpvtk_browser/timefmt.py
+msgctxt "12-hour clock"
+msgid "PM"
+msgstr ""
+
 #: jellyfin_mpv_shim/mpvtk_browser/views.py
 #: jellyfin_mpv_shim/mpvtk_browser/window_chrome.py
 msgid "Search"
@@ -4927,13 +5029,32 @@ msgid "Enable SVP"
 msgstr "Omogoči SVP"
 
 #: jellyfin_mpv_shim/sync/manager.py
+msgid "The downloads are already in that folder."
+msgstr ""
+
+#: jellyfin_mpv_shim/sync/manager.py
 msgid ""
 "Can't change the download folder while a download is in progress. Wait for "
 "it to finish, then try again."
 msgstr ""
 
 #: jellyfin_mpv_shim/sync/manager.py
+msgid ""
+"That folder is inside the current download folder. Choose one outside it."
+msgstr ""
+
+#: jellyfin_mpv_shim/sync/manager.py
+msgid "Can't read that folder. Check the path and its permissions."
+msgstr ""
+
+#: jellyfin_mpv_shim/sync/manager.py
 msgid "That folder already contains downloads. Choose an empty folder."
+msgstr ""
+
+#: jellyfin_mpv_shim/sync/manager.py
+msgid ""
+"That folder isn't empty. Choose an empty folder — the download folder is "
+"managed by this app and anything else in it can be moved or removed."
 msgstr ""
 
 #: jellyfin_mpv_shim/sync/manager.py
@@ -4942,6 +5063,12 @@ msgstr ""
 
 #: jellyfin_mpv_shim/sync/manager.py
 msgid "A download is still finishing. Wait for it to stop, then try again."
+msgstr ""
+
+#: jellyfin_mpv_shim/sync/manager.py
+msgid ""
+"There isn't enough space on that drive to move the downloads. Free some "
+"space and try again — nothing was moved."
 msgstr ""
 
 #: jellyfin_mpv_shim/sync/manager.py

--- a/jellyfin_mpv_shim/messages/sq/LC_MESSAGES/base.po
+++ b/jellyfin_mpv_shim/messages/sq/LC_MESSAGES/base.po
@@ -6,7 +6,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2026-08-30 22:19-0400\n"
+"POT-Creation-Date: 2026-09-07 17:35-0400\n"
 "PO-Revision-Date: 2026-08-15 01:00+0000\n"
 "Last-Translator: AlaronAndes <diaforeseggrafes@gmail.com>\n"
 "Language-Team: Albanian <https://translate.jellyfin.org/projects/jellyfin/"
@@ -520,6 +520,11 @@ msgid "Night Mode (Auto Volume Adj)"
 msgstr ""
 
 #: jellyfin_mpv_shim/mpvtk_browser/app.py
+#: jellyfin_mpv_shim/mpvtk_browser/auth.py
+msgid "Locked"
+msgstr ""
+
+#: jellyfin_mpv_shim/mpvtk_browser/app.py
 msgid "Failed to load. Check the connection."
 msgstr ""
 
@@ -796,10 +801,6 @@ msgstr ""
 "Ju lutem shikoni informacionin e lidhjes."
 
 #: jellyfin_mpv_shim/mpvtk_browser/auth.py
-msgid "Locked"
-msgstr ""
-
-#: jellyfin_mpv_shim/mpvtk_browser/auth.py
 #: jellyfin_mpv_shim/mpvtk_browser/pages/home.py
 msgid "Connecting to your server…"
 msgstr ""
@@ -880,6 +881,10 @@ msgstr "Mbyll dhe Shënoje si e Pa shikuar"
 #: jellyfin_mpv_shim/mpvtk_browser/pages/books.py
 msgid "Favorite"
 msgstr "Të preferuara"
+
+#: jellyfin_mpv_shim/mpvtk_browser/components/detail.py
+msgid "Web"
+msgstr ""
 
 # seeded from jellyfin-web: HeaderVideos
 #: jellyfin_mpv_shim/mpvtk_browser/components/media_info.py
@@ -1431,11 +1436,7 @@ msgid "Jellyfin UI"
 msgstr ""
 
 #: jellyfin_mpv_shim/mpvtk_browser/config.py
-msgid "MPV UI with thumbnails"
-msgstr ""
-
-#: jellyfin_mpv_shim/mpvtk_browser/config.py
-msgid "MPV built-in default"
+msgid "MPV UI"
 msgstr ""
 
 #: jellyfin_mpv_shim/mpvtk_browser/config.py
@@ -1782,8 +1783,22 @@ msgid "Window Buttons in the Top Bar"
 msgstr ""
 
 #: jellyfin_mpv_shim/mpvtk_browser/config.py
+msgid "Keep Window Buttons in Full Screen"
+msgstr ""
+
+#: jellyfin_mpv_shim/mpvtk_browser/config.py
+msgid "Hide the Desktop Title Bar"
+msgstr ""
+
+#: jellyfin_mpv_shim/mpvtk_browser/config.py
 msgid "Player Controls Style"
 msgstr ""
+
+#: jellyfin_mpv_shim/mpvtk_browser/config.py
+#, fuzzy
+#| msgid "Enable thumbnail previews"
+msgid "Enable Trickplay Thumbnails"
+msgstr "Aktivizo pamjet paraprake"
 
 #: jellyfin_mpv_shim/mpvtk_browser/config.py
 msgid "Load All Seek Previews at Once"
@@ -1812,6 +1827,10 @@ msgstr ""
 
 #: jellyfin_mpv_shim/mpvtk_browser/config.py
 msgid "Full-Width Backdrops"
+msgstr ""
+
+#: jellyfin_mpv_shim/mpvtk_browser/config.py
+msgid "12-Hour Clock"
 msgstr ""
 
 #: jellyfin_mpv_shim/mpvtk_browser/config.py
@@ -1855,11 +1874,19 @@ msgid "Fullscreen Library Browser"
 msgstr ""
 
 #: jellyfin_mpv_shim/mpvtk_browser/config.py
+msgid "Block Player Keybinds While Browsing"
+msgstr ""
+
+#: jellyfin_mpv_shim/mpvtk_browser/config.py
 msgid "Always Bind Arrow Keys to Player Controls"
 msgstr ""
 
 #: jellyfin_mpv_shim/mpvtk_browser/config.py
 msgid "Player Controls Activation Key"
+msgstr ""
+
+#: jellyfin_mpv_shim/mpvtk_browser/config.py
+msgid "Select Key"
 msgstr ""
 
 #: jellyfin_mpv_shim/mpvtk_browser/config.py
@@ -1872,6 +1899,10 @@ msgstr ""
 
 #: jellyfin_mpv_shim/mpvtk_browser/config.py
 msgid "Hide the Player Controls After (seconds)"
+msgstr ""
+
+#: jellyfin_mpv_shim/mpvtk_browser/config.py
+msgid "Shrink the Player Controls on a Narrow Window"
 msgstr ""
 
 #: jellyfin_mpv_shim/mpvtk_browser/config.py
@@ -1958,6 +1989,21 @@ msgstr ""
 
 #: jellyfin_mpv_shim/mpvtk_browser/config.py
 msgid ""
+"Stops MPV's own shortcuts -- picture adjustment, screenshots, subtitle and "
+"audio switching -- from acting while you are in the library, where there is "
+"no video for them to act on. Turn it off to use your own MPV key bindings "
+"there."
+msgstr ""
+
+#: jellyfin_mpv_shim/mpvtk_browser/config.py
+msgid ""
+"Activates whatever is highlighted, in the library and on the player "
+"controls. An mpv key name; changing it hands Enter back to MPV. The game "
+"controller's Confirm button and a phone's Select follow it."
+msgstr ""
+
+#: jellyfin_mpv_shim/mpvtk_browser/config.py
+msgid ""
 "Leave these blank unless downloads are waking your disks too often. Set both "
 "of the first two together: episodes are then fetched in one batch when a "
 "series runs low, instead of one at a time."
@@ -1971,7 +2017,8 @@ msgstr ""
 #: jellyfin_mpv_shim/mpvtk_browser/config.py
 msgid ""
 "Off gives MPV's own mouse behaviour instead: drag the video to move the "
-"window, and right click to pause. Double click is full screen either way."
+"window, and the right button does whatever your MPV config gives it. Double "
+"click is full screen either way."
 msgstr ""
 
 #: jellyfin_mpv_shim/mpvtk_browser/config.py
@@ -2061,6 +2108,30 @@ msgid ""
 "maximize and close in the top bar instead, and lets you drag the window by "
 "it. On \"Only when the window has no title bar\", MPV is asked whether this "
 "window got one, so desktops that draw a title bar are left alone."
+msgstr ""
+
+#: jellyfin_mpv_shim/mpvtk_browser/config.py
+msgid ""
+"Full screen has no title bar anywhere and nothing to move or maximize, so "
+"the buttons are normally hidden there. Turn this on to keep a way out of "
+"full screen that is not a keyboard shortcut."
+msgstr ""
+
+#: jellyfin_mpv_shim/mpvtk_browser/config.py
+msgid ""
+"Asks the desktop for no title bar on the player window, so the top bar above "
+"is the only one. Pairs with the setting above: on \"Only when the window has "
+"no title bar\" the buttons appear as soon as this is on. Leave both off "
+"unless you want them, since a window with neither can be awkward to move on "
+"some desktops."
+msgstr ""
+
+#: jellyfin_mpv_shim/mpvtk_browser/config.py
+msgid ""
+"Shows a preview frame while you drag the seek bar. Works with every player "
+"control style, including your own OSC script if it supports thumbfast. The "
+"images are fetched from the server per video, which costs disk space and "
+"memory -- tens of MB for an episode, a few hundred for a long film."
 msgstr ""
 
 #: jellyfin_mpv_shim/mpvtk_browser/config.py
@@ -2170,6 +2241,13 @@ msgstr ""
 
 #: jellyfin_mpv_shim/mpvtk_browser/config.py
 msgid ""
+"Show times of day as \"8:30 PM\" rather than \"20:30\" — the Live TV guide "
+"and its air times, and the \"Ends at\" labels on a detail page and the "
+"player controls."
+msgstr ""
+
+#: jellyfin_mpv_shim/mpvtk_browser/config.py
+msgid ""
 "The controls have to stay legible over any frame. \"None\" gives the text a "
 "drop shadow instead of shading the picture behind it."
 msgstr ""
@@ -2184,6 +2262,13 @@ msgstr ""
 msgid ""
 "0 hides them as soon as the pointer is not on them, and forces \"Hide unless "
 "hovered\"."
+msgstr ""
+
+#: jellyfin_mpv_shim/mpvtk_browser/config.py
+msgid ""
+"Narrowing the window shrinks the controls until the smallest button reaches "
+"the accessibility minimum, instead of dropping buttons sooner. Off keeps the "
+"older, larger floor."
 msgstr ""
 
 #: jellyfin_mpv_shim/mpvtk_browser/config.py
@@ -3735,6 +3820,7 @@ msgid "More Like This"
 msgstr "Më shumë si kjo"
 
 #: jellyfin_mpv_shim/mpvtk_browser/pages/detail.py
+#: jellyfin_mpv_shim/mpvtk_browser/tiles.py
 msgid "Go to Series"
 msgstr ""
 
@@ -4894,6 +4980,22 @@ msgstr "Hiq Serverin"
 msgid "There is nothing here to queue."
 msgstr ""
 
+#: jellyfin_mpv_shim/mpvtk_browser/timefmt.py
+#, python-brace-format
+msgctxt "12-hour clock"
+msgid "{time} {period}"
+msgstr ""
+
+#: jellyfin_mpv_shim/mpvtk_browser/timefmt.py
+msgctxt "12-hour clock"
+msgid "AM"
+msgstr ""
+
+#: jellyfin_mpv_shim/mpvtk_browser/timefmt.py
+msgctxt "12-hour clock"
+msgid "PM"
+msgstr ""
+
 #: jellyfin_mpv_shim/mpvtk_browser/views.py
 #: jellyfin_mpv_shim/mpvtk_browser/window_chrome.py
 msgid "Search"
@@ -5057,13 +5159,32 @@ msgid "Enable SVP"
 msgstr "Aktivizo SVP"
 
 #: jellyfin_mpv_shim/sync/manager.py
+msgid "The downloads are already in that folder."
+msgstr ""
+
+#: jellyfin_mpv_shim/sync/manager.py
 msgid ""
 "Can't change the download folder while a download is in progress. Wait for "
 "it to finish, then try again."
 msgstr ""
 
 #: jellyfin_mpv_shim/sync/manager.py
+msgid ""
+"That folder is inside the current download folder. Choose one outside it."
+msgstr ""
+
+#: jellyfin_mpv_shim/sync/manager.py
+msgid "Can't read that folder. Check the path and its permissions."
+msgstr ""
+
+#: jellyfin_mpv_shim/sync/manager.py
 msgid "That folder already contains downloads. Choose an empty folder."
+msgstr ""
+
+#: jellyfin_mpv_shim/sync/manager.py
+msgid ""
+"That folder isn't empty. Choose an empty folder — the download folder is "
+"managed by this app and anything else in it can be moved or removed."
 msgstr ""
 
 #: jellyfin_mpv_shim/sync/manager.py
@@ -5072,6 +5193,12 @@ msgstr ""
 
 #: jellyfin_mpv_shim/sync/manager.py
 msgid "A download is still finishing. Wait for it to stop, then try again."
+msgstr ""
+
+#: jellyfin_mpv_shim/sync/manager.py
+msgid ""
+"There isn't enough space on that drive to move the downloads. Free some "
+"space and try again — nothing was moved."
 msgstr ""
 
 #: jellyfin_mpv_shim/sync/manager.py

--- a/jellyfin_mpv_shim/messages/sr/LC_MESSAGES/base.po
+++ b/jellyfin_mpv_shim/messages/sr/LC_MESSAGES/base.po
@@ -6,7 +6,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2026-08-30 22:19-0400\n"
+"POT-Creation-Date: 2026-09-07 17:35-0400\n"
 "PO-Revision-Date: 2026-08-17 17:57+0000\n"
 "Last-Translator: nenadsuperzmaj <nenadsuperzmaj@gmail.com>\n"
 "Language-Team: Serbian <https://translate.jellyfin.org/projects/jellyfin/"
@@ -550,6 +550,11 @@ msgid "Night Mode (Auto Volume Adj)"
 msgstr "Ноћни режим (аутоматско подешавање гласноће)"
 
 #: jellyfin_mpv_shim/mpvtk_browser/app.py
+#: jellyfin_mpv_shim/mpvtk_browser/auth.py
+msgid "Locked"
+msgstr "Закључано"
+
+#: jellyfin_mpv_shim/mpvtk_browser/app.py
 msgid "Failed to load. Check the connection."
 msgstr "Није успело учитавање. Проверите конекцију."
 
@@ -829,10 +834,6 @@ msgstr ""
 "Молимо проверите податке о вези."
 
 #: jellyfin_mpv_shim/mpvtk_browser/auth.py
-msgid "Locked"
-msgstr "Закључано"
-
-#: jellyfin_mpv_shim/mpvtk_browser/auth.py
 #: jellyfin_mpv_shim/mpvtk_browser/pages/home.py
 msgid "Connecting to your server…"
 msgstr "Повезивање на ваш сервер…"
@@ -913,6 +914,10 @@ msgstr "Изађи и означи негледано"
 #: jellyfin_mpv_shim/mpvtk_browser/pages/books.py
 msgid "Favorite"
 msgstr "Омиљено"
+
+#: jellyfin_mpv_shim/mpvtk_browser/components/detail.py
+msgid "Web"
+msgstr ""
 
 # seeded from jellyfin-web: Video
 #: jellyfin_mpv_shim/mpvtk_browser/components/media_info.py
@@ -1528,11 +1533,7 @@ msgid "Jellyfin UI"
 msgstr ""
 
 #: jellyfin_mpv_shim/mpvtk_browser/config.py
-msgid "MPV UI with thumbnails"
-msgstr ""
-
-#: jellyfin_mpv_shim/mpvtk_browser/config.py
-msgid "MPV built-in default"
+msgid "MPV UI"
 msgstr ""
 
 #: jellyfin_mpv_shim/mpvtk_browser/config.py
@@ -1881,8 +1882,22 @@ msgid "Window Buttons in the Top Bar"
 msgstr ""
 
 #: jellyfin_mpv_shim/mpvtk_browser/config.py
+msgid "Keep Window Buttons in Full Screen"
+msgstr ""
+
+#: jellyfin_mpv_shim/mpvtk_browser/config.py
+msgid "Hide the Desktop Title Bar"
+msgstr ""
+
+#: jellyfin_mpv_shim/mpvtk_browser/config.py
 msgid "Player Controls Style"
 msgstr "Изглед контрола плејера"
+
+#: jellyfin_mpv_shim/mpvtk_browser/config.py
+#, fuzzy
+#| msgid "Enable thumbnail previews"
+msgid "Enable Trickplay Thumbnails"
+msgstr "Омогући преглед сличица"
 
 #: jellyfin_mpv_shim/mpvtk_browser/config.py
 msgid "Load All Seek Previews at Once"
@@ -1913,6 +1928,10 @@ msgstr "Величина омота"
 
 #: jellyfin_mpv_shim/mpvtk_browser/config.py
 msgid "Full-Width Backdrops"
+msgstr ""
+
+#: jellyfin_mpv_shim/mpvtk_browser/config.py
+msgid "12-Hour Clock"
 msgstr ""
 
 #: jellyfin_mpv_shim/mpvtk_browser/config.py
@@ -1958,12 +1977,23 @@ msgid "Fullscreen Library Browser"
 msgstr "Преглед библиотеке преко целог екрана"
 
 #: jellyfin_mpv_shim/mpvtk_browser/config.py
+msgid "Block Player Keybinds While Browsing"
+msgstr ""
+
+#: jellyfin_mpv_shim/mpvtk_browser/config.py
 msgid "Always Bind Arrow Keys to Player Controls"
 msgstr "Увек вежи дугмиће са стрелицама за контроле плејера"
 
 #: jellyfin_mpv_shim/mpvtk_browser/config.py
 msgid "Player Controls Activation Key"
 msgstr "Кључ за активацију контрола плејера"
+
+# seeded from jellyfin-web: SelectAll
+#: jellyfin_mpv_shim/mpvtk_browser/config.py
+#, fuzzy
+#| msgid "Select All"
+msgid "Select Key"
+msgstr "Изабери све"
 
 #: jellyfin_mpv_shim/mpvtk_browser/config.py
 msgid "Shading Behind the Player Controls"
@@ -1976,6 +2006,12 @@ msgstr "Кад се сакривају контроле плејера"
 #: jellyfin_mpv_shim/mpvtk_browser/config.py
 msgid "Hide the Player Controls After (seconds)"
 msgstr "Сакриј контроле плејера после (секунде)"
+
+#: jellyfin_mpv_shim/mpvtk_browser/config.py
+#, fuzzy
+#| msgid "When the Player Controls Hide"
+msgid "Shrink the Player Controls on a Narrow Window"
+msgstr "Кад се сакривају контроле плејера"
 
 #: jellyfin_mpv_shim/mpvtk_browser/config.py
 msgid "Mouse Back/Forward Buttons Skip Chapters"
@@ -2064,6 +2100,21 @@ msgstr ""
 
 #: jellyfin_mpv_shim/mpvtk_browser/config.py
 msgid ""
+"Stops MPV's own shortcuts -- picture adjustment, screenshots, subtitle and "
+"audio switching -- from acting while you are in the library, where there is "
+"no video for them to act on. Turn it off to use your own MPV key bindings "
+"there."
+msgstr ""
+
+#: jellyfin_mpv_shim/mpvtk_browser/config.py
+msgid ""
+"Activates whatever is highlighted, in the library and on the player "
+"controls. An mpv key name; changing it hands Enter back to MPV. The game "
+"controller's Confirm button and a phone's Select follow it."
+msgstr ""
+
+#: jellyfin_mpv_shim/mpvtk_browser/config.py
+msgid ""
 "Leave these blank unless downloads are waking your disks too often. Set both "
 "of the first two together: episodes are then fetched in one batch when a "
 "series runs low, instead of one at a time."
@@ -2077,9 +2128,14 @@ msgid ""
 msgstr "Сличица епизоде је слика из епозоде коју још није погледали."
 
 #: jellyfin_mpv_shim/mpvtk_browser/config.py
+#, fuzzy
+#| msgid ""
+#| "Off gives MPV's own mouse behaviour instead: drag the video to move the "
+#| "window, and right click to pause. Double click is full screen either way."
 msgid ""
 "Off gives MPV's own mouse behaviour instead: drag the video to move the "
-"window, and right click to pause. Double click is full screen either way."
+"window, and the right button does whatever your MPV config gives it. Double "
+"click is full screen either way."
 msgstr ""
 "Искључено чини да се миш понаша као у MPV-у: вуците видео да помериоте "
 "прозор, десни клик за паузу и дупли клик за пун екран."
@@ -2211,6 +2267,30 @@ msgstr ""
 
 #: jellyfin_mpv_shim/mpvtk_browser/config.py
 msgid ""
+"Full screen has no title bar anywhere and nothing to move or maximize, so "
+"the buttons are normally hidden there. Turn this on to keep a way out of "
+"full screen that is not a keyboard shortcut."
+msgstr ""
+
+#: jellyfin_mpv_shim/mpvtk_browser/config.py
+msgid ""
+"Asks the desktop for no title bar on the player window, so the top bar above "
+"is the only one. Pairs with the setting above: on \"Only when the window has "
+"no title bar\" the buttons appear as soon as this is on. Leave both off "
+"unless you want them, since a window with neither can be awkward to move on "
+"some desktops."
+msgstr ""
+
+#: jellyfin_mpv_shim/mpvtk_browser/config.py
+msgid ""
+"Shows a preview frame while you drag the seek bar. Works with every player "
+"control style, including your own OSC script if it supports thumbfast. The "
+"images are fetched from the server per video, which costs disk space and "
+"memory -- tens of MB for an episode, a few hundred for a long film."
+msgstr ""
+
+#: jellyfin_mpv_shim/mpvtk_browser/config.py
+msgid ""
 "Seek previews are normally fetched a few minutes at a time around where you "
 "are seeking, so scrubbing somewhere new waits briefly. Turn this on to load "
 "them all up front instead: nothing ever waits, but a long film can cost "
@@ -2326,6 +2406,13 @@ msgstr ""
 
 #: jellyfin_mpv_shim/mpvtk_browser/config.py
 msgid ""
+"Show times of day as \"8:30 PM\" rather than \"20:30\" — the Live TV guide "
+"and its air times, and the \"Ends at\" labels on a detail page and the "
+"player controls."
+msgstr ""
+
+#: jellyfin_mpv_shim/mpvtk_browser/config.py
+msgid ""
 "The controls have to stay legible over any frame. \"None\" gives the text a "
 "drop shadow instead of shading the picture behind it."
 msgstr ""
@@ -2340,6 +2427,13 @@ msgstr ""
 msgid ""
 "0 hides them as soon as the pointer is not on them, and forces \"Hide unless "
 "hovered\"."
+msgstr ""
+
+#: jellyfin_mpv_shim/mpvtk_browser/config.py
+msgid ""
+"Narrowing the window shrinks the controls until the smallest button reaches "
+"the accessibility minimum, instead of dropping buttons sooner. Off keeps the "
+"older, larger floor."
 msgstr ""
 
 #: jellyfin_mpv_shim/mpvtk_browser/config.py
@@ -3943,6 +4037,7 @@ msgid "More Like This"
 msgstr "Више оваквих"
 
 #: jellyfin_mpv_shim/mpvtk_browser/pages/detail.py
+#: jellyfin_mpv_shim/mpvtk_browser/tiles.py
 msgid "Go to Series"
 msgstr ""
 
@@ -5134,6 +5229,22 @@ msgstr "Уклоните сервер"
 msgid "There is nothing here to queue."
 msgstr ""
 
+#: jellyfin_mpv_shim/mpvtk_browser/timefmt.py
+#, python-brace-format
+msgctxt "12-hour clock"
+msgid "{time} {period}"
+msgstr ""
+
+#: jellyfin_mpv_shim/mpvtk_browser/timefmt.py
+msgctxt "12-hour clock"
+msgid "AM"
+msgstr ""
+
+#: jellyfin_mpv_shim/mpvtk_browser/timefmt.py
+msgctxt "12-hour clock"
+msgid "PM"
+msgstr ""
+
 # seeded from jellyfin-web: Search
 #: jellyfin_mpv_shim/mpvtk_browser/views.py
 #: jellyfin_mpv_shim/mpvtk_browser/window_chrome.py
@@ -5302,13 +5413,32 @@ msgid "Enable SVP"
 msgstr "Омогући SVP"
 
 #: jellyfin_mpv_shim/sync/manager.py
+msgid "The downloads are already in that folder."
+msgstr ""
+
+#: jellyfin_mpv_shim/sync/manager.py
 msgid ""
 "Can't change the download folder while a download is in progress. Wait for "
 "it to finish, then try again."
 msgstr ""
 
 #: jellyfin_mpv_shim/sync/manager.py
+msgid ""
+"That folder is inside the current download folder. Choose one outside it."
+msgstr ""
+
+#: jellyfin_mpv_shim/sync/manager.py
+msgid "Can't read that folder. Check the path and its permissions."
+msgstr ""
+
+#: jellyfin_mpv_shim/sync/manager.py
 msgid "That folder already contains downloads. Choose an empty folder."
+msgstr ""
+
+#: jellyfin_mpv_shim/sync/manager.py
+msgid ""
+"That folder isn't empty. Choose an empty folder — the download folder is "
+"managed by this app and anything else in it can be moved or removed."
 msgstr ""
 
 #: jellyfin_mpv_shim/sync/manager.py
@@ -5317,6 +5447,12 @@ msgstr ""
 
 #: jellyfin_mpv_shim/sync/manager.py
 msgid "A download is still finishing. Wait for it to stop, then try again."
+msgstr ""
+
+#: jellyfin_mpv_shim/sync/manager.py
+msgid ""
+"There isn't enough space on that drive to move the downloads. Free some "
+"space and try again — nothing was moved."
 msgstr ""
 
 #: jellyfin_mpv_shim/sync/manager.py

--- a/jellyfin_mpv_shim/messages/sv/LC_MESSAGES/base.po
+++ b/jellyfin_mpv_shim/messages/sv/LC_MESSAGES/base.po
@@ -6,7 +6,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2026-08-30 22:19-0400\n"
+"POT-Creation-Date: 2026-09-07 17:35-0400\n"
 "PO-Revision-Date: 2026-09-03 10:33+0000\n"
 "Last-Translator: therealhampus <hampus.eriksson@proton.me>\n"
 "Language-Team: Swedish <https://translate.jellyfin.org/projects/jellyfin/"
@@ -511,6 +511,11 @@ msgid "Night Mode (Auto Volume Adj)"
 msgstr "Nattläge (Automatisk volumsjustering)"
 
 #: jellyfin_mpv_shim/mpvtk_browser/app.py
+#: jellyfin_mpv_shim/mpvtk_browser/auth.py
+msgid "Locked"
+msgstr ""
+
+#: jellyfin_mpv_shim/mpvtk_browser/app.py
 msgid "Failed to load. Check the connection."
 msgstr "Lyckades inte ladda. Undersök uppkopplingen."
 
@@ -782,10 +787,6 @@ msgstr ""
 "Var snäll och kolla din uppkoppling."
 
 #: jellyfin_mpv_shim/mpvtk_browser/auth.py
-msgid "Locked"
-msgstr ""
-
-#: jellyfin_mpv_shim/mpvtk_browser/auth.py
 #: jellyfin_mpv_shim/mpvtk_browser/pages/home.py
 msgid "Connecting to your server…"
 msgstr ""
@@ -866,6 +867,10 @@ msgstr "Avsluta och märk som ospelad"
 #: jellyfin_mpv_shim/mpvtk_browser/pages/books.py
 msgid "Favorite"
 msgstr "Favorit"
+
+#: jellyfin_mpv_shim/mpvtk_browser/components/detail.py
+msgid "Web"
+msgstr ""
 
 # seeded from jellyfin-web: HeaderVideos
 #: jellyfin_mpv_shim/mpvtk_browser/components/media_info.py
@@ -1484,11 +1489,7 @@ msgid "Jellyfin UI"
 msgstr ""
 
 #: jellyfin_mpv_shim/mpvtk_browser/config.py
-msgid "MPV UI with thumbnails"
-msgstr ""
-
-#: jellyfin_mpv_shim/mpvtk_browser/config.py
-msgid "MPV built-in default"
+msgid "MPV UI"
 msgstr ""
 
 #: jellyfin_mpv_shim/mpvtk_browser/config.py
@@ -1835,8 +1836,22 @@ msgid "Window Buttons in the Top Bar"
 msgstr ""
 
 #: jellyfin_mpv_shim/mpvtk_browser/config.py
+msgid "Keep Window Buttons in Full Screen"
+msgstr ""
+
+#: jellyfin_mpv_shim/mpvtk_browser/config.py
+msgid "Hide the Desktop Title Bar"
+msgstr ""
+
+#: jellyfin_mpv_shim/mpvtk_browser/config.py
 msgid "Player Controls Style"
 msgstr ""
+
+#: jellyfin_mpv_shim/mpvtk_browser/config.py
+#, fuzzy
+#| msgid "Enable thumbnail previews"
+msgid "Enable Trickplay Thumbnails"
+msgstr "Använd miniatyr-förhandsvisning"
 
 #: jellyfin_mpv_shim/mpvtk_browser/config.py
 msgid "Load All Seek Previews at Once"
@@ -1866,6 +1881,10 @@ msgstr ""
 
 #: jellyfin_mpv_shim/mpvtk_browser/config.py
 msgid "Full-Width Backdrops"
+msgstr ""
+
+#: jellyfin_mpv_shim/mpvtk_browser/config.py
+msgid "12-Hour Clock"
 msgstr ""
 
 #: jellyfin_mpv_shim/mpvtk_browser/config.py
@@ -1911,12 +1930,23 @@ msgid "Fullscreen Library Browser"
 msgstr ""
 
 #: jellyfin_mpv_shim/mpvtk_browser/config.py
+msgid "Block Player Keybinds While Browsing"
+msgstr ""
+
+#: jellyfin_mpv_shim/mpvtk_browser/config.py
 msgid "Always Bind Arrow Keys to Player Controls"
 msgstr ""
 
 #: jellyfin_mpv_shim/mpvtk_browser/config.py
 msgid "Player Controls Activation Key"
 msgstr ""
+
+# seeded from jellyfin-web: SelectAll
+#: jellyfin_mpv_shim/mpvtk_browser/config.py
+#, fuzzy
+#| msgid "Select All"
+msgid "Select Key"
+msgstr "Välj alla"
 
 #: jellyfin_mpv_shim/mpvtk_browser/config.py
 msgid "Shading Behind the Player Controls"
@@ -1928,6 +1958,10 @@ msgstr ""
 
 #: jellyfin_mpv_shim/mpvtk_browser/config.py
 msgid "Hide the Player Controls After (seconds)"
+msgstr ""
+
+#: jellyfin_mpv_shim/mpvtk_browser/config.py
+msgid "Shrink the Player Controls on a Narrow Window"
 msgstr ""
 
 #: jellyfin_mpv_shim/mpvtk_browser/config.py
@@ -2014,6 +2048,21 @@ msgstr ""
 
 #: jellyfin_mpv_shim/mpvtk_browser/config.py
 msgid ""
+"Stops MPV's own shortcuts -- picture adjustment, screenshots, subtitle and "
+"audio switching -- from acting while you are in the library, where there is "
+"no video for them to act on. Turn it off to use your own MPV key bindings "
+"there."
+msgstr ""
+
+#: jellyfin_mpv_shim/mpvtk_browser/config.py
+msgid ""
+"Activates whatever is highlighted, in the library and on the player "
+"controls. An mpv key name; changing it hands Enter back to MPV. The game "
+"controller's Confirm button and a phone's Select follow it."
+msgstr ""
+
+#: jellyfin_mpv_shim/mpvtk_browser/config.py
+msgid ""
 "Leave these blank unless downloads are waking your disks too often. Set both "
 "of the first two together: episodes are then fetched in one batch when a "
 "series runs low, instead of one at a time."
@@ -2027,7 +2076,8 @@ msgstr ""
 #: jellyfin_mpv_shim/mpvtk_browser/config.py
 msgid ""
 "Off gives MPV's own mouse behaviour instead: drag the video to move the "
-"window, and right click to pause. Double click is full screen either way."
+"window, and the right button does whatever your MPV config gives it. Double "
+"click is full screen either way."
 msgstr ""
 
 #: jellyfin_mpv_shim/mpvtk_browser/config.py
@@ -2117,6 +2167,30 @@ msgid ""
 "maximize and close in the top bar instead, and lets you drag the window by "
 "it. On \"Only when the window has no title bar\", MPV is asked whether this "
 "window got one, so desktops that draw a title bar are left alone."
+msgstr ""
+
+#: jellyfin_mpv_shim/mpvtk_browser/config.py
+msgid ""
+"Full screen has no title bar anywhere and nothing to move or maximize, so "
+"the buttons are normally hidden there. Turn this on to keep a way out of "
+"full screen that is not a keyboard shortcut."
+msgstr ""
+
+#: jellyfin_mpv_shim/mpvtk_browser/config.py
+msgid ""
+"Asks the desktop for no title bar on the player window, so the top bar above "
+"is the only one. Pairs with the setting above: on \"Only when the window has "
+"no title bar\" the buttons appear as soon as this is on. Leave both off "
+"unless you want them, since a window with neither can be awkward to move on "
+"some desktops."
+msgstr ""
+
+#: jellyfin_mpv_shim/mpvtk_browser/config.py
+msgid ""
+"Shows a preview frame while you drag the seek bar. Works with every player "
+"control style, including your own OSC script if it supports thumbfast. The "
+"images are fetched from the server per video, which costs disk space and "
+"memory -- tens of MB for an episode, a few hundred for a long film."
 msgstr ""
 
 #: jellyfin_mpv_shim/mpvtk_browser/config.py
@@ -2226,6 +2300,13 @@ msgstr ""
 
 #: jellyfin_mpv_shim/mpvtk_browser/config.py
 msgid ""
+"Show times of day as \"8:30 PM\" rather than \"20:30\" — the Live TV guide "
+"and its air times, and the \"Ends at\" labels on a detail page and the "
+"player controls."
+msgstr ""
+
+#: jellyfin_mpv_shim/mpvtk_browser/config.py
+msgid ""
 "The controls have to stay legible over any frame. \"None\" gives the text a "
 "drop shadow instead of shading the picture behind it."
 msgstr ""
@@ -2240,6 +2321,13 @@ msgstr ""
 msgid ""
 "0 hides them as soon as the pointer is not on them, and forces \"Hide unless "
 "hovered\"."
+msgstr ""
+
+#: jellyfin_mpv_shim/mpvtk_browser/config.py
+msgid ""
+"Narrowing the window shrinks the controls until the smallest button reaches "
+"the accessibility minimum, instead of dropping buttons sooner. Off keeps the "
+"older, larger floor."
 msgstr ""
 
 #: jellyfin_mpv_shim/mpvtk_browser/config.py
@@ -3843,6 +3931,7 @@ msgid "More Like This"
 msgstr "Mer som detta"
 
 #: jellyfin_mpv_shim/mpvtk_browser/pages/detail.py
+#: jellyfin_mpv_shim/mpvtk_browser/tiles.py
 msgid "Go to Series"
 msgstr ""
 
@@ -5034,6 +5123,22 @@ msgstr "Ta bort server"
 msgid "There is nothing here to queue."
 msgstr ""
 
+#: jellyfin_mpv_shim/mpvtk_browser/timefmt.py
+#, python-brace-format
+msgctxt "12-hour clock"
+msgid "{time} {period}"
+msgstr ""
+
+#: jellyfin_mpv_shim/mpvtk_browser/timefmt.py
+msgctxt "12-hour clock"
+msgid "AM"
+msgstr ""
+
+#: jellyfin_mpv_shim/mpvtk_browser/timefmt.py
+msgctxt "12-hour clock"
+msgid "PM"
+msgstr ""
+
 # seeded from jellyfin-web: Search
 #: jellyfin_mpv_shim/mpvtk_browser/views.py
 #: jellyfin_mpv_shim/mpvtk_browser/window_chrome.py
@@ -5203,13 +5308,32 @@ msgid "Enable SVP"
 msgstr "Aktivera SVP"
 
 #: jellyfin_mpv_shim/sync/manager.py
+msgid "The downloads are already in that folder."
+msgstr ""
+
+#: jellyfin_mpv_shim/sync/manager.py
 msgid ""
 "Can't change the download folder while a download is in progress. Wait for "
 "it to finish, then try again."
 msgstr ""
 
 #: jellyfin_mpv_shim/sync/manager.py
+msgid ""
+"That folder is inside the current download folder. Choose one outside it."
+msgstr ""
+
+#: jellyfin_mpv_shim/sync/manager.py
+msgid "Can't read that folder. Check the path and its permissions."
+msgstr ""
+
+#: jellyfin_mpv_shim/sync/manager.py
 msgid "That folder already contains downloads. Choose an empty folder."
+msgstr ""
+
+#: jellyfin_mpv_shim/sync/manager.py
+msgid ""
+"That folder isn't empty. Choose an empty folder — the download folder is "
+"managed by this app and anything else in it can be moved or removed."
 msgstr ""
 
 #: jellyfin_mpv_shim/sync/manager.py
@@ -5218,6 +5342,12 @@ msgstr ""
 
 #: jellyfin_mpv_shim/sync/manager.py
 msgid "A download is still finishing. Wait for it to stop, then try again."
+msgstr ""
+
+#: jellyfin_mpv_shim/sync/manager.py
+msgid ""
+"There isn't enough space on that drive to move the downloads. Free some "
+"space and try again — nothing was moved."
 msgstr ""
 
 #: jellyfin_mpv_shim/sync/manager.py

--- a/jellyfin_mpv_shim/messages/sw/LC_MESSAGES/base.po
+++ b/jellyfin_mpv_shim/messages/sw/LC_MESSAGES/base.po
@@ -6,7 +6,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2026-08-30 22:19-0400\n"
+"POT-Creation-Date: 2026-09-07 17:35-0400\n"
 "PO-Revision-Date: 2026-06-28 10:04+0000\n"
 "Last-Translator: Ricky Kimani <rkmacharia@outlook.com>\n"
 "Language-Team: Swahili <https://translate.jellyfin.org/projects/jellyfin/"
@@ -507,6 +507,11 @@ msgid "Night Mode (Auto Volume Adj)"
 msgstr ""
 
 #: jellyfin_mpv_shim/mpvtk_browser/app.py
+#: jellyfin_mpv_shim/mpvtk_browser/auth.py
+msgid "Locked"
+msgstr ""
+
+#: jellyfin_mpv_shim/mpvtk_browser/app.py
 msgid "Failed to load. Check the connection."
 msgstr ""
 
@@ -747,10 +752,6 @@ msgid "Could not connect. Please check your details."
 msgstr ""
 
 #: jellyfin_mpv_shim/mpvtk_browser/auth.py
-msgid "Locked"
-msgstr ""
-
-#: jellyfin_mpv_shim/mpvtk_browser/auth.py
 #: jellyfin_mpv_shim/mpvtk_browser/pages/home.py
 msgid "Connecting to your server…"
 msgstr ""
@@ -820,6 +821,10 @@ msgstr ""
 #: jellyfin_mpv_shim/mpvtk_browser/hud.py
 #: jellyfin_mpv_shim/mpvtk_browser/pages/books.py
 msgid "Favorite"
+msgstr ""
+
+#: jellyfin_mpv_shim/mpvtk_browser/components/detail.py
+msgid "Web"
 msgstr ""
 
 #: jellyfin_mpv_shim/mpvtk_browser/components/media_info.py
@@ -1325,11 +1330,7 @@ msgid "Jellyfin UI"
 msgstr ""
 
 #: jellyfin_mpv_shim/mpvtk_browser/config.py
-msgid "MPV UI with thumbnails"
-msgstr ""
-
-#: jellyfin_mpv_shim/mpvtk_browser/config.py
-msgid "MPV built-in default"
+msgid "MPV UI"
 msgstr ""
 
 #: jellyfin_mpv_shim/mpvtk_browser/config.py
@@ -1662,7 +1663,19 @@ msgid "Window Buttons in the Top Bar"
 msgstr ""
 
 #: jellyfin_mpv_shim/mpvtk_browser/config.py
+msgid "Keep Window Buttons in Full Screen"
+msgstr ""
+
+#: jellyfin_mpv_shim/mpvtk_browser/config.py
+msgid "Hide the Desktop Title Bar"
+msgstr ""
+
+#: jellyfin_mpv_shim/mpvtk_browser/config.py
 msgid "Player Controls Style"
+msgstr ""
+
+#: jellyfin_mpv_shim/mpvtk_browser/config.py
+msgid "Enable Trickplay Thumbnails"
 msgstr ""
 
 #: jellyfin_mpv_shim/mpvtk_browser/config.py
@@ -1692,6 +1705,10 @@ msgstr ""
 
 #: jellyfin_mpv_shim/mpvtk_browser/config.py
 msgid "Full-Width Backdrops"
+msgstr ""
+
+#: jellyfin_mpv_shim/mpvtk_browser/config.py
+msgid "12-Hour Clock"
 msgstr ""
 
 #: jellyfin_mpv_shim/mpvtk_browser/config.py
@@ -1735,11 +1752,19 @@ msgid "Fullscreen Library Browser"
 msgstr ""
 
 #: jellyfin_mpv_shim/mpvtk_browser/config.py
+msgid "Block Player Keybinds While Browsing"
+msgstr ""
+
+#: jellyfin_mpv_shim/mpvtk_browser/config.py
 msgid "Always Bind Arrow Keys to Player Controls"
 msgstr ""
 
 #: jellyfin_mpv_shim/mpvtk_browser/config.py
 msgid "Player Controls Activation Key"
+msgstr ""
+
+#: jellyfin_mpv_shim/mpvtk_browser/config.py
+msgid "Select Key"
 msgstr ""
 
 #: jellyfin_mpv_shim/mpvtk_browser/config.py
@@ -1752,6 +1777,10 @@ msgstr ""
 
 #: jellyfin_mpv_shim/mpvtk_browser/config.py
 msgid "Hide the Player Controls After (seconds)"
+msgstr ""
+
+#: jellyfin_mpv_shim/mpvtk_browser/config.py
+msgid "Shrink the Player Controls on a Narrow Window"
 msgstr ""
 
 #: jellyfin_mpv_shim/mpvtk_browser/config.py
@@ -1834,6 +1863,21 @@ msgstr ""
 
 #: jellyfin_mpv_shim/mpvtk_browser/config.py
 msgid ""
+"Stops MPV's own shortcuts -- picture adjustment, screenshots, subtitle and "
+"audio switching -- from acting while you are in the library, where there is "
+"no video for them to act on. Turn it off to use your own MPV key bindings "
+"there."
+msgstr ""
+
+#: jellyfin_mpv_shim/mpvtk_browser/config.py
+msgid ""
+"Activates whatever is highlighted, in the library and on the player "
+"controls. An mpv key name; changing it hands Enter back to MPV. The game "
+"controller's Confirm button and a phone's Select follow it."
+msgstr ""
+
+#: jellyfin_mpv_shim/mpvtk_browser/config.py
+msgid ""
 "Leave these blank unless downloads are waking your disks too often. Set both "
 "of the first two together: episodes are then fetched in one batch when a "
 "series runs low, instead of one at a time."
@@ -1847,7 +1891,8 @@ msgstr ""
 #: jellyfin_mpv_shim/mpvtk_browser/config.py
 msgid ""
 "Off gives MPV's own mouse behaviour instead: drag the video to move the "
-"window, and right click to pause. Double click is full screen either way."
+"window, and the right button does whatever your MPV config gives it. Double "
+"click is full screen either way."
 msgstr ""
 
 #: jellyfin_mpv_shim/mpvtk_browser/config.py
@@ -1937,6 +1982,30 @@ msgid ""
 "maximize and close in the top bar instead, and lets you drag the window by "
 "it. On \"Only when the window has no title bar\", MPV is asked whether this "
 "window got one, so desktops that draw a title bar are left alone."
+msgstr ""
+
+#: jellyfin_mpv_shim/mpvtk_browser/config.py
+msgid ""
+"Full screen has no title bar anywhere and nothing to move or maximize, so "
+"the buttons are normally hidden there. Turn this on to keep a way out of "
+"full screen that is not a keyboard shortcut."
+msgstr ""
+
+#: jellyfin_mpv_shim/mpvtk_browser/config.py
+msgid ""
+"Asks the desktop for no title bar on the player window, so the top bar above "
+"is the only one. Pairs with the setting above: on \"Only when the window has "
+"no title bar\" the buttons appear as soon as this is on. Leave both off "
+"unless you want them, since a window with neither can be awkward to move on "
+"some desktops."
+msgstr ""
+
+#: jellyfin_mpv_shim/mpvtk_browser/config.py
+msgid ""
+"Shows a preview frame while you drag the seek bar. Works with every player "
+"control style, including your own OSC script if it supports thumbfast. The "
+"images are fetched from the server per video, which costs disk space and "
+"memory -- tens of MB for an episode, a few hundred for a long film."
 msgstr ""
 
 #: jellyfin_mpv_shim/mpvtk_browser/config.py
@@ -2044,6 +2113,13 @@ msgstr ""
 
 #: jellyfin_mpv_shim/mpvtk_browser/config.py
 msgid ""
+"Show times of day as \"8:30 PM\" rather than \"20:30\" — the Live TV guide "
+"and its air times, and the \"Ends at\" labels on a detail page and the "
+"player controls."
+msgstr ""
+
+#: jellyfin_mpv_shim/mpvtk_browser/config.py
+msgid ""
 "The controls have to stay legible over any frame. \"None\" gives the text a "
 "drop shadow instead of shading the picture behind it."
 msgstr ""
@@ -2058,6 +2134,13 @@ msgstr ""
 msgid ""
 "0 hides them as soon as the pointer is not on them, and forces \"Hide unless "
 "hovered\"."
+msgstr ""
+
+#: jellyfin_mpv_shim/mpvtk_browser/config.py
+msgid ""
+"Narrowing the window shrinks the controls until the smallest button reaches "
+"the accessibility minimum, instead of dropping buttons sooner. Off keeps the "
+"older, larger floor."
 msgstr ""
 
 #: jellyfin_mpv_shim/mpvtk_browser/config.py
@@ -3385,6 +3468,7 @@ msgid "More Like This"
 msgstr ""
 
 #: jellyfin_mpv_shim/mpvtk_browser/pages/detail.py
+#: jellyfin_mpv_shim/mpvtk_browser/tiles.py
 msgid "Go to Series"
 msgstr ""
 
@@ -4385,6 +4469,22 @@ msgstr ""
 msgid "There is nothing here to queue."
 msgstr ""
 
+#: jellyfin_mpv_shim/mpvtk_browser/timefmt.py
+#, python-brace-format
+msgctxt "12-hour clock"
+msgid "{time} {period}"
+msgstr ""
+
+#: jellyfin_mpv_shim/mpvtk_browser/timefmt.py
+msgctxt "12-hour clock"
+msgid "AM"
+msgstr ""
+
+#: jellyfin_mpv_shim/mpvtk_browser/timefmt.py
+msgctxt "12-hour clock"
+msgid "PM"
+msgstr ""
+
 #: jellyfin_mpv_shim/mpvtk_browser/views.py
 #: jellyfin_mpv_shim/mpvtk_browser/window_chrome.py
 msgid "Search"
@@ -4535,13 +4635,32 @@ msgid "Enable SVP"
 msgstr ""
 
 #: jellyfin_mpv_shim/sync/manager.py
+msgid "The downloads are already in that folder."
+msgstr ""
+
+#: jellyfin_mpv_shim/sync/manager.py
 msgid ""
 "Can't change the download folder while a download is in progress. Wait for "
 "it to finish, then try again."
 msgstr ""
 
 #: jellyfin_mpv_shim/sync/manager.py
+msgid ""
+"That folder is inside the current download folder. Choose one outside it."
+msgstr ""
+
+#: jellyfin_mpv_shim/sync/manager.py
+msgid "Can't read that folder. Check the path and its permissions."
+msgstr ""
+
+#: jellyfin_mpv_shim/sync/manager.py
 msgid "That folder already contains downloads. Choose an empty folder."
+msgstr ""
+
+#: jellyfin_mpv_shim/sync/manager.py
+msgid ""
+"That folder isn't empty. Choose an empty folder — the download folder is "
+"managed by this app and anything else in it can be moved or removed."
 msgstr ""
 
 #: jellyfin_mpv_shim/sync/manager.py
@@ -4550,6 +4669,12 @@ msgstr ""
 
 #: jellyfin_mpv_shim/sync/manager.py
 msgid "A download is still finishing. Wait for it to stop, then try again."
+msgstr ""
+
+#: jellyfin_mpv_shim/sync/manager.py
+msgid ""
+"There isn't enough space on that drive to move the downloads. Free some "
+"space and try again — nothing was moved."
 msgstr ""
 
 #: jellyfin_mpv_shim/sync/manager.py

--- a/jellyfin_mpv_shim/messages/ta/LC_MESSAGES/base.po
+++ b/jellyfin_mpv_shim/messages/ta/LC_MESSAGES/base.po
@@ -6,7 +6,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2026-08-30 22:19-0400\n"
+"POT-Creation-Date: 2026-09-07 17:35-0400\n"
 "PO-Revision-Date: 2026-08-18 18:37+0000\n"
 "Last-Translator: deepak r <deepak.r232629@gmail.com>\n"
 "Language-Team: Tamil <https://translate.jellyfin.org/projects/jellyfin/"
@@ -548,6 +548,11 @@ msgid "Night Mode (Auto Volume Adj)"
 msgstr ""
 
 #: jellyfin_mpv_shim/mpvtk_browser/app.py
+#: jellyfin_mpv_shim/mpvtk_browser/auth.py
+msgid "Locked"
+msgstr ""
+
+#: jellyfin_mpv_shim/mpvtk_browser/app.py
 msgid "Failed to load. Check the connection."
 msgstr ""
 
@@ -827,10 +832,6 @@ msgstr ""
 "உங்கள் இணைப்பு தகவலை சரிபார்க்கவும்."
 
 #: jellyfin_mpv_shim/mpvtk_browser/auth.py
-msgid "Locked"
-msgstr ""
-
-#: jellyfin_mpv_shim/mpvtk_browser/auth.py
 #: jellyfin_mpv_shim/mpvtk_browser/pages/home.py
 msgid "Connecting to your server…"
 msgstr ""
@@ -911,6 +912,10 @@ msgstr "வெளியேறி, கவனிக்கப்படாததை�
 #: jellyfin_mpv_shim/mpvtk_browser/pages/books.py
 msgid "Favorite"
 msgstr "பிடித்தது"
+
+#: jellyfin_mpv_shim/mpvtk_browser/components/detail.py
+msgid "Web"
+msgstr ""
 
 # seeded from jellyfin-web: Video
 #: jellyfin_mpv_shim/mpvtk_browser/components/media_info.py
@@ -1527,11 +1532,7 @@ msgid "Jellyfin UI"
 msgstr ""
 
 #: jellyfin_mpv_shim/mpvtk_browser/config.py
-msgid "MPV UI with thumbnails"
-msgstr ""
-
-#: jellyfin_mpv_shim/mpvtk_browser/config.py
-msgid "MPV built-in default"
+msgid "MPV UI"
 msgstr ""
 
 #: jellyfin_mpv_shim/mpvtk_browser/config.py
@@ -1880,8 +1881,22 @@ msgid "Window Buttons in the Top Bar"
 msgstr ""
 
 #: jellyfin_mpv_shim/mpvtk_browser/config.py
+msgid "Keep Window Buttons in Full Screen"
+msgstr ""
+
+#: jellyfin_mpv_shim/mpvtk_browser/config.py
+msgid "Hide the Desktop Title Bar"
+msgstr ""
+
+#: jellyfin_mpv_shim/mpvtk_browser/config.py
 msgid "Player Controls Style"
 msgstr ""
+
+#: jellyfin_mpv_shim/mpvtk_browser/config.py
+#, fuzzy
+#| msgid "Enable thumbnail previews"
+msgid "Enable Trickplay Thumbnails"
+msgstr "படங்களின் முன்னோட்டங்களை கான்பி"
 
 #: jellyfin_mpv_shim/mpvtk_browser/config.py
 msgid "Load All Seek Previews at Once"
@@ -1911,6 +1926,10 @@ msgstr ""
 
 #: jellyfin_mpv_shim/mpvtk_browser/config.py
 msgid "Full-Width Backdrops"
+msgstr ""
+
+#: jellyfin_mpv_shim/mpvtk_browser/config.py
+msgid "12-Hour Clock"
 msgstr ""
 
 #: jellyfin_mpv_shim/mpvtk_browser/config.py
@@ -1956,12 +1975,23 @@ msgid "Fullscreen Library Browser"
 msgstr ""
 
 #: jellyfin_mpv_shim/mpvtk_browser/config.py
+msgid "Block Player Keybinds While Browsing"
+msgstr ""
+
+#: jellyfin_mpv_shim/mpvtk_browser/config.py
 msgid "Always Bind Arrow Keys to Player Controls"
 msgstr ""
 
 #: jellyfin_mpv_shim/mpvtk_browser/config.py
 msgid "Player Controls Activation Key"
 msgstr ""
+
+# seeded from jellyfin-web: SelectAll
+#: jellyfin_mpv_shim/mpvtk_browser/config.py
+#, fuzzy
+#| msgid "Select All"
+msgid "Select Key"
+msgstr "அனைத்தையும் தெரிவுசெய்"
 
 #: jellyfin_mpv_shim/mpvtk_browser/config.py
 msgid "Shading Behind the Player Controls"
@@ -1973,6 +2003,10 @@ msgstr ""
 
 #: jellyfin_mpv_shim/mpvtk_browser/config.py
 msgid "Hide the Player Controls After (seconds)"
+msgstr ""
+
+#: jellyfin_mpv_shim/mpvtk_browser/config.py
+msgid "Shrink the Player Controls on a Narrow Window"
 msgstr ""
 
 #: jellyfin_mpv_shim/mpvtk_browser/config.py
@@ -2059,6 +2093,21 @@ msgstr ""
 
 #: jellyfin_mpv_shim/mpvtk_browser/config.py
 msgid ""
+"Stops MPV's own shortcuts -- picture adjustment, screenshots, subtitle and "
+"audio switching -- from acting while you are in the library, where there is "
+"no video for them to act on. Turn it off to use your own MPV key bindings "
+"there."
+msgstr ""
+
+#: jellyfin_mpv_shim/mpvtk_browser/config.py
+msgid ""
+"Activates whatever is highlighted, in the library and on the player "
+"controls. An mpv key name; changing it hands Enter back to MPV. The game "
+"controller's Confirm button and a phone's Select follow it."
+msgstr ""
+
+#: jellyfin_mpv_shim/mpvtk_browser/config.py
+msgid ""
 "Leave these blank unless downloads are waking your disks too often. Set both "
 "of the first two together: episodes are then fetched in one batch when a "
 "series runs low, instead of one at a time."
@@ -2072,7 +2121,8 @@ msgstr ""
 #: jellyfin_mpv_shim/mpvtk_browser/config.py
 msgid ""
 "Off gives MPV's own mouse behaviour instead: drag the video to move the "
-"window, and right click to pause. Double click is full screen either way."
+"window, and the right button does whatever your MPV config gives it. Double "
+"click is full screen either way."
 msgstr ""
 
 #: jellyfin_mpv_shim/mpvtk_browser/config.py
@@ -2162,6 +2212,30 @@ msgid ""
 "maximize and close in the top bar instead, and lets you drag the window by "
 "it. On \"Only when the window has no title bar\", MPV is asked whether this "
 "window got one, so desktops that draw a title bar are left alone."
+msgstr ""
+
+#: jellyfin_mpv_shim/mpvtk_browser/config.py
+msgid ""
+"Full screen has no title bar anywhere and nothing to move or maximize, so "
+"the buttons are normally hidden there. Turn this on to keep a way out of "
+"full screen that is not a keyboard shortcut."
+msgstr ""
+
+#: jellyfin_mpv_shim/mpvtk_browser/config.py
+msgid ""
+"Asks the desktop for no title bar on the player window, so the top bar above "
+"is the only one. Pairs with the setting above: on \"Only when the window has "
+"no title bar\" the buttons appear as soon as this is on. Leave both off "
+"unless you want them, since a window with neither can be awkward to move on "
+"some desktops."
+msgstr ""
+
+#: jellyfin_mpv_shim/mpvtk_browser/config.py
+msgid ""
+"Shows a preview frame while you drag the seek bar. Works with every player "
+"control style, including your own OSC script if it supports thumbfast. The "
+"images are fetched from the server per video, which costs disk space and "
+"memory -- tens of MB for an episode, a few hundred for a long film."
 msgstr ""
 
 #: jellyfin_mpv_shim/mpvtk_browser/config.py
@@ -2271,6 +2345,13 @@ msgstr ""
 
 #: jellyfin_mpv_shim/mpvtk_browser/config.py
 msgid ""
+"Show times of day as \"8:30 PM\" rather than \"20:30\" — the Live TV guide "
+"and its air times, and the \"Ends at\" labels on a detail page and the "
+"player controls."
+msgstr ""
+
+#: jellyfin_mpv_shim/mpvtk_browser/config.py
+msgid ""
 "The controls have to stay legible over any frame. \"None\" gives the text a "
 "drop shadow instead of shading the picture behind it."
 msgstr ""
@@ -2285,6 +2366,13 @@ msgstr ""
 msgid ""
 "0 hides them as soon as the pointer is not on them, and forces \"Hide unless "
 "hovered\"."
+msgstr ""
+
+#: jellyfin_mpv_shim/mpvtk_browser/config.py
+msgid ""
+"Narrowing the window shrinks the controls until the smallest button reaches "
+"the accessibility minimum, instead of dropping buttons sooner. Off keeps the "
+"older, larger floor."
 msgstr ""
 
 #: jellyfin_mpv_shim/mpvtk_browser/config.py
@@ -3889,6 +3977,7 @@ msgid "More Like This"
 msgstr "இது போன்றது"
 
 #: jellyfin_mpv_shim/mpvtk_browser/pages/detail.py
+#: jellyfin_mpv_shim/mpvtk_browser/tiles.py
 msgid "Go to Series"
 msgstr ""
 
@@ -5080,6 +5169,22 @@ msgstr "சேவையகத்தை அகற்று"
 msgid "There is nothing here to queue."
 msgstr ""
 
+#: jellyfin_mpv_shim/mpvtk_browser/timefmt.py
+#, python-brace-format
+msgctxt "12-hour clock"
+msgid "{time} {period}"
+msgstr ""
+
+#: jellyfin_mpv_shim/mpvtk_browser/timefmt.py
+msgctxt "12-hour clock"
+msgid "AM"
+msgstr ""
+
+#: jellyfin_mpv_shim/mpvtk_browser/timefmt.py
+msgctxt "12-hour clock"
+msgid "PM"
+msgstr ""
+
 # seeded from jellyfin-web: Search
 #: jellyfin_mpv_shim/mpvtk_browser/views.py
 #: jellyfin_mpv_shim/mpvtk_browser/window_chrome.py
@@ -5247,13 +5352,32 @@ msgid "Enable SVP"
 msgstr "SVP ஐ இயக்கு"
 
 #: jellyfin_mpv_shim/sync/manager.py
+msgid "The downloads are already in that folder."
+msgstr ""
+
+#: jellyfin_mpv_shim/sync/manager.py
 msgid ""
 "Can't change the download folder while a download is in progress. Wait for "
 "it to finish, then try again."
 msgstr ""
 
 #: jellyfin_mpv_shim/sync/manager.py
+msgid ""
+"That folder is inside the current download folder. Choose one outside it."
+msgstr ""
+
+#: jellyfin_mpv_shim/sync/manager.py
+msgid "Can't read that folder. Check the path and its permissions."
+msgstr ""
+
+#: jellyfin_mpv_shim/sync/manager.py
 msgid "That folder already contains downloads. Choose an empty folder."
+msgstr ""
+
+#: jellyfin_mpv_shim/sync/manager.py
+msgid ""
+"That folder isn't empty. Choose an empty folder — the download folder is "
+"managed by this app and anything else in it can be moved or removed."
 msgstr ""
 
 #: jellyfin_mpv_shim/sync/manager.py
@@ -5262,6 +5386,12 @@ msgstr ""
 
 #: jellyfin_mpv_shim/sync/manager.py
 msgid "A download is still finishing. Wait for it to stop, then try again."
+msgstr ""
+
+#: jellyfin_mpv_shim/sync/manager.py
+msgid ""
+"There isn't enough space on that drive to move the downloads. Free some "
+"space and try again — nothing was moved."
 msgstr ""
 
 #: jellyfin_mpv_shim/sync/manager.py

--- a/jellyfin_mpv_shim/messages/th/LC_MESSAGES/base.po
+++ b/jellyfin_mpv_shim/messages/th/LC_MESSAGES/base.po
@@ -6,7 +6,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2026-08-30 22:19-0400\n"
+"POT-Creation-Date: 2026-09-07 17:35-0400\n"
 "PO-Revision-Date: 2026-09-05 13:42+0000\n"
 "Last-Translator: AlphaBeta <mangahadplae@gmail.com>\n"
 "Language-Team: Thai <https://translate.jellyfin.org/projects/jellyfin/"
@@ -539,6 +539,11 @@ msgid "Night Mode (Auto Volume Adj)"
 msgstr ""
 
 #: jellyfin_mpv_shim/mpvtk_browser/app.py
+#: jellyfin_mpv_shim/mpvtk_browser/auth.py
+msgid "Locked"
+msgstr ""
+
+#: jellyfin_mpv_shim/mpvtk_browser/app.py
 msgid "Failed to load. Check the connection."
 msgstr ""
 
@@ -796,10 +801,6 @@ msgid "Could not connect. Please check your details."
 msgstr "ไม่สามารถเชื่อมต่อได้ โปรดตรวจสอบรายละเอียดของคุณ"
 
 #: jellyfin_mpv_shim/mpvtk_browser/auth.py
-msgid "Locked"
-msgstr ""
-
-#: jellyfin_mpv_shim/mpvtk_browser/auth.py
 #: jellyfin_mpv_shim/mpvtk_browser/pages/home.py
 msgid "Connecting to your server…"
 msgstr ""
@@ -879,6 +880,10 @@ msgstr "ออกจากโปรแกรมและทำเครื่อ
 #: jellyfin_mpv_shim/mpvtk_browser/pages/books.py
 msgid "Favorite"
 msgstr "รายการโปรด"
+
+#: jellyfin_mpv_shim/mpvtk_browser/components/detail.py
+msgid "Web"
+msgstr ""
 
 #: jellyfin_mpv_shim/mpvtk_browser/components/media_info.py
 msgid "Video"
@@ -1424,11 +1429,7 @@ msgid "Jellyfin UI"
 msgstr ""
 
 #: jellyfin_mpv_shim/mpvtk_browser/config.py
-msgid "MPV UI with thumbnails"
-msgstr ""
-
-#: jellyfin_mpv_shim/mpvtk_browser/config.py
-msgid "MPV built-in default"
+msgid "MPV UI"
 msgstr ""
 
 #: jellyfin_mpv_shim/mpvtk_browser/config.py
@@ -1773,8 +1774,22 @@ msgid "Window Buttons in the Top Bar"
 msgstr ""
 
 #: jellyfin_mpv_shim/mpvtk_browser/config.py
+msgid "Keep Window Buttons in Full Screen"
+msgstr ""
+
+#: jellyfin_mpv_shim/mpvtk_browser/config.py
+msgid "Hide the Desktop Title Bar"
+msgstr ""
+
+#: jellyfin_mpv_shim/mpvtk_browser/config.py
 msgid "Player Controls Style"
 msgstr ""
+
+#: jellyfin_mpv_shim/mpvtk_browser/config.py
+#, fuzzy
+#| msgid "Enable thumbnail previews"
+msgid "Enable Trickplay Thumbnails"
+msgstr "เปิดใช้งานการแสดงตัวอย่างภาพขนาดย่อ"
 
 #: jellyfin_mpv_shim/mpvtk_browser/config.py
 msgid "Load All Seek Previews at Once"
@@ -1804,6 +1819,10 @@ msgstr ""
 
 #: jellyfin_mpv_shim/mpvtk_browser/config.py
 msgid "Full-Width Backdrops"
+msgstr ""
+
+#: jellyfin_mpv_shim/mpvtk_browser/config.py
+msgid "12-Hour Clock"
 msgstr ""
 
 #: jellyfin_mpv_shim/mpvtk_browser/config.py
@@ -1847,11 +1866,19 @@ msgid "Fullscreen Library Browser"
 msgstr ""
 
 #: jellyfin_mpv_shim/mpvtk_browser/config.py
+msgid "Block Player Keybinds While Browsing"
+msgstr ""
+
+#: jellyfin_mpv_shim/mpvtk_browser/config.py
 msgid "Always Bind Arrow Keys to Player Controls"
 msgstr ""
 
 #: jellyfin_mpv_shim/mpvtk_browser/config.py
 msgid "Player Controls Activation Key"
+msgstr ""
+
+#: jellyfin_mpv_shim/mpvtk_browser/config.py
+msgid "Select Key"
 msgstr ""
 
 #: jellyfin_mpv_shim/mpvtk_browser/config.py
@@ -1864,6 +1891,10 @@ msgstr ""
 
 #: jellyfin_mpv_shim/mpvtk_browser/config.py
 msgid "Hide the Player Controls After (seconds)"
+msgstr ""
+
+#: jellyfin_mpv_shim/mpvtk_browser/config.py
+msgid "Shrink the Player Controls on a Narrow Window"
 msgstr ""
 
 #: jellyfin_mpv_shim/mpvtk_browser/config.py
@@ -1950,6 +1981,21 @@ msgstr ""
 
 #: jellyfin_mpv_shim/mpvtk_browser/config.py
 msgid ""
+"Stops MPV's own shortcuts -- picture adjustment, screenshots, subtitle and "
+"audio switching -- from acting while you are in the library, where there is "
+"no video for them to act on. Turn it off to use your own MPV key bindings "
+"there."
+msgstr ""
+
+#: jellyfin_mpv_shim/mpvtk_browser/config.py
+msgid ""
+"Activates whatever is highlighted, in the library and on the player "
+"controls. An mpv key name; changing it hands Enter back to MPV. The game "
+"controller's Confirm button and a phone's Select follow it."
+msgstr ""
+
+#: jellyfin_mpv_shim/mpvtk_browser/config.py
+msgid ""
 "Leave these blank unless downloads are waking your disks too often. Set both "
 "of the first two together: episodes are then fetched in one batch when a "
 "series runs low, instead of one at a time."
@@ -1963,7 +2009,8 @@ msgstr ""
 #: jellyfin_mpv_shim/mpvtk_browser/config.py
 msgid ""
 "Off gives MPV's own mouse behaviour instead: drag the video to move the "
-"window, and right click to pause. Double click is full screen either way."
+"window, and the right button does whatever your MPV config gives it. Double "
+"click is full screen either way."
 msgstr ""
 
 #: jellyfin_mpv_shim/mpvtk_browser/config.py
@@ -2053,6 +2100,30 @@ msgid ""
 "maximize and close in the top bar instead, and lets you drag the window by "
 "it. On \"Only when the window has no title bar\", MPV is asked whether this "
 "window got one, so desktops that draw a title bar are left alone."
+msgstr ""
+
+#: jellyfin_mpv_shim/mpvtk_browser/config.py
+msgid ""
+"Full screen has no title bar anywhere and nothing to move or maximize, so "
+"the buttons are normally hidden there. Turn this on to keep a way out of "
+"full screen that is not a keyboard shortcut."
+msgstr ""
+
+#: jellyfin_mpv_shim/mpvtk_browser/config.py
+msgid ""
+"Asks the desktop for no title bar on the player window, so the top bar above "
+"is the only one. Pairs with the setting above: on \"Only when the window has "
+"no title bar\" the buttons appear as soon as this is on. Leave both off "
+"unless you want them, since a window with neither can be awkward to move on "
+"some desktops."
+msgstr ""
+
+#: jellyfin_mpv_shim/mpvtk_browser/config.py
+msgid ""
+"Shows a preview frame while you drag the seek bar. Works with every player "
+"control style, including your own OSC script if it supports thumbfast. The "
+"images are fetched from the server per video, which costs disk space and "
+"memory -- tens of MB for an episode, a few hundred for a long film."
 msgstr ""
 
 #: jellyfin_mpv_shim/mpvtk_browser/config.py
@@ -2162,6 +2233,13 @@ msgstr ""
 
 #: jellyfin_mpv_shim/mpvtk_browser/config.py
 msgid ""
+"Show times of day as \"8:30 PM\" rather than \"20:30\" — the Live TV guide "
+"and its air times, and the \"Ends at\" labels on a detail page and the "
+"player controls."
+msgstr ""
+
+#: jellyfin_mpv_shim/mpvtk_browser/config.py
+msgid ""
 "The controls have to stay legible over any frame. \"None\" gives the text a "
 "drop shadow instead of shading the picture behind it."
 msgstr ""
@@ -2176,6 +2254,13 @@ msgstr ""
 msgid ""
 "0 hides them as soon as the pointer is not on them, and forces \"Hide unless "
 "hovered\"."
+msgstr ""
+
+#: jellyfin_mpv_shim/mpvtk_browser/config.py
+msgid ""
+"Narrowing the window shrinks the controls until the smallest button reaches "
+"the accessibility minimum, instead of dropping buttons sooner. Off keeps the "
+"older, larger floor."
 msgstr ""
 
 #: jellyfin_mpv_shim/mpvtk_browser/config.py
@@ -3649,6 +3734,7 @@ msgid "More Like This"
 msgstr ""
 
 #: jellyfin_mpv_shim/mpvtk_browser/pages/detail.py
+#: jellyfin_mpv_shim/mpvtk_browser/tiles.py
 msgid "Go to Series"
 msgstr ""
 
@@ -4730,6 +4816,22 @@ msgstr "ลบ %s ออกจากคอลเลกชันนี้หร�
 msgid "There is nothing here to queue."
 msgstr ""
 
+#: jellyfin_mpv_shim/mpvtk_browser/timefmt.py
+#, python-brace-format
+msgctxt "12-hour clock"
+msgid "{time} {period}"
+msgstr ""
+
+#: jellyfin_mpv_shim/mpvtk_browser/timefmt.py
+msgctxt "12-hour clock"
+msgid "AM"
+msgstr ""
+
+#: jellyfin_mpv_shim/mpvtk_browser/timefmt.py
+msgctxt "12-hour clock"
+msgid "PM"
+msgstr ""
+
 # seeded from jellyfin-web: Search
 #: jellyfin_mpv_shim/mpvtk_browser/views.py
 #: jellyfin_mpv_shim/mpvtk_browser/window_chrome.py
@@ -4891,13 +4993,32 @@ msgid "Enable SVP"
 msgstr "เปิดใช้งาน SVP"
 
 #: jellyfin_mpv_shim/sync/manager.py
+msgid "The downloads are already in that folder."
+msgstr ""
+
+#: jellyfin_mpv_shim/sync/manager.py
 msgid ""
 "Can't change the download folder while a download is in progress. Wait for "
 "it to finish, then try again."
 msgstr ""
 
 #: jellyfin_mpv_shim/sync/manager.py
+msgid ""
+"That folder is inside the current download folder. Choose one outside it."
+msgstr ""
+
+#: jellyfin_mpv_shim/sync/manager.py
+msgid "Can't read that folder. Check the path and its permissions."
+msgstr ""
+
+#: jellyfin_mpv_shim/sync/manager.py
 msgid "That folder already contains downloads. Choose an empty folder."
+msgstr ""
+
+#: jellyfin_mpv_shim/sync/manager.py
+msgid ""
+"That folder isn't empty. Choose an empty folder — the download folder is "
+"managed by this app and anything else in it can be moved or removed."
 msgstr ""
 
 #: jellyfin_mpv_shim/sync/manager.py
@@ -4906,6 +5027,12 @@ msgstr ""
 
 #: jellyfin_mpv_shim/sync/manager.py
 msgid "A download is still finishing. Wait for it to stop, then try again."
+msgstr ""
+
+#: jellyfin_mpv_shim/sync/manager.py
+msgid ""
+"There isn't enough space on that drive to move the downloads. Free some "
+"space and try again — nothing was moved."
 msgstr ""
 
 #: jellyfin_mpv_shim/sync/manager.py

--- a/jellyfin_mpv_shim/messages/tr/LC_MESSAGES/base.po
+++ b/jellyfin_mpv_shim/messages/tr/LC_MESSAGES/base.po
@@ -6,7 +6,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2026-08-30 22:19-0400\n"
+"POT-Creation-Date: 2026-09-07 17:35-0400\n"
 "PO-Revision-Date: 2026-09-04 23:50+0000\n"
 "Last-Translator: queeup <queeup@zoho.com>\n"
 "Language-Team: Turkish <https://translate.jellyfin.org/projects/jellyfin/"
@@ -549,6 +549,11 @@ msgid "Night Mode (Auto Volume Adj)"
 msgstr "Gece modu (Otomatik Ses Ayarlama)"
 
 #: jellyfin_mpv_shim/mpvtk_browser/app.py
+#: jellyfin_mpv_shim/mpvtk_browser/auth.py
+msgid "Locked"
+msgstr "Kilitli"
+
+#: jellyfin_mpv_shim/mpvtk_browser/app.py
 msgid "Failed to load. Check the connection."
 msgstr "Yüklenemedi. Bağlantıyı kontrol edin."
 
@@ -826,10 +831,6 @@ msgstr ""
 "Lütfen bağlantınızı kontrol ediniz."
 
 #: jellyfin_mpv_shim/mpvtk_browser/auth.py
-msgid "Locked"
-msgstr "Kilitli"
-
-#: jellyfin_mpv_shim/mpvtk_browser/auth.py
 #: jellyfin_mpv_shim/mpvtk_browser/pages/home.py
 msgid "Connecting to your server…"
 msgstr "Sunucunuza bağlanılıyor…"
@@ -910,6 +911,10 @@ msgstr "İzlenmedi Olarak İşaretle ve Çıkış Yap"
 #: jellyfin_mpv_shim/mpvtk_browser/pages/books.py
 msgid "Favorite"
 msgstr "Favori"
+
+#: jellyfin_mpv_shim/mpvtk_browser/components/detail.py
+msgid "Web"
+msgstr ""
 
 # seeded from jellyfin-web: HeaderVideos
 #: jellyfin_mpv_shim/mpvtk_browser/components/media_info.py
@@ -1527,12 +1532,8 @@ msgid "Jellyfin UI"
 msgstr "Jellyfin Arayüzü"
 
 #: jellyfin_mpv_shim/mpvtk_browser/config.py
-msgid "MPV UI with thumbnails"
-msgstr "Küçük resimli MPV arayüzü"
-
-#: jellyfin_mpv_shim/mpvtk_browser/config.py
-msgid "MPV built-in default"
-msgstr "MPV gömülü varsayılan"
+msgid "MPV UI"
+msgstr ""
 
 #: jellyfin_mpv_shim/mpvtk_browser/config.py
 msgid "Custom OSC"
@@ -1877,8 +1878,22 @@ msgid "Window Buttons in the Top Bar"
 msgstr ""
 
 #: jellyfin_mpv_shim/mpvtk_browser/config.py
+msgid "Keep Window Buttons in Full Screen"
+msgstr ""
+
+#: jellyfin_mpv_shim/mpvtk_browser/config.py
+msgid "Hide the Desktop Title Bar"
+msgstr ""
+
+#: jellyfin_mpv_shim/mpvtk_browser/config.py
 msgid "Player Controls Style"
 msgstr ""
+
+#: jellyfin_mpv_shim/mpvtk_browser/config.py
+#, fuzzy
+#| msgid "Enable thumbnail previews"
+msgid "Enable Trickplay Thumbnails"
+msgstr "Küçük resim önizlemelerini etkinleştirin"
 
 #: jellyfin_mpv_shim/mpvtk_browser/config.py
 msgid "Load All Seek Previews at Once"
@@ -1909,6 +1924,10 @@ msgstr ""
 
 #: jellyfin_mpv_shim/mpvtk_browser/config.py
 msgid "Full-Width Backdrops"
+msgstr ""
+
+#: jellyfin_mpv_shim/mpvtk_browser/config.py
+msgid "12-Hour Clock"
 msgstr ""
 
 #: jellyfin_mpv_shim/mpvtk_browser/config.py
@@ -1954,12 +1973,23 @@ msgid "Fullscreen Library Browser"
 msgstr ""
 
 #: jellyfin_mpv_shim/mpvtk_browser/config.py
+msgid "Block Player Keybinds While Browsing"
+msgstr ""
+
+#: jellyfin_mpv_shim/mpvtk_browser/config.py
 msgid "Always Bind Arrow Keys to Player Controls"
 msgstr ""
 
 #: jellyfin_mpv_shim/mpvtk_browser/config.py
 msgid "Player Controls Activation Key"
 msgstr ""
+
+# seeded from jellyfin-web: SelectAll
+#: jellyfin_mpv_shim/mpvtk_browser/config.py
+#, fuzzy
+#| msgid "Select All"
+msgid "Select Key"
+msgstr "Tümünü Seç"
 
 #: jellyfin_mpv_shim/mpvtk_browser/config.py
 msgid "Shading Behind the Player Controls"
@@ -1971,6 +2001,10 @@ msgstr ""
 
 #: jellyfin_mpv_shim/mpvtk_browser/config.py
 msgid "Hide the Player Controls After (seconds)"
+msgstr ""
+
+#: jellyfin_mpv_shim/mpvtk_browser/config.py
+msgid "Shrink the Player Controls on a Narrow Window"
 msgstr ""
 
 #: jellyfin_mpv_shim/mpvtk_browser/config.py
@@ -2057,6 +2091,21 @@ msgstr ""
 
 #: jellyfin_mpv_shim/mpvtk_browser/config.py
 msgid ""
+"Stops MPV's own shortcuts -- picture adjustment, screenshots, subtitle and "
+"audio switching -- from acting while you are in the library, where there is "
+"no video for them to act on. Turn it off to use your own MPV key bindings "
+"there."
+msgstr ""
+
+#: jellyfin_mpv_shim/mpvtk_browser/config.py
+msgid ""
+"Activates whatever is highlighted, in the library and on the player "
+"controls. An mpv key name; changing it hands Enter back to MPV. The game "
+"controller's Confirm button and a phone's Select follow it."
+msgstr ""
+
+#: jellyfin_mpv_shim/mpvtk_browser/config.py
+msgid ""
 "Leave these blank unless downloads are waking your disks too often. Set both "
 "of the first two together: episodes are then fetched in one batch when a "
 "series runs low, instead of one at a time."
@@ -2070,7 +2119,8 @@ msgstr ""
 #: jellyfin_mpv_shim/mpvtk_browser/config.py
 msgid ""
 "Off gives MPV's own mouse behaviour instead: drag the video to move the "
-"window, and right click to pause. Double click is full screen either way."
+"window, and the right button does whatever your MPV config gives it. Double "
+"click is full screen either way."
 msgstr ""
 
 #: jellyfin_mpv_shim/mpvtk_browser/config.py
@@ -2160,6 +2210,30 @@ msgid ""
 "maximize and close in the top bar instead, and lets you drag the window by "
 "it. On \"Only when the window has no title bar\", MPV is asked whether this "
 "window got one, so desktops that draw a title bar are left alone."
+msgstr ""
+
+#: jellyfin_mpv_shim/mpvtk_browser/config.py
+msgid ""
+"Full screen has no title bar anywhere and nothing to move or maximize, so "
+"the buttons are normally hidden there. Turn this on to keep a way out of "
+"full screen that is not a keyboard shortcut."
+msgstr ""
+
+#: jellyfin_mpv_shim/mpvtk_browser/config.py
+msgid ""
+"Asks the desktop for no title bar on the player window, so the top bar above "
+"is the only one. Pairs with the setting above: on \"Only when the window has "
+"no title bar\" the buttons appear as soon as this is on. Leave both off "
+"unless you want them, since a window with neither can be awkward to move on "
+"some desktops."
+msgstr ""
+
+#: jellyfin_mpv_shim/mpvtk_browser/config.py
+msgid ""
+"Shows a preview frame while you drag the seek bar. Works with every player "
+"control style, including your own OSC script if it supports thumbfast. The "
+"images are fetched from the server per video, which costs disk space and "
+"memory -- tens of MB for an episode, a few hundred for a long film."
 msgstr ""
 
 #: jellyfin_mpv_shim/mpvtk_browser/config.py
@@ -2278,6 +2352,13 @@ msgstr ""
 
 #: jellyfin_mpv_shim/mpvtk_browser/config.py
 msgid ""
+"Show times of day as \"8:30 PM\" rather than \"20:30\" — the Live TV guide "
+"and its air times, and the \"Ends at\" labels on a detail page and the "
+"player controls."
+msgstr ""
+
+#: jellyfin_mpv_shim/mpvtk_browser/config.py
+msgid ""
 "The controls have to stay legible over any frame. \"None\" gives the text a "
 "drop shadow instead of shading the picture behind it."
 msgstr ""
@@ -2292,6 +2373,13 @@ msgstr ""
 msgid ""
 "0 hides them as soon as the pointer is not on them, and forces \"Hide unless "
 "hovered\"."
+msgstr ""
+
+#: jellyfin_mpv_shim/mpvtk_browser/config.py
+msgid ""
+"Narrowing the window shrinks the controls until the smallest button reaches "
+"the accessibility minimum, instead of dropping buttons sooner. Off keeps the "
+"older, larger floor."
 msgstr ""
 
 #: jellyfin_mpv_shim/mpvtk_browser/config.py
@@ -3895,6 +3983,7 @@ msgid "More Like This"
 msgstr "Benzerleri"
 
 #: jellyfin_mpv_shim/mpvtk_browser/pages/detail.py
+#: jellyfin_mpv_shim/mpvtk_browser/tiles.py
 msgid "Go to Series"
 msgstr ""
 
@@ -5079,6 +5168,22 @@ msgstr "Sunucuyu Kaldır"
 msgid "There is nothing here to queue."
 msgstr ""
 
+#: jellyfin_mpv_shim/mpvtk_browser/timefmt.py
+#, python-brace-format
+msgctxt "12-hour clock"
+msgid "{time} {period}"
+msgstr ""
+
+#: jellyfin_mpv_shim/mpvtk_browser/timefmt.py
+msgctxt "12-hour clock"
+msgid "AM"
+msgstr ""
+
+#: jellyfin_mpv_shim/mpvtk_browser/timefmt.py
+msgctxt "12-hour clock"
+msgid "PM"
+msgstr ""
+
 # seeded from jellyfin-web: Search
 #: jellyfin_mpv_shim/mpvtk_browser/views.py
 #: jellyfin_mpv_shim/mpvtk_browser/window_chrome.py
@@ -5247,13 +5352,32 @@ msgid "Enable SVP"
 msgstr "SVP'yi etkinleştir"
 
 #: jellyfin_mpv_shim/sync/manager.py
+msgid "The downloads are already in that folder."
+msgstr ""
+
+#: jellyfin_mpv_shim/sync/manager.py
 msgid ""
 "Can't change the download folder while a download is in progress. Wait for "
 "it to finish, then try again."
 msgstr ""
 
 #: jellyfin_mpv_shim/sync/manager.py
+msgid ""
+"That folder is inside the current download folder. Choose one outside it."
+msgstr ""
+
+#: jellyfin_mpv_shim/sync/manager.py
+msgid "Can't read that folder. Check the path and its permissions."
+msgstr ""
+
+#: jellyfin_mpv_shim/sync/manager.py
 msgid "That folder already contains downloads. Choose an empty folder."
+msgstr ""
+
+#: jellyfin_mpv_shim/sync/manager.py
+msgid ""
+"That folder isn't empty. Choose an empty folder — the download folder is "
+"managed by this app and anything else in it can be moved or removed."
 msgstr ""
 
 #: jellyfin_mpv_shim/sync/manager.py
@@ -5262,6 +5386,12 @@ msgstr ""
 
 #: jellyfin_mpv_shim/sync/manager.py
 msgid "A download is still finishing. Wait for it to stop, then try again."
+msgstr ""
+
+#: jellyfin_mpv_shim/sync/manager.py
+msgid ""
+"There isn't enough space on that drive to move the downloads. Free some "
+"space and try again — nothing was moved."
 msgstr ""
 
 #: jellyfin_mpv_shim/sync/manager.py
@@ -5464,6 +5594,12 @@ msgstr "Video Oynatma Profilleri"
 #: jellyfin_mpv_shim/video_profile.py
 msgid "Select Shader Profile"
 msgstr "Gölgelendirici Profili Seçin"
+
+#~ msgid "MPV UI with thumbnails"
+#~ msgstr "Küçük resimli MPV arayüzü"
+
+#~ msgid "MPV built-in default"
+#~ msgstr "MPV gömülü varsayılan"
 
 #, fuzzy
 #~| msgid ""

--- a/jellyfin_mpv_shim/messages/ug/LC_MESSAGES/base.po
+++ b/jellyfin_mpv_shim/messages/ug/LC_MESSAGES/base.po
@@ -6,7 +6,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2026-08-30 22:19-0400\n"
+"POT-Creation-Date: 2026-09-07 17:35-0400\n"
 "PO-Revision-Date: 2022-10-07 21:34+0000\n"
 "Last-Translator: YusanTayir <208060627@qq.com>\n"
 "Language-Team: Uyghur <https://translate.jellyfin.org/projects/jellyfin/"
@@ -508,6 +508,11 @@ msgid "Night Mode (Auto Volume Adj)"
 msgstr ""
 
 #: jellyfin_mpv_shim/mpvtk_browser/app.py
+#: jellyfin_mpv_shim/mpvtk_browser/auth.py
+msgid "Locked"
+msgstr ""
+
+#: jellyfin_mpv_shim/mpvtk_browser/app.py
 msgid "Failed to load. Check the connection."
 msgstr ""
 
@@ -759,10 +764,6 @@ msgid "Could not connect. Please check your details."
 msgstr ""
 
 #: jellyfin_mpv_shim/mpvtk_browser/auth.py
-msgid "Locked"
-msgstr ""
-
-#: jellyfin_mpv_shim/mpvtk_browser/auth.py
 #: jellyfin_mpv_shim/mpvtk_browser/pages/home.py
 msgid "Connecting to your server…"
 msgstr ""
@@ -832,6 +833,10 @@ msgstr ""
 #: jellyfin_mpv_shim/mpvtk_browser/hud.py
 #: jellyfin_mpv_shim/mpvtk_browser/pages/books.py
 msgid "Favorite"
+msgstr ""
+
+#: jellyfin_mpv_shim/mpvtk_browser/components/detail.py
+msgid "Web"
 msgstr ""
 
 #: jellyfin_mpv_shim/mpvtk_browser/components/media_info.py
@@ -1345,11 +1350,7 @@ msgid "Jellyfin UI"
 msgstr ""
 
 #: jellyfin_mpv_shim/mpvtk_browser/config.py
-msgid "MPV UI with thumbnails"
-msgstr ""
-
-#: jellyfin_mpv_shim/mpvtk_browser/config.py
-msgid "MPV built-in default"
+msgid "MPV UI"
 msgstr ""
 
 #: jellyfin_mpv_shim/mpvtk_browser/config.py
@@ -1682,7 +1683,19 @@ msgid "Window Buttons in the Top Bar"
 msgstr ""
 
 #: jellyfin_mpv_shim/mpvtk_browser/config.py
+msgid "Keep Window Buttons in Full Screen"
+msgstr ""
+
+#: jellyfin_mpv_shim/mpvtk_browser/config.py
+msgid "Hide the Desktop Title Bar"
+msgstr ""
+
+#: jellyfin_mpv_shim/mpvtk_browser/config.py
 msgid "Player Controls Style"
+msgstr ""
+
+#: jellyfin_mpv_shim/mpvtk_browser/config.py
+msgid "Enable Trickplay Thumbnails"
 msgstr ""
 
 #: jellyfin_mpv_shim/mpvtk_browser/config.py
@@ -1712,6 +1725,10 @@ msgstr ""
 
 #: jellyfin_mpv_shim/mpvtk_browser/config.py
 msgid "Full-Width Backdrops"
+msgstr ""
+
+#: jellyfin_mpv_shim/mpvtk_browser/config.py
+msgid "12-Hour Clock"
 msgstr ""
 
 #: jellyfin_mpv_shim/mpvtk_browser/config.py
@@ -1755,11 +1772,19 @@ msgid "Fullscreen Library Browser"
 msgstr ""
 
 #: jellyfin_mpv_shim/mpvtk_browser/config.py
+msgid "Block Player Keybinds While Browsing"
+msgstr ""
+
+#: jellyfin_mpv_shim/mpvtk_browser/config.py
 msgid "Always Bind Arrow Keys to Player Controls"
 msgstr ""
 
 #: jellyfin_mpv_shim/mpvtk_browser/config.py
 msgid "Player Controls Activation Key"
+msgstr ""
+
+#: jellyfin_mpv_shim/mpvtk_browser/config.py
+msgid "Select Key"
 msgstr ""
 
 #: jellyfin_mpv_shim/mpvtk_browser/config.py
@@ -1772,6 +1797,10 @@ msgstr ""
 
 #: jellyfin_mpv_shim/mpvtk_browser/config.py
 msgid "Hide the Player Controls After (seconds)"
+msgstr ""
+
+#: jellyfin_mpv_shim/mpvtk_browser/config.py
+msgid "Shrink the Player Controls on a Narrow Window"
 msgstr ""
 
 #: jellyfin_mpv_shim/mpvtk_browser/config.py
@@ -1854,6 +1883,21 @@ msgstr ""
 
 #: jellyfin_mpv_shim/mpvtk_browser/config.py
 msgid ""
+"Stops MPV's own shortcuts -- picture adjustment, screenshots, subtitle and "
+"audio switching -- from acting while you are in the library, where there is "
+"no video for them to act on. Turn it off to use your own MPV key bindings "
+"there."
+msgstr ""
+
+#: jellyfin_mpv_shim/mpvtk_browser/config.py
+msgid ""
+"Activates whatever is highlighted, in the library and on the player "
+"controls. An mpv key name; changing it hands Enter back to MPV. The game "
+"controller's Confirm button and a phone's Select follow it."
+msgstr ""
+
+#: jellyfin_mpv_shim/mpvtk_browser/config.py
+msgid ""
 "Leave these blank unless downloads are waking your disks too often. Set both "
 "of the first two together: episodes are then fetched in one batch when a "
 "series runs low, instead of one at a time."
@@ -1867,7 +1911,8 @@ msgstr ""
 #: jellyfin_mpv_shim/mpvtk_browser/config.py
 msgid ""
 "Off gives MPV's own mouse behaviour instead: drag the video to move the "
-"window, and right click to pause. Double click is full screen either way."
+"window, and the right button does whatever your MPV config gives it. Double "
+"click is full screen either way."
 msgstr ""
 
 #: jellyfin_mpv_shim/mpvtk_browser/config.py
@@ -1957,6 +2002,30 @@ msgid ""
 "maximize and close in the top bar instead, and lets you drag the window by "
 "it. On \"Only when the window has no title bar\", MPV is asked whether this "
 "window got one, so desktops that draw a title bar are left alone."
+msgstr ""
+
+#: jellyfin_mpv_shim/mpvtk_browser/config.py
+msgid ""
+"Full screen has no title bar anywhere and nothing to move or maximize, so "
+"the buttons are normally hidden there. Turn this on to keep a way out of "
+"full screen that is not a keyboard shortcut."
+msgstr ""
+
+#: jellyfin_mpv_shim/mpvtk_browser/config.py
+msgid ""
+"Asks the desktop for no title bar on the player window, so the top bar above "
+"is the only one. Pairs with the setting above: on \"Only when the window has "
+"no title bar\" the buttons appear as soon as this is on. Leave both off "
+"unless you want them, since a window with neither can be awkward to move on "
+"some desktops."
+msgstr ""
+
+#: jellyfin_mpv_shim/mpvtk_browser/config.py
+msgid ""
+"Shows a preview frame while you drag the seek bar. Works with every player "
+"control style, including your own OSC script if it supports thumbfast. The "
+"images are fetched from the server per video, which costs disk space and "
+"memory -- tens of MB for an episode, a few hundred for a long film."
 msgstr ""
 
 #: jellyfin_mpv_shim/mpvtk_browser/config.py
@@ -2064,6 +2133,13 @@ msgstr ""
 
 #: jellyfin_mpv_shim/mpvtk_browser/config.py
 msgid ""
+"Show times of day as \"8:30 PM\" rather than \"20:30\" — the Live TV guide "
+"and its air times, and the \"Ends at\" labels on a detail page and the "
+"player controls."
+msgstr ""
+
+#: jellyfin_mpv_shim/mpvtk_browser/config.py
+msgid ""
 "The controls have to stay legible over any frame. \"None\" gives the text a "
 "drop shadow instead of shading the picture behind it."
 msgstr ""
@@ -2078,6 +2154,13 @@ msgstr ""
 msgid ""
 "0 hides them as soon as the pointer is not on them, and forces \"Hide unless "
 "hovered\"."
+msgstr ""
+
+#: jellyfin_mpv_shim/mpvtk_browser/config.py
+msgid ""
+"Narrowing the window shrinks the controls until the smallest button reaches "
+"the accessibility minimum, instead of dropping buttons sooner. Off keeps the "
+"older, larger floor."
 msgstr ""
 
 #: jellyfin_mpv_shim/mpvtk_browser/config.py
@@ -3436,6 +3519,7 @@ msgid "More Like This"
 msgstr ""
 
 #: jellyfin_mpv_shim/mpvtk_browser/pages/detail.py
+#: jellyfin_mpv_shim/mpvtk_browser/tiles.py
 msgid "Go to Series"
 msgstr ""
 
@@ -4466,6 +4550,22 @@ msgstr ""
 msgid "There is nothing here to queue."
 msgstr ""
 
+#: jellyfin_mpv_shim/mpvtk_browser/timefmt.py
+#, python-brace-format
+msgctxt "12-hour clock"
+msgid "{time} {period}"
+msgstr ""
+
+#: jellyfin_mpv_shim/mpvtk_browser/timefmt.py
+msgctxt "12-hour clock"
+msgid "AM"
+msgstr ""
+
+#: jellyfin_mpv_shim/mpvtk_browser/timefmt.py
+msgctxt "12-hour clock"
+msgid "PM"
+msgstr ""
+
 #: jellyfin_mpv_shim/mpvtk_browser/views.py
 #: jellyfin_mpv_shim/mpvtk_browser/window_chrome.py
 msgid "Search"
@@ -4620,13 +4720,32 @@ msgid "Enable SVP"
 msgstr ""
 
 #: jellyfin_mpv_shim/sync/manager.py
+msgid "The downloads are already in that folder."
+msgstr ""
+
+#: jellyfin_mpv_shim/sync/manager.py
 msgid ""
 "Can't change the download folder while a download is in progress. Wait for "
 "it to finish, then try again."
 msgstr ""
 
 #: jellyfin_mpv_shim/sync/manager.py
+msgid ""
+"That folder is inside the current download folder. Choose one outside it."
+msgstr ""
+
+#: jellyfin_mpv_shim/sync/manager.py
+msgid "Can't read that folder. Check the path and its permissions."
+msgstr ""
+
+#: jellyfin_mpv_shim/sync/manager.py
 msgid "That folder already contains downloads. Choose an empty folder."
+msgstr ""
+
+#: jellyfin_mpv_shim/sync/manager.py
+msgid ""
+"That folder isn't empty. Choose an empty folder — the download folder is "
+"managed by this app and anything else in it can be moved or removed."
 msgstr ""
 
 #: jellyfin_mpv_shim/sync/manager.py
@@ -4635,6 +4754,12 @@ msgstr ""
 
 #: jellyfin_mpv_shim/sync/manager.py
 msgid "A download is still finishing. Wait for it to stop, then try again."
+msgstr ""
+
+#: jellyfin_mpv_shim/sync/manager.py
+msgid ""
+"There isn't enough space on that drive to move the downloads. Free some "
+"space and try again — nothing was moved."
 msgstr ""
 
 #: jellyfin_mpv_shim/sync/manager.py

--- a/jellyfin_mpv_shim/messages/uk/LC_MESSAGES/base.po
+++ b/jellyfin_mpv_shim/messages/uk/LC_MESSAGES/base.po
@@ -6,7 +6,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2026-08-30 22:19-0400\n"
+"POT-Creation-Date: 2026-09-07 17:35-0400\n"
 "PO-Revision-Date: 2026-08-04 00:34+0000\n"
 "Last-Translator: potuzhnyj <ivvvvvca@gmail.com>\n"
 "Language-Team: Ukrainian <https://translate.jellyfin.org/projects/jellyfin/"
@@ -521,6 +521,11 @@ msgid "Night Mode (Auto Volume Adj)"
 msgstr ""
 
 #: jellyfin_mpv_shim/mpvtk_browser/app.py
+#: jellyfin_mpv_shim/mpvtk_browser/auth.py
+msgid "Locked"
+msgstr ""
+
+#: jellyfin_mpv_shim/mpvtk_browser/app.py
 msgid "Failed to load. Check the connection."
 msgstr ""
 
@@ -800,10 +805,6 @@ msgstr ""
 "Перевірте дані для підключення."
 
 #: jellyfin_mpv_shim/mpvtk_browser/auth.py
-msgid "Locked"
-msgstr ""
-
-#: jellyfin_mpv_shim/mpvtk_browser/auth.py
 #: jellyfin_mpv_shim/mpvtk_browser/pages/home.py
 msgid "Connecting to your server…"
 msgstr ""
@@ -884,6 +885,10 @@ msgstr "Вийти та відмітити як непереглянуте"
 #: jellyfin_mpv_shim/mpvtk_browser/pages/books.py
 msgid "Favorite"
 msgstr "Обране"
+
+#: jellyfin_mpv_shim/mpvtk_browser/components/detail.py
+msgid "Web"
+msgstr ""
 
 # seeded from jellyfin-web: Video
 #: jellyfin_mpv_shim/mpvtk_browser/components/media_info.py
@@ -1500,11 +1505,7 @@ msgid "Jellyfin UI"
 msgstr ""
 
 #: jellyfin_mpv_shim/mpvtk_browser/config.py
-msgid "MPV UI with thumbnails"
-msgstr ""
-
-#: jellyfin_mpv_shim/mpvtk_browser/config.py
-msgid "MPV built-in default"
+msgid "MPV UI"
 msgstr ""
 
 #: jellyfin_mpv_shim/mpvtk_browser/config.py
@@ -1853,8 +1854,22 @@ msgid "Window Buttons in the Top Bar"
 msgstr ""
 
 #: jellyfin_mpv_shim/mpvtk_browser/config.py
+msgid "Keep Window Buttons in Full Screen"
+msgstr ""
+
+#: jellyfin_mpv_shim/mpvtk_browser/config.py
+msgid "Hide the Desktop Title Bar"
+msgstr ""
+
+#: jellyfin_mpv_shim/mpvtk_browser/config.py
 msgid "Player Controls Style"
 msgstr ""
+
+#: jellyfin_mpv_shim/mpvtk_browser/config.py
+#, fuzzy
+#| msgid "Enable thumbnail previews"
+msgid "Enable Trickplay Thumbnails"
+msgstr "Увімкнути попередній перегляд мініатюр"
 
 #: jellyfin_mpv_shim/mpvtk_browser/config.py
 msgid "Load All Seek Previews at Once"
@@ -1884,6 +1899,10 @@ msgstr ""
 
 #: jellyfin_mpv_shim/mpvtk_browser/config.py
 msgid "Full-Width Backdrops"
+msgstr ""
+
+#: jellyfin_mpv_shim/mpvtk_browser/config.py
+msgid "12-Hour Clock"
 msgstr ""
 
 #: jellyfin_mpv_shim/mpvtk_browser/config.py
@@ -1929,12 +1948,23 @@ msgid "Fullscreen Library Browser"
 msgstr ""
 
 #: jellyfin_mpv_shim/mpvtk_browser/config.py
+msgid "Block Player Keybinds While Browsing"
+msgstr ""
+
+#: jellyfin_mpv_shim/mpvtk_browser/config.py
 msgid "Always Bind Arrow Keys to Player Controls"
 msgstr ""
 
 #: jellyfin_mpv_shim/mpvtk_browser/config.py
 msgid "Player Controls Activation Key"
 msgstr ""
+
+# seeded from jellyfin-web: SelectAll
+#: jellyfin_mpv_shim/mpvtk_browser/config.py
+#, fuzzy
+#| msgid "Select All"
+msgid "Select Key"
+msgstr "Обрати все"
 
 #: jellyfin_mpv_shim/mpvtk_browser/config.py
 msgid "Shading Behind the Player Controls"
@@ -1946,6 +1976,10 @@ msgstr ""
 
 #: jellyfin_mpv_shim/mpvtk_browser/config.py
 msgid "Hide the Player Controls After (seconds)"
+msgstr ""
+
+#: jellyfin_mpv_shim/mpvtk_browser/config.py
+msgid "Shrink the Player Controls on a Narrow Window"
 msgstr ""
 
 #: jellyfin_mpv_shim/mpvtk_browser/config.py
@@ -2032,6 +2066,21 @@ msgstr ""
 
 #: jellyfin_mpv_shim/mpvtk_browser/config.py
 msgid ""
+"Stops MPV's own shortcuts -- picture adjustment, screenshots, subtitle and "
+"audio switching -- from acting while you are in the library, where there is "
+"no video for them to act on. Turn it off to use your own MPV key bindings "
+"there."
+msgstr ""
+
+#: jellyfin_mpv_shim/mpvtk_browser/config.py
+msgid ""
+"Activates whatever is highlighted, in the library and on the player "
+"controls. An mpv key name; changing it hands Enter back to MPV. The game "
+"controller's Confirm button and a phone's Select follow it."
+msgstr ""
+
+#: jellyfin_mpv_shim/mpvtk_browser/config.py
+msgid ""
 "Leave these blank unless downloads are waking your disks too often. Set both "
 "of the first two together: episodes are then fetched in one batch when a "
 "series runs low, instead of one at a time."
@@ -2045,7 +2094,8 @@ msgstr ""
 #: jellyfin_mpv_shim/mpvtk_browser/config.py
 msgid ""
 "Off gives MPV's own mouse behaviour instead: drag the video to move the "
-"window, and right click to pause. Double click is full screen either way."
+"window, and the right button does whatever your MPV config gives it. Double "
+"click is full screen either way."
 msgstr ""
 
 #: jellyfin_mpv_shim/mpvtk_browser/config.py
@@ -2135,6 +2185,30 @@ msgid ""
 "maximize and close in the top bar instead, and lets you drag the window by "
 "it. On \"Only when the window has no title bar\", MPV is asked whether this "
 "window got one, so desktops that draw a title bar are left alone."
+msgstr ""
+
+#: jellyfin_mpv_shim/mpvtk_browser/config.py
+msgid ""
+"Full screen has no title bar anywhere and nothing to move or maximize, so "
+"the buttons are normally hidden there. Turn this on to keep a way out of "
+"full screen that is not a keyboard shortcut."
+msgstr ""
+
+#: jellyfin_mpv_shim/mpvtk_browser/config.py
+msgid ""
+"Asks the desktop for no title bar on the player window, so the top bar above "
+"is the only one. Pairs with the setting above: on \"Only when the window has "
+"no title bar\" the buttons appear as soon as this is on. Leave both off "
+"unless you want them, since a window with neither can be awkward to move on "
+"some desktops."
+msgstr ""
+
+#: jellyfin_mpv_shim/mpvtk_browser/config.py
+msgid ""
+"Shows a preview frame while you drag the seek bar. Works with every player "
+"control style, including your own OSC script if it supports thumbfast. The "
+"images are fetched from the server per video, which costs disk space and "
+"memory -- tens of MB for an episode, a few hundred for a long film."
 msgstr ""
 
 #: jellyfin_mpv_shim/mpvtk_browser/config.py
@@ -2244,6 +2318,13 @@ msgstr ""
 
 #: jellyfin_mpv_shim/mpvtk_browser/config.py
 msgid ""
+"Show times of day as \"8:30 PM\" rather than \"20:30\" — the Live TV guide "
+"and its air times, and the \"Ends at\" labels on a detail page and the "
+"player controls."
+msgstr ""
+
+#: jellyfin_mpv_shim/mpvtk_browser/config.py
+msgid ""
 "The controls have to stay legible over any frame. \"None\" gives the text a "
 "drop shadow instead of shading the picture behind it."
 msgstr ""
@@ -2258,6 +2339,13 @@ msgstr ""
 msgid ""
 "0 hides them as soon as the pointer is not on them, and forces \"Hide unless "
 "hovered\"."
+msgstr ""
+
+#: jellyfin_mpv_shim/mpvtk_browser/config.py
+msgid ""
+"Narrowing the window shrinks the controls until the smallest button reaches "
+"the accessibility minimum, instead of dropping buttons sooner. Off keeps the "
+"older, larger floor."
 msgstr ""
 
 #: jellyfin_mpv_shim/mpvtk_browser/config.py
@@ -3864,6 +3952,7 @@ msgid "More Like This"
 msgstr "Подібні до цього"
 
 #: jellyfin_mpv_shim/mpvtk_browser/pages/detail.py
+#: jellyfin_mpv_shim/mpvtk_browser/tiles.py
 msgid "Go to Series"
 msgstr ""
 
@@ -5057,6 +5146,22 @@ msgstr "Видалити сервер"
 msgid "There is nothing here to queue."
 msgstr ""
 
+#: jellyfin_mpv_shim/mpvtk_browser/timefmt.py
+#, python-brace-format
+msgctxt "12-hour clock"
+msgid "{time} {period}"
+msgstr ""
+
+#: jellyfin_mpv_shim/mpvtk_browser/timefmt.py
+msgctxt "12-hour clock"
+msgid "AM"
+msgstr ""
+
+#: jellyfin_mpv_shim/mpvtk_browser/timefmt.py
+msgctxt "12-hour clock"
+msgid "PM"
+msgstr ""
+
 # seeded from jellyfin-web: Search
 #: jellyfin_mpv_shim/mpvtk_browser/views.py
 #: jellyfin_mpv_shim/mpvtk_browser/window_chrome.py
@@ -5225,13 +5330,32 @@ msgid "Enable SVP"
 msgstr "Увімкніть SVP"
 
 #: jellyfin_mpv_shim/sync/manager.py
+msgid "The downloads are already in that folder."
+msgstr ""
+
+#: jellyfin_mpv_shim/sync/manager.py
 msgid ""
 "Can't change the download folder while a download is in progress. Wait for "
 "it to finish, then try again."
 msgstr ""
 
 #: jellyfin_mpv_shim/sync/manager.py
+msgid ""
+"That folder is inside the current download folder. Choose one outside it."
+msgstr ""
+
+#: jellyfin_mpv_shim/sync/manager.py
+msgid "Can't read that folder. Check the path and its permissions."
+msgstr ""
+
+#: jellyfin_mpv_shim/sync/manager.py
 msgid "That folder already contains downloads. Choose an empty folder."
+msgstr ""
+
+#: jellyfin_mpv_shim/sync/manager.py
+msgid ""
+"That folder isn't empty. Choose an empty folder — the download folder is "
+"managed by this app and anything else in it can be moved or removed."
 msgstr ""
 
 #: jellyfin_mpv_shim/sync/manager.py
@@ -5240,6 +5364,12 @@ msgstr ""
 
 #: jellyfin_mpv_shim/sync/manager.py
 msgid "A download is still finishing. Wait for it to stop, then try again."
+msgstr ""
+
+#: jellyfin_mpv_shim/sync/manager.py
+msgid ""
+"There isn't enough space on that drive to move the downloads. Free some "
+"space and try again — nothing was moved."
 msgstr ""
 
 #: jellyfin_mpv_shim/sync/manager.py

--- a/jellyfin_mpv_shim/messages/uz/LC_MESSAGES/base.po
+++ b/jellyfin_mpv_shim/messages/uz/LC_MESSAGES/base.po
@@ -6,7 +6,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2026-08-30 22:19-0400\n"
+"POT-Creation-Date: 2026-09-07 17:35-0400\n"
 "PO-Revision-Date: 2026-06-21 14:18+0000\n"
 "Last-Translator: someone522 <eldorerkin99@gmail.com>\n"
 "Language-Team: Uzbek <https://translate.jellyfin.org/projects/jellyfin/"
@@ -512,6 +512,11 @@ msgid "Night Mode (Auto Volume Adj)"
 msgstr ""
 
 #: jellyfin_mpv_shim/mpvtk_browser/app.py
+#: jellyfin_mpv_shim/mpvtk_browser/auth.py
+msgid "Locked"
+msgstr ""
+
+#: jellyfin_mpv_shim/mpvtk_browser/app.py
 msgid "Failed to load. Check the connection."
 msgstr ""
 
@@ -766,10 +771,6 @@ msgid "Could not connect. Please check your details."
 msgstr ""
 
 #: jellyfin_mpv_shim/mpvtk_browser/auth.py
-msgid "Locked"
-msgstr ""
-
-#: jellyfin_mpv_shim/mpvtk_browser/auth.py
 #: jellyfin_mpv_shim/mpvtk_browser/pages/home.py
 msgid "Connecting to your server…"
 msgstr ""
@@ -846,6 +847,10 @@ msgstr ""
 #: jellyfin_mpv_shim/mpvtk_browser/pages/books.py
 msgid "Favorite"
 msgstr "Sevimlilar"
+
+#: jellyfin_mpv_shim/mpvtk_browser/components/detail.py
+msgid "Web"
+msgstr ""
 
 # seeded from jellyfin-web: HeaderVideos
 #: jellyfin_mpv_shim/mpvtk_browser/components/media_info.py
@@ -1383,11 +1388,7 @@ msgid "Jellyfin UI"
 msgstr ""
 
 #: jellyfin_mpv_shim/mpvtk_browser/config.py
-msgid "MPV UI with thumbnails"
-msgstr ""
-
-#: jellyfin_mpv_shim/mpvtk_browser/config.py
-msgid "MPV built-in default"
+msgid "MPV UI"
 msgstr ""
 
 #: jellyfin_mpv_shim/mpvtk_browser/config.py
@@ -1725,7 +1726,19 @@ msgid "Window Buttons in the Top Bar"
 msgstr ""
 
 #: jellyfin_mpv_shim/mpvtk_browser/config.py
+msgid "Keep Window Buttons in Full Screen"
+msgstr ""
+
+#: jellyfin_mpv_shim/mpvtk_browser/config.py
+msgid "Hide the Desktop Title Bar"
+msgstr ""
+
+#: jellyfin_mpv_shim/mpvtk_browser/config.py
 msgid "Player Controls Style"
+msgstr ""
+
+#: jellyfin_mpv_shim/mpvtk_browser/config.py
+msgid "Enable Trickplay Thumbnails"
 msgstr ""
 
 #: jellyfin_mpv_shim/mpvtk_browser/config.py
@@ -1755,6 +1768,10 @@ msgstr ""
 
 #: jellyfin_mpv_shim/mpvtk_browser/config.py
 msgid "Full-Width Backdrops"
+msgstr ""
+
+#: jellyfin_mpv_shim/mpvtk_browser/config.py
+msgid "12-Hour Clock"
 msgstr ""
 
 #: jellyfin_mpv_shim/mpvtk_browser/config.py
@@ -1798,11 +1815,19 @@ msgid "Fullscreen Library Browser"
 msgstr ""
 
 #: jellyfin_mpv_shim/mpvtk_browser/config.py
+msgid "Block Player Keybinds While Browsing"
+msgstr ""
+
+#: jellyfin_mpv_shim/mpvtk_browser/config.py
 msgid "Always Bind Arrow Keys to Player Controls"
 msgstr ""
 
 #: jellyfin_mpv_shim/mpvtk_browser/config.py
 msgid "Player Controls Activation Key"
+msgstr ""
+
+#: jellyfin_mpv_shim/mpvtk_browser/config.py
+msgid "Select Key"
 msgstr ""
 
 #: jellyfin_mpv_shim/mpvtk_browser/config.py
@@ -1815,6 +1840,10 @@ msgstr ""
 
 #: jellyfin_mpv_shim/mpvtk_browser/config.py
 msgid "Hide the Player Controls After (seconds)"
+msgstr ""
+
+#: jellyfin_mpv_shim/mpvtk_browser/config.py
+msgid "Shrink the Player Controls on a Narrow Window"
 msgstr ""
 
 #: jellyfin_mpv_shim/mpvtk_browser/config.py
@@ -1897,6 +1926,21 @@ msgstr ""
 
 #: jellyfin_mpv_shim/mpvtk_browser/config.py
 msgid ""
+"Stops MPV's own shortcuts -- picture adjustment, screenshots, subtitle and "
+"audio switching -- from acting while you are in the library, where there is "
+"no video for them to act on. Turn it off to use your own MPV key bindings "
+"there."
+msgstr ""
+
+#: jellyfin_mpv_shim/mpvtk_browser/config.py
+msgid ""
+"Activates whatever is highlighted, in the library and on the player "
+"controls. An mpv key name; changing it hands Enter back to MPV. The game "
+"controller's Confirm button and a phone's Select follow it."
+msgstr ""
+
+#: jellyfin_mpv_shim/mpvtk_browser/config.py
+msgid ""
 "Leave these blank unless downloads are waking your disks too often. Set both "
 "of the first two together: episodes are then fetched in one batch when a "
 "series runs low, instead of one at a time."
@@ -1910,7 +1954,8 @@ msgstr ""
 #: jellyfin_mpv_shim/mpvtk_browser/config.py
 msgid ""
 "Off gives MPV's own mouse behaviour instead: drag the video to move the "
-"window, and right click to pause. Double click is full screen either way."
+"window, and the right button does whatever your MPV config gives it. Double "
+"click is full screen either way."
 msgstr ""
 
 #: jellyfin_mpv_shim/mpvtk_browser/config.py
@@ -2000,6 +2045,30 @@ msgid ""
 "maximize and close in the top bar instead, and lets you drag the window by "
 "it. On \"Only when the window has no title bar\", MPV is asked whether this "
 "window got one, so desktops that draw a title bar are left alone."
+msgstr ""
+
+#: jellyfin_mpv_shim/mpvtk_browser/config.py
+msgid ""
+"Full screen has no title bar anywhere and nothing to move or maximize, so "
+"the buttons are normally hidden there. Turn this on to keep a way out of "
+"full screen that is not a keyboard shortcut."
+msgstr ""
+
+#: jellyfin_mpv_shim/mpvtk_browser/config.py
+msgid ""
+"Asks the desktop for no title bar on the player window, so the top bar above "
+"is the only one. Pairs with the setting above: on \"Only when the window has "
+"no title bar\" the buttons appear as soon as this is on. Leave both off "
+"unless you want them, since a window with neither can be awkward to move on "
+"some desktops."
+msgstr ""
+
+#: jellyfin_mpv_shim/mpvtk_browser/config.py
+msgid ""
+"Shows a preview frame while you drag the seek bar. Works with every player "
+"control style, including your own OSC script if it supports thumbfast. The "
+"images are fetched from the server per video, which costs disk space and "
+"memory -- tens of MB for an episode, a few hundred for a long film."
 msgstr ""
 
 #: jellyfin_mpv_shim/mpvtk_browser/config.py
@@ -2107,6 +2176,13 @@ msgstr ""
 
 #: jellyfin_mpv_shim/mpvtk_browser/config.py
 msgid ""
+"Show times of day as \"8:30 PM\" rather than \"20:30\" — the Live TV guide "
+"and its air times, and the \"Ends at\" labels on a detail page and the "
+"player controls."
+msgstr ""
+
+#: jellyfin_mpv_shim/mpvtk_browser/config.py
+msgid ""
 "The controls have to stay legible over any frame. \"None\" gives the text a "
 "drop shadow instead of shading the picture behind it."
 msgstr ""
@@ -2121,6 +2197,13 @@ msgstr ""
 msgid ""
 "0 hides them as soon as the pointer is not on them, and forces \"Hide unless "
 "hovered\"."
+msgstr ""
+
+#: jellyfin_mpv_shim/mpvtk_browser/config.py
+msgid ""
+"Narrowing the window shrinks the controls until the smallest button reaches "
+"the accessibility minimum, instead of dropping buttons sooner. Off keeps the "
+"older, larger floor."
 msgstr ""
 
 #: jellyfin_mpv_shim/mpvtk_browser/config.py
@@ -3563,6 +3646,7 @@ msgid "More Like This"
 msgstr "Shunga o'xshash"
 
 #: jellyfin_mpv_shim/mpvtk_browser/pages/detail.py
+#: jellyfin_mpv_shim/mpvtk_browser/tiles.py
 msgid "Go to Series"
 msgstr ""
 
@@ -4627,6 +4711,22 @@ msgstr ""
 msgid "There is nothing here to queue."
 msgstr ""
 
+#: jellyfin_mpv_shim/mpvtk_browser/timefmt.py
+#, python-brace-format
+msgctxt "12-hour clock"
+msgid "{time} {period}"
+msgstr ""
+
+#: jellyfin_mpv_shim/mpvtk_browser/timefmt.py
+msgctxt "12-hour clock"
+msgid "AM"
+msgstr ""
+
+#: jellyfin_mpv_shim/mpvtk_browser/timefmt.py
+msgctxt "12-hour clock"
+msgid "PM"
+msgstr ""
+
 #: jellyfin_mpv_shim/mpvtk_browser/views.py
 #: jellyfin_mpv_shim/mpvtk_browser/window_chrome.py
 msgid "Search"
@@ -4785,13 +4885,32 @@ msgid "Enable SVP"
 msgstr ""
 
 #: jellyfin_mpv_shim/sync/manager.py
+msgid "The downloads are already in that folder."
+msgstr ""
+
+#: jellyfin_mpv_shim/sync/manager.py
 msgid ""
 "Can't change the download folder while a download is in progress. Wait for "
 "it to finish, then try again."
 msgstr ""
 
 #: jellyfin_mpv_shim/sync/manager.py
+msgid ""
+"That folder is inside the current download folder. Choose one outside it."
+msgstr ""
+
+#: jellyfin_mpv_shim/sync/manager.py
+msgid "Can't read that folder. Check the path and its permissions."
+msgstr ""
+
+#: jellyfin_mpv_shim/sync/manager.py
 msgid "That folder already contains downloads. Choose an empty folder."
+msgstr ""
+
+#: jellyfin_mpv_shim/sync/manager.py
+msgid ""
+"That folder isn't empty. Choose an empty folder — the download folder is "
+"managed by this app and anything else in it can be moved or removed."
 msgstr ""
 
 #: jellyfin_mpv_shim/sync/manager.py
@@ -4800,6 +4919,12 @@ msgstr ""
 
 #: jellyfin_mpv_shim/sync/manager.py
 msgid "A download is still finishing. Wait for it to stop, then try again."
+msgstr ""
+
+#: jellyfin_mpv_shim/sync/manager.py
+msgid ""
+"There isn't enough space on that drive to move the downloads. Free some "
+"space and try again — nothing was moved."
 msgstr ""
 
 #: jellyfin_mpv_shim/sync/manager.py

--- a/jellyfin_mpv_shim/messages/vi/LC_MESSAGES/base.po
+++ b/jellyfin_mpv_shim/messages/vi/LC_MESSAGES/base.po
@@ -6,7 +6,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2026-08-30 22:19-0400\n"
+"POT-Creation-Date: 2026-09-07 17:35-0400\n"
 "PO-Revision-Date: 2026-08-13 18:11+0000\n"
 "Last-Translator: hoanghuy309 <hoanghuy309@gmail.com>\n"
 "Language-Team: Vietnamese <https://translate.jellyfin.org/projects/jellyfin/"
@@ -547,6 +547,11 @@ msgid "Night Mode (Auto Volume Adj)"
 msgstr ""
 
 #: jellyfin_mpv_shim/mpvtk_browser/app.py
+#: jellyfin_mpv_shim/mpvtk_browser/auth.py
+msgid "Locked"
+msgstr ""
+
+#: jellyfin_mpv_shim/mpvtk_browser/app.py
 msgid "Failed to load. Check the connection."
 msgstr ""
 
@@ -826,10 +831,6 @@ msgstr ""
 "Vui lòng kiểm tra thông tin kết nối của bạn."
 
 #: jellyfin_mpv_shim/mpvtk_browser/auth.py
-msgid "Locked"
-msgstr ""
-
-#: jellyfin_mpv_shim/mpvtk_browser/auth.py
 #: jellyfin_mpv_shim/mpvtk_browser/pages/home.py
 msgid "Connecting to your server…"
 msgstr ""
@@ -910,6 +911,10 @@ msgstr "Thoát và đánh dấu là chưa xem"
 #: jellyfin_mpv_shim/mpvtk_browser/pages/books.py
 msgid "Favorite"
 msgstr "Yêu thích"
+
+#: jellyfin_mpv_shim/mpvtk_browser/components/detail.py
+msgid "Web"
+msgstr ""
 
 # seeded from jellyfin-web: HeaderVideos
 #: jellyfin_mpv_shim/mpvtk_browser/components/media_info.py
@@ -1522,11 +1527,7 @@ msgid "Jellyfin UI"
 msgstr ""
 
 #: jellyfin_mpv_shim/mpvtk_browser/config.py
-msgid "MPV UI with thumbnails"
-msgstr ""
-
-#: jellyfin_mpv_shim/mpvtk_browser/config.py
-msgid "MPV built-in default"
+msgid "MPV UI"
 msgstr ""
 
 #: jellyfin_mpv_shim/mpvtk_browser/config.py
@@ -1875,8 +1876,22 @@ msgid "Window Buttons in the Top Bar"
 msgstr ""
 
 #: jellyfin_mpv_shim/mpvtk_browser/config.py
+msgid "Keep Window Buttons in Full Screen"
+msgstr ""
+
+#: jellyfin_mpv_shim/mpvtk_browser/config.py
+msgid "Hide the Desktop Title Bar"
+msgstr ""
+
+#: jellyfin_mpv_shim/mpvtk_browser/config.py
 msgid "Player Controls Style"
 msgstr ""
+
+#: jellyfin_mpv_shim/mpvtk_browser/config.py
+#, fuzzy
+#| msgid "Enable thumbnail previews"
+msgid "Enable Trickplay Thumbnails"
+msgstr "Bật hình nhỏ xem trước"
 
 #: jellyfin_mpv_shim/mpvtk_browser/config.py
 msgid "Load All Seek Previews at Once"
@@ -1906,6 +1921,10 @@ msgstr ""
 
 #: jellyfin_mpv_shim/mpvtk_browser/config.py
 msgid "Full-Width Backdrops"
+msgstr ""
+
+#: jellyfin_mpv_shim/mpvtk_browser/config.py
+msgid "12-Hour Clock"
 msgstr ""
 
 #: jellyfin_mpv_shim/mpvtk_browser/config.py
@@ -1951,12 +1970,23 @@ msgid "Fullscreen Library Browser"
 msgstr ""
 
 #: jellyfin_mpv_shim/mpvtk_browser/config.py
+msgid "Block Player Keybinds While Browsing"
+msgstr ""
+
+#: jellyfin_mpv_shim/mpvtk_browser/config.py
 msgid "Always Bind Arrow Keys to Player Controls"
 msgstr ""
 
 #: jellyfin_mpv_shim/mpvtk_browser/config.py
 msgid "Player Controls Activation Key"
 msgstr ""
+
+# seeded from jellyfin-web: SelectAll
+#: jellyfin_mpv_shim/mpvtk_browser/config.py
+#, fuzzy
+#| msgid "Select All"
+msgid "Select Key"
+msgstr "Chọn Tất Cả"
 
 #: jellyfin_mpv_shim/mpvtk_browser/config.py
 msgid "Shading Behind the Player Controls"
@@ -1968,6 +1998,10 @@ msgstr ""
 
 #: jellyfin_mpv_shim/mpvtk_browser/config.py
 msgid "Hide the Player Controls After (seconds)"
+msgstr ""
+
+#: jellyfin_mpv_shim/mpvtk_browser/config.py
+msgid "Shrink the Player Controls on a Narrow Window"
 msgstr ""
 
 #: jellyfin_mpv_shim/mpvtk_browser/config.py
@@ -2054,6 +2088,21 @@ msgstr ""
 
 #: jellyfin_mpv_shim/mpvtk_browser/config.py
 msgid ""
+"Stops MPV's own shortcuts -- picture adjustment, screenshots, subtitle and "
+"audio switching -- from acting while you are in the library, where there is "
+"no video for them to act on. Turn it off to use your own MPV key bindings "
+"there."
+msgstr ""
+
+#: jellyfin_mpv_shim/mpvtk_browser/config.py
+msgid ""
+"Activates whatever is highlighted, in the library and on the player "
+"controls. An mpv key name; changing it hands Enter back to MPV. The game "
+"controller's Confirm button and a phone's Select follow it."
+msgstr ""
+
+#: jellyfin_mpv_shim/mpvtk_browser/config.py
+msgid ""
 "Leave these blank unless downloads are waking your disks too often. Set both "
 "of the first two together: episodes are then fetched in one batch when a "
 "series runs low, instead of one at a time."
@@ -2067,7 +2116,8 @@ msgstr ""
 #: jellyfin_mpv_shim/mpvtk_browser/config.py
 msgid ""
 "Off gives MPV's own mouse behaviour instead: drag the video to move the "
-"window, and right click to pause. Double click is full screen either way."
+"window, and the right button does whatever your MPV config gives it. Double "
+"click is full screen either way."
 msgstr ""
 
 #: jellyfin_mpv_shim/mpvtk_browser/config.py
@@ -2157,6 +2207,30 @@ msgid ""
 "maximize and close in the top bar instead, and lets you drag the window by "
 "it. On \"Only when the window has no title bar\", MPV is asked whether this "
 "window got one, so desktops that draw a title bar are left alone."
+msgstr ""
+
+#: jellyfin_mpv_shim/mpvtk_browser/config.py
+msgid ""
+"Full screen has no title bar anywhere and nothing to move or maximize, so "
+"the buttons are normally hidden there. Turn this on to keep a way out of "
+"full screen that is not a keyboard shortcut."
+msgstr ""
+
+#: jellyfin_mpv_shim/mpvtk_browser/config.py
+msgid ""
+"Asks the desktop for no title bar on the player window, so the top bar above "
+"is the only one. Pairs with the setting above: on \"Only when the window has "
+"no title bar\" the buttons appear as soon as this is on. Leave both off "
+"unless you want them, since a window with neither can be awkward to move on "
+"some desktops."
+msgstr ""
+
+#: jellyfin_mpv_shim/mpvtk_browser/config.py
+msgid ""
+"Shows a preview frame while you drag the seek bar. Works with every player "
+"control style, including your own OSC script if it supports thumbfast. The "
+"images are fetched from the server per video, which costs disk space and "
+"memory -- tens of MB for an episode, a few hundred for a long film."
 msgstr ""
 
 #: jellyfin_mpv_shim/mpvtk_browser/config.py
@@ -2266,6 +2340,13 @@ msgstr ""
 
 #: jellyfin_mpv_shim/mpvtk_browser/config.py
 msgid ""
+"Show times of day as \"8:30 PM\" rather than \"20:30\" — the Live TV guide "
+"and its air times, and the \"Ends at\" labels on a detail page and the "
+"player controls."
+msgstr ""
+
+#: jellyfin_mpv_shim/mpvtk_browser/config.py
+msgid ""
 "The controls have to stay legible over any frame. \"None\" gives the text a "
 "drop shadow instead of shading the picture behind it."
 msgstr ""
@@ -2280,6 +2361,13 @@ msgstr ""
 msgid ""
 "0 hides them as soon as the pointer is not on them, and forces \"Hide unless "
 "hovered\"."
+msgstr ""
+
+#: jellyfin_mpv_shim/mpvtk_browser/config.py
+msgid ""
+"Narrowing the window shrinks the controls until the smallest button reaches "
+"the accessibility minimum, instead of dropping buttons sooner. Off keeps the "
+"older, larger floor."
 msgstr ""
 
 #: jellyfin_mpv_shim/mpvtk_browser/config.py
@@ -3881,6 +3969,7 @@ msgid "More Like This"
 msgstr "Nội Dung Tương Tự"
 
 #: jellyfin_mpv_shim/mpvtk_browser/pages/detail.py
+#: jellyfin_mpv_shim/mpvtk_browser/tiles.py
 msgid "Go to Series"
 msgstr ""
 
@@ -5071,6 +5160,22 @@ msgstr "Xóa máy chủ"
 msgid "There is nothing here to queue."
 msgstr ""
 
+#: jellyfin_mpv_shim/mpvtk_browser/timefmt.py
+#, python-brace-format
+msgctxt "12-hour clock"
+msgid "{time} {period}"
+msgstr ""
+
+#: jellyfin_mpv_shim/mpvtk_browser/timefmt.py
+msgctxt "12-hour clock"
+msgid "AM"
+msgstr ""
+
+#: jellyfin_mpv_shim/mpvtk_browser/timefmt.py
+msgctxt "12-hour clock"
+msgid "PM"
+msgstr ""
+
 # seeded from jellyfin-web: Search
 #: jellyfin_mpv_shim/mpvtk_browser/views.py
 #: jellyfin_mpv_shim/mpvtk_browser/window_chrome.py
@@ -5238,13 +5343,32 @@ msgid "Enable SVP"
 msgstr "Bật SVP"
 
 #: jellyfin_mpv_shim/sync/manager.py
+msgid "The downloads are already in that folder."
+msgstr ""
+
+#: jellyfin_mpv_shim/sync/manager.py
 msgid ""
 "Can't change the download folder while a download is in progress. Wait for "
 "it to finish, then try again."
 msgstr ""
 
 #: jellyfin_mpv_shim/sync/manager.py
+msgid ""
+"That folder is inside the current download folder. Choose one outside it."
+msgstr ""
+
+#: jellyfin_mpv_shim/sync/manager.py
+msgid "Can't read that folder. Check the path and its permissions."
+msgstr ""
+
+#: jellyfin_mpv_shim/sync/manager.py
 msgid "That folder already contains downloads. Choose an empty folder."
+msgstr ""
+
+#: jellyfin_mpv_shim/sync/manager.py
+msgid ""
+"That folder isn't empty. Choose an empty folder — the download folder is "
+"managed by this app and anything else in it can be moved or removed."
 msgstr ""
 
 #: jellyfin_mpv_shim/sync/manager.py
@@ -5253,6 +5377,12 @@ msgstr ""
 
 #: jellyfin_mpv_shim/sync/manager.py
 msgid "A download is still finishing. Wait for it to stop, then try again."
+msgstr ""
+
+#: jellyfin_mpv_shim/sync/manager.py
+msgid ""
+"There isn't enough space on that drive to move the downloads. Free some "
+"space and try again — nothing was moved."
 msgstr ""
 
 #: jellyfin_mpv_shim/sync/manager.py

--- a/jellyfin_mpv_shim/messages/zh_Hans/LC_MESSAGES/base.po
+++ b/jellyfin_mpv_shim/messages/zh_Hans/LC_MESSAGES/base.po
@@ -6,7 +6,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2026-08-30 22:19-0400\n"
+"POT-Creation-Date: 2026-09-07 17:35-0400\n"
 "PO-Revision-Date: 2026-09-01 11:27+0000\n"
 "Last-Translator: 無情天 <kofzhanganguo@126.com>\n"
 "Language-Team: Chinese (Simplified Han script) <https://"
@@ -507,6 +507,11 @@ msgid "Night Mode (Auto Volume Adj)"
 msgstr "夜间模式（自动音量调节）"
 
 #: jellyfin_mpv_shim/mpvtk_browser/app.py
+#: jellyfin_mpv_shim/mpvtk_browser/auth.py
+msgid "Locked"
+msgstr "已锁定"
+
+#: jellyfin_mpv_shim/mpvtk_browser/app.py
 msgid "Failed to load. Check the connection."
 msgstr "加载失败，请检查网络连接。"
 
@@ -747,10 +752,6 @@ msgid "Could not connect. Please check your details."
 msgstr "连接失败，请核对填写信息。"
 
 #: jellyfin_mpv_shim/mpvtk_browser/auth.py
-msgid "Locked"
-msgstr "已锁定"
-
-#: jellyfin_mpv_shim/mpvtk_browser/auth.py
 #: jellyfin_mpv_shim/mpvtk_browser/pages/home.py
 msgid "Connecting to your server…"
 msgstr "正在连接你的服务器…"
@@ -821,6 +822,10 @@ msgstr "已观看"
 #: jellyfin_mpv_shim/mpvtk_browser/pages/books.py
 msgid "Favorite"
 msgstr "收藏"
+
+#: jellyfin_mpv_shim/mpvtk_browser/components/detail.py
+msgid "Web"
+msgstr ""
 
 #: jellyfin_mpv_shim/mpvtk_browser/components/media_info.py
 msgid "Video"
@@ -1375,12 +1380,8 @@ msgid "Jellyfin UI"
 msgstr "Jellyfin UI 样式"
 
 #: jellyfin_mpv_shim/mpvtk_browser/config.py
-msgid "MPV UI with thumbnails"
-msgstr "带缩略图的 MPV UI"
-
-#: jellyfin_mpv_shim/mpvtk_browser/config.py
-msgid "MPV built-in default"
-msgstr "MPV 原生默认界面"
+msgid "MPV UI"
+msgstr ""
 
 #: jellyfin_mpv_shim/mpvtk_browser/config.py
 msgid "Custom OSC"
@@ -1713,8 +1714,24 @@ msgid "Window Buttons in the Top Bar"
 msgstr "顶部栏中的窗口按钮"
 
 #: jellyfin_mpv_shim/mpvtk_browser/config.py
+#, fuzzy
+#| msgid "Window Buttons in the Top Bar"
+msgid "Keep Window Buttons in Full Screen"
+msgstr "顶部栏中的窗口按钮"
+
+#: jellyfin_mpv_shim/mpvtk_browser/config.py
+msgid "Hide the Desktop Title Bar"
+msgstr ""
+
+#: jellyfin_mpv_shim/mpvtk_browser/config.py
 msgid "Player Controls Style"
 msgstr "播放器控制界面样式"
+
+#: jellyfin_mpv_shim/mpvtk_browser/config.py
+#, fuzzy
+#| msgid "Enable thumbnail previews"
+msgid "Enable Trickplay Thumbnails"
+msgstr "启用缩略图预览"
 
 #: jellyfin_mpv_shim/mpvtk_browser/config.py
 msgid "Load All Seek Previews at Once"
@@ -1744,6 +1761,10 @@ msgstr "封面尺寸"
 #: jellyfin_mpv_shim/mpvtk_browser/config.py
 msgid "Full-Width Backdrops"
 msgstr "全幅背景图"
+
+#: jellyfin_mpv_shim/mpvtk_browser/config.py
+msgid "12-Hour Clock"
+msgstr ""
 
 #: jellyfin_mpv_shim/mpvtk_browser/config.py
 msgid "Grid Spacing"
@@ -1786,12 +1807,23 @@ msgid "Fullscreen Library Browser"
 msgstr "媒体库全屏显示"
 
 #: jellyfin_mpv_shim/mpvtk_browser/config.py
+msgid "Block Player Keybinds While Browsing"
+msgstr ""
+
+#: jellyfin_mpv_shim/mpvtk_browser/config.py
 msgid "Always Bind Arrow Keys to Player Controls"
 msgstr "方向键始终绑定播放控制"
 
 #: jellyfin_mpv_shim/mpvtk_browser/config.py
 msgid "Player Controls Activation Key"
 msgstr "唤起播放控制快捷键"
+
+# seeded from jellyfin-web: SelectAll
+#: jellyfin_mpv_shim/mpvtk_browser/config.py
+#, fuzzy
+#| msgid "Select All"
+msgid "Select Key"
+msgstr "全选"
 
 #: jellyfin_mpv_shim/mpvtk_browser/config.py
 msgid "Shading Behind the Player Controls"
@@ -1804,6 +1836,12 @@ msgstr "当播放器控制隐藏时"
 #: jellyfin_mpv_shim/mpvtk_browser/config.py
 msgid "Hide the Player Controls After (seconds)"
 msgstr "（秒数）后隐藏播放器控制按钮"
+
+#: jellyfin_mpv_shim/mpvtk_browser/config.py
+#, fuzzy
+#| msgid "When the Player Controls Hide"
+msgid "Shrink the Player Controls on a Narrow Window"
+msgstr "当播放器控制隐藏时"
 
 #: jellyfin_mpv_shim/mpvtk_browser/config.py
 msgid "Mouse Back/Forward Buttons Skip Chapters"
@@ -1894,6 +1932,21 @@ msgstr ""
 
 #: jellyfin_mpv_shim/mpvtk_browser/config.py
 msgid ""
+"Stops MPV's own shortcuts -- picture adjustment, screenshots, subtitle and "
+"audio switching -- from acting while you are in the library, where there is "
+"no video for them to act on. Turn it off to use your own MPV key bindings "
+"there."
+msgstr ""
+
+#: jellyfin_mpv_shim/mpvtk_browser/config.py
+msgid ""
+"Activates whatever is highlighted, in the library and on the player "
+"controls. An mpv key name; changing it hands Enter back to MPV. The game "
+"controller's Confirm button and a phone's Select follow it."
+msgstr ""
+
+#: jellyfin_mpv_shim/mpvtk_browser/config.py
+msgid ""
 "Leave these blank unless downloads are waking your disks too often. Set both "
 "of the first two together: episodes are then fetched in one batch when a "
 "series runs low, instead of one at a time."
@@ -1907,9 +1960,14 @@ msgid ""
 msgstr "剧集缩略图是您可能尚未观看的剧集的一个画面。"
 
 #: jellyfin_mpv_shim/mpvtk_browser/config.py
+#, fuzzy
+#| msgid ""
+#| "Off gives MPV's own mouse behaviour instead: drag the video to move the "
+#| "window, and right click to pause. Double click is full screen either way."
 msgid ""
 "Off gives MPV's own mouse behaviour instead: drag the video to move the "
-"window, and right click to pause. Double click is full screen either way."
+"window, and the right button does whatever your MPV config gives it. Double "
+"click is full screen either way."
 msgstr ""
 "关闭此选项后，MPV 将采用其自身的鼠标操作方式：拖动视频窗口移动视频，右键单击"
 "暂停。双击则可全屏显示。"
@@ -2038,6 +2096,30 @@ msgstr ""
 "法移动或关闭窗口。在这种情况下，最小化、最大化和关闭按钮会显示在顶部栏中，并"
 "允许用户拖动窗口。在“仅当窗口没有标题栏时”的设置下，MPV 会询问此窗口是否绘制"
 "了标题栏，因此不会影响那些绘制了标题栏的桌面环境。"
+
+#: jellyfin_mpv_shim/mpvtk_browser/config.py
+msgid ""
+"Full screen has no title bar anywhere and nothing to move or maximize, so "
+"the buttons are normally hidden there. Turn this on to keep a way out of "
+"full screen that is not a keyboard shortcut."
+msgstr ""
+
+#: jellyfin_mpv_shim/mpvtk_browser/config.py
+msgid ""
+"Asks the desktop for no title bar on the player window, so the top bar above "
+"is the only one. Pairs with the setting above: on \"Only when the window has "
+"no title bar\" the buttons appear as soon as this is on. Leave both off "
+"unless you want them, since a window with neither can be awkward to move on "
+"some desktops."
+msgstr ""
+
+#: jellyfin_mpv_shim/mpvtk_browser/config.py
+msgid ""
+"Shows a preview frame while you drag the seek bar. Works with every player "
+"control style, including your own OSC script if it supports thumbfast. The "
+"images are fetched from the server per video, which costs disk space and "
+"memory -- tens of MB for an episode, a few hundred for a long film."
+msgstr ""
 
 #: jellyfin_mpv_shim/mpvtk_browser/config.py
 msgid ""
@@ -2179,6 +2261,13 @@ msgstr "覆盖主题的封面大小。也可以在任何媒体库的“查看”
 
 #: jellyfin_mpv_shim/mpvtk_browser/config.py
 msgid ""
+"Show times of day as \"8:30 PM\" rather than \"20:30\" — the Live TV guide "
+"and its air times, and the \"Ends at\" labels on a detail page and the "
+"player controls."
+msgstr ""
+
+#: jellyfin_mpv_shim/mpvtk_browser/config.py
+msgid ""
 "The controls have to stay legible over any frame. \"None\" gives the text a "
 "drop shadow instead of shading the picture behind it."
 msgstr ""
@@ -2196,6 +2285,13 @@ msgid ""
 "0 hides them as soon as the pointer is not on them, and forces \"Hide unless "
 "hovered\"."
 msgstr "0 表示当指针不在它们上面时立即隐藏它们，并强制“除非悬停，否则隐藏”。"
+
+#: jellyfin_mpv_shim/mpvtk_browser/config.py
+msgid ""
+"Narrowing the window shrinks the controls until the smallest button reaches "
+"the accessibility minimum, instead of dropping buttons sooner. Off keeps the "
+"older, larger floor."
+msgstr ""
 
 #: jellyfin_mpv_shim/mpvtk_browser/config.py
 msgid ""
@@ -3596,6 +3692,7 @@ msgid "More Like This"
 msgstr "更多类似内容"
 
 #: jellyfin_mpv_shim/mpvtk_browser/pages/detail.py
+#: jellyfin_mpv_shim/mpvtk_browser/tiles.py
 msgid "Go to Series"
 msgstr "转到节目"
 
@@ -4640,6 +4737,22 @@ msgstr "是否将 %s 从该合集中移除？"
 msgid "There is nothing here to queue."
 msgstr "无可加入队列的媒体。"
 
+#: jellyfin_mpv_shim/mpvtk_browser/timefmt.py
+#, python-brace-format
+msgctxt "12-hour clock"
+msgid "{time} {period}"
+msgstr ""
+
+#: jellyfin_mpv_shim/mpvtk_browser/timefmt.py
+msgctxt "12-hour clock"
+msgid "AM"
+msgstr ""
+
+#: jellyfin_mpv_shim/mpvtk_browser/timefmt.py
+msgctxt "12-hour clock"
+msgid "PM"
+msgstr ""
+
 #: jellyfin_mpv_shim/mpvtk_browser/views.py
 #: jellyfin_mpv_shim/mpvtk_browser/window_chrome.py
 msgid "Search"
@@ -4794,14 +4907,39 @@ msgid "Enable SVP"
 msgstr "启用 SVP"
 
 #: jellyfin_mpv_shim/sync/manager.py
+#, fuzzy
+#| msgid "Move the downloads back to the default folder?"
+msgid "The downloads are already in that folder."
+msgstr "将下载内容移回默认文件夹？"
+
+#: jellyfin_mpv_shim/sync/manager.py
 msgid ""
 "Can't change the download folder while a download is in progress. Wait for "
 "it to finish, then try again."
 msgstr "下载任务进行中无法修改下载目录，请等待全部任务完成后重试。"
 
 #: jellyfin_mpv_shim/sync/manager.py
+#, fuzzy
+#| msgid "That folder already contains downloads. Choose an empty folder."
+msgid ""
+"That folder is inside the current download folder. Choose one outside it."
+msgstr "目标目录已存在缓存文件，请选择空文件夹。"
+
+#: jellyfin_mpv_shim/sync/manager.py
+#, fuzzy
+#| msgid "Can't create that folder. Check the path and its permissions."
+msgid "Can't read that folder. Check the path and its permissions."
+msgstr "无法创建该目录，请检查路径与读写权限。"
+
+#: jellyfin_mpv_shim/sync/manager.py
 msgid "That folder already contains downloads. Choose an empty folder."
 msgstr "目标目录已存在缓存文件，请选择空文件夹。"
+
+#: jellyfin_mpv_shim/sync/manager.py
+msgid ""
+"That folder isn't empty. Choose an empty folder — the download folder is "
+"managed by this app and anything else in it can be moved or removed."
+msgstr ""
 
 #: jellyfin_mpv_shim/sync/manager.py
 msgid "Can't create that folder. Check the path and its permissions."
@@ -4810,6 +4948,12 @@ msgstr "无法创建该目录，请检查路径与读写权限。"
 #: jellyfin_mpv_shim/sync/manager.py
 msgid "A download is still finishing. Wait for it to stop, then try again."
 msgstr "存在正在收尾的下载任务，请等待完成后重试。"
+
+#: jellyfin_mpv_shim/sync/manager.py
+msgid ""
+"There isn't enough space on that drive to move the downloads. Free some "
+"space and try again — nothing was moved."
+msgstr ""
 
 #: jellyfin_mpv_shim/sync/manager.py
 msgid ""
@@ -5010,6 +5154,12 @@ msgstr "视频播放预设"
 #: jellyfin_mpv_shim/video_profile.py
 msgid "Select Shader Profile"
 msgstr "选择着色器配置预设"
+
+#~ msgid "MPV UI with thumbnails"
+#~ msgstr "带缩略图的 MPV UI"
+
+#~ msgid "MPV built-in default"
+#~ msgstr "MPV 原生默认界面"
 
 #~ msgid "Discord Rich Presence. Takes effect after a restart."
 #~ msgstr "Discord Rich Presence，重启后生效。"

--- a/jellyfin_mpv_shim/messages/zh_Hant/LC_MESSAGES/base.po
+++ b/jellyfin_mpv_shim/messages/zh_Hant/LC_MESSAGES/base.po
@@ -6,7 +6,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2026-08-30 22:19-0400\n"
+"POT-Creation-Date: 2026-09-07 17:35-0400\n"
 "PO-Revision-Date: 2026-08-20 02:33+0000\n"
 "Last-Translator: Jacky He <hekinghung@gmail.com>\n"
 "Language-Team: Chinese (Traditional Han script) <https://"
@@ -537,6 +537,11 @@ msgid "Night Mode (Auto Volume Adj)"
 msgstr ""
 
 #: jellyfin_mpv_shim/mpvtk_browser/app.py
+#: jellyfin_mpv_shim/mpvtk_browser/auth.py
+msgid "Locked"
+msgstr ""
+
+#: jellyfin_mpv_shim/mpvtk_browser/app.py
 msgid "Failed to load. Check the connection."
 msgstr ""
 
@@ -816,10 +821,6 @@ msgstr ""
 "請檢查您的連接資訊。"
 
 #: jellyfin_mpv_shim/mpvtk_browser/auth.py
-msgid "Locked"
-msgstr ""
-
-#: jellyfin_mpv_shim/mpvtk_browser/auth.py
 #: jellyfin_mpv_shim/mpvtk_browser/pages/home.py
 msgid "Connecting to your server…"
 msgstr ""
@@ -900,6 +901,10 @@ msgstr "退出並標為未觀看"
 #: jellyfin_mpv_shim/mpvtk_browser/pages/books.py
 msgid "Favorite"
 msgstr "加到最愛"
+
+#: jellyfin_mpv_shim/mpvtk_browser/components/detail.py
+msgid "Web"
+msgstr ""
 
 # seeded from jellyfin-web: HeaderVideos
 #: jellyfin_mpv_shim/mpvtk_browser/components/media_info.py
@@ -1517,11 +1522,7 @@ msgid "Jellyfin UI"
 msgstr ""
 
 #: jellyfin_mpv_shim/mpvtk_browser/config.py
-msgid "MPV UI with thumbnails"
-msgstr ""
-
-#: jellyfin_mpv_shim/mpvtk_browser/config.py
-msgid "MPV built-in default"
+msgid "MPV UI"
 msgstr ""
 
 #: jellyfin_mpv_shim/mpvtk_browser/config.py
@@ -1870,8 +1871,22 @@ msgid "Window Buttons in the Top Bar"
 msgstr ""
 
 #: jellyfin_mpv_shim/mpvtk_browser/config.py
+msgid "Keep Window Buttons in Full Screen"
+msgstr ""
+
+#: jellyfin_mpv_shim/mpvtk_browser/config.py
+msgid "Hide the Desktop Title Bar"
+msgstr ""
+
+#: jellyfin_mpv_shim/mpvtk_browser/config.py
 msgid "Player Controls Style"
 msgstr ""
+
+#: jellyfin_mpv_shim/mpvtk_browser/config.py
+#, fuzzy
+#| msgid "Enable thumbnail previews"
+msgid "Enable Trickplay Thumbnails"
+msgstr "啟用縮圖預覽"
 
 #: jellyfin_mpv_shim/mpvtk_browser/config.py
 msgid "Load All Seek Previews at Once"
@@ -1901,6 +1916,10 @@ msgstr ""
 
 #: jellyfin_mpv_shim/mpvtk_browser/config.py
 msgid "Full-Width Backdrops"
+msgstr ""
+
+#: jellyfin_mpv_shim/mpvtk_browser/config.py
+msgid "12-Hour Clock"
 msgstr ""
 
 #: jellyfin_mpv_shim/mpvtk_browser/config.py
@@ -1946,12 +1965,23 @@ msgid "Fullscreen Library Browser"
 msgstr ""
 
 #: jellyfin_mpv_shim/mpvtk_browser/config.py
+msgid "Block Player Keybinds While Browsing"
+msgstr ""
+
+#: jellyfin_mpv_shim/mpvtk_browser/config.py
 msgid "Always Bind Arrow Keys to Player Controls"
 msgstr ""
 
 #: jellyfin_mpv_shim/mpvtk_browser/config.py
 msgid "Player Controls Activation Key"
 msgstr ""
+
+# seeded from jellyfin-web: SelectAll
+#: jellyfin_mpv_shim/mpvtk_browser/config.py
+#, fuzzy
+#| msgid "Select All"
+msgid "Select Key"
+msgstr "全選"
 
 #: jellyfin_mpv_shim/mpvtk_browser/config.py
 msgid "Shading Behind the Player Controls"
@@ -1963,6 +1993,10 @@ msgstr ""
 
 #: jellyfin_mpv_shim/mpvtk_browser/config.py
 msgid "Hide the Player Controls After (seconds)"
+msgstr ""
+
+#: jellyfin_mpv_shim/mpvtk_browser/config.py
+msgid "Shrink the Player Controls on a Narrow Window"
 msgstr ""
 
 #: jellyfin_mpv_shim/mpvtk_browser/config.py
@@ -2049,6 +2083,21 @@ msgstr ""
 
 #: jellyfin_mpv_shim/mpvtk_browser/config.py
 msgid ""
+"Stops MPV's own shortcuts -- picture adjustment, screenshots, subtitle and "
+"audio switching -- from acting while you are in the library, where there is "
+"no video for them to act on. Turn it off to use your own MPV key bindings "
+"there."
+msgstr ""
+
+#: jellyfin_mpv_shim/mpvtk_browser/config.py
+msgid ""
+"Activates whatever is highlighted, in the library and on the player "
+"controls. An mpv key name; changing it hands Enter back to MPV. The game "
+"controller's Confirm button and a phone's Select follow it."
+msgstr ""
+
+#: jellyfin_mpv_shim/mpvtk_browser/config.py
+msgid ""
 "Leave these blank unless downloads are waking your disks too often. Set both "
 "of the first two together: episodes are then fetched in one batch when a "
 "series runs low, instead of one at a time."
@@ -2062,7 +2111,8 @@ msgstr ""
 #: jellyfin_mpv_shim/mpvtk_browser/config.py
 msgid ""
 "Off gives MPV's own mouse behaviour instead: drag the video to move the "
-"window, and right click to pause. Double click is full screen either way."
+"window, and the right button does whatever your MPV config gives it. Double "
+"click is full screen either way."
 msgstr ""
 
 #: jellyfin_mpv_shim/mpvtk_browser/config.py
@@ -2152,6 +2202,30 @@ msgid ""
 "maximize and close in the top bar instead, and lets you drag the window by "
 "it. On \"Only when the window has no title bar\", MPV is asked whether this "
 "window got one, so desktops that draw a title bar are left alone."
+msgstr ""
+
+#: jellyfin_mpv_shim/mpvtk_browser/config.py
+msgid ""
+"Full screen has no title bar anywhere and nothing to move or maximize, so "
+"the buttons are normally hidden there. Turn this on to keep a way out of "
+"full screen that is not a keyboard shortcut."
+msgstr ""
+
+#: jellyfin_mpv_shim/mpvtk_browser/config.py
+msgid ""
+"Asks the desktop for no title bar on the player window, so the top bar above "
+"is the only one. Pairs with the setting above: on \"Only when the window has "
+"no title bar\" the buttons appear as soon as this is on. Leave both off "
+"unless you want them, since a window with neither can be awkward to move on "
+"some desktops."
+msgstr ""
+
+#: jellyfin_mpv_shim/mpvtk_browser/config.py
+msgid ""
+"Shows a preview frame while you drag the seek bar. Works with every player "
+"control style, including your own OSC script if it supports thumbfast. The "
+"images are fetched from the server per video, which costs disk space and "
+"memory -- tens of MB for an episode, a few hundred for a long film."
 msgstr ""
 
 #: jellyfin_mpv_shim/mpvtk_browser/config.py
@@ -2261,6 +2335,13 @@ msgstr ""
 
 #: jellyfin_mpv_shim/mpvtk_browser/config.py
 msgid ""
+"Show times of day as \"8:30 PM\" rather than \"20:30\" — the Live TV guide "
+"and its air times, and the \"Ends at\" labels on a detail page and the "
+"player controls."
+msgstr ""
+
+#: jellyfin_mpv_shim/mpvtk_browser/config.py
+msgid ""
 "The controls have to stay legible over any frame. \"None\" gives the text a "
 "drop shadow instead of shading the picture behind it."
 msgstr ""
@@ -2275,6 +2356,13 @@ msgstr ""
 msgid ""
 "0 hides them as soon as the pointer is not on them, and forces \"Hide unless "
 "hovered\"."
+msgstr ""
+
+#: jellyfin_mpv_shim/mpvtk_browser/config.py
+msgid ""
+"Narrowing the window shrinks the controls until the smallest button reaches "
+"the accessibility minimum, instead of dropping buttons sooner. Off keeps the "
+"older, larger floor."
 msgstr ""
 
 #: jellyfin_mpv_shim/mpvtk_browser/config.py
@@ -3876,6 +3964,7 @@ msgid "More Like This"
 msgstr "更多類似的"
 
 #: jellyfin_mpv_shim/mpvtk_browser/pages/detail.py
+#: jellyfin_mpv_shim/mpvtk_browser/tiles.py
 msgid "Go to Series"
 msgstr ""
 
@@ -5066,6 +5155,22 @@ msgstr "刪除伺服器"
 msgid "There is nothing here to queue."
 msgstr ""
 
+#: jellyfin_mpv_shim/mpvtk_browser/timefmt.py
+#, python-brace-format
+msgctxt "12-hour clock"
+msgid "{time} {period}"
+msgstr ""
+
+#: jellyfin_mpv_shim/mpvtk_browser/timefmt.py
+msgctxt "12-hour clock"
+msgid "AM"
+msgstr ""
+
+#: jellyfin_mpv_shim/mpvtk_browser/timefmt.py
+msgctxt "12-hour clock"
+msgid "PM"
+msgstr ""
+
 # seeded from jellyfin-web: Search
 #: jellyfin_mpv_shim/mpvtk_browser/views.py
 #: jellyfin_mpv_shim/mpvtk_browser/window_chrome.py
@@ -5233,13 +5338,32 @@ msgid "Enable SVP"
 msgstr "啟用SVP"
 
 #: jellyfin_mpv_shim/sync/manager.py
+msgid "The downloads are already in that folder."
+msgstr ""
+
+#: jellyfin_mpv_shim/sync/manager.py
 msgid ""
 "Can't change the download folder while a download is in progress. Wait for "
 "it to finish, then try again."
 msgstr ""
 
 #: jellyfin_mpv_shim/sync/manager.py
+msgid ""
+"That folder is inside the current download folder. Choose one outside it."
+msgstr ""
+
+#: jellyfin_mpv_shim/sync/manager.py
+msgid "Can't read that folder. Check the path and its permissions."
+msgstr ""
+
+#: jellyfin_mpv_shim/sync/manager.py
 msgid "That folder already contains downloads. Choose an empty folder."
+msgstr ""
+
+#: jellyfin_mpv_shim/sync/manager.py
+msgid ""
+"That folder isn't empty. Choose an empty folder — the download folder is "
+"managed by this app and anything else in it can be moved or removed."
 msgstr ""
 
 #: jellyfin_mpv_shim/sync/manager.py
@@ -5248,6 +5372,12 @@ msgstr ""
 
 #: jellyfin_mpv_shim/sync/manager.py
 msgid "A download is still finishing. Wait for it to stop, then try again."
+msgstr ""
+
+#: jellyfin_mpv_shim/sync/manager.py
+msgid ""
+"There isn't enough space on that drive to move the downloads. Free some "
+"space and try again — nothing was moved."
 msgstr ""
 
 #: jellyfin_mpv_shim/sync/manager.py

--- a/jellyfin_mpv_shim/messages/zh_Hant_HK/LC_MESSAGES/base.po
+++ b/jellyfin_mpv_shim/messages/zh_Hant_HK/LC_MESSAGES/base.po
@@ -6,7 +6,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2026-08-30 22:19-0400\n"
+"POT-Creation-Date: 2026-09-07 17:35-0400\n"
 "PO-Revision-Date: 2026-08-20 02:33+0000\n"
 "Last-Translator: Jacky He <hekinghung@gmail.com>\n"
 "Language-Team: Chinese (Traditional Han script, Hong Kong) <https://"
@@ -509,6 +509,11 @@ msgid "Night Mode (Auto Volume Adj)"
 msgstr "夜間模式（自動音量調整）"
 
 #: jellyfin_mpv_shim/mpvtk_browser/app.py
+#: jellyfin_mpv_shim/mpvtk_browser/auth.py
+msgid "Locked"
+msgstr "已鎖定"
+
+#: jellyfin_mpv_shim/mpvtk_browser/app.py
 msgid "Failed to load. Check the connection."
 msgstr "載入失敗。請檢查連線。"
 
@@ -750,10 +755,6 @@ msgid "Could not connect. Please check your details."
 msgstr "無法連線。唔該check吓你嘅詳細資料。"
 
 #: jellyfin_mpv_shim/mpvtk_browser/auth.py
-msgid "Locked"
-msgstr "已鎖定"
-
-#: jellyfin_mpv_shim/mpvtk_browser/auth.py
 #: jellyfin_mpv_shim/mpvtk_browser/pages/home.py
 msgid "Connecting to your server…"
 msgstr "連線去你嘅伺服器…"
@@ -831,6 +832,10 @@ msgstr "離開兼標記做未睇"
 #: jellyfin_mpv_shim/mpvtk_browser/pages/books.py
 msgid "Favorite"
 msgstr "心水"
+
+#: jellyfin_mpv_shim/mpvtk_browser/components/detail.py
+msgid "Web"
+msgstr ""
 
 # seeded from jellyfin-web: HeaderVideos
 #: jellyfin_mpv_shim/mpvtk_browser/components/media_info.py
@@ -1444,12 +1449,8 @@ msgid "Jellyfin UI"
 msgstr "Jellyfin 介面"
 
 #: jellyfin_mpv_shim/mpvtk_browser/config.py
-msgid "MPV UI with thumbnails"
-msgstr "附預覽圖嘅 MPV 介面"
-
-#: jellyfin_mpv_shim/mpvtk_browser/config.py
-msgid "MPV built-in default"
-msgstr "MPV 內建預設"
+msgid "MPV UI"
+msgstr ""
 
 #: jellyfin_mpv_shim/mpvtk_browser/config.py
 msgid "Custom OSC"
@@ -1799,8 +1800,22 @@ msgid "Window Buttons in the Top Bar"
 msgstr ""
 
 #: jellyfin_mpv_shim/mpvtk_browser/config.py
+msgid "Keep Window Buttons in Full Screen"
+msgstr ""
+
+#: jellyfin_mpv_shim/mpvtk_browser/config.py
+msgid "Hide the Desktop Title Bar"
+msgstr ""
+
+#: jellyfin_mpv_shim/mpvtk_browser/config.py
 msgid "Player Controls Style"
 msgstr ""
+
+#: jellyfin_mpv_shim/mpvtk_browser/config.py
+#, fuzzy
+#| msgid "Enable thumbnail previews"
+msgid "Enable Trickplay Thumbnails"
+msgstr "啟用預覽圖"
 
 #: jellyfin_mpv_shim/mpvtk_browser/config.py
 msgid "Load All Seek Previews at Once"
@@ -1830,6 +1845,10 @@ msgstr ""
 
 #: jellyfin_mpv_shim/mpvtk_browser/config.py
 msgid "Full-Width Backdrops"
+msgstr ""
+
+#: jellyfin_mpv_shim/mpvtk_browser/config.py
+msgid "12-Hour Clock"
 msgstr ""
 
 #: jellyfin_mpv_shim/mpvtk_browser/config.py
@@ -1875,12 +1894,23 @@ msgid "Fullscreen Library Browser"
 msgstr ""
 
 #: jellyfin_mpv_shim/mpvtk_browser/config.py
+msgid "Block Player Keybinds While Browsing"
+msgstr ""
+
+#: jellyfin_mpv_shim/mpvtk_browser/config.py
 msgid "Always Bind Arrow Keys to Player Controls"
 msgstr ""
 
 #: jellyfin_mpv_shim/mpvtk_browser/config.py
 msgid "Player Controls Activation Key"
 msgstr ""
+
+# seeded from jellyfin-web: SelectAll
+#: jellyfin_mpv_shim/mpvtk_browser/config.py
+#, fuzzy
+#| msgid "Select All"
+msgid "Select Key"
+msgstr "全選"
 
 #: jellyfin_mpv_shim/mpvtk_browser/config.py
 msgid "Shading Behind the Player Controls"
@@ -1892,6 +1922,10 @@ msgstr ""
 
 #: jellyfin_mpv_shim/mpvtk_browser/config.py
 msgid "Hide the Player Controls After (seconds)"
+msgstr ""
+
+#: jellyfin_mpv_shim/mpvtk_browser/config.py
+msgid "Shrink the Player Controls on a Narrow Window"
 msgstr ""
 
 #: jellyfin_mpv_shim/mpvtk_browser/config.py
@@ -1978,6 +2012,21 @@ msgstr ""
 
 #: jellyfin_mpv_shim/mpvtk_browser/config.py
 msgid ""
+"Stops MPV's own shortcuts -- picture adjustment, screenshots, subtitle and "
+"audio switching -- from acting while you are in the library, where there is "
+"no video for them to act on. Turn it off to use your own MPV key bindings "
+"there."
+msgstr ""
+
+#: jellyfin_mpv_shim/mpvtk_browser/config.py
+msgid ""
+"Activates whatever is highlighted, in the library and on the player "
+"controls. An mpv key name; changing it hands Enter back to MPV. The game "
+"controller's Confirm button and a phone's Select follow it."
+msgstr ""
+
+#: jellyfin_mpv_shim/mpvtk_browser/config.py
+msgid ""
 "Leave these blank unless downloads are waking your disks too often. Set both "
 "of the first two together: episodes are then fetched in one batch when a "
 "series runs low, instead of one at a time."
@@ -1991,7 +2040,8 @@ msgstr ""
 #: jellyfin_mpv_shim/mpvtk_browser/config.py
 msgid ""
 "Off gives MPV's own mouse behaviour instead: drag the video to move the "
-"window, and right click to pause. Double click is full screen either way."
+"window, and the right button does whatever your MPV config gives it. Double "
+"click is full screen either way."
 msgstr ""
 
 #: jellyfin_mpv_shim/mpvtk_browser/config.py
@@ -2081,6 +2131,30 @@ msgid ""
 "maximize and close in the top bar instead, and lets you drag the window by "
 "it. On \"Only when the window has no title bar\", MPV is asked whether this "
 "window got one, so desktops that draw a title bar are left alone."
+msgstr ""
+
+#: jellyfin_mpv_shim/mpvtk_browser/config.py
+msgid ""
+"Full screen has no title bar anywhere and nothing to move or maximize, so "
+"the buttons are normally hidden there. Turn this on to keep a way out of "
+"full screen that is not a keyboard shortcut."
+msgstr ""
+
+#: jellyfin_mpv_shim/mpvtk_browser/config.py
+msgid ""
+"Asks the desktop for no title bar on the player window, so the top bar above "
+"is the only one. Pairs with the setting above: on \"Only when the window has "
+"no title bar\" the buttons appear as soon as this is on. Leave both off "
+"unless you want them, since a window with neither can be awkward to move on "
+"some desktops."
+msgstr ""
+
+#: jellyfin_mpv_shim/mpvtk_browser/config.py
+msgid ""
+"Shows a preview frame while you drag the seek bar. Works with every player "
+"control style, including your own OSC script if it supports thumbfast. The "
+"images are fetched from the server per video, which costs disk space and "
+"memory -- tens of MB for an episode, a few hundred for a long film."
 msgstr ""
 
 #: jellyfin_mpv_shim/mpvtk_browser/config.py
@@ -2190,6 +2264,13 @@ msgstr ""
 
 #: jellyfin_mpv_shim/mpvtk_browser/config.py
 msgid ""
+"Show times of day as \"8:30 PM\" rather than \"20:30\" — the Live TV guide "
+"and its air times, and the \"Ends at\" labels on a detail page and the "
+"player controls."
+msgstr ""
+
+#: jellyfin_mpv_shim/mpvtk_browser/config.py
+msgid ""
 "The controls have to stay legible over any frame. \"None\" gives the text a "
 "drop shadow instead of shading the picture behind it."
 msgstr ""
@@ -2204,6 +2285,13 @@ msgstr ""
 msgid ""
 "0 hides them as soon as the pointer is not on them, and forces \"Hide unless "
 "hovered\"."
+msgstr ""
+
+#: jellyfin_mpv_shim/mpvtk_browser/config.py
+msgid ""
+"Narrowing the window shrinks the controls until the smallest button reaches "
+"the accessibility minimum, instead of dropping buttons sooner. Off keeps the "
+"older, larger floor."
 msgstr ""
 
 #: jellyfin_mpv_shim/mpvtk_browser/config.py
@@ -3784,6 +3872,7 @@ msgid "More Like This"
 msgstr "更多類似嘅內容"
 
 #: jellyfin_mpv_shim/mpvtk_browser/pages/detail.py
+#: jellyfin_mpv_shim/mpvtk_browser/tiles.py
 msgid "Go to Series"
 msgstr ""
 
@@ -4942,6 +5031,22 @@ msgstr ""
 msgid "There is nothing here to queue."
 msgstr ""
 
+#: jellyfin_mpv_shim/mpvtk_browser/timefmt.py
+#, python-brace-format
+msgctxt "12-hour clock"
+msgid "{time} {period}"
+msgstr ""
+
+#: jellyfin_mpv_shim/mpvtk_browser/timefmt.py
+msgctxt "12-hour clock"
+msgid "AM"
+msgstr ""
+
+#: jellyfin_mpv_shim/mpvtk_browser/timefmt.py
+msgctxt "12-hour clock"
+msgid "PM"
+msgstr ""
+
 # seeded from jellyfin-web: Search
 #: jellyfin_mpv_shim/mpvtk_browser/views.py
 #: jellyfin_mpv_shim/mpvtk_browser/window_chrome.py
@@ -5109,13 +5214,32 @@ msgid "Enable SVP"
 msgstr "啟用 SVP"
 
 #: jellyfin_mpv_shim/sync/manager.py
+msgid "The downloads are already in that folder."
+msgstr ""
+
+#: jellyfin_mpv_shim/sync/manager.py
 msgid ""
 "Can't change the download folder while a download is in progress. Wait for "
 "it to finish, then try again."
 msgstr ""
 
 #: jellyfin_mpv_shim/sync/manager.py
+msgid ""
+"That folder is inside the current download folder. Choose one outside it."
+msgstr ""
+
+#: jellyfin_mpv_shim/sync/manager.py
+msgid "Can't read that folder. Check the path and its permissions."
+msgstr ""
+
+#: jellyfin_mpv_shim/sync/manager.py
 msgid "That folder already contains downloads. Choose an empty folder."
+msgstr ""
+
+#: jellyfin_mpv_shim/sync/manager.py
+msgid ""
+"That folder isn't empty. Choose an empty folder — the download folder is "
+"managed by this app and anything else in it can be moved or removed."
 msgstr ""
 
 #: jellyfin_mpv_shim/sync/manager.py
@@ -5124,6 +5248,12 @@ msgstr ""
 
 #: jellyfin_mpv_shim/sync/manager.py
 msgid "A download is still finishing. Wait for it to stop, then try again."
+msgstr ""
+
+#: jellyfin_mpv_shim/sync/manager.py
+msgid ""
+"There isn't enough space on that drive to move the downloads. Free some "
+"space and try again — nothing was moved."
 msgstr ""
 
 #: jellyfin_mpv_shim/sync/manager.py
@@ -5328,6 +5458,12 @@ msgstr "影片播放設定檔"
 #: jellyfin_mpv_shim/video_profile.py
 msgid "Select Shader Profile"
 msgstr "揀著色器 (Shader) 設定檔"
+
+#~ msgid "MPV UI with thumbnails"
+#~ msgstr "附預覽圖嘅 MPV 介面"
+
+#~ msgid "MPV built-in default"
+#~ msgstr "MPV 內建預設"
 
 #, fuzzy
 #~| msgid "Quit and Mark Unwatched"

--- a/jellyfin_mpv_shim/mpvtk/GUIDE.md
+++ b/jellyfin_mpv_shim/mpvtk/GUIDE.md
@@ -85,6 +85,15 @@ Every element takes `tip="…"` — a renderer-drawn tooltip after a
 layout feedback for the next build (header offsets above virtualized
 lists, overflow decisions).
 
+**Only a drawable is in that scene, so only a drawable can be measured.**
+A bare `Row`/`Column`/`Box` emits no scene node at all, whatever `id` you
+gave it, and `node_rect` then returns `None` — which reads as "no answer
+yet" and sends the caller down its first-frame fallback *on every frame*,
+silently and forever. To measure a container, give it a background and
+`alpha=0`: it draws nothing and emits a `rect` with your id. The epub
+reader sized its page bitmap from the fallback for its whole life this
+way, which was right until anything else shared the window.
+
 Inputs: `TextBox` (editing, paste, selection, `mask=True` for
 passwords; `on_change`/`on_submit`), `Dropdown` (readonly picker,
 `on_select`), `Slider` (`on_change`, throttled while dragging;

--- a/jellyfin_mpv_shim/mpvtk/app.py
+++ b/jellyfin_mpv_shim/mpvtk/app.py
@@ -20,6 +20,10 @@ from .layout import layout, set_metrics
 from .metrics import extend_metrics, measure_font
 
 log = logging.getLogger("mpvtk")
+#: Per-frame render timing. Its OWN logger so the in-app log viewer can
+#: exclude it by name (log_utils.RING_EXCLUDED): drawing the Logs tab emits
+#: one of these, which the tab would then see as new content and redraw for.
+render_log = logging.getLogger("mpvtk.render")
 
 _RENDERER = os.path.join(os.path.dirname(os.path.abspath(__file__)), "renderer.lua")
 
@@ -674,8 +678,10 @@ class MpvtkApp:
         t3 = time.perf_counter()
         # Per-frame timing: useful while the renderer was being built, pure
         # noise in a normal log now. Debug-level so it can still be turned
-        # on when something is actually slow.
-        log.debug(
+        # on when something is actually slow -- and on `render_log`, which
+        # the in-app viewer excludes, because drawing the Logs tab is what
+        # emits this line.
+        render_log.debug(
             "render: build %.1fms, layout %.1fms, push %.1fms (%d nodes)",
             (t1 - t0) * 1000,
             (t2 - t1) * 1000,

--- a/jellyfin_mpv_shim/mpvtk/app.py
+++ b/jellyfin_mpv_shim/mpvtk/app.py
@@ -27,6 +27,18 @@ render_log = logging.getLogger("mpvtk.render")
 
 _RENDERER = os.path.join(os.path.dirname(os.path.abspath(__file__)), "renderer.lua")
 
+
+class _Unknown:
+    """"We do not know what the renderer holds" -- distinct from every value
+    a caller can push, which is why it is not None: `set_picture_pan(None)`
+    is a real request ("stop panning") and has to be sendable."""
+
+    def __repr__(self):
+        return "UNKNOWN"
+
+
+UNKNOWN = _Unknown()
+
 _SPAWN_OPTS = {
     "idle": "yes",
     "force_window": "yes",
@@ -948,12 +960,30 @@ class MpvtkApp:
         close and a tray reopen they would answer "already pushed" about a
         claim that no longer exists — and a reader would come back with
         LEFT/RIGHT walking the focus ring and SPACE toggling mpv's pause.
+
+        **`UNKNOWN`, not empty, and only that is the difference between the
+        two directions.** The renderer drops those things when it goes
+        INACTIVE. On the way back IN it drops nothing -- `mpvtk-active yes`
+        never calls `keyclaim.set({})` -- so recording "we have pushed the
+        empty set" is a claim about the renderer that is false. The next
+        genuine release then compares equal and is skipped, and the keys
+        stay force-bound with nothing driving them.
+
+        Reported: play music (which claims 9/0/m/SPACE so the key block
+        cannot swallow them), STOP it, then start a video -- SPACE and m are
+        dead for the video while `p`, which is never claimed, still works.
+        Stopping is what routes through `enter_browse` -> `set_active(True)`;
+        going straight from music to a video releases correctly, because the
+        cache still held the real value.
+
+        A sentinel rather than leaving the cache alone: after a renderer
+        restart it is stale either way, and "unknown" costs one extra push.
         """
         # Under the same lock the two pushes use, so a claim or a pan model
         # already in flight cannot store itself over the forgetting.
         with self._pan_lock:
-            self._claimed_keys = ()
-            self._picture_pan = None
+            self._claimed_keys = UNKNOWN
+            self._picture_pan = UNKNOWN
         self.backend.command(
             "script-message", "mpvtk-active", "yes" if active else "no"
         )

--- a/jellyfin_mpv_shim/mpvtk/renderer.lua
+++ b/jellyfin_mpv_shim/mpvtk/renderer.lua
@@ -4688,7 +4688,15 @@ function keyclaim.take(key)
     -- control it landed on. A remote has no TAB, so that made the bar's
     -- buttons unreachable by remote entirely. The claim resumes as soon as
     -- the ring is dismissed (any mouse press drops it).
-    if state.nav_mode and state.nav then
+    --
+    -- **Only the keys the ring itself uses.** The reason above is entirely
+    -- about the arrows, and refusing a claim is not a fallback: under
+    -- `browse_block_keys` the block swallows what `take` declines, so a ring
+    -- also killed SPACE -- the shim's pause -- for as long as it was up, and
+    -- a ring is dropped by a MOUSE press, which is not where a keyboard user
+    -- is. Pausing music from the keyboard therefore stopped working the
+    -- moment the arrows were touched, with nothing on screen to say so.
+    if state.nav_mode and state.nav and keyclaim.nav_names[key] then
         return false
     end
     send({ t = 'key', key = key })

--- a/jellyfin_mpv_shim/mpvtk_browser/app.py
+++ b/jellyfin_mpv_shim/mpvtk_browser/app.py
@@ -1736,12 +1736,7 @@ class MpvtkBrowser(DialogsMixin, LiveTvDialogsMixin, AuthMixin, SettingsMixin,
         clamp. And the picture's zoom and pan are global mpv options, so
         the film plays at whatever the last comic page was set to.
         """
-        claim = getattr(self.app, "claim_keys", None)
-        if claim is not None:
-            try:
-                claim(())
-            except Exception:
-                log.debug("could not drop the key claim", exc_info=True)
+        self._drop_key_claims()
         self._set_picture_pan(None)
         # The window is being handed over, so whatever picture was in it is
         # not on screen any more. The page checks this on its way back in;
@@ -1755,6 +1750,20 @@ class MpvtkBrowser(DialogsMixin, LiveTvDialogsMixin, AuthMixin, SettingsMixin,
                 self.controller.reset_picture_view()
             except Exception:
                 log.debug("could not reset the picture view", exc_info=True)
+
+    def _drop_key_claims(self):
+        """Give every claimed key back to mpv.
+
+        Its own method because `_yield` calls it TWICE, and the second call
+        is the point: see the note there.
+        """
+        claim = getattr(self.app, "claim_keys", None)
+        if claim is None:
+            return
+        try:
+            claim(())
+        except Exception:
+            log.debug("could not drop the key claim", exc_info=True)
 
     def _retire_page(self, route):
         """Tell the page we just stopped drawing that it is off screen.
@@ -1817,6 +1826,13 @@ class MpvtkBrowser(DialogsMixin, LiveTvDialogsMixin, AuthMixin, SettingsMixin,
         page = self._page_for(route) if self._browsing else None
         keys = tuple(getattr(page, "claimed_keys", ()) or ())
         keys += self._shell_claimed_keys()
+        # Re-read immediately before the call, not only at the top: the two
+        # reads above are separated by page lookups and a settings read, and
+        # the flag can flip in between. `_yield` re-asserts the release after
+        # it finishes, which is what actually closes the race; this just
+        # keeps the common case from reaching it.
+        if not self._browsing:
+            keys = ()
         try:
             claim(keys)
         except Exception:
@@ -2302,6 +2318,21 @@ class MpvtkBrowser(DialogsMixin, LiveTvDialogsMixin, AuthMixin, SettingsMixin,
                 log.debug("set_hud failed", exc_info=True)
         else:
             self._set_renderer_active(False)
+        # **Again, at the end.** `_claim_page_keys` reads `_browsing` and
+        # then calls `claim()`, and a playback update on a foreign thread
+        # flips that flag between the two -- so a frame already in flight
+        # when the yield began can land its claim AFTER the release above.
+        # A claimed key gets a FORCED binding, which outranks the player's
+        # own, so a stale SPACE claim is `kb_pause` dead for the rest of the
+        # session against a video, with music long since stopped. The
+        # comment in `_claim_page_keys` records that exact symptom from
+        # before; answering "no keys" there narrows the window but cannot
+        # close it, because the read and the call are not atomic.
+        #
+        # Making the release the LAST write closes it without a lock: a
+        # racing frame either lands before this and is overwritten, or after
+        # it and finds `_browsing` already false.
+        self._drop_key_claims()
         self.invalidate()  # empty scene clears overlays off the video
 
     def _start(self, audio, title=""):

--- a/jellyfin_mpv_shim/mpvtk_browser/app.py
+++ b/jellyfin_mpv_shim/mpvtk_browser/app.py
@@ -241,7 +241,8 @@ class MpvtkBrowser(DialogsMixin, LiveTvDialogsMixin, AuthMixin, SettingsMixin,
             get_controller=lambda: self.controller,
             invalidate=lambda: self.invalidate(),
             ctl=lambda fn: self._ctl(fn),
-            start_ticker=lambda: self._start_np_ticker())
+            start_ticker=lambda: self._start_np_ticker(),
+            is_browsing=lambda: self._browsing)
         # Cast/idle screen state (see cast.py). Present whether or not
         # headless is set — without it, this is what a DisplayContent from a
         # phone renders.

--- a/jellyfin_mpv_shim/mpvtk_browser/app.py
+++ b/jellyfin_mpv_shim/mpvtk_browser/app.py
@@ -2289,9 +2289,15 @@ class MpvtkBrowser(DialogsMixin, LiveTvDialogsMixin, AuthMixin, SettingsMixin,
         self._release_page_grabs()
         self._tell_controller("on_browse_leave")
         if self.hud.available():
-            # keep the renderer attached: blank scene + summon bindings
+            # keep the renderer attached: blank scene + summon bindings.
+            #
+            # `reset=True` because this is a HANDOFF: a new stream is taking
+            # the window, so whatever the HUD was showing belonged to the one
+            # that just ended. Without it a restart -- changing an audio or
+            # subtitle track on a transcode re-creates it -- left the bar
+            # marked shown for a stream that was gone, with summon unbound.
             try:
-                self.hud.engage()
+                self.hud.engage(reset=True)
             except Exception:
                 log.debug("set_hud failed", exc_info=True)
         else:

--- a/jellyfin_mpv_shim/mpvtk_browser/app.py
+++ b/jellyfin_mpv_shim/mpvtk_browser/app.py
@@ -2511,6 +2511,17 @@ class MpvtkBrowser(DialogsMixin, LiveTvDialogsMixin, AuthMixin, SettingsMixin,
             return
         if state.get("is_audio"):
             self._now_playing = state
+            # The film's HUD state does not survive into the track. Only a
+            # `stopped` push cleared it, and a queue advance does not always
+            # make one -- the player suppresses the incidental stopped
+            # pushes a load produces. `reassert_window_state` reads
+            # `hud.state is not None` as "a video is in flight", so a stale
+            # one puts the renderer back into HUD mode -- with its auto-hide
+            # armed and the library as the scene it hides -- the moment mpv
+            # is re-created under a playing track.
+            self.hud.state = None
+            self.hud.shown = False
+            self.hud.menu = None
             if not self._browsing:
                 self.enter_browse()   # audio: stay in browse, show the bar
             else:

--- a/jellyfin_mpv_shim/mpvtk_browser/app.py
+++ b/jellyfin_mpv_shim/mpvtk_browser/app.py
@@ -2208,10 +2208,28 @@ class MpvtkBrowser(DialogsMixin, LiveTvDialogsMixin, AuthMixin, SettingsMixin,
         """Re-assert window ownership on a FRESH renderer (which starts
         active): browse takes the window back; a video in flight
         re-enters attached-but-idle HUD mode; otherwise get fully out
-        of the way (lua OSC / minimized)."""
+        of the way (lua OSC / minimized).
+
+        `hud.state` alone is not "a video is in flight". It is cleared only
+        by a `stopped` push, and a queue advance does not always make one --
+        the player suppresses the incidental stopped pushes a load produces
+        -- so after a film it holds that film's playstate for the whole of
+        the track that followed, and mpv being re-created under a playing
+        track put the renderer into HUD mode over the library, auto-hide and
+        all.
+
+        Asked here rather than fixed by clearing `hud.state` when a track
+        starts, which is what the first attempt did: a start is not atomic
+        from this side, so late audio pushes (the now-playing ticker sends
+        one a second) arrive *after* `_start(audio=False)` has yielded the
+        window, and a destructive write on that path tore the HUD down off
+        the video that had just begun -- no player controls at all. A read
+        cannot race anything.
+        """
         if self._browsing:
             self._set_renderer_active(True)
-        elif self.hud.available() and self.hud.state is not None:
+        elif (self.hud.available() and self._now_playing is None
+              and self.hud.state is not None):
             try:
                 self.hud.engage()
             except Exception:
@@ -2511,17 +2529,6 @@ class MpvtkBrowser(DialogsMixin, LiveTvDialogsMixin, AuthMixin, SettingsMixin,
             return
         if state.get("is_audio"):
             self._now_playing = state
-            # The film's HUD state does not survive into the track. Only a
-            # `stopped` push cleared it, and a queue advance does not always
-            # make one -- the player suppresses the incidental stopped
-            # pushes a load produces. `reassert_window_state` reads
-            # `hud.state is not None` as "a video is in flight", so a stale
-            # one puts the renderer back into HUD mode -- with its auto-hide
-            # armed and the library as the scene it hides -- the moment mpv
-            # is re-created under a playing track.
-            self.hud.state = None
-            self.hud.shown = False
-            self.hud.menu = None
             if not self._browsing:
                 self.enter_browse()   # audio: stay in browse, show the bar
             else:

--- a/jellyfin_mpv_shim/mpvtk_browser/auth.py
+++ b/jellyfin_mpv_shim/mpvtk_browser/auth.py
@@ -340,6 +340,7 @@ class AuthMixin:
                         "cancelled": False}
         self.invalidate()
         ep = self._epoch
+        before = self._known_server_uuids()
 
         def on_code(code):
             qc = route.get("_qc")
@@ -359,7 +360,7 @@ class AuthMixin:
             route.pop("_qc", None)
             if ok:
                 self._login_error = None
-                self._after_login()
+                self._after_login(before)
             else:
                 self._login_error = _("Quick Connect was not approved.")
         self.run_async(work, done, ep)
@@ -378,6 +379,7 @@ class AuthMixin:
         self._login_error = _("Connecting…")
         self.invalidate()
         ep = self._epoch
+        before = self._known_server_uuids()
 
         def work():
             return self.controller.add_server(
@@ -386,21 +388,52 @@ class AuthMixin:
         def done(ok):
             if ok:
                 self._login_error = None
-                self._after_login()
+                self._after_login(before)
             else:
                 self._login_error = _(
                     "Could not connect. Please check your details.")
         self.run_async(work, done, ep)
 
-    def _after_login(self):
+    def _known_server_uuids(self):
+        """The servers the current source has, before a login adds one."""
+        try:
+            return {s.get("uuid") for s in (self.source.servers() or [])}
+        except Exception:
+            return set()
+
+    def _after_login(self, before=None):
+        """Land on the server that was just added, not the last one browsed.
+
+        `set_source` with no uuid asks `_pick_server`, whose fallback is
+        `get_last_server()` -- right for a reconnect and wrong here, because
+        adding a server IS a request to look at it. Adding one from the
+        server manager dropped you back on the previous server's home, which
+        reads as the login having done nothing.
+
+        Identified by difference rather than by plumbing a uuid back through
+        `add_server` -> `clientManager.login` -> `_finalize_login`: a login
+        can also re-authenticate a server already in the list (and
+        `force_unique` deliberately reuses its uuid), and there the honest
+        answer is "nothing new", which is exactly what an empty difference
+        says. `before=None` keeps the old behaviour for any caller that did
+        not sample it.
+        """
         source = None
         if self.controller is not None:
             try:
                 source = self.controller.rebuild_source()
             except Exception:
                 log.warning("rebuild_source failed", exc_info=True)
-        if source is not None:
-            self.set_source(source)
+        if source is None:
+            return
+        added = None
+        if before is not None:
+            try:
+                added = next((s.get("uuid") for s in (source.servers() or [])
+                              if s.get("uuid") not in before), None)
+            except Exception:
+                log.debug("could not identify the new server", exc_info=True)
+        self.set_source(source, server_uuid=added)
 
     # -------------------------------------------------------------- locked
 

--- a/jellyfin_mpv_shim/mpvtk_browser/hud_control.py
+++ b/jellyfin_mpv_shim/mpvtk_browser/hud_control.py
@@ -11,8 +11,22 @@ see docs/browser-shell.md section 14.
 """
 
 import logging
+import sys
 
 log = logging.getLogger("mpvtk_browser.hud_control")
+
+
+def _caller(depth=2):
+    """``module.function:line`` of whatever asked for a transition.
+
+    Cheap: these happen a handful of times per session, not per frame.
+    """
+    try:
+        frame = sys._getframe(depth)
+        return "%s.%s:%d" % (frame.f_globals.get("__name__", "?"),
+                             frame.f_code.co_name, frame.f_lineno)
+    except Exception:
+        return "?"
 
 
 class HudController:
@@ -103,7 +117,14 @@ class HudController:
         if self._is_browsing is not None:
             try:
                 if self._is_browsing():
-                    log.debug("refusing a HUD engage while browsing")
+                    # WHICH caller is the finding. Every known call site
+                    # tests `not self._browsing` first, so a refusal means
+                    # one of them raced the flag or there is a fifth -- and
+                    # it fires reliably on a video -> music playlist advance
+                    # [iw], so it is not rare. Same reasoning, and the same
+                    # helper shape, as player_window._caller.
+                    log.debug("refusing a HUD engage while browsing <- %s",
+                              _caller())
                     return
             except Exception:
                 pass

--- a/jellyfin_mpv_shim/mpvtk_browser/hud_control.py
+++ b/jellyfin_mpv_shim/mpvtk_browser/hud_control.py
@@ -18,7 +18,8 @@ log = logging.getLogger("mpvtk_browser.hud_control")
 class HudController:
     """Owns the playback HUD's state and handles its events."""
 
-    def __init__(self, get_app, get_controller, invalidate, ctl, start_ticker):
+    def __init__(self, get_app, get_controller, invalidate, ctl, start_ticker,
+                 is_browsing=None):
         #: The live renderer handle. A callable rather than a value: the
         #: browser swaps it when mpv is re-created (``set_app``).
         self._get_app = get_app
@@ -29,6 +30,9 @@ class HudController:
         self._ctl = ctl
         #: Start the 1s clock ticker the bar shares with the music bar.
         self._start_ticker = start_ticker
+        #: "Is the library on screen right now", read live. The ONE place
+        #: the HUD invariant is enforced -- see :meth:`engage`.
+        self._is_browsing = is_browsing
         self.reset()
         self.state = None
 
@@ -79,7 +83,30 @@ class HudController:
 
         Idempotent, and that matters -- re-engaging is the ONLY thing that
         carries a changed setting to the renderer, so those apply without a
-        restart. Full list: see docs/browser-shell.md section 14."""
+        restart. Full list: see docs/browser-shell.md section 14.
+
+        **Never while the library is on screen.** [iw] "Cursor hiding should
+        never happen when the main UI is visible, only the mpvtk HUD" -- and
+        that is the visible edge of a worse state. `set_hud(True)` is a MODE
+        CHANGE: `ui_suspend()` drops the mouse section, and the renderer
+        withholds `allow-hide-cursor` from that section precisely to keep the
+        pointer alive over a UI (docs/mpv-backends.md). So a HUD engaged over
+        the library hides the cursor, auto-hides after `hud_hide_secs` --
+        `phud_hide` calls `ui_suspend`, which takes the LIBRARY off screen --
+        and brings it back on motion, because `mouse-pos` is observed
+        directly and does not need the section.
+
+        Every call site already guards on `not self._browsing`; this is the
+        same rule in one place rather than four, so a guard evaluated a beat
+        before the flag flips cannot get past it. It can only ever REFUSE an
+        engage, never cause one."""
+        if self._is_browsing is not None:
+            try:
+                if self._is_browsing():
+                    log.debug("refusing a HUD engage while browsing")
+                    return
+            except Exception:
+                pass
         opts = None
         get = getattr(self.controller, "hud_key_opts", None)
         if get is not None:

--- a/jellyfin_mpv_shim/mpvtk_browser/hud_control.py
+++ b/jellyfin_mpv_shim/mpvtk_browser/hud_control.py
@@ -91,7 +91,7 @@ class HudController:
                 and c is not None and getattr(c, "use_hud", None) is not None
                 and c.use_hud())
 
-    def engage(self):
+    def engage(self, reset=False):
         """``set_hud(True)`` with everything the renderer owns attached: the
         keyboard policy, the auto-hide delay and mode, the glyph shadow.
 
@@ -113,7 +113,22 @@ class HudController:
         Every call site already guards on `not self._browsing`; this is the
         same rule in one place rather than four, so a guard evaluated a beat
         before the flag flips cannot get past it. It can only ever REFUSE an
-        engage, never cause one."""
+        engage, never cause one.
+
+        ``reset`` is for a HANDOFF -- a new stream taking the window. The
+        renderer early-returns from `mpvtk-hud yes` when it is already in
+        HUD mode, so a restart (changing an audio or subtitle track on a
+        transcode deletes and re-creates it) re-established nothing: if the
+        bar was still up from the gear menu the user changed the track in,
+        `phud.shown` stayed true for a stream that had ended, summon was
+        never re-bound, and moving the mouse did nothing because the
+        renderer believed it was already showing. Measured in tests/lua/:
+        the wake binding is gone after the second engage and a False/True
+        cycle restores it.
+
+        Only a handoff resets. The other callers are re-sends -- a settings
+        change, a SyncPlay join, a fresh renderer -- and hiding a bar
+        somebody is using would be its own bug."""
         if self._is_browsing is not None:
             try:
                 if self._is_browsing():
@@ -135,6 +150,16 @@ class HudController:
                 opts = get()
             except Exception:
                 opts = None
+        if reset:
+            # Unconditional, not `if self.shown`: this mirror can be stale
+            # (the renderer owns the real answer) and the cycle is free when
+            # the HUD is not up -- `mpvtk-hud no` early-returns when the mode
+            # already matches.
+            try:
+                self.app.set_hud(False)
+            except Exception:
+                log.debug("could not reset the HUD", exc_info=True)
+            self.shown = False
         self.app.set_hud(True, opts)
 
     # -- scrubbing ---------------------------------------------------------

--- a/jellyfin_mpv_shim/mpvtk_browser/item_actions.py
+++ b/jellyfin_mpv_shim/mpvtk_browser/item_actions.py
@@ -36,6 +36,7 @@ import logging
 import random
 
 from ..i18n import _
+from ..utils import item_is_audio
 
 log = logging.getLogger("mpvtk_browser.item_actions")
 
@@ -140,7 +141,10 @@ class ItemActions:
         """Yield/keep-browse and start a single ``item``. Episodes queue the
         rest of the season so autoplay-next chains them (like the Tk
         browser)."""
-        self._on_launch(audio=item.get("Type") == "Audio",
+        # `item_is_audio`, not `Type == "Audio"`: that half of the rule
+        # calls an AUDIOBOOK a video (Type="AudioBook", MediaType="Audio"),
+        # and the video branch clears `_browsing` and hands the window over.
+        self._on_launch(audio=item_is_audio(item),
                         title=item.get("Name") or "")
         if self.services.controller is None:
             return

--- a/jellyfin_mpv_shim/mpvtk_browser/pages/reader.py
+++ b/jellyfin_mpv_shim/mpvtk_browser/pages/reader.py
@@ -21,8 +21,8 @@ import logging
 
 from ...books import fraction_of, ticks_for_fraction
 from ...i18n import _
-from ...mpvtk.widgets import (Button, Column, Dropdown, ImageMap, Menu,
-                              Row, Spacer, Text)
+from ...mpvtk.widgets import (Box, Button, Column, Dropdown, ImageMap,
+                              Menu, Row, Spacer, Text)
 from .. import theme
 from ..components import chrome
 from .base import Page
@@ -570,9 +570,10 @@ class ReaderPage(Page):
             message = _("The download failed.")
         else:
             message = _("Getting the book…")
-        return Column([Spacer(), Text(message, size="large",
-                                      color=theme.SUBTLE_FG, align="center"),
-                       Spacer()], id=self.AREA_ID, flex=1, align="center")
+        return Box([Spacer(), Text(message, size="large",
+                                   color=theme.SUBTLE_FG, align="center"),
+                    Spacer()], id=self.AREA_ID, flex=1, align="center",
+                   bg="000000", alpha=0)
 
     def _sync_style(self, doc):
         """Adopt the settings if they have moved since the last frame.
@@ -599,8 +600,8 @@ class ReaderPage(Page):
         entry = self._bitmap(doc, raster(page_w, page_h), (page_w, page_h),
                              self.palette_name())
         if entry is None:
-            return Column([Spacer(), chrome.busy(), Spacer()],
-                          id=self.AREA_ID, flex=1)
+            return Box([Spacer(), chrome.busy(), Spacer()],
+                       id=self.AREA_ID, flex=1, bg="000000", alpha=0)
         # An ImageMap rather than an Image under transparent boxes: regions
         # are the toolkit's answer for "this bitmap is clickable in places"
         # (GUIDE §6). A click on the right-hand side turns forward, on the
@@ -618,10 +619,17 @@ class ReaderPage(Page):
              "h": lh, "zone": True, "on_click": lambda: self._turn(1),
              "on_context": self._open_menu},
         ]
-        return Row([ImageMap(entry["src"], entry["iw"], entry["ih"],
+        # A `Box` with a fully transparent background, not a `Row`, and the
+        # difference is the whole of this: **a plain container emits no
+        # scene node**, whatever id it carries -- only drawables (a Box with
+        # a bg, an Image) keep one. So `node_rect(AREA_ID)` answered None on
+        # every frame and `_area_height`'s fallback was the only path that
+        # ever ran. `alpha=0` draws nothing and measures.
+        return Box([ImageMap(entry["src"], entry["iw"], entry["ih"],
                              id=self.PAGE_ID, regions=regions, w=lw, h=lh,
                              v=entry.get("v", 0))],
-                   id=self.AREA_ID, flex=1, justify="center", align="center")
+                   direction="row", id=self.AREA_ID, flex=1,
+                   justify="center", align="center", bg="000000", alpha=0)
 
     def _bitmap(self, doc, physical, logical, palette_name):
         """The current page's bitmap entry, composited on the pool.

--- a/jellyfin_mpv_shim/mpvtk_browser/repository.py
+++ b/jellyfin_mpv_shim/mpvtk_browser/repository.py
@@ -1031,13 +1031,30 @@ class LibrarySource:
                               media_types="Book")()
 
         def next_up_row():
-            nextup = api.get_next(
-                limit=20, fields=LIST_FIELDS,
-                enable_image_types="Primary,Thumb,Backdrop",
+            # The endpoint directly, not the apiclient's `get_next`: that
+            # helper has no parameter for `EnableResumable`, and the server
+            # DEFAULTS IT TO TRUE (TvShowsController.GetNextUp), so a part-
+            # watched episode appeared in Continue Watching and again in Next
+            # Up. jellyfin-web's home section sends false for exactly this
+            # (components/homesections/sections/nextUp.ts).
+            #
+            # Only this row. `get_next_up(series_id)` is "what plays after
+            # this one", where the episode you are part-way through IS the
+            # answer.
+            #
+            # `EnableRewatching` is not sent: the server already defaults it
+            # to false, and web drives it from a user setting we do not have.
+            nextup = api.shows("/NextUp", {
+                "UserId": "{UserId}",
+                "Limit": 20,
+                "Fields": LIST_FIELDS,
+                "EnableImageTypes": "Primary,Thumb,Backdrop",
                 # Every other home query caps this; Next Up was the one that
                 # did not, so a series with twenty backdrops sent twenty tags
                 # per card for the one the tile draws.
-                image_type_limit=1) or {}
+                "ImageTypeLimit": 1,
+                "EnableResumable": False,
+            }) or {}
             return (_("Next Up"), nextup.get("Items", []), None, None)
 
         def live_tv_row():

--- a/jellyfin_mpv_shim/mpvtk_browser/settings/general.py
+++ b/jellyfin_mpv_shim/mpvtk_browser/settings/general.py
@@ -246,9 +246,19 @@ class GeneralTabMixin:
                 # Moves what is in the field. It used to pass None, whose
                 # only effect was a status line telling you to press Enter
                 # — a button that could never do its own job.
+                #
+                # **Presence, not truthiness.** `get("path") or val` cannot
+                # tell "not edited" from "cleared", and an empty field is a
+                # real request: move back to the default folder. So clearing
+                # the box and pressing Move sent the CURRENT path back in,
+                # `relocate` found old == new and returned success, and the
+                # status line said "Download folder moved" having moved
+                # nothing. ENTER never had the bug -- it passes the field
+                # straight through -- which is why only the button was dead.
                 Button(_("Move"), id="set-sync-move",
                        on_click=lambda: self._move_downloads(
-                           self._sync_path.get("path") or val)),
+                           self._sync_path["path"]
+                           if "path" in self._sync_path else val)),
             ], gap=8, align="center")
         else:
             # on_commit as well as on_submit: ENTER is not the only way people

--- a/jellyfin_mpv_shim/mpvtk_browser/tiles.py
+++ b/jellyfin_mpv_shim/mpvtk_browser/tiles.py
@@ -13,6 +13,7 @@ import logging
 
 
 from ..i18n import _, _p
+from ..utils import launches_as_audio
 from ..mpvtk.widgets import Menu
 from . import components
 from .repository import PLAYABLE_TYPES, PLAYLIST_SUPPORTED_TYPES
@@ -231,7 +232,11 @@ class TilesMixin:
                 # pause_stills=False for the same reason Play All has it: the
                 # gesture means "run it", and a queue that opens on a photo
                 # would otherwise sit paused on frame one.
-                self._actions.play_list(ids, server, 0, pause_stills=False)
+                # Same rule, second site: a music library's Play All sent
+                # no `audio` at all, so it defaulted to video.
+                self._actions.play_list(
+                    ids, server, 0, pause_stills=False,
+                    audio=launches_as_audio(item, ctype))
             else:
                 self.set_status(_("There is nothing here to play."))
 
@@ -623,7 +628,20 @@ class TilesMixin:
         self.run_async(work, done, ep, on_error=failed)
 
     def _resolve_play_ids(self, item, server, parent_id=None):
-        """The item ids "Play"/"Add to play queue" should act on.
+        """Ids only, for callers that queue without deciding a mode."""
+        return [i.get("Id") for i in
+                self._resolve_play_items(item, server, parent_id)
+                if i.get("Id")]
+
+    def _resolve_play_items(self, item, server, parent_id=None):
+        """The item DTOs "Play"/"Add to play queue" should act on.
+
+        **DTOs, not ids, because the container lies.** A playlist's own
+        `MediaType` is computed by the server from its contents, and a
+        playlist can arrive looking like video while holding music [iw] --
+        so the only reliable answer to "is this launch audio" is the first
+        thing actually being queued. It is also the right answer for a
+        MIXED playlist, where what starts is what decides.
 
         A music container (album/artist/playlist/series) is not itself a
         playable item — queueing or playing its own id does nothing, which
@@ -638,28 +656,24 @@ class TilesMixin:
             return []
         try:
             if t == "MusicAlbum":
-                return [i.get("Id")
-                        for i in self.source.get_album_tracks(server, iid)]
+                return list(self.source.get_album_tracks(server, iid))
             if t == "MusicArtist":
-                return [i.get("Id")
-                        for i in self.source.get_artist_songs(server, iid)]
+                return list(self.source.get_artist_songs(server, iid))
             if t == "Playlist":
-                return [i.get("Id") for i in
+                return [i for i in
                         self.source.get_playlist_items(server, iid)
                         if i.get("Type") in PLAYLIST_SUPPORTED_TYPES]
             if t == "MusicGenre":
-                return [i.get("Id") for i in self.source.get_genre_songs(
-                    server, parent_id, iid)]
+                return list(self.source.get_genre_songs(
+                    server, parent_id, iid))
             if t == "Season":
-                return [i.get("Id") for i in
-                        self._season_queue(item, server)]
+                return list(self._season_queue(item, server))
             if t == "Series":
-                return [i.get("Id") for i in
-                        self.source.get_series_queue(server, iid)]
+                return list(self.source.get_series_queue(server, iid))
         except Exception:
             log.warning("could not resolve %s for playback", t, exc_info=True)
             return []
-        return [iid]
+        return [item]
 
     def _season_queue(self, item, server):
         """A season's episodes, in order. Runs off the loop thread.
@@ -733,15 +747,28 @@ class TilesMixin:
         # A container: resolve it to its items and play those, rather than
         # navigating (a "Play" that browses instead is just a lie).
         ep = self._epoch
-        audio = t in ("MusicAlbum", "MusicArtist", "MusicGenre")
+        # Decided from what is about to be QUEUED, not from a type list and
+        # not from the container's own label. A music playlist is in no such
+        # list, and its `MediaType` can say video while it holds music [iw]
+        # -- so it launched down the video branch, which clears `_browsing`,
+        # yields the window and puts the renderer in HUD mode. The visible
+        # half was a HUD flash before the music started; the damaging half
+        # was that moving the pointer off the window then auto-hid the HUD,
+        # and `phud_hide` calls `ui_suspend` -- blanking the whole library.
+        #
+        # The first entry, because that is what will be on screen: a MIXED
+        # playlist starting on a film is a video launch, and the same
+        # playlist started on a song is not.
         parent = self.route.get("parent_id")
 
         def work():
-            return self._resolve_play_ids(item, server, parent)
+            return self._resolve_play_items(item, server, parent)
 
-        def done(ids):
-            if ids:
-                self._play_list(ids, server, 0, audio=audio)
+        def done(items):
+            if items:
+                ids = [i.get("Id") for i in items if i.get("Id")]
+                self._play_list(ids, server, 0,
+                                audio=launches_as_audio(item, first=items[0]))
             else:
                 self._open_item(item)
         self.run_async(work, done, ep)

--- a/jellyfin_mpv_shim/player.py
+++ b/jellyfin_mpv_shim/player.py
@@ -2290,10 +2290,16 @@ class PlayerManager(AudioMixin, ReportingMixin, WindowMixin):
                 # button (scene button while summoned, standalone
                 # overlay while idle) instead of the seek-to-skip OSD
                 # text prompt; _hud_skip carries the live segment.
-                hud_skip_button = (
-                    getattr(self, "_osc_style_resolved", None) == "mpvtk"
-                    and self.mpvtk_active
-                )
+                # Two questions, and one boolean used to answer both.
+                # "Is there a HUD at all" decides whether the OSD-text
+                # prompt is the fallback; "is the renderer attached right
+                # now" does not, and conflating them put "Seek to Skip" on
+                # screen while CASTING -- where the renderer is detached,
+                # and where there is no local keyboard to seek with anyway.
+                # The segment is still tracked, so the playstate carries
+                # `skip_label` for whatever is driving.
+                have_hud = (
+                    getattr(self, "_osc_style_resolved", None) == "mpvtk")
 
                 if intro is not None:
                     action = conf.segment_action(intro.type)
@@ -2319,7 +2325,7 @@ class PlayerManager(AudioMixin, ReportingMixin, WindowMixin):
                             segment_labels(intro.type)[1], 3000, 1)
                         self._last_intro_msg_time = time.time()
 
-                    if hud_skip_button:
+                    if have_hud:
                         self._hud_skip = (
                             intro if should_prompt and not should_skip
                             else None

--- a/jellyfin_mpv_shim/player.py
+++ b/jellyfin_mpv_shim/player.py
@@ -2193,6 +2193,21 @@ class PlayerManager(AudioMixin, ReportingMixin, WindowMixin):
         self._last_ui_seek_time = time.time()
         self.seek(target, absolute=True)
 
+    def _apply_resume_offset(self, offset):
+        """Seek to the saved position on a fresh start.
+
+        **Marked as one of ours**, which is the whole reason this is a method:
+        `_on_seeking` treats any forward seek while `is_in_intro` as the
+        user asking to skip (`skip_intro_on_seek`), and a resume INTO an
+        intro is a forward seek. So quitting mid-intro and resuming skipped
+        the intro on open with no input at all. The exemption already exists
+        for seeks the UI makes; the resume simply never claimed it, and
+        keeping the claim next to the seek is what stops the two drifting.
+        """
+        self.last_seek = offset
+        self._last_ui_seek_time = time.time()
+        self._player.playback_time = offset
+
     def timeline_handle(self):
         if self.timeline_trigger:
             self.timeline_trigger.set()
@@ -2333,6 +2348,12 @@ class PlayerManager(AudioMixin, ReportingMixin, WindowMixin):
                     elif (
                         not self.is_in_intro
                         and should_prompt
+                        # The message is "Seek to Skip X", and seeking only
+                        # skips when `skip_intro_on_seek` is on -- which is
+                        # OFF by default. Without this it told every
+                        # classic-OSC user to make a gesture that does
+                        # nothing, for the whole of every intro.
+                        and settings.skip_intro_on_seek
                         and time.time() - self._last_intro_msg_time > 3
                     ):
                         self._player.show_text(
@@ -3009,8 +3030,7 @@ class PlayerManager(AudioMixin, ReportingMixin, WindowMixin):
             win_utils.raise_mpv()
 
         if offset is not None and offset > 0:
-            self.last_seek = offset
-            self._player.playback_time = offset
+            self._apply_resume_offset(offset)
 
         if not no_initial_timeline:
             self.send_timeline_initial()

--- a/jellyfin_mpv_shim/player.py
+++ b/jellyfin_mpv_shim/player.py
@@ -29,7 +29,8 @@ from typing import TYPE_CHECKING, Optional
 from . import conffile
 import threading
 
-from .utils import same_origin, synchronous, Timer, get_resource
+from .utils import (same_origin, synchronous, Timer, get_resource,
+                    item_is_audio)
 from .media import segment_labels
 from .mpv_events import observe as observe_property
 from .mpv_events import wait_property
@@ -506,7 +507,7 @@ def _item_is_audio(video):
     mpv's track list, so it answers before a byte has been demuxed.
     """
     item = getattr(video, "item", None) or {} if video is not None else {}
-    return item.get("MediaType") == "Audio" or item.get("Type") == "Audio"
+    return item_is_audio(item)
 
 
 def _rank_stream(prev_source, prev_index, streams, stream_type):

--- a/jellyfin_mpv_shim/player.py
+++ b/jellyfin_mpv_shim/player.py
@@ -1516,7 +1516,7 @@ class PlayerManager(AudioMixin, ReportingMixin, WindowMixin):
             # bitmaps and steals the arrow keys from the browser, so it
             # must not open here even when the HUD declines (browsing,
             # idle, no video).
-            if self._video is not None and self.on_hud_menu is not None:
+            if self._video_on_screen() and self.on_hud_menu is not None:
                 try:
                     self.on_hud_menu()
                 except Exception:
@@ -4942,6 +4942,16 @@ class PlayerManager(AudioMixin, ReportingMixin, WindowMixin):
         reason.
         """
         return self._video is None or self._current_is_audio()
+
+    def _video_on_screen(self):
+        """The complement of :meth:`_library_showing`, by name.
+
+        Both meanings were spelled `self._video`, so no reader could tell
+        which one a site meant without deriving it -- and three sites got it
+        wrong that way. Derived from the other, never a second answer to the
+        same question.
+        """
+        return not self._library_showing()
 
     def _library_has_input(self):
         """The *library* owns input — not merely the renderer.

--- a/jellyfin_mpv_shim/player_reporting.py
+++ b/jellyfin_mpv_shim/player_reporting.py
@@ -30,7 +30,7 @@ from typing import TYPE_CHECKING, Any, Optional
 from .books import AUDIOBOOK_TYPE
 from .i18n import _
 from .media import segment_labels
-from .utils import none_fallback, synchronous
+from .utils import item_is_audio, none_fallback, synchronous
 
 log = logging.getLogger("player")
 
@@ -181,8 +181,10 @@ class ReportingMixin:
             skip = self._hud_skip
             cb({
                 "stopped": False,
-                "is_audio": (item.get("MediaType") == "Audio"
-                             or item.get("Type") == "Audio"),
+                # The rule, not a copy of it: the browser routes browse
+                # vs HUD mode on this flag, so a second answer here would
+                # hand the window away on the states it disagreed about.
+                "is_audio": item_is_audio(item),
                 # A book, not a song. The now-playing bar grows two things
                 # for one -- skip-back-10 / skip-forward-30, and chapter
                 # ticks on the scrubber -- because an audiobook is listened

--- a/jellyfin_mpv_shim/player_window.py
+++ b/jellyfin_mpv_shim/player_window.py
@@ -338,9 +338,12 @@ class WindowMixin:
         off — and ``browser_fullscreen`` is about the library, which headless
         does not even have.
 
-        The `elif` is what keeps audio out of it: music leaves `_video` set
-        and keeps the library on screen, and the fullscreen the *video*
-        session chose outranks this one.
+        `_library_showing()`, not `not self._video`: music keeps `_video` set
+        and keeps the library up, so the OFF direction never ran while a
+        track played -- ticking the box went fullscreen and unticking it did
+        nothing. The old spelling was coherent when `set_fullscreen`
+        persisted a music-time toggle as the VIDEO preference; fixing that
+        is what made it stale.
 
         Called on every browse transition and, since #729, whenever the
         setting itself is written — one decision in one place, because two
@@ -348,7 +351,7 @@ class WindowMixin:
         """
         if settings.browser_fullscreen or settings.headless:
             self._player.fs = True
-        elif not self._video:
+        elif self._library_showing():
             self._player.fs = False
 
     @synchronous("_lock")
@@ -372,9 +375,9 @@ class WindowMixin:
         # **Only while the library actually owns the window.** The gateway's
         # `_act` defers through `run_action`, so a write made while the
         # player lock was held by a playback start lands AFTER that start --
-        # and `_apply_browse_fullscreen`'s `_video` guard protects only the
-        # OFF direction, so `browser_fullscreen` would have taken a playing
-        # video fullscreen against the user's choice.
+        # and `_apply_browse_fullscreen` guards only the OFF direction, so
+        # `browser_fullscreen` would have taken a playing video fullscreen
+        # against the user's choice.
         #
         # `_library_showing()`, never `_video is None`: music keeps `_video`
         # set and keeps the library up, and that is the case this whole
@@ -793,10 +796,19 @@ class WindowMixin:
         showing around it. Only meaningful while the browse window is up; a
         no-op otherwise, and never fatal, because a theme change must not be
         able to take the player down with it.
+
+        `_showing_browse_bg` alone was the wrong gate. It means "we issued a
+        stop and the window is painted with nothing loaded", which is never
+        true during music -- a track is loaded -- yet the window is still
+        painted by `background-color`, because these are global vo options
+        that survive the file change (see set_browse_window). So a theme
+        changed while music played left the old colour on screen until the
+        music stopped.
         """
         try:
-            if self._player is not None and getattr(
-                    self, "_showing_browse_bg", False):
+            if self._player is not None and (
+                    getattr(self, "_showing_browse_bg", False)
+                    or self._library_showing()):
                 self._player.background_color = BROWSE_BG_HEX
         except Exception:
             wlog.debug("could not repaint the browse background",

--- a/jellyfin_mpv_shim/player_window.py
+++ b/jellyfin_mpv_shim/player_window.py
@@ -108,6 +108,12 @@ class WindowMixin:
         # `_video is None` is the wrong answer during music.
         def _library_showing(self) -> bool: ...
 
+        # Same reason, one step on: `show_picture` has to tell a track from
+        # a film, and `stop` is how a page takes the window off the music.
+        def _current_is_audio(self) -> bool: ...
+
+        def stop(self, leave_group: bool = ...) -> None: ...
+
         def idle_quit(self, reason: str = ...) -> None: ...
 
         def _handle_mpv_disconnect(self) -> None: ...
@@ -485,8 +491,23 @@ class WindowMixin:
         here, and a later ``set_browse_window(True)`` has to know to stop
         the picture before claiming it again.
         """
-        if not self._mpv_alive or self._video is not None:
+        if not self._mpv_alive:
             return False
+        if self._video is not None:
+            # `_video is not None` was the whole guard, and for AUDIO it is
+            # the wrong question: music keeps `_video` set *and* keeps the
+            # library on screen, so a comic opened from behind the
+            # now-playing bar was refused here -- silently, because the page
+            # sets `route["_showing"]` regardless and disarms its own
+            # self-repair. The reader drew its bars and never a page.
+            #
+            # There is one mpv and one file, so a page cannot share the
+            # window with a track: opening a comic stops the music [iw].
+            # A VIDEO still refuses -- it owns the window, and the library
+            # is not on screen to navigate from in the first place.
+            if not self._current_is_audio():
+                return False
+            self.stop()
         from .player import _mpv_errors     # per call: see the module docs
         try:
             # **keepaspect, first.** set_browse_window turns it OFF so the

--- a/jellyfin_mpv_shim/player_window.py
+++ b/jellyfin_mpv_shim/player_window.py
@@ -507,6 +507,15 @@ class WindowMixin:
             # image_display_duration (1s) and then idles.
             self._player.image_display_duration = "inf"
             self._player.keep_open = True
+            # **Re-arm at the live size before the load.** A picture is a VO
+            # reconfig like any other file, and X11 re-applies the geometry
+            # option on one -- so without this the window snaps back to
+            # whatever was armed when something last PLAYED. `_play_media`
+            # has always done this; `show_picture` was the one load that did
+            # not, and a comic opened after the window was dragged to a new
+            # size jumped [iw]. Same call, same reason: see
+            # _sync_window_geometry for why arming beats clearing.
+            self._sync_window_geometry()
             self._player.command("loadfile", path, "replace")
             self._showing_browse_bg = False
         except _mpv_errors:

--- a/jellyfin_mpv_shim/sync/manager.py
+++ b/jellyfin_mpv_shim/sync/manager.py
@@ -550,7 +550,11 @@ class SyncManager:
         else:
             new_root = os.path.join(confdir(APP_NAME), "offline")
         if old_root and os.path.abspath(old_root) == new_root:
-            return True, ""
+            # Truthfully, rather than as a successful move. The caller shows
+            # `message or "Download folder moved"`, so an empty string here
+            # claimed a move that never happened -- which is exactly how a
+            # dead Move button read as a working one.
+            return True, _("The downloads are already in that folder.")
         with self._active_lock:
             if self._active_item is not None:
                 return False, _("Can't change the download folder while a "

--- a/jellyfin_mpv_shim/utils.py
+++ b/jellyfin_mpv_shim/utils.py
@@ -39,6 +39,22 @@ class Timer(object):
         return (datetime.now() - self.started).total_seconds()
 
 
+
+def item_is_audio(item):
+    """Whether a Jellyfin item is audio, from its metadata alone.
+
+    **The server is not consistent about which field carries it**, so both
+    are checked -- and a site testing only `Type` gets an *audiobook* wrong
+    (`Type="AudioBook"`, `MediaType="Audio"`), which is how one of these
+    launched down the video branch and handed the window away.
+
+    Here rather than in `player`: the browser asks it at launch time and
+    importing `player` builds an mpv.
+    """
+    item = item or {}
+    return item.get("MediaType") == "Audio" or item.get("Type") == "Audio"
+
+
 def synchronous(tlockname: str):
     """
     A decorator to place an instance based lock around a method.

--- a/jellyfin_mpv_shim/utils.py
+++ b/jellyfin_mpv_shim/utils.py
@@ -40,6 +40,45 @@ class Timer(object):
 
 
 
+#: Containers that hold audio but carry no MediaType of their own.
+#: A music PLAYLIST is deliberately absent: it *does* carry one, computed by
+#: the server from its contents (PlaylistManager.cs sets MediaType.Audio or
+#: .Video), so `item_is_audio` already answers for it -- and a hardcoded list
+#: is what got this wrong.
+_AUDIO_CONTAINERS = ("MusicAlbum", "MusicArtist", "MusicGenre")
+
+
+def launches_as_audio(item, collection_type=None, first=None):
+    """Whether starting ``item`` should keep the library on screen with the
+    now-playing bar, instead of handing the window to a video.
+
+    The browser picks browse mode or HUD mode from this, and HUD mode's
+    auto-hide calls ``ui_suspend`` -- so a wrong answer does not misplace a
+    bar, it **blanks the library** the moment the pointer leaves.
+
+    ``first`` is the entry that will actually start, and **it wins outright**
+    when the caller has it. A container's own label is a summary and can be
+    wrong: a playlist can arrive looking like video while holding music [iw],
+    because the server derives `Playlist.MediaType` from the contents and the
+    two can disagree by the time the DTO reaches us. It is also the only
+    answer that is right for a MIXED playlist, where what is queued first is
+    what ends up on screen.
+
+    Without it: the item's own MediaType, then the containers that carry
+    none, then the library it came from. All three are guesses, and the
+    playstate that follows corrects them -- this only decides whether the
+    user sees a flash first.
+    """
+    item = item or {}
+    if first is not None:
+        return item_is_audio(first)
+    if item_is_audio(item):
+        return True
+    if item.get("Type") in _AUDIO_CONTAINERS:
+        return True
+    return (collection_type or item.get("CollectionType")) == "music"
+
+
 def item_is_audio(item):
     """Whether a Jellyfin item is audio, from its metadata alone.
 

--- a/tests/e2e/run_e2e.py
+++ b/tests/e2e/run_e2e.py
@@ -76,6 +76,10 @@ CONTRACT = [
     # (ChildCount is 0 for a collection read off disk while the listing has
     # every member), plus the three edit endpoints nothing else calls.
     "tests.e2e.test_collections",
+    # A music playlist reports MediaType "Audio" and a video one reports
+    # "Video" -- the one fact the launch rule rests on, and one the fast
+    # suite can only assume, because it builds the DTO it then reads.
+    "tests.e2e.test_music_playlist",
     "tests.e2e.test_items_endpoint",
     # The server-truth backing for batch 4 -- CanDelete absent unless
     # asked, TranscodeReasons in the TranscodingUrl, StartItemId

--- a/tests/e2e/test_music_playlist.py
+++ b/tests/e2e/test_music_playlist.py
@@ -1,0 +1,118 @@
+"""A music playlist is audio, and only the server knows it.
+
+The shim decides between "keep the library up with the now-playing bar" and
+"hand the window to a video" from whether the thing being started is audio.
+It decided with a hardcoded container list::
+
+    audio = t in ("MusicAlbum", "MusicArtist", "MusicGenre")
+
+A **playlist** is in no such list, and cannot be: the same `Type` carries
+either answer. So a music playlist launched down the video branch, which
+clears `_browsing`, yields the window and puts the renderer in HUD mode --
+and `phud_hide`, which fires when the pointer leaves the window, calls
+`ui_suspend`. The library is what got suspended, because the library is what
+was on screen. Reported as "the entire library UI blanks", with a flash of
+the HUD loading before the music started as the tell.
+
+The item knew all along: `Playlist.MediaType` is `PlaylistMediaType`, which
+`PlaylistManager` computes from the contents (`MediaType.Audio` or
+`.Video`). **That is the fact this file exists to pin.** The unit tests
+assert that a DTO shaped `{"Type": "Playlist", "MediaType": "Audio"}`
+launches as audio; nothing in them proves a real Jellyfin playlist IS that
+shape, and a fix resting on an invented DTO is the failure mode this suite
+is for.
+
+Both playlists are created here and deleted on the way out -- the same
+create/restore shape `set_policy` uses for the Live TV policy tests.
+"""
+
+import os
+import sys
+import unittest
+
+sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+import _e2e  # noqa: E402
+
+
+@_e2e.require_server
+class MusicPlaylistShapeTest(_e2e.E2ETestCase):
+
+    @classmethod
+    def _make(cls, session, name, media_type, ids):
+        made = session._request("/Playlists", method="POST", body={
+            "Name": name, "Ids": ids, "UserId": session.user_id,
+            "MediaType": media_type})
+        return (made or {}).get("Id")
+
+    def setUp(self):
+        super().setUp()
+        songs = self._ids("Audio", 3)
+        self.assertTrue(songs, "the QA library has no audio to build a "
+                               "playlist from")
+        self.music_id = self._make(self.session, "jms-e2e-music", "Audio",
+                                   songs)
+        self.addCleanup(self._delete, self.music_id)
+        self.song_ids = songs
+
+    def _ids(self, item_type, limit):
+        found = self.session.find_all(item_type=item_type, Limit=limit)
+        items = found if isinstance(found, list) else found.get("Items", [])
+        return [i["Id"] for i in items]
+
+    def _delete(self, item_id):
+        if item_id:
+            try:
+                self.session._request("/Items/" + item_id, method="DELETE")
+            except Exception:
+                pass
+
+    def test_a_music_playlist_says_it_is_audio(self):
+        """The premise of the whole fix, measured rather than assumed."""
+        dto = self.session.api.get_item(self.music_id)
+        self.assertEqual("Playlist", dto.get("Type"))
+        self.assertEqual(
+            "Audio", dto.get("MediaType"),
+            "a music playlist did not report MediaType Audio, so the launch "
+            "rule has nothing to read and the type list was right after all")
+
+    def test_the_launch_rule_agrees_with_the_server(self):
+        from jellyfin_mpv_shim.utils import launches_as_audio
+
+        dto = self.session.api.get_item(self.music_id)
+        self.assertTrue(
+            launches_as_audio(dto),
+            "a real music playlist launches down the video branch, which "
+            "yields the window and lets the auto-hide blank the library")
+
+    def test_a_video_playlist_is_not_audio(self):
+        """The control, and the reason this is not "playlists are audio":
+        one `Type`, both answers, and only `MediaType` separates them."""
+        from jellyfin_mpv_shim.utils import launches_as_audio
+
+        videos = self._ids("Movie", 2)
+        if not videos:
+            self.skipTest("no video items to build a video playlist from")
+        vid = self._make(self.session, "jms-e2e-video", "Video", videos)
+        self.addCleanup(self._delete, vid)
+        dto = self.session.api.get_item(vid)
+        self.assertEqual("Video", dto.get("MediaType"))
+        self.assertFalse(
+            launches_as_audio(dto),
+            "a video playlist would keep the library up and never hand the "
+            "window over")
+
+    def test_the_playlist_resolves_to_its_tracks(self):
+        """The smoke half: the ids the launch would queue are the songs that
+        went in, in order. A playlist that resolves to nothing takes the
+        `_open_item` branch instead and never plays at all."""
+        found = self.session.find_all(parent_id=self.music_id)
+        items = found if isinstance(found, list) else found.get("Items", [])
+        self.assertEqual(
+            self.song_ids, [i["Id"] for i in items],
+            "the playlist did not resolve to the tracks it was built from")
+        for item in items:
+            self.assertEqual("Audio", item.get("MediaType"))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/lua/test_renderer.lua
+++ b/tests/lua/test_renderer.lua
@@ -3549,6 +3549,38 @@ ok(fake.log.keybinds["mpvtk_nav_j"] ~= nil, "j did not become the nav binding")
 ok(fake.log.keybinds["mpvtk_nav_k"] == nil, "the previous select key was left bound")
 fake.send("mpvtk-keys", fake.token({ keys = {} }))
 
+-- A FOCUS RING must not silently eat every claim.
+--
+-- `keyclaim.take` refused all claims while a ring was up, for a reason that
+-- is only about the arrows: without it DOWN moves the ring into the reader's
+-- own bottom bar and RIGHT then turns the page instead of stepping to the
+-- next button. SPACE is not an arrow, and refusing a claim on it does not
+-- fall back to anything -- under `browse_block_keys` a refused claim is
+-- SWALLOWED, so raising the ring killed pause for music with no way back
+-- from the keyboard (only a mouse press drops a ring).
+--
+-- DOWN is claimed only AFTER the ring is up, deliberately: claiming it first
+-- means the claim answers the very press meant to raise the ring, and the
+-- test then proves nothing about either half.
+fake.send("mpvtk-keys", fake.token({ keys = { "SPACE" } }))
+scene({ tile("ring1", 0, 0), tile("ring2", 0, 100) })
+fake.key("mpvtk_nav_DOWN")            -- raise the ring
+fake.reset_events()
+fake.key("mpvtk_key_SPACE")
+local held = last_event("key")
+eq(held and held.key, "SPACE",
+   "a focus ring swallowed a claim on a key it does not use")
+
+-- ...and the half the refusal exists for is unchanged: a claim on a key the
+-- ring DOES use still loses to it, or the ring can never leave the control
+-- it landed on.
+fake.send("mpvtk-keys", fake.token({ keys = { "SPACE", "DOWN" } }))
+fake.reset_events()
+fake.key("mpvtk_nav_DOWN")
+ok(last_event("key") == nil,
+   "a claim on DOWN outranked the focus ring, so the ring cannot move")
+fake.send("mpvtk-keys", fake.token({ keys = {} }))
+
 -- It survives the playback round trip, because `bind_nav_keys` runs again
 -- on every resume and would otherwise put ENTER back.
 fake.send("mpvtk-active", "no")

--- a/tests/test_claim_cache_after_activate.py
+++ b/tests/test_claim_cache_after_activate.py
@@ -1,0 +1,119 @@
+"""Re-activating the renderer must not claim it dropped what it still holds.
+
+`claim_keys` and `set_picture_pan` are compare-and-skip caches, and
+`set_active` forgets them because **the renderer drops its key claim and its
+pan model on its own when it goes inactive and never says so**. That is true
+of `mpvtk-active no`. It is not true of `yes`: the handler there drops
+nothing, so recording "we have pushed the empty set" is a statement about the
+renderer that is false, and the next genuine release compares equal and is
+skipped.
+
+Reported, and the sequence matters:
+
+    play music -> STOP it -> start a video  =>  SPACE and m dead
+
+Music claims 9/0/m/SPACE, because `browse_block_keys` swallows them
+otherwise. Stopping routes through `enter_browse()` -> `set_active(True)`,
+which zeroed the cache while the renderer kept the keys; the release that
+followed was skipped, and the keys stayed force-bound with nothing driving
+them. A forced binding outranks the player's own, so it is not a missing
+feature -- it is pause and mute dead for every video after. `p` keeps
+working throughout, because `p` is never claimed, and that asymmetry is what
+identified it.
+
+Going straight from music to a video does NOT reproduce it: no
+`set_active(True)` runs, so the cache still holds the real value and the
+release goes out. The stop is the whole of the difference.
+"""
+
+# Run as a script, this is what puts the repo root on sys.path -- without
+# it `jellyfin_mpv_shim` resolves to whatever is pip-installed. A no-op
+# under `discover`; tests/test_module_paths.py is the guard.
+if __name__ == "__main__":
+    import os
+    import sys
+
+    sys.path.insert(0, os.path.dirname(
+        os.path.dirname(os.path.abspath(__file__))))
+
+import sys
+import unittest
+
+sys.argv = [sys.argv[0]]
+
+MUSIC_KEYS = ("9", "0", "m", "SPACE")
+
+
+class _Backend:
+    def __init__(self):
+        self.sent = []
+
+    def command(self, *args):
+        self.sent.append(args)
+
+    def claims(self):
+        import json
+        out = []
+        for args in self.sent:
+            if len(args) >= 3 and args[1] == "mpvtk-keys":
+                out.append(tuple(json.loads(args[2])["keys"]))
+        return out
+
+
+class ClaimSurvivesReactivationTest(unittest.TestCase):
+
+    def _app(self):
+        from jellyfin_mpv_shim.mpvtk.app import MpvtkApp
+
+        app = MpvtkApp.__new__(MpvtkApp)
+        app.backend = _Backend()
+        import threading
+        app._pan_lock = threading.RLock()
+        app._claimed_keys = ()
+        app._picture_pan = None
+        return app
+
+    def test_a_release_after_reactivating_reaches_the_renderer(self):
+        app = self._app()
+        app.claim_keys(MUSIC_KEYS)          # music: the keys are claimed
+        app.set_active(True)                # stopping music re-enters browse
+        app.claim_keys(())                  # the build that should release
+        self.assertEqual(
+            [MUSIC_KEYS, ()], app.backend.claims(),
+            "the release was skipped, so SPACE and m stay force-bound and "
+            "the next video cannot be paused or muted")
+
+    def test_the_straight_path_still_releases(self):
+        """The control, and the reason this went unnoticed: music straight to
+        a video never re-activates, so the cache held the real value and the
+        release went out."""
+        app = self._app()
+        app.claim_keys(MUSIC_KEYS)
+        app.claim_keys(())
+        self.assertEqual([MUSIC_KEYS, ()], app.backend.claims())
+
+    def test_an_unchanged_claim_is_still_skipped(self):
+        """The cache still has to do its job: this is pushed from build(),
+        i.e. every frame."""
+        app = self._app()
+        app.claim_keys(MUSIC_KEYS)
+        app.claim_keys(MUSIC_KEYS)
+        self.assertEqual([MUSIC_KEYS], app.backend.claims())
+
+    def test_stopping_a_pan_after_reactivating_reaches_the_renderer(self):
+        """The same cache, the same fix: `None` is a real request here --
+        "stop panning" -- so the sentinel cannot be None."""
+        app = self._app()
+        app.set_picture_pan({"unitx": 1, "unity": 1})
+        app.set_active(True)
+        app.set_picture_pan(None)
+        pans = [a for a in app.backend.sent
+                if len(a) >= 2 and a[1] == "mpvtk-vpan"]
+        self.assertEqual(
+            2, len(pans),
+            "the pan model was left set, so the wheel keeps panning against "
+            "a clamp for a picture that is gone")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_home_rows.py
+++ b/tests/test_home_rows.py
@@ -70,11 +70,13 @@ class FakeApi:
         # /Latest answers with a bare list, not an Items envelope.
         return list(self.latest_items)
 
-    def get_next(self, limit=1, fields=None, enable_image_types=None,
-                 image_type_limit=None):
-        self._enter("get_next", {"fields": fields,
-                                 "enable_image_types": enable_image_types,
-                                 "image_type_limit": image_type_limit})
+    # Deliberately NO get_next, for the same reason as get_resume_items
+    # above: the apiclient helper has no EnableResumable parameter, and the
+    # server defaults it to TRUE -- so a fake answering it made the row look
+    # correct while part-watched episodes appeared in two places. Production
+    # reaches the endpoint directly.
+    def shows(self, handler, params=None):
+        self._enter("Shows" + handler, params)
         return {"Items": [{"Id": "n", "Name": "NextUp"}]}
 
 
@@ -326,35 +328,51 @@ class LeanFieldsTest(HomeRowsHarness):
     def test_image_tags_are_capped_to_one_per_type(self):
         """Without this every backdrop tag comes back, often five to ten.
 
-        Scoped to the queries we build ourselves. Next Up goes through the
-        apiclient's get_next helper, whose signature has no image_type_limit
-        parameter — capping it there would mean bypassing the helper for a
-        single-row saving, which is not worth the extra surface.
+        Scoped to the queries we build ourselves — which Next Up now is
+        too, so it is no longer excluded here. It asks in the endpoint's own
+        spelling (`ImageTypeLimit`) rather than the helper's.
         """
         api = FakeApi()
         self._source(api).get_home_rows("srv", libraries=LIBS)
         checked = 0
         for name, params in zip(api.calls, api.params):
-            if name != "get_next" and params.get("enable_image_types"):
+            if params.get("enable_image_types"):
                 self.assertEqual(params.get("image_type_limit"), 1)
+                checked += 1
+            elif params.get("EnableImageTypes"):
+                self.assertEqual(params.get("ImageTypeLimit"), 1)
                 checked += 1
         self.assertGreater(checked, 0, "the assertion matched nothing")
 
-    def test_next_up_asks_for_the_lean_fields_too(self):
+    def _nextup_params(self):
         api = FakeApi()
         self._source(api).get_home_rows("srv", libraries=LIBS)
-        nextup = [p for name, p in zip(api.calls, api.params)
-                  if name == "get_next"][0]
-        self.assertEqual(nextup.get("fields"), LIST_FIELDS)
+        rows = [p for name, p in zip(api.calls, api.params)
+                if name == "Shows/NextUp"]
+        self.assertEqual(1, len(rows), "Next Up was not fetched exactly once")
+        return rows[0]
+
+    def test_next_up_asks_for_the_lean_fields_too(self):
+        self.assertEqual(self._nextup_params().get("Fields"), LIST_FIELDS)
 
     def test_next_up_caps_image_tags_like_every_other_home_query(self):
         """It was the one that did not, so a series with twenty backdrops
         sent twenty tags per card for the one the tile draws."""
-        api = FakeApi()
-        self._source(api).get_home_rows("srv", libraries=LIBS)
-        nextup = [p for name, p in zip(api.calls, api.params)
-                  if name == "get_next"][0]
-        self.assertEqual(nextup.get("image_type_limit"), 1)
+        self.assertEqual(self._nextup_params().get("ImageTypeLimit"), 1)
+
+    def test_next_up_excludes_what_continue_watching_already_shows(self):
+        """`EnableResumable` DEFAULTS TO TRUE on the server
+        (TvShowsController.GetNextUp), so a part-watched episode appeared in
+        Continue Watching and again in Next Up. jellyfin-web's home section
+        sends false for exactly this.
+
+        False and not absent: absent is the server's true.
+        """
+        params = self._nextup_params()
+        self.assertIn("EnableResumable", params,
+                      "the parameter is absent, which the server reads as "
+                      "the default -- true")
+        self.assertIs(params["EnableResumable"], False)
 
 
 if __name__ == "__main__":

--- a/tests/test_library_showing.py
+++ b/tests/test_library_showing.py
@@ -37,6 +37,7 @@ if __name__ == "__main__":
 
 import sys
 import types
+from unittest import mock
 import unittest
 
 sys.argv = [sys.argv[0]]      # importing the shim reaches args.get_args()
@@ -331,3 +332,187 @@ class FullscreenPersistTest(unittest.TestCase):
                 else:
                     self.assertTrue(video_key, "%s" % label)
                     self.assertFalse(browser_key, "%s" % label)
+
+
+class BrowseFullscreenAppliesTest(unittest.TestCase):
+    """The OFF direction of `browser_fullscreen`, which never ran during music.
+
+    `_apply_browse_fullscreen` reads::
+
+        if settings.browser_fullscreen or settings.headless:
+            self._player.fs = True
+        elif not self._video:
+            self._player.fs = False
+
+    so ticking the box while a track played went fullscreen and unticking it
+    did nothing -- the `elif` is the third site of this rule, and the audit
+    that fixed the other two did not reach it because it lives one call below
+    the method that was fixed.
+
+    The `elif` was defensible when it was written: `set_fullscreen` persisted
+    a music-time toggle as the VIDEO preference, so deferring to "the
+    fullscreen the video session chose" was coherent. Fixing that (the
+    sibling repair on this branch) is what made this one stale -- during
+    music `browser_fullscreen` is now both what a toggle writes and what
+    should be applied.
+    """
+
+    def _pm_for(self, video):
+        pm = _window_pm(video)
+        pm._player.fs = True          # start fullscreen, so OFF is observable
+        return pm
+
+    def test_unticking_applies_wherever_the_library_is_showing(self):
+        from jellyfin_mpv_shim.conf import settings
+
+        for label, video, showing in STATES:
+            if not showing:
+                continue
+            with self.subTest(state=label):
+                pm = self._pm_for(video)
+                with mock.patch.object(settings, "browser_fullscreen", False), \
+                        mock.patch.object(settings, "headless", False):
+                    pm._apply_browse_fullscreen()
+                self.assertFalse(
+                    pm._player.fs,
+                    "%s: the library is on screen and browser_fullscreen is "
+                    "off, but the window stayed fullscreen" % label)
+
+    def test_ticking_applies_wherever_the_library_is_showing(self):
+        """The direction that already worked. Kept because it is the half a
+        repair of the other one could break, and because a test that only
+        asserts the broken direction cannot tell a fix from a regression."""
+        from jellyfin_mpv_shim.conf import settings
+
+        for label, video, showing in STATES:
+            if not showing:
+                continue
+            with self.subTest(state=label):
+                pm = _window_pm(video)
+                pm._player.fs = False
+                with mock.patch.object(settings, "browser_fullscreen", True), \
+                        mock.patch.object(settings, "headless", False):
+                    pm._apply_browse_fullscreen()
+                self.assertTrue(pm._player.fs, "%s: did not go fullscreen"
+                                % label)
+
+    def test_a_video_on_screen_is_left_alone(self):
+        """The reason the guard exists at all: a film owns the window and
+        `settings.fullscreen` is what governs it."""
+        from jellyfin_mpv_shim.conf import settings
+
+        for label, video, showing in STATES:
+            if showing:
+                continue
+            with self.subTest(state=label):
+                pm = self._pm_for(video)
+                with mock.patch.object(settings, "browser_fullscreen", False), \
+                        mock.patch.object(settings, "headless", False):
+                    pm._apply_browse_fullscreen()
+                self.assertTrue(
+                    pm._player.fs,
+                    "%s: browsing's fullscreen preference was applied to a "
+                    "video that owns the window" % label)
+
+
+class BrowseBackgroundRepaintTest(unittest.TestCase):
+    """A live theme change has to repaint mpv's background during music too.
+
+    The colour behind the browser is an mpv *property*; nothing in the scene
+    paints the whole window. `refresh_browse_bg` gated on
+    `_showing_browse_bg`, which means "we issued a stop and the window is
+    painted with nothing loaded" -- and that is never true during music,
+    because a track is loaded. But the window is still painted by
+    `background-color` (a picture-less audio file, and these are global vo
+    options that survive the file change -- `set_browse_window` says so), so
+    the flag is being read as "is the browse background visible" when it
+    answers something narrower.
+    """
+
+    def _pm_for(self, video, showing_bg):
+        pm = _window_pm(video)
+        pm._showing_browse_bg = showing_bg
+        pm._player.background_color = "#000000"
+        return pm
+
+    def test_the_background_repaints_wherever_the_library_is_showing(self):
+        from jellyfin_mpv_shim import player_window
+
+        for label, video, showing in STATES:
+            if not showing:
+                continue
+            with self.subTest(state=label):
+                # False, because that is the state music is actually in: a
+                # track is loaded, so nothing ever set this flag.
+                pm = self._pm_for(video, showing_bg=(video is None))
+                with mock.patch.object(player_window, "BROWSE_BG_HEX",
+                                       "#abcdef"):
+                    pm.refresh_browse_bg()
+                self.assertEqual(
+                    pm._player.background_color, "#abcdef",
+                    "%s: the library is on screen showing the old theme's "
+                    "background" % label)
+
+    def test_a_video_keeps_mpvs_own_background(self):
+        """The half that must not change: during playback the background is
+        what letterbox bars are painted with, and `browse_yield` deliberately
+        puts mpv's own colour back there."""
+        from jellyfin_mpv_shim import player_window
+
+        for label, video, showing in STATES:
+            if showing:
+                continue
+            with self.subTest(state=label):
+                pm = self._pm_for(video, showing_bg=False)
+                with mock.patch.object(player_window, "BROWSE_BG_HEX",
+                                       "#abcdef"):
+                    pm.refresh_browse_bg()
+                self.assertEqual(
+                    pm._player.background_color, "#000000",
+                    "%s: the browse background was painted behind a video"
+                    % label)
+
+
+class SettingsMenuStaysShutTest(unittest.TestCase):
+    """The OSD menu must not open while the library is on screen.
+
+    `toggle_settings_menu`'s own comment states the rule -- the OSD menu
+    "lands *under* the mpvtk overlay bitmaps and steals the arrow keys from
+    the browser, so it must not open here even when the HUD declines
+    (browsing, idle, no video)" -- and then gates on `_video is not None`,
+    which is true during music.
+
+    Reachable today despite `browse_block_keys`: the key is only one of the
+    two callers. `menu_action` comes from a **remote**, which no key block
+    touches, so a cog press on a phone while a track plays opens a menu
+    under the library and takes its arrows.
+    """
+
+    def _pm_for(self, video):
+        pm = _pm(video)
+        pm._osc_style_resolved = "mpvtk"
+        pm.do_not_handle_pause = False
+        pm.opened = []
+        pm.on_hud_menu = lambda: pm.opened.append(1)
+        return pm
+
+    def test_it_stays_shut_wherever_the_library_is_showing(self):
+        for label, video, showing in STATES:
+            if not showing:
+                continue
+            with self.subTest(state=label):
+                pm = self._pm_for(video)
+                pm.toggle_settings_menu()
+                self.assertEqual(
+                    pm.opened, [],
+                    "%s: the HUD menu opened over the library" % label)
+
+    def test_it_still_opens_over_a_video(self):
+        for label, video, showing in STATES:
+            if showing:
+                continue
+            with self.subTest(state=label):
+                pm = self._pm_for(video)
+                pm.toggle_settings_menu()
+                self.assertEqual(pm.opened, [1],
+                                 "%s: the gear menu did not open" % label)

--- a/tests/test_library_showing.py
+++ b/tests/test_library_showing.py
@@ -700,6 +700,77 @@ class TheCursorNeverHidesOverTheLibraryTest(unittest.TestCase):
             ("active", True), app.calls[-1],
             "the renderer was not left asserted for browse")
 
+    def test_a_frame_racing_the_yield_cannot_keep_space(self):
+        """Izzie's hypothesis, and `_claim_page_keys` records the same
+        symptom from before: "SPACE stopped pausing the video for the rest
+        of the session".
+
+        Music playing with the library up claims SPACE (the key block
+        swallows it otherwise, and a forced binding that returns does not
+        hand it back, so `kb_pause` would never see it). Starting a video
+        yields, and the yield drops the claim. But `_claim_page_keys` reads
+        `_browsing` and then calls `claim()`, and a playback update on a
+        foreign thread flips the flag between the two -- so a frame already
+        in flight can land its claim AFTER the release.
+
+        A claimed key gets a FORCED binding, which outranks the player's own
+        `space`. So the stale claim is not a missing feature, it is pause
+        dead against every video for the rest of the session, with the music
+        that justified the claim long since stopped.
+
+        The release is the last write of the yield now, so a racing frame
+        either lands before it and is overwritten, or after it and finds the
+        flag already false.
+        """
+        b, app = self._browser()
+        b._browsing = True
+        b._now_playing = {"stopped": False, "is_audio": True, "id": "a1"}
+        b.hud.state = {"stopped": False, "is_audio": False, "id": "v1"}
+
+        claims = []
+        b.app.claim_keys = lambda keys=(): claims.append(tuple(keys))
+
+        real_tell = b._tell_controller
+
+        def racing(name):
+            real_tell(name)
+            if name == "on_browse_leave":
+                # What a frame that began while music was up DOES when it
+                # lands mid-yield: applies the set it computed back then.
+                #
+                # Driven as the effect rather than by calling
+                # `_claim_page_keys` here -- that reads the flag afresh, sees
+                # it already false, and answers "no keys", so the test would
+                # pass on the late re-check alone and never touch the release
+                # it is named for. (It did: the mutation that removed the
+                # release left it green.)
+                b.app.claim_keys(("9", "0", "m", "SPACE"))
+
+        b._tell_controller = racing
+        b._yield()
+
+        self.assertTrue(claims, "nothing claimed or released at all")
+        self.assertEqual(
+            (), claims[-1],
+            "the yield ended with keys still claimed: a forced SPACE "
+            "binding outranks kb_pause, so the video cannot be paused")
+
+    def test_music_still_claims_space_while_browsing(self):
+        """The control. The claim exists because the key block swallows
+        SPACE, so releasing it unconditionally would kill pause for MUSIC
+        instead -- the bug this claim was added to fix."""
+        from jellyfin_mpv_shim.conf import settings
+
+        b, _app = self._browser()
+        b._browsing = True
+        b._now_playing = {"stopped": False, "is_audio": True, "id": "a1"}
+        claims = []
+        b.app.claim_keys = lambda keys=(): claims.append(tuple(keys))
+        with mock.patch.object(settings, "browse_block_keys", True):
+            b._claim_page_keys(dict(b.route))
+        self.assertTrue(claims and "SPACE" in claims[-1],
+                        "music lost its pause key")
+
     def test_a_handoff_returns_the_hud_to_idle(self):
         """Reported: changing an audio or subtitle track during a transcode
         sometimes yields "to a dead HUD where moving the mouse does not bring

--- a/tests/test_library_showing.py
+++ b/tests/test_library_showing.py
@@ -597,6 +597,84 @@ class OneAudioRuleTest(unittest.TestCase):
                     % (item, "video" if expected else "audio"))
 
 
+class TheCursorNeverHidesOverTheLibraryTest(unittest.TestCase):
+    """[iw] "Cursor hiding should never happen when the main UI is visible,
+    only the mpvtk HUD."
+
+    That is the visible edge of a worse state, and the whole of the reported
+    bug. `set_hud(True)` is a MODE CHANGE: `ui_suspend()` drops the mouse
+    section, and the renderer withholds `allow-hide-cursor` from that section
+    exactly so the pointer stays alive over a UI
+    (docs/mpv-backends.md). So a HUD engaged while the library is on screen
+
+      * hides the cursor -- the tell,
+      * auto-hides after `hud_hide_secs`, and `phud_hide` calls
+        `ui_suspend`, which takes the LIBRARY off screen with it,
+      * and brings it back on motion, because `mouse-pos` is observed
+        directly and needs no section.
+
+    Every symptom reported for the video -> music playlist advance, from one
+    state. Reproduction: a playlist of one video then one song, skip to the
+    next track, stop moving the mouse.
+
+    Enforced in `HudController.engage` rather than at the four call sites
+    that already guard it, so a guard read a beat before `_browsing` flips
+    cannot get past it.
+    """
+
+    def _browser(self):
+        sys.path.insert(0, os.path.join(os.path.dirname(
+            os.path.dirname(os.path.abspath(__file__))), "tests"))
+        from _shell_harness import FakeSource, HudController, StubHudApp
+        from jellyfin_mpv_shim.mpvtk_browser.app import MpvtkBrowser
+
+        b = MpvtkBrowser(app=None, source=FakeSource(),
+                         controller=HudController())
+        app = StubHudApp()
+        b.set_app(app)
+        return b, app
+
+    def test_an_engage_while_browsing_is_refused(self):
+        b, app = self._browser()
+        b._browsing = True
+        b.hud.state = {"stopped": False, "is_audio": False, "id": "v1"}
+        app.calls.clear()
+        b.hud.engage()
+        self.assertNotIn(
+            ("hud", True), app.calls,
+            "the HUD was engaged over the library: the cursor now hides, and "
+            "the auto-hide takes the library with it")
+
+    def test_playback_still_engages_it(self):
+        """The control. A refusal that also refused the real case would take
+        the player controls away entirely."""
+        b, app = self._browser()
+        b._browsing = False
+        b.hud.state = {"stopped": False, "is_audio": False, "id": "v1"}
+        app.calls.clear()
+        b.hud.engage()
+        self.assertIn(("hud", True), app.calls,
+                      "a video got no HUD at all")
+
+    def test_the_reported_sequence_leaves_browse_asserted(self):
+        """Video, then the queue advances to a track: whatever order the
+        pushes arrive in, the renderer must not be left in HUD mode while
+        the library is what is drawn."""
+        b, app = self._browser()
+        b._browsing = True
+        b.on_playstate({"stopped": False, "is_audio": False, "id": "v1"})
+        b.on_playstate({"stopped": False, "is_audio": True, "id": "a1"})
+        self.assertTrue(b._browsing, "the library is not on screen")
+        # A late video push from the timeline thread, built before the
+        # advance -- the shape that would re-engage behind the library.
+        b.on_playstate({"stopped": False, "is_audio": False, "id": "v1"})
+        if b._browsing:
+            self.assertNotEqual(
+                ("hud", True), app.calls[-1],
+                "a late push left the renderer in HUD mode with the library "
+                "on screen")
+
+
 class LaunchingAsAudioTest(unittest.TestCase):
     """The FOURTH copy of "is this audio", and the one a type list cannot fix.
 

--- a/tests/test_library_showing.py
+++ b/tests/test_library_showing.py
@@ -656,6 +656,50 @@ class TheCursorNeverHidesOverTheLibraryTest(unittest.TestCase):
         self.assertIn(("hud", True), app.calls,
                       "a video got no HUD at all")
 
+    def test_a_yield_overtaken_by_enter_browse_does_not_engage(self):
+        """The actual interleaving, from Izzie's log:
+
+            Player is busy; deferring UI action to the action thread
+            window: browse=on <- gateway.playback.on_browse_enter:23
+            refusing a HUD engage while browsing <- app._yield:2294
+
+        `_yield` clears `_browsing` FIRST and engages LAST, and the work in
+        between is not atomic: `_tell_controller("on_browse_leave")` reaches
+        the gateway, `run_action` defers because the player lock is held for
+        the whole of a start, and the next queue item -- a song -- brings the
+        library back inside that window. The engage that follows is stale by
+        the time it runs.
+
+        Not a fifth caller and not a flag read early: one call spanning a
+        re-entry. Modelled by re-entering browse from the leave callback,
+        which is exactly where the log shows it happening.
+        """
+        b, app = self._browser()
+        b._browsing = True
+        b.hud.state = {"stopped": False, "is_audio": False, "id": "v1"}
+
+        real_tell = b._tell_controller
+
+        def overtaking(name):
+            real_tell(name)
+            if name == "on_browse_leave":
+                b.enter_browse()      # the song arrives mid-yield
+
+        b._tell_controller = overtaking
+        app.calls.clear()
+        b._yield()
+
+        self.assertTrue(b._browsing,
+                        "the library did not come back, so this models the "
+                        "wrong thing")
+        self.assertNotIn(
+            ("hud", True), app.calls,
+            "the yield's trailing engage landed after browse had been "
+            "re-entered, leaving HUD mode over the library")
+        self.assertEqual(
+            ("active", True), app.calls[-1],
+            "the renderer was not left asserted for browse")
+
     def test_the_reported_sequence_leaves_browse_asserted(self):
         """Video, then the queue advances to a track: whatever order the
         pushes arrive in, the renderer must not be left in HUD mode while

--- a/tests/test_library_showing.py
+++ b/tests/test_library_showing.py
@@ -35,6 +35,7 @@ if __name__ == "__main__":
     sys.path.insert(0, os.path.dirname(
         os.path.dirname(os.path.abspath(__file__))))
 
+import os
 import sys
 import types
 from unittest import mock
@@ -516,3 +517,131 @@ class SettingsMenuStaysShutTest(unittest.TestCase):
                 pm.toggle_settings_menu()
                 self.assertEqual(pm.opened, [1],
                                  "%s: the gear menu did not open" % label)
+
+
+class OneAudioRuleTest(unittest.TestCase):
+    """"Is this item audio?" is asked at three sites, and two had their own copy.
+
+    `_item_is_audio` is the rule -- ``MediaType == "Audio" or Type ==
+    "Audio"`` -- and the server is not consistent about which field carries
+    it, which is why the predicate accepts either and why STATES above models
+    both. The copies:
+
+    * `player_reporting.push_playstate` inlined the rule verbatim. Not a bug
+      by itself, but it is a second authority, and the two would diverge the
+      first time either moved.
+    * `ItemActions.play` implemented **half** of it -- ``Type == "Audio"``
+      only -- so an item carrying `MediaType` and any other `Type` launched
+      down the VIDEO branch: `_start(audio=False)` clears `_browsing` and
+      hands the window over. An **audiobook** is exactly that shape
+      (`Type="AudioBook"`, `MediaType="Audio"`).
+
+    What makes this worth a lint's worth of care rather than two edits: the
+    browser decides between browse and HUD mode on this answer, and a
+    playstate that says "not audio" while the library is up takes the
+    `_yield()` branch -- which puts the renderer in HUD mode with its
+    auto-hide armed and the library as the scene it hides.
+    """
+
+    def test_the_playstate_flag_agrees_with_the_predicate(self):
+        """The reported flag is what the browser routes on, so it is the one
+        that has to match -- not the expression that computes it."""
+        from jellyfin_mpv_shim.player import _item_is_audio
+        from jellyfin_mpv_shim.utils import item_is_audio
+
+        for label, video, _showing in STATES:
+            with self.subTest(state=label):
+                item = getattr(video, "item", None) or {}
+                self.assertEqual(
+                    item_is_audio(item), _item_is_audio(video),
+                    "%s: the item-level and video-level answers differ"
+                    % label)
+
+    def test_an_audiobook_launches_as_audio(self):
+        """The half-rule's actual victim, named because `Type` alone reads
+        as complete until you meet one."""
+        from jellyfin_mpv_shim.utils import item_is_audio
+
+        self.assertTrue(item_is_audio({"Type": "AudioBook",
+                                       "MediaType": "Audio"}))
+        self.assertTrue(item_is_audio({"MediaType": "Audio"}))
+        self.assertTrue(item_is_audio({"Type": "Audio"}))
+        self.assertFalse(item_is_audio({"Type": "Movie",
+                                        "MediaType": "Video"}))
+        self.assertFalse(item_is_audio({}))
+        self.assertFalse(item_is_audio(None))
+
+    def test_the_launch_path_uses_it(self):
+        """Driven rather than read: asserting that `play` *calls* a helper
+        would pass just as well if it passed the wrong item to it."""
+        from jellyfin_mpv_shim.mpvtk_browser.item_actions import ItemActions
+
+        for item, expected in (
+            ({"Type": "Audio", "Name": "Song"}, True),
+            ({"Type": "AudioBook", "MediaType": "Audio", "Name": "Book"},
+             True),
+            ({"MediaType": "Audio", "Name": "Untyped"}, True),
+            ({"Type": "Movie", "MediaType": "Video", "Name": "Film"}, False),
+        ):
+            with self.subTest(item=item.get("Name")):
+                launched = []
+                actions = ItemActions(
+                    services=types.SimpleNamespace(controller=None,
+                                                   source=None),
+                    run=None, dialogs=None,
+                    on_launch=lambda audio, title: launched.append(audio))
+                actions.play(item, server="srv")
+                self.assertEqual(
+                    [expected], launched,
+                    "%r launched down the %s branch"
+                    % (item, "video" if expected else "audio"))
+
+
+class HudStateDoesNotOutliveItsVideoTest(unittest.TestCase):
+    """A song after a film must not leave the film's HUD state behind.
+
+    `hud.state` is cleared on a `stopped` push, and a queue advance does not
+    always produce one -- the player suppresses the incidental stopped pushes
+    a load makes. So advancing from a video straight into a track left the
+    HUD holding the film's playstate for the whole song, and
+    `reassert_window_state` reads exactly that (`hud.state is not None`) as
+    "a video is in flight, re-enter HUD mode" -- which it does the moment mpv
+    is re-created under a playing track.
+    """
+
+    def _browser(self):
+        sys.path.insert(0, os.path.join(os.path.dirname(
+            os.path.dirname(os.path.abspath(__file__))), "tests"))
+        from _shell_harness import FakeSource, HudController, StubHudApp
+        from jellyfin_mpv_shim.mpvtk_browser.app import MpvtkBrowser
+
+        b = MpvtkBrowser(app=None, source=FakeSource(),
+                         controller=HudController())
+        app = StubHudApp()
+        b.set_app(app)
+        b._browsing = True
+        return b, app
+
+    VIDEO = {"stopped": False, "is_audio": False, "id": "v1"}
+    SONG = {"stopped": False, "is_audio": True, "id": "a1"}
+
+    def test_a_song_after_a_video_clears_the_hud_state(self):
+        b, _app = self._browser()
+        b.on_playstate(self.VIDEO)
+        self.assertIsNotNone(b.hud.state, "the video did not arm the HUD, so "
+                                          "this test proves nothing")
+        b.on_playstate(self.SONG)
+        self.assertIsNone(
+            b.hud.state,
+            "the film's playstate outlived it, so a renderer re-create "
+            "during the song re-enters HUD mode over the library")
+
+    def test_the_renderer_stays_in_browse_across_the_advance(self):
+        b, app = self._browser()
+        b.on_playstate(self.VIDEO)
+        b.on_playstate(self.SONG)
+        self.assertTrue(b._browsing)
+        b.reassert_window_state()
+        self.assertEqual(
+            ("active", True), app.calls[-1],
+            "a re-assert during music put the renderer back into HUD mode")

--- a/tests/test_library_showing.py
+++ b/tests/test_library_showing.py
@@ -231,6 +231,64 @@ def _window_pm(video):
     return pm
 
 
+class ShowPictureTest(unittest.TestCase):
+    """A comic page needs mpv's video output, and `show_picture` decides
+    whether it may have it.
+
+    The guard used to be `self._video is not None` -- the wrong question for
+    the one type that plays without taking the library away. A comic opened
+    from behind the now-playing bar was refused **silently**: the page sets
+    `route["_showing"]` regardless, which disarms its own self-repair, so the
+    reader drew its top bar, its page counter and its Next/Prev buttons, and
+    never a page.
+
+    That this went unnoticed is a fake-shaped hole, not an oversight of
+    testing: `tests/_shell_harness.py`'s stand-in is
+    ``def show_picture(self, path): self.pictures.append(path); return True``
+    -- it has no `_video` at all, so the refusal could not happen in any
+    shell test. The review question for a new fake, applied backwards.
+    """
+
+    def test_a_page_opens_with_nothing_playing(self):
+        pm = _window_pm(None)
+        self.assertTrue(pm.show_picture("/tmp/page.png"))
+        self.assertEqual(pm._player.loaded, ["/tmp/page.png"])
+        self.assertEqual(pm.stopped, [], "nothing was playing to stop")
+
+    def test_a_page_stops_the_music_and_takes_the_window(self):
+        """One mpv, one file: the page cannot share the window with a track,
+        so opening a comic stops the music [iw]. The refusal was neither --
+        it left the music playing AND showed no page."""
+        for label, video, showing in STATES:
+            if not showing or video is None:
+                continue      # the audio rows
+            with self.subTest(state=label):
+                pm = _window_pm(video)
+                self.assertTrue(
+                    pm.show_picture("/tmp/page.png"),
+                    "%s: the reader was refused the window" % label)
+                self.assertEqual(pm._player.loaded, ["/tmp/page.png"],
+                                 "%s: no page reached mpv" % label)
+                self.assertEqual(pm.stopped, [1],
+                                 "%s: the music kept playing under the page"
+                                 % label)
+
+    def test_a_video_still_keeps_the_window(self):
+        """The other direction, and it is not symmetry for its own sake: a
+        film owns the window, so the library is not on screen to reach a
+        comic from in the first place."""
+        for label, video, showing in STATES:
+            if showing:
+                continue
+            with self.subTest(state=label):
+                pm = _window_pm(video)
+                self.assertFalse(pm.show_picture("/tmp/page.png"),
+                                 "%s: a picture took the window from a "
+                                 "video" % label)
+                self.assertEqual(pm._player.loaded, [])
+                self.assertEqual(pm.stopped, [])
+
+
 class FullscreenPersistTest(unittest.TestCase):
     """Which settings key a persisted fullscreen toggle lands in.
 

--- a/tests/test_library_showing.py
+++ b/tests/test_library_showing.py
@@ -597,6 +597,96 @@ class OneAudioRuleTest(unittest.TestCase):
                     % (item, "video" if expected else "audio"))
 
 
+class LaunchingAsAudioTest(unittest.TestCase):
+    """The FOURTH copy of "is this audio", and the one a type list cannot fix.
+
+    Reported: playing a music playlist and moving the pointer off the window
+    blanked the entire library, with "the flash of it loading the HUD before
+    it starts playing" as the tell -- and only for playlists, not plain music
+    and not audiobooks.
+
+    `tiles.py` decided with ``t in ("MusicAlbum", "MusicArtist",
+    "MusicGenre")``. A music PLAYLIST is in no such list, so it launched down
+    the video branch: `_start(audio=False)` clears `_browsing` and yields the
+    window, the renderer enters HUD mode, and `phud_hide` -- which fires when
+    the pointer leaves -- calls `ui_suspend`. The library is what gets
+    suspended, because the library is what is on screen.
+
+    The item knew all along. `Playlist.MediaType` is `PlaylistMediaType`,
+    which `PlaylistManager` computes from the contents (Audio or Video), so
+    the server had already answered the question the list was guessing at.
+    """
+
+    def test_a_music_playlist_launches_as_audio(self):
+        from jellyfin_mpv_shim.utils import launches_as_audio
+
+        self.assertTrue(launches_as_audio(
+            {"Type": "Playlist", "MediaType": "Audio", "Name": "Mix"}))
+
+    def test_a_video_playlist_does_not(self):
+        """The control, and the reason this is not "playlists are audio":
+        the same type carries either answer."""
+        from jellyfin_mpv_shim.utils import launches_as_audio
+
+        self.assertFalse(launches_as_audio(
+            {"Type": "Playlist", "MediaType": "Video", "Name": "Films"}))
+
+    def test_the_music_containers_still_do(self):
+        from jellyfin_mpv_shim.utils import launches_as_audio
+
+        for t in ("MusicAlbum", "MusicArtist", "MusicGenre"):
+            with self.subTest(type=t):
+                self.assertTrue(launches_as_audio({"Type": t}))
+
+    def test_an_audio_item_and_an_audiobook_do(self):
+        from jellyfin_mpv_shim.utils import launches_as_audio
+
+        self.assertTrue(launches_as_audio({"Type": "Audio"}))
+        self.assertTrue(launches_as_audio({"Type": "AudioBook",
+                                           "MediaType": "Audio"}))
+
+    def test_a_music_library_play_all_does(self):
+        """The second site: a music library's Play All sent no `audio` at
+        all. `CollectionType` is what it has to go on."""
+        from jellyfin_mpv_shim.utils import launches_as_audio
+
+        self.assertTrue(launches_as_audio({"Type": "CollectionFolder"},
+                                          "music"))
+        self.assertTrue(launches_as_audio(
+            {"Type": "CollectionFolder", "CollectionType": "music"}))
+
+    def test_video_and_photos_are_untouched(self):
+        from jellyfin_mpv_shim.utils import launches_as_audio
+
+        for item in ({"Type": "Movie", "MediaType": "Video"},
+                     {"Type": "Episode", "MediaType": "Video"},
+                     {"Type": "Photo", "MediaType": "Photo"},
+                     {"Type": "BoxSet"},
+                     {"Type": "CollectionFolder", "CollectionType": "movies"},
+                     {}):
+            with self.subTest(item=item):
+                self.assertFalse(launches_as_audio(item))
+
+    def test_the_first_queued_entry_outranks_the_container(self):
+        """Izzie: a playlist can arrive "looking like a video going into the
+        software" and only turn out to be music later. So the container's own
+        label cannot be trusted, and the entry that will actually start is
+        the answer -- which is also the right answer for a MIXED playlist."""
+        from jellyfin_mpv_shim.utils import launches_as_audio
+
+        lying = {"Type": "Playlist", "MediaType": "Video", "Name": "Mix"}
+        song = {"Type": "Audio", "MediaType": "Audio"}
+        film = {"Type": "Movie", "MediaType": "Video"}
+        self.assertTrue(
+            launches_as_audio(lying, first=song),
+            "a playlist mislabelled as video still launched as video, so it "
+            "yields the window and the auto-hide blanks the library")
+        self.assertFalse(
+            launches_as_audio({"Type": "Playlist", "MediaType": "Audio"},
+                              first=film),
+            "a mixed playlist starting on a film kept the library up")
+
+
 class HudStateDoesNotOutliveItsVideoTest(unittest.TestCase):
     """A song after a film must not leave the film's HUD state behind.
 

--- a/tests/test_library_showing.py
+++ b/tests/test_library_showing.py
@@ -700,6 +700,54 @@ class TheCursorNeverHidesOverTheLibraryTest(unittest.TestCase):
             ("active", True), app.calls[-1],
             "the renderer was not left asserted for browse")
 
+    def test_a_handoff_returns_the_hud_to_idle(self):
+        """Reported: changing an audio or subtitle track during a transcode
+        sometimes yields "to a dead HUD where moving the mouse does not bring
+        the player back", intermittently.
+
+        A track change on a transcode deletes and re-creates it, so the
+        loading screen comes up and `LoadFeedback.clear()` hands off through
+        `_yield()`. The renderer early-returns from `mpvtk-hud yes` when it
+        is ALREADY in HUD mode -- which it is, playback never left it -- so
+        nothing was re-established. If the bar was still up (the gear menu
+        the track was changed in), `phud.shown` stayed true for a stream that
+        had ended and summon was never re-bound: the mouse does nothing,
+        because the renderer believes it is already showing.
+
+        Intermittent because it depends on the bar still being up when the
+        handoff lands; if the auto-hide fired first, `phud_hide` re-binds
+        summon and it recovers on its own.
+
+        Measured in tests/lua/: after the second engage the wake binding is
+        gone, and a False/True cycle restores it.
+        """
+        b, app = self._browser()
+        b._browsing = False          # playing; the window is already ours
+        b.hud.state = {"stopped": False, "is_audio": False, "id": "v1"}
+        b.hud.shown = True           # the bar the user changed the track in
+        app.calls.clear()
+        b._yield()
+        self.assertEqual(
+            [("hud", False), ("hud", True)],
+            [c for c in app.calls if c[0] == "hud"],
+            "the handoff re-sent the engage without resetting, so the "
+            "renderer kept a shown flag from the stream that ended")
+        self.assertFalse(b.hud.shown)
+
+    def test_a_re_send_does_not_hide_a_bar_in_use(self):
+        """The control. Only a handoff resets: the other callers are
+        re-sends -- a settings change, a SyncPlay join, a fresh renderer --
+        and hiding a bar somebody is using would be its own bug."""
+        b, app = self._browser()
+        b._browsing = False
+        b.hud.state = {"stopped": False, "is_audio": False, "id": "v1"}
+        b.hud.shown = True
+        app.calls.clear()
+        b.hud.engage()
+        self.assertNotIn(("hud", False), app.calls,
+                         "a settings re-push hid the HUD")
+        self.assertTrue(b.hud.shown)
+
     def test_the_reported_sequence_leaves_browse_asserted(self):
         """Video, then the queue advances to a track: whatever order the
         pushes arrive in, the renderer must not be left in HUD mode while

--- a/tests/test_library_showing.py
+++ b/tests/test_library_showing.py
@@ -625,16 +625,65 @@ class HudStateDoesNotOutliveItsVideoTest(unittest.TestCase):
     VIDEO = {"stopped": False, "is_audio": False, "id": "v1"}
     SONG = {"stopped": False, "is_audio": True, "id": "a1"}
 
-    def test_a_song_after_a_video_clears_the_hud_state(self):
-        b, _app = self._browser()
+    def test_a_renderer_recreate_during_music_stays_in_browse(self):
+        """The property, not the mechanism.
+
+        The first version of this asserted `hud.state is None` after the
+        advance -- the mechanism -- and the fix that satisfied it wrote
+        destructively from a path that races a video start. What actually
+        matters is what a fresh renderer is told, so that is what is
+        asserted, and any way of getting it right passes.
+        """
+        b, app = self._browser()
         b.on_playstate(self.VIDEO)
         self.assertIsNotNone(b.hud.state, "the video did not arm the HUD, so "
                                           "this test proves nothing")
         b.on_playstate(self.SONG)
-        self.assertIsNone(
-            b.hud.state,
-            "the film's playstate outlived it, so a renderer re-create "
-            "during the song re-enters HUD mode over the library")
+        # Minimized, which is where this actually bites: browsing takes the
+        # first branch of reassert_window_state and never reaches the one
+        # under test. A first draft asserted from the browsing state and so
+        # could not fail -- the mutation that dropped the guard passed it.
+        b.minimize()
+        app.calls.clear()
+        b.reassert_window_state()
+        self.assertEqual(
+            ("active", False), app.calls[-1],
+            "mpv re-created under a playing track re-entered HUD mode from "
+            "the film that preceded it")
+
+    def test_the_video_after_the_song_gets_its_hud_back(self):
+        """The return leg, which the forward fix must not cost.
+
+        Reported after the first fix landed: "when I go back in the playlist
+        back to the video, the HUD stays dismissed and I have no player
+        controls at all." Not reproduced here -- at this layer the round trip
+        is correct -- so this pins the layer rather than claiming the bug.
+        """
+        b, app = self._browser()
+        b.on_playstate(self.VIDEO)
+        b.on_playstate(self.SONG)
+        b.on_playstate(self.VIDEO)
+        self.assertIsNotNone(b.hud.state,
+                             "the returning video armed no HUD state, so "
+                             "nothing can draw the bar")
+        self.assertFalse(b._browsing, "the window was not yielded to video")
+        self.assertIn(("hud", True), app.calls[-3:],
+                      "the renderer was never put back into HUD mode")
+
+    def test_a_ticker_push_does_not_wipe_a_video_start(self):
+        """The clearing above runs on the TRANSITION, not on every audio
+        push. The now-playing ticker sends one a second, and a start is not
+        atomic -- `_start(audio=False)` clears `_browsing` and raises the
+        loading screen while late audio pushes can still land."""
+        b, _app = self._browser()
+        b.on_playstate(self.VIDEO)
+        b.on_playstate(self.SONG)
+        b.on_playstate(self.VIDEO)
+        state = b.hud.state
+        b.on_playstate(dict(self.SONG))     # a late push, built pre-advance
+        self.assertIs(b.hud.state, state,
+                      "a late audio push wiped the HUD state of the video "
+                      "that had already started -- no player controls")
 
     def test_the_renderer_stays_in_browse_across_the_advance(self):
         b, app = self._browser()

--- a/tests/test_log_ring_feedback.py
+++ b/tests/test_log_ring_feedback.py
@@ -1,0 +1,82 @@
+"""The in-app log viewer must not be able to see its own output.
+
+The Logs tab polls the ring buffer and re-renders when the content changed.
+Rendering emits a per-frame timing line. So without an exclusion: the line
+lands in the ring, the next poll sees new content, redraws, and emits
+another one -- one render and one line per poll, forever, and the "only when
+something changed" guard cannot help because **the render IS the change**.
+
+It bites exactly when someone has debug logging on, which is exactly when
+they are reading the log.
+
+This is the only feedback loop of its kind in the process: nothing else
+reads the log it writes. The rule is therefore about the RING, not about
+logging in general -- `log.txt` still gets every line.
+"""
+
+# Run as a script, this is what puts the repo root on sys.path -- without
+# it `jellyfin_mpv_shim` resolves to whatever is pip-installed. A no-op
+# under `discover`; tests/test_module_paths.py is the guard.
+if __name__ == "__main__":
+    import os
+    import sys
+
+    sys.path.insert(0, os.path.dirname(
+        os.path.dirname(os.path.abspath(__file__))))
+
+import logging
+import sys
+import unittest
+
+sys.argv = [sys.argv[0]]
+
+
+def _record(name, message):
+    return logging.LogRecord(name, logging.DEBUG, "f.py", 1, message, (), None)
+
+
+class RingExcludesItsOwnCauseTest(unittest.TestCase):
+
+    def _ring(self):
+        from jellyfin_mpv_shim.log_utils import RingLogHandler
+
+        handler = RingLogHandler(capacity=10)
+        handler.setFormatter(logging.Formatter("%(name)s: %(message)s"))
+        return handler
+
+    def test_the_render_line_never_reaches_the_viewer(self):
+        handler = self._ring()
+        handler.emit(_record("mpvtk.render", "render: build 1.2ms"))
+        self.assertEqual(
+            [], list(handler.lines),
+            "the log viewer can see the line that drawing it produces, so "
+            "polling the tab renders forever")
+
+    def test_ordinary_lines_still_reach_it(self):
+        """The control. A ring that dropped everything would make the Logs
+        tab pass this file's rule by showing nothing at all."""
+        handler = self._ring()
+        handler.emit(_record("player", "Playing something"))
+        handler.emit(_record("mpvtk", "theme: Default"))
+        self.assertEqual(2, len(handler.lines))
+
+    def test_the_excluded_name_is_the_one_actually_used(self):
+        """The two halves are in different modules, so nothing but this
+        stops a rename on one side silently un-excluding the line."""
+        from jellyfin_mpv_shim import log_utils
+        from jellyfin_mpv_shim.mpvtk import app as mpvtk_app
+
+        self.assertIn(mpvtk_app.render_log.name, log_utils.RING_EXCLUDED)
+
+    def test_the_render_line_still_goes_to_the_log_file(self):
+        """Excluded from the RING only. Someone who turned debug logging on
+        to find a slow frame must still find the timings in log.txt."""
+        from jellyfin_mpv_shim.mpvtk import app as mpvtk_app
+
+        self.assertTrue(mpvtk_app.render_log.propagate,
+                        "the render logger no longer reaches the root "
+                        "handlers, so log.txt lost the timings entirely")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_mpvtk_ui_wiring.py
+++ b/tests/test_mpvtk_ui_wiring.py
@@ -748,6 +748,44 @@ class TestLoginActions(AuthHarness):
         b._do_login()
         self.assertNotIn("hunter2", b._login_error or "")
 
+    def test_adding_a_server_lands_on_it(self):
+        """`set_source` with no uuid asks `_pick_server`, whose fallback is
+        `get_last_server()`. Right for a reconnect; wrong for a login, which
+        IS a request to look at the server just added -- so adding one from
+        the server manager dropped you back on the previous server's home
+        and read as the login having done nothing."""
+        from tests._shell_harness import FakeSource
+
+        class TwoServers(FakeSource):
+            def servers(self):
+                return [{"uuid": "srv1", "name": "Old"},
+                        {"uuid": "srv2", "name": "New"}]
+
+        b = self._browser(add_server=lambda *a: True,
+                          rebuild_source=lambda: TwoServers(),
+                          get_last_server=lambda: "srv1")
+        b.show_login()
+        b._login.update({"server": "http://new", "user": "u", "pass": "p"})
+        b._do_login()
+        self.assertEqual("srv2", b.server,
+                         "the login landed on the server that was already "
+                         "there")
+
+    def test_re_authenticating_an_existing_server_keeps_the_place(self):
+        """The half a "just pick the last one in the list" fix would break.
+        A login can re-authenticate a server already present -- `force_unique`
+        deliberately reuses its uuid -- and there nothing was added, so the
+        remembered choice must still win."""
+        from tests._shell_harness import FakeSource
+
+        b = self._browser(add_server=lambda *a: True,
+                          rebuild_source=lambda: FakeSource(),
+                          get_last_server=lambda: "srv1")
+        b.show_login()
+        b._login.update({"server": "http://s", "user": "u", "pass": "p"})
+        b._do_login()
+        self.assertEqual("srv1", b.server)
+
     def test_login_credentials_reach_the_controller_intact(self):
         seen = []
         b = self._browser(

--- a/tests/test_no_raw_video_predicate.py
+++ b/tests/test_no_raw_video_predicate.py
@@ -1,0 +1,127 @@
+"""`self._video` answers two questions; a site has to say which one.
+
+The rule is in `tools/audit_video_predicate.py`. This is the guard, and it
+exists because the rule survived its own repair: an audit run for exactly
+this shape fixed two sites and missed a third one call below the method it
+fixed, plus two more elsewhere. Prose plus a careful reading has now failed
+at it twice, which is the case for a checker.
+
+Adding a `self._video` truth-test is not a defect -- most of them are the
+right question. It just has to be declared, and writing the declaration is
+where a reader finds out `_library_showing()` exists.
+"""
+
+# Run as a script, this is what puts the repo root on sys.path -- without
+# it `jellyfin_mpv_shim` resolves to whatever is pip-installed. A no-op
+# under `discover`; tests/test_module_paths.py is the guard.
+if __name__ == "__main__":
+    import os
+    import sys
+
+    sys.path.insert(0, os.path.dirname(
+        os.path.dirname(os.path.abspath(__file__))))
+
+import ast
+import os
+import sys
+import unittest
+
+sys.path.insert(0, os.path.join(
+    os.path.dirname(os.path.dirname(os.path.abspath(__file__))), "tools"))
+
+import audit_video_predicate as audit      # noqa: E402
+
+
+class RawVideoPredicateTest(unittest.TestCase):
+
+    def test_every_site_is_declared(self):
+        bad = audit.undeclared()
+        self.assertEqual(
+            [], bad,
+            "a new `self._video` truth-test is undeclared. Decide which "
+            "question it asks -- \"is something playing\" (audio counts) or "
+            "\"is the library on screen\" (`_library_showing()`, because "
+            "music keeps `_video` set AND keeps the browser up) -- then add "
+            "it to DECLARED in tools/audit_video_predicate.py with the "
+            "reason. Sites: %r" % (bad,))
+
+    def test_no_declaration_has_gone_stale(self):
+        """A declaration for a site that no longer exists is a claim about
+        code that is not there, and the next reader believes it."""
+        reached = {(base, fn) for base, fn, _ in audit.find()}
+        stale = sorted(set(audit.DECLARED) - reached)
+        self.assertEqual(
+            [], stale,
+            "these declarations name functions that no longer test "
+            "self._video; delete them: %r" % (stale,))
+
+    def test_the_declared_files_still_exist(self):
+        """FILES is a path list, and a renamed module would empty this
+        checker silently -- passing while covering nothing."""
+        root = audit.ROOT
+        missing = [f for f in audit.FILES
+                   if not os.path.exists(os.path.join(root, f))]
+        self.assertEqual([], missing)
+        self.assertTrue(audit.find(), "the audit found no sites at all")
+
+
+class TheFinderHasTeethTest(unittest.TestCase):
+    """The negative control, on synthetic source rather than by breaking the
+    tree: a checker that reports nothing passes just as quietly whether it
+    works or is inert."""
+
+    def _hits(self, src):
+        finder = audit._Finder()
+        finder.visit(ast.parse(src))
+        return sorted({fn for fn, _ in finder.hits})
+
+    def test_it_sees_each_spelling(self):
+        for src in (
+            "def f(self):\n    if self._video is None: pass",
+            "def f(self):\n    if self._video is not None: pass",
+            "def f(self):\n    if not self._video: pass",
+            "def f(self):\n    if self._video: pass",
+            "def f(self):\n    if self._video and x: pass",
+            "def f(self):\n    if a or not self._video: pass",
+            "def f(self):\n    return bool(self._video and x)",
+            "def f(self):\n    return self._video is not None",
+            "def f(self):\n    while self._video: pass",
+            "def f(self):\n    x = 1 if self._video else 2",
+        ):
+            with self.subTest(src=src.splitlines()[-1].strip()):
+                self.assertEqual(["f"], self._hits(src))
+
+    def test_it_ignores_uses_that_are_not_questions(self):
+        """Reading through `_video` or assigning it is not asking whether
+        the library is on screen, and reporting those would make the
+        declaration table meaningless."""
+        for src in (
+            "def f(self):\n    self._video = x",
+            "def f(self):\n    return self._video.parent.has_next",
+            "def f(self):\n    self._video.aid = 2",
+            "def f(self):\n    return self._video.item",
+            "def f(self):\n    if other._video is None: pass",
+        ):
+            with self.subTest(src=src.splitlines()[-1].strip()):
+                self.assertEqual([], self._hits(src))
+
+    def test_an_undeclared_site_is_reported(self):
+        """End to end, against a temporary tree -- the assertion the guard
+        above makes only if this machinery is live."""
+        import tempfile
+
+        with tempfile.TemporaryDirectory() as tmp:
+            pkg = os.path.join(tmp, "jellyfin_mpv_shim")
+            os.makedirs(pkg)
+            with open(os.path.join(pkg, "player.py"), "w",
+                      encoding="utf-8") as fh:
+                fh.write("class P:\n"
+                         "    def brand_new_thing(self):\n"
+                         "        if self._video is None:\n"
+                         "            return 1\n")
+            found = audit.undeclared(root=tmp)
+        self.assertEqual([("player.py", "brand_new_thing", 3)], found)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_playstate_payload.py
+++ b/tests/test_playstate_payload.py
@@ -462,12 +462,40 @@ class TestTheButtonSurvivesSeekToSkipBeingOff(unittest.TestCase):
         Was an `assertIn('== "mpvtk"')` against `update()`'s SOURCE, which
         passes for any arrangement of that string -- including the one this
         pair of tests exists to tell apart."""
-        self.assertIsNone(
-            self._hud_skip_after_update(osc_style="none",
-                                        segment_intro="ask"))
+        from jellyfin_mpv_shim.conf import settings
+
+        with mock.patch.object(settings, "skip_intro_on_seek", True):
+            self.assertIsNone(
+                self._hud_skip_after_update(osc_style="none",
+                                            segment_intro="ask"))
         self.assertTrue(self._prompts(),
                         "no HUD and no OSD prompt either: the segment is "
                         "unskippable")
+
+    def test_the_osd_prompt_is_silent_when_seeking_would_not_skip(self):
+        """The message is "Seek to Skip X" and `skip_intro_on_seek` is OFF by
+        default, so on a classic OSC it told the user to make a gesture that
+        does nothing -- for the whole of every intro, every episode.
+
+        Reported: "Seek to skip doesn't seem to actually work via keyboard,
+        but I have 'Skip intro on seek' turned off so the prompt shouldn't
+        appear."
+        """
+        from jellyfin_mpv_shim.conf import settings
+
+        with mock.patch.object(settings, "skip_intro_on_seek", False):
+            self._hud_skip_after_update(osc_style="none", segment_intro="ask")
+        self.assertEqual([], self._prompts(),
+                         "the prompt named a gesture that is switched off")
+
+    def test_the_osd_prompt_returns_when_the_gesture_works(self):
+        """The control -- and the half a blanket suppression would break."""
+        from jellyfin_mpv_shim.conf import settings
+
+        with mock.patch.object(settings, "skip_intro_on_seek", True):
+            self._hud_skip_after_update(osc_style="none", segment_intro="ask")
+        self.assertTrue(self._prompts(),
+                        "seeking skips, but nothing said so")
 
     def test_the_hud_suppresses_the_osd_prompt(self):
         self.assertIsNotNone(
@@ -816,6 +844,73 @@ class TestNoPlayerControls(unittest.TestCase):
 
     def test_the_setting_is_gone_rather_than_migrated(self):
         self.assertFalse(hasattr(settings, "enable_osc"))
+
+
+class ResumingIntoAnIntroDoesNotSkipItTest(unittest.TestCase):
+    """Reported: "If the video is quit and resumed while inside an intro, it
+    skips it on open without user input."
+
+    `_on_seeking` reads any forward seek made while `is_in_intro` as the user
+    asking to skip -- that is what `skip_intro_on_seek` is. The resume seek on
+    a fresh start is a forward seek, and it never claimed the exemption that
+    the UI's own seeks have, so the segment was skipped before the user had
+    touched anything.
+
+    A method rather than two statements at the call site: the claim and the
+    seek have to stay together, and a name is what stops the next edit
+    separating them.
+    """
+
+    def _pm(self):
+        pm = PlayerManager.__new__(PlayerManager)
+        pm._player = _Player()
+        pm.do_not_handle_pause = False
+        pm.is_in_intro = True
+        pm.playback_time_before_seek = None
+        pm.last_seek = None
+        pm._last_ui_seek_time = 0.0
+        pm.skips = []
+        pm.skip_intro = lambda: pm.skips.append(1)
+        pm.syncplay = type("S", (), {"is_enabled": staticmethod(
+            lambda: False)})()
+        return pm
+
+    def _seek_round_trip(self, pm, before, after):
+        """mpv reports a seek as `seeking` true then false."""
+        pm._player.playback_time = before
+        pm._on_seeking("seeking", True)
+        pm._player.playback_time = after
+        pm._on_seeking("seeking", False)
+
+    def test_a_resume_into_an_intro_leaves_it_alone(self):
+        from jellyfin_mpv_shim.conf import settings
+
+        pm = self._pm()
+        with mock.patch.object(settings, "skip_intro_on_seek", True):
+            pm._apply_resume_offset(30.0)
+            self._seek_round_trip(pm, 0.0, 30.0)
+        self.assertEqual(pm._player.playback_time, 30.0,
+                         "the resume did not seek at all")
+        self.assertEqual(pm.skips, [],
+                         "resuming inside an intro skipped it with no input")
+
+    def test_a_real_forward_seek_still_skips(self):
+        """The control. The feature is the whole point of the setting, and a
+        fix that exempted every seek would switch it off."""
+        from jellyfin_mpv_shim.conf import settings
+
+        pm = self._pm()
+        with mock.patch.object(settings, "skip_intro_on_seek", True):
+            self._seek_round_trip(pm, 10.0, 40.0)
+        self.assertEqual(pm.skips, [1], "a user forward seek did not skip")
+
+    def test_the_setting_still_governs(self):
+        from jellyfin_mpv_shim.conf import settings
+
+        pm = self._pm()
+        with mock.patch.object(settings, "skip_intro_on_seek", False):
+            self._seek_round_trip(pm, 10.0, 40.0)
+        self.assertEqual(pm.skips, [])
 
 
 class TestMediaSegmentTypes(unittest.TestCase):

--- a/tests/test_playstate_payload.py
+++ b/tests/test_playstate_payload.py
@@ -38,8 +38,16 @@ class _Player:
     fullscreen = False
     demuxer_cache_state = None
 
-    def show_text(self, *a, **kw):
+    def __init__(self):
+        #: Recorded, not swallowed. A stand-in that drops what it is handed
+        #: makes the OSD-prompt branch unreachable while reporting a pass --
+        #: which is what left "does the seek-to-skip prompt appear" checked
+        #: by an `assertIn` against update()'s SOURCE.
+        self.texts = []
+
+    def show_text(self, text, *a, **kw):
         """An automatic skip announces itself on the OSD."""
+        self.texts.append(text)
 
 
 class _EmptyQueue:
@@ -428,8 +436,13 @@ class TestTheButtonSurvivesSeekToSkipBeingOff(unittest.TestCase):
         pm.should_send_timeline = False
         return pm
 
-    def _hud_skip_after_update(self, in_group=False, ready=False, **flags):
+    def _hud_skip_after_update(self, in_group=False, ready=False,
+                               osc_style=None, mpvtk_active=None, **flags):
         pm = self._pm(in_group=in_group, ready=ready)
+        if osc_style is not None:
+            pm._osc_style_resolved = osc_style
+        if mpvtk_active is not None:
+            pm.mpvtk_active = mpvtk_active
         self._last_pm = pm
         patches = [mock.patch.object(settings, k, v)
                    for k, v in flags.items()]
@@ -438,6 +451,48 @@ class TestTheButtonSurvivesSeekToSkipBeingOff(unittest.TestCase):
             self.addCleanup(p.stop)
         PlayerManager.update(pm)
         return pm._hud_skip
+
+    def _prompts(self):
+        return [t for t in self._last_pm._player.texts if "Skip" in t]
+
+    def test_the_skip_prompt_falls_back_to_the_osd_without_a_hud(self):
+        """The HUD's Skip button is the mpvtk surface for "ask" mode; with
+        no HUD the OSD "Seek to Skip" prompt is the one left.
+
+        Was an `assertIn('== "mpvtk"')` against `update()`'s SOURCE, which
+        passes for any arrangement of that string -- including the one this
+        pair of tests exists to tell apart."""
+        self.assertIsNone(
+            self._hud_skip_after_update(osc_style="none",
+                                        segment_intro="ask"))
+        self.assertTrue(self._prompts(),
+                        "no HUD and no OSD prompt either: the segment is "
+                        "unskippable")
+
+    def test_the_hud_suppresses_the_osd_prompt(self):
+        self.assertIsNotNone(
+            self._hud_skip_after_update(osc_style="mpvtk",
+                                        segment_intro="ask"))
+        self.assertEqual([], self._prompts(),
+                         "both surfaces offered the same skip")
+
+    def test_casting_gets_neither_a_detached_renderer_nor_the_osd(self):
+        """Reported: "seek to skip" shows when casting.
+
+        `mpvtk_active` is false while the renderer is detached -- which is
+        what casting is -- and it was ANDed into the same flag that decides
+        whether the OSD text is the fallback. Those are two questions: there
+        IS a HUD, it is simply not attached this moment, and a cast target
+        has no local keyboard to seek with. The segment is still tracked, so
+        the playstate carries `skip_label` for whatever is driving.
+        """
+        self.assertIsNotNone(
+            self._hud_skip_after_update(osc_style="mpvtk",
+                                        mpvtk_active=False,
+                                        segment_intro="ask"),
+            "the segment was not tracked, so nothing can offer the skip")
+        self.assertEqual([], self._prompts(),
+                         "the OSD prompt appeared on a cast target")
 
     def test_a_group_is_offered_the_button_instead_of_being_skipped(self):
         """SyncPlay used to turn segment handling off entirely -- no auto
@@ -758,15 +813,6 @@ class TestNoPlayerControls(unittest.TestCase):
                                self._pm("mpvtk")):
             self.assertTrue(gw.use_hud())
 
-    def test_the_skip_prompt_falls_back_to_the_osd(self):
-        """The HUD's Skip button is the mpvtk surface for "ask" mode. With
-        no HUD the OSD "Seek to Skip" prompt is the one left, and it is
-        already what any non-mpvtk style gets -- so this is a check that
-        the branch keys off the style rather than off having a browser."""
-        import inspect
-
-        src = inspect.getsource(PlayerManager.update)
-        self.assertIn('== "mpvtk"', src)
 
     def test_the_setting_is_gone_rather_than_migrated(self):
         self.assertFalse(hasattr(settings, "enable_osc"))

--- a/tests/test_shell_chrome.py
+++ b/tests/test_shell_chrome.py
@@ -749,11 +749,17 @@ class TestATransitionSurvivesARaisingController(unittest.TestCase):
         b._browsing = True
         engaged = []
         b.hud.available = lambda: True
-        b.hud.engage = lambda: engaged.append(True)
+        # `**kw`, and the reset asserted below: a yield is a HANDOFF, so it
+        # engages with reset=True. A stub pinned to the old zero-argument
+        # signature swallowed a TypeError into `_yield`'s except and read as
+        # "the engage was skipped" -- which is this test's real failure mode,
+        # so it would have hidden the thing it exists to catch.
+        b.hud.engage = lambda **kw: engaged.append(kw.get("reset", False))
         b._yield()
         self.assertFalse(b._browsing, "the yield was abandoned")
         self.assertEqual(engaged, [True],
-                         "the HUD engage behind the callback was skipped")
+                         "the HUD engage behind the callback was skipped, or "
+                         "did not reset the bar left by the previous stream")
 
     def test_enter_browse_still_reactivates_the_renderer(self):
         b = self._browser()

--- a/tests/test_shell_comic.py
+++ b/tests/test_shell_comic.py
@@ -316,6 +316,13 @@ class TestPaging(ComicHarness):
     def test_a_page_entered_backwards_starts_at_its_bottom(self):
         """Paging back and landing at the top means scrolling down to see
         what you went back for, on every page you walk back through."""
+        # Fit-width explicitly: this test is about how a page TALLER
+        # than the window behaves, and it used to get that from the
+        # `comic_fit` default. The default is now "page", and a test
+        # that reads a default is a test of the default.
+        from jellyfin_mpv_shim.conf import settings
+
+        settings.comic_fit = "width"
         browser = self.open_comic()
         build_scene(browser)
         page = self.page(browser)
@@ -359,7 +366,28 @@ class TestPaging(ComicHarness):
 
 
 class TestPlacement(ComicHarness):
+    def test_the_default_opens_a_whole_page(self):
+        """The shipped default is Fit Page.
+
+        It was Fit Width, and on most window sizes that opens a comic zoomed
+        into the top of the page with the rest below the fold, which is not
+        what opening a book should look like [iw]. Pinned because it is a
+        decision: the four tests below that need fit-width now say so, and
+        this is the one that says what a reader who has chosen nothing gets.
+        """
+        from jellyfin_mpv_shim.conf import settings
+
+        self.assertEqual(settings.comic_fit, "page",
+                         "the shipped default changed without this test "
+                         "being part of the decision")
+        browser = self.open_comic()
+        build_scene(browser)
+        self.assertEqual(self.page(browser).mode(), "page")
+
     def test_the_first_page_is_fitted_to_the_width(self):
+        from jellyfin_mpv_shim.conf import settings
+
+        settings.comic_fit = "width"      # the mode this test is about
         browser = self.open_comic()
         build_scene(browser)
         view = browser.controller.picture_views[-1]
@@ -369,6 +397,13 @@ class TestPlacement(ComicHarness):
         self.assertGreater(view["zoom"], 0.0)
 
     def test_fit_page_is_smaller_than_fit_width(self):
+        # Fit-width explicitly: this test is about how a page TALLER
+        # than the window behaves, and it used to get that from the
+        # `comic_fit` default. The default is now "page", and a test
+        # that reads a default is a test of the default.
+        from jellyfin_mpv_shim.conf import settings
+
+        settings.comic_fit = "width"
         browser = self.open_comic()
         build_scene(browser)
         page = self.page(browser)
@@ -430,6 +465,13 @@ class TestPlacement(ComicHarness):
     def test_resizing_the_window_replaces_the_page(self):
         """The window is what the zoom is measured against, so a resize
         moves it — and the page is only redrawn when something asks."""
+        # Fit-width explicitly: this test is about how a page TALLER
+        # than the window behaves, and it used to get that from the
+        # `comic_fit` default. The default is now "page", and a test
+        # that reads a default is a test of the default.
+        from jellyfin_mpv_shim.conf import settings
+
+        settings.comic_fit = "width"
         browser = self.open_comic()
         build_scene(browser, size=(1280, 720))
         before = browser.controller.picture_views[-1]["zoom"]
@@ -487,6 +529,13 @@ class TestGestures(ComicHarness):
         """mpv's pan is measured in the scaled picture (measured — see
         tests/test_picture_view.py). Handing over the window's size instead
         makes every drag wrong by whatever the zoom is."""
+        # Fit-width explicitly: this test is about how a page TALLER
+        # than the window behaves, and it used to get that from the
+        # `comic_fit` default. The default is now "page", and a test
+        # that reads a default is a test of the default.
+        from jellyfin_mpv_shim.conf import settings
+
+        settings.comic_fit = "width"
         browser = self.open_comic()
         page = self.page(browser)
         page._place()

--- a/tests/test_shell_library.py
+++ b/tests/test_shell_library.py
@@ -2091,6 +2091,40 @@ class TestMenuQueueAndPlay(unittest.TestCase):
         self.b._menu_play({"Id": "a1", "Type": "MusicAlbum"}, "srv1")
         self.assertEqual(played, [["t1", "t2"]], "navigated instead of playing")
 
+    def test_a_mislabelled_music_playlist_still_launches_as_audio(self):
+        """A playlist can arrive "looking like a video going into the
+        software" and only turn out to be music [iw], because the server
+        derives `Playlist.MediaType` from the contents and the two can
+        disagree by the time we see the DTO.
+
+        So the launch reads the first entry it is about to QUEUE. A wrong
+        answer here is not cosmetic: `audio=False` clears `_browsing` and
+        yields the window, the renderer enters HUD mode, and moving the
+        pointer off the window auto-hides it -- `phud_hide` calls
+        `ui_suspend`, which blanks the library that is on screen.
+        """
+        self.b._browsing = True
+        self.b._menu_play({"Id": "PL1", "Type": "Playlist",
+                           "MediaType": "Video"}, "srv1")
+        self.assertTrue(
+            self.b._browsing,
+            "the container's label won over the track about to play, so the "
+            "window was yielded and the library can be blanked")
+
+    def test_a_playlist_of_films_still_launches_as_video(self):
+        """The control. Deciding from the first entry has to be able to say
+        no, or every playlist keeps the library up and no film gets the
+        window."""
+        self.src.get_playlist_items = lambda srv, pid: [
+            {"Id": "f1", "Name": "Film", "Type": "Movie",
+             "MediaType": "Video"}]
+        self.b._browsing = True
+        self.b._menu_play({"Id": "PL1", "Type": "Playlist",
+                           "MediaType": "Audio"}, "srv1")
+        self.assertFalse(self.b._browsing,
+                         "a playlist of films kept the library up instead of "
+                         "handing the window to the video")
+
     def test_an_unresolvable_container_falls_back_to_opening_it(self):
         self.src.get_album_tracks = lambda srv, aid: []
         self.b._menu_play({"Id": "a1", "Type": "MusicAlbum"}, "srv1")

--- a/tests/test_shell_reader.py
+++ b/tests/test_shell_reader.py
@@ -123,6 +123,89 @@ class ReaderHarness(unittest.TestCase):
         return browser._page_for(browser.route)
 
 
+class TestTheAreaIsMeasured(ReaderHarness):
+    """The reader sizes its page bitmap to "the hole the bars left", by
+    measuring `AREA_ID` from the last pushed scene -- and that measurement
+    has never once succeeded.
+
+    **A plain Row or Column emits no scene node**, whatever `id` it carries;
+    only drawables (a Box with a background, an Image) keep an id. So
+    `node_rect("rd-area")` answered None on every frame and the fallback --
+    `window_height - TOP_BAR_H - BOTTOM_BAR_H` -- was the only path that ever
+    ran. That is right whenever the reader owns the whole window, which is
+    why nobody noticed, and too tall by exactly the now-playing bar when a
+    track is playing: the oversized bitmap is centred in its row and spills
+    over the reader's own top AND bottom bars.
+
+    The fixture is the other half of the story. `FakeApp.rects` starts empty
+    and every test left it that way, so the fake reproduced the bug's answer
+    (None) rather than the app's -- the measurement path was unreachable in
+    the suite for the same reason it was inert in production.
+    """
+
+    #: Enough of a track for the shell to draw the bar.
+    NOW_PLAYING = {"stopped": False, "is_audio": True, "id": "a1",
+                   "title": "Something", "artist": "Someone",
+                   "position": 10.0, "duration": 300.0}
+
+    SIZE = (1280, 800)
+
+    def _frame(self, browser):
+        """Render, then feed what layout produced back to the fake app --
+        which is what the real one does from the last pushed scene. Without
+        this the fake answers None forever and the reader never measures."""
+        nodes, _handlers = build_scene(browser, self.SIZE)
+        browser.app.rects = {n["id"]: n for n in nodes if n.get("id")}
+        return nodes
+
+    @staticmethod
+    def _by_id(nodes, node_id):
+        return next((n for n in nodes if n.get("id") == node_id), None)
+
+    def test_the_area_node_reaches_the_scene(self):
+        b = self.open_reader()
+        nodes = self._frame(b)
+        self.assertIsNotNone(
+            self._by_id(nodes, "rd-area"),
+            "the node the reader measures is not in the scene, so "
+            "`node_rect` answers None and the fallback runs on every frame")
+
+    def test_the_page_fits_the_hole_the_bars_left(self):
+        """The invariant, and it needs no bar heights: whatever the shell
+        put on screen, the page bitmap fits inside the area measured for
+        it."""
+        b = self.open_reader()
+        b._now_playing = dict(self.NOW_PLAYING)
+        self._frame(b)          # measure
+        nodes = self._frame(b)  # ...and bake to it
+        area = self._by_id(nodes, "rd-area")
+        page = self._by_id(nodes, "rd-page")
+        self.assertIsNotNone(area, "no area to fit into")
+        self.assertIsNotNone(page, "the page bitmap did not render")
+        self.assertGreaterEqual(
+            round(page["y"]), round(area["y"]),
+            "the page overflows the top of its area, covering the "
+            "reader's own top bar")
+        self.assertLessEqual(
+            round(page["y"] + page["h"]), round(area["y"] + area["h"]),
+            "the page overflows the bottom of its area, covering the "
+            "reader's controls and the now-playing bar")
+
+    def test_the_page_still_fills_the_window_without_a_bar(self):
+        """The control: the fallback was right for this case all along, and
+        a fix that shrinks the page whether or not anything is playing would
+        waste half the screen."""
+        b = self.open_reader()
+        b._now_playing = None
+        self._frame(b)
+        nodes = self._frame(b)
+        page = self._by_id(nodes, "rd-page")
+        self.assertIsNotNone(page)
+        self.assertGreater(
+            page["h"], self.SIZE[1] * 0.75,
+            "the page shrank on a window it has entirely to itself")
+
+
 class TestOpening(ReaderHarness):
     def test_a_downloaded_book_opens_and_draws_a_page(self):
         browser = self.open_reader()

--- a/tests/test_shell_routing.py
+++ b/tests/test_shell_routing.py
@@ -961,6 +961,44 @@ class TestLatentFixes(unittest.TestCase):
         h["set-sync-move"]["click"]()
         self.assertEqual(moved, ["/new/path"])
 
+    def _sync_row(self, current="/old"):
+        cfg = FakeConfig()
+        cfg.schema["sync_path"] = "str"
+        cfg.values["sync_path"] = current
+        self.b._config_obj = cfg
+        row = self.b._setting_row(cfg, cfg.settings_schema(),
+                                  cfg.get_settings(), "sync_path")
+        _n, h = layout(row, 1280, 720)
+        return h
+
+    def test_clearing_the_field_and_pressing_move_means_the_default(self):
+        """Reported: setting the folder to "" says it moved and does not.
+
+        `get("path") or val` cannot tell "not edited" from "cleared", so an
+        empty field fell back to the CURRENT path -- `relocate` then found
+        old == new, returned success, and the status line claimed a move
+        that never happened. ENTER never had the bug, because it passes the
+        field straight through; only the button was dead.
+        """
+        moved = []
+        self.b._move_downloads = lambda p: moved.append(p)
+        h = self._sync_row()
+        h["set-sync_path"]["change"]("")      # the user clears the box
+        h["set-sync-move"]["click"]()
+        self.assertEqual(
+            moved, [""],
+            "clearing the field and pressing Move sent the old path back, "
+            "so nothing moved and the UI said it had")
+
+    def test_an_untouched_field_still_moves_what_is_shown(self):
+        """The control, and the reason this is not `get("path", val)`: with
+        no edit at all the button must still act on the visible value."""
+        moved = []
+        self.b._move_downloads = lambda p: moved.append(p)
+        h = self._sync_row(current="/old")
+        h["set-sync-move"]["click"]()
+        self.assertEqual(moved, ["/old"])
+
     def test_an_update_notice_shows_while_offline(self):
         """The offline banner is persistent, so checking it first meant an
         update was never surfaced offline."""

--- a/tests/test_sync_manager.py
+++ b/tests/test_sync_manager.py
@@ -530,10 +530,20 @@ class RelocateTest(TmpTest):
         self.assertEqual(m.db.get("keep")["status"], STATUS_COMPLETE)
 
     def test_noop_when_path_unchanged(self):
+        """Success, but it must SAY it did nothing.
+
+        The caller shows ``message or "Download folder moved"``, so an empty
+        string here claimed a move that never happened -- which is how a
+        dead Move button read as a working one: clearing the field sent the
+        current path back in, this branch answered, and the status line
+        reported a move. Asserting the message rather than its absence is
+        the difference.
+        """
         m = make_manager(self.tmp, self.addCleanup)
         ok, msg = m.relocate(self.tmp)
         self.assertTrue(ok)
-        self.assertEqual(msg, "")
+        self.assertTrue(msg, "a no-op reported itself as a completed move")
+        self.assertIn("already", msg.lower())
 
     def test_refuse_while_download_active(self):
         m = make_manager(self.tmp, self.addCleanup)

--- a/tests/test_window_geometry.py
+++ b/tests/test_window_geometry.py
@@ -125,6 +125,52 @@ class SyncOnPlaybackTest(_GeometryTest):
         pm._sync_window_geometry()   # must not raise on the load path
 
 
+class SyncOnPictureTest(_GeometryTest):
+    """A comic page is a load too, and it was the one load that skipped this.
+
+    `_sync_window_geometry` had exactly one caller -- `_play_media`. But
+    `show_picture` also hands mpv a file, which is a VO reconfig, and X11
+    re-applies the geometry option on reconfig. So the window jumped back to
+    whatever was armed the last time something PLAYED, and the mechanism that
+    makes that re-apply a no-op never ran for a picture.
+
+    Reported from the outside as: resize the window by dragging it, then open
+    a comic, and it jumps [iw]. That is the precondition -- a WM drag moves
+    the window without touching mpv's geometry option, so live size and armed
+    value diverge, which is the only state in which the re-apply is visible.
+    """
+
+    def _picture_pm(self, **kw):
+        pm = self._pm(**kw)
+        pm._mpv_alive = True
+        pm._video = None
+        pm._showing_browse_bg = True
+        pm._suspend_shaders_for_still = lambda: None
+        pm._player.command = lambda *a, **k: None
+        return pm
+
+    def test_showing_a_picture_re_arms_to_the_live_size(self):
+        pm = self._picture_pm(armed="1280x720", w=1600, h=900)
+        self.assertTrue(pm.show_picture("/tmp/page.png"))
+        self.assertEqual(
+            pm._geometry_armed, "1600x900",
+            "opening a picture left the geometry armed at the size something "
+            "else was playing at, so the VO reconfig snaps the window back")
+
+    def test_an_unchanged_size_is_still_not_rewritten(self):
+        """The same restraint as the playback path: a redundant write is a
+        resize command, and un-maximizes on Windows and X11."""
+        pm = self._picture_pm(armed="1280x720", w=1280, h=720)
+        self.assertTrue(pm.show_picture("/tmp/page.png"))
+        self.assertEqual(pm._player.geometry_writes, [])
+
+    def test_a_maximized_window_is_left_alone_for_a_picture_too(self):
+        pm = self._picture_pm(armed="1280x720", w=1600, h=900,
+                              maximized=True)
+        self.assertTrue(pm.show_picture("/tmp/page.png"))
+        self.assertEqual(pm._player.geometry_writes, [])
+
+
 class MinimizeOrderTest(_GeometryTest):
     """Releasing force_window destroys the window; the re-arm rides after."""
 

--- a/tools/audit_video_predicate.py
+++ b/tools/audit_video_predicate.py
@@ -1,0 +1,205 @@
+#!/usr/bin/env python3
+"""Every raw `self._video` truth-test has to say which question it is asking.
+
+`self._video` answers two different questions and the code spelled both the
+same way::
+
+    is something playing?          -> self._video is not None
+    is the library on screen?      -> self._video is not None   # WRONG
+
+Music is what splits them: audio keeps `_video` set **and** keeps the browser
+up -- that is what the now-playing bar is for. So the second question has its
+own predicate, `_library_showing()` (and `_video_on_screen()` for the
+complement), and a site that spells it `self._video` is either asking the
+first question or is a bug.
+
+**Three sites got it wrong, and they were found one at a time.** `show_picture`
+refused a comic behind the now-playing bar; `set_fullscreen` persisted the
+video preference during music; `_apply_browse_fullscreen` applied only the ON
+direction. The audit that fixed the first two missed the third, which lives one
+call *below* the method it fixed -- so the shape survived its own repair, and
+two more (`refresh_browse_bg`, `toggle_settings_menu`) were still open after
+it. That is the argument for a lint rather than a fourth careful reading: this
+rule is right in prose, applied at N-1 of N sites, and re-read by someone who
+already believes it.
+
+So: no judgement about which meaning is correct, because a checker cannot know
+that. It requires only that the site be **declared**, which puts the question
+in front of whoever adds one -- and the declaration is where a reader learns
+`_library_showing()` exists.
+
+Run it directly to list undeclared sites; `tests/test_no_raw_video_predicate.py`
+is the guard.
+"""
+
+import ast
+import os
+import sys
+
+ROOT = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+
+#: The player object and its mixins -- everywhere `self._video` is in scope.
+FILES = (
+    "jellyfin_mpv_shim/player.py",
+    "jellyfin_mpv_shim/player_window.py",
+    "jellyfin_mpv_shim/player_audio.py",
+    "jellyfin_mpv_shim/player_reporting.py",
+)
+
+#: Declared sites, by (file, function), each saying which question it asks.
+#:
+#: "playback" -- is an item loaded/playing. Audio counts, and should.
+#: "picture"  -- is a VIDEO PICTURE on screen. Pairs with `_current_is_audio`.
+#: "window"   -- who owns the window. Deliberate, and each says why.
+DECLARED = {
+    # -- the definition itself
+    ("player.py", "_library_showing"): "playback; this IS the predicate",
+
+    # -- playback: is an item loaded. Audio counts.
+    ("player.py", "_on_eof_reached"): "playback; the item that just ended",
+    ("player.py", "_on_playback_abort"): "playback; the item being aborted",
+    ("player.py", "_on_pause_change"): "playback; the item being paused",
+    ("player.py", "update"): "playback; the item being polled",
+    ("player.py", "watched_skip"): "playback; acts on the current item",
+    ("player.py", "unwatched_quit"): "playback; acts on the current item",
+    ("player.py", "get_video_attr"): "playback; reads the current item",
+    ("player.py", "_maybe_save_volume"): (
+        "playback; the per-type volume bucket needs the item, and music has "
+        "its own bucket -- excluding audio here would stop it saving"),
+    ("player.py", "idle_quit"): (
+        "playback; do not quit mpv out from under a track. The library being "
+        "on screen is not the question -- music keeps it up and still must "
+        "not be quit"),
+    ("player.py", "is_active"): "playback; public API, named for it",
+    ("player.py", "is_playing"): "playback; public API, named for it",
+    ("player.py", "is_not_paused"): "playback; public API, named for it",
+    ("player.py", "has_video"): "playback; public API, named for it",
+    ("player.py", "get_video"): "playback; returns the item",
+
+    # -- picture: paired with _current_is_audio, which is the correct spelling
+    ("player.py", "_stats_key"): (
+        "picture; a video is on screen to annotate. Audio falls through to "
+        "the swallow, deliberately"),
+    ("player_window.py", "show_picture"): (
+        "picture; a video owns the window and refuses, audio is stopped and "
+        "gives it up"),
+
+    # -- window: who owns it, and why _video is the right question here
+    ("player_window.py", "reset_picture_view"): (
+        "window; keepaspect must NOT be put back while ANYTHING plays. "
+        "`_library_showing()` would let this run during music, and this "
+        "method runs from _release_page_grabs through the deferring _act -- "
+        "landing second is what made every film play stretched. See "
+        "test_window_geometry.py:PictureViewHandoffTest"),
+    ("player_window.py", "clear_picture"): (
+        "window; a video owns the window, so the browse window is not ours "
+        "to restore. A picture always stops audio first (show_picture), so "
+        "there is no music state to reach here"),
+    ("player_window.py", "set_browse_window"): (
+        "playback, three times: the colorspace hint would cost a playing "
+        "video its HDR passthrough; `stop` must not be fired at a track; and "
+        "force_window must not be released while anything plays"),
+    ("player_window.py", "force_window"): (
+        "playback; same release rule as set_browse_window"),
+}
+
+
+def _is_self_video(node):
+    return (isinstance(node, ast.Attribute) and node.attr == "_video"
+            and isinstance(node.value, ast.Name) and node.value.id == "self")
+
+
+class _Finder(ast.NodeVisitor):
+    """Truth-tests only. `self._video.parent`, `self._video = x` and
+    `self._video.item` are uses, not questions, and are none of this
+    checker's business."""
+
+    def __init__(self):
+        self.fn = None
+        self.hits = []
+
+    def visit_FunctionDef(self, node):
+        prev, self.fn = self.fn, node.name
+        self.generic_visit(node)
+        self.fn = prev
+
+    visit_AsyncFunctionDef = visit_FunctionDef
+
+    def _test(self, node):
+        for sub in ast.walk(node):
+            if (isinstance(sub, ast.Compare) and _is_self_video(sub.left)
+                    and any(isinstance(o, (ast.Is, ast.IsNot))
+                            for o in sub.ops)):
+                self.hits.append((self.fn, sub.lineno))
+                return
+        self._bare(node)
+
+    def _bare(self, node):
+        if _is_self_video(node):
+            self.hits.append((self.fn, node.lineno))
+        elif isinstance(node, ast.BoolOp):
+            for v in node.values:
+                self._bare(v)
+        elif isinstance(node, ast.UnaryOp) and isinstance(node.op, ast.Not):
+            self._bare(node.operand)
+        elif (isinstance(node, ast.Call)
+              and getattr(node.func, "id", "") == "bool"):
+            for a in node.args:
+                self._bare(a)
+
+    def visit_If(self, node):
+        self._test(node.test)
+        self.generic_visit(node)
+
+    def visit_IfExp(self, node):
+        self._test(node.test)
+        self.generic_visit(node)
+
+    def visit_While(self, node):
+        self._test(node.test)
+        self.generic_visit(node)
+
+    def visit_Return(self, node):
+        if node.value is not None:
+            self._test(node.value)
+        self.generic_visit(node)
+
+
+def find(root=ROOT):
+    """[(file, function, lineno)] for every raw truth-test found."""
+    out = []
+    for rel in FILES:
+        path = os.path.join(root, rel)
+        if not os.path.exists(path):
+            continue
+        with open(path, encoding="utf-8") as fh:
+            tree = ast.parse(fh.read(), filename=rel)
+        finder = _Finder()
+        finder.visit(tree)
+        base = os.path.basename(rel)
+        for fn, lineno in sorted(set(finder.hits), key=lambda h: h[1]):
+            out.append((base, fn, lineno))
+    return out
+
+
+def undeclared(root=ROOT):
+    return [h for h in find(root) if (h[0], h[1]) not in DECLARED]
+
+
+def main():
+    hits = find()
+    bad = [h for h in hits if (h[0], h[1]) not in DECLARED]
+    for base, fn, lineno in bad:
+        print("%s:%d: %s() tests self._video without declaring which "
+              "question it asks" % (base, lineno, fn))
+    reached = {(b, f) for b, f, _ in hits}
+    for key in sorted(set(DECLARED) - reached):
+        print("stale declaration: %s %s() no longer tests self._video"
+              % key)
+    print("%d declared, %d undeclared" % (len(reached & set(DECLARED)),
+                                          len(bad)))
+    return 1 if bad else 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
Output from a final hand-done regression test of the entire player surface, which uncovered some potentially annoying edge case bugs.

Fixes:
- Update version and flatpak appdata to 3.0.0.
- Fix spacebar not pausing videos after playing and stopping music.
- Fix library UI blanking in a playlist that combines videos and music.
- Fix library UI blanking after changing a transcode subtitle.
- Prevent resuming inside an intro with seek to skip intro skipping the intro.
- Fix moving downloads back to default location.
- Remove continue watching items from the next up section.
- Fixed comic view breaking on custom OSC and windows media themes.
- Fix keynav focus not losing spacebar in media browser.  