### PR TITLE
Fix font rendering

### DIFF
--- a/README.md
+++ b/README.md
@@ -473,6 +473,44 @@ support `--enable-libmpv-shared` in the `mpv_options` file, you can clear the fi
 is now enabled by default. Add `-Dsdl2-gamepad=enabled` to `mpv_options` if you want gamepad
 support.
 
+### Right-to-left text and kerning need FriBiDi
+
+Some of what the client draws is baked into the picture with Pillow, and Pillow
+does complex text layout only through **Raqm**. Raqm and HarfBuzz are compiled
+into Pillow's wheels, but **FriBiDi is loaded at runtime and is not bundled on
+any platform** — so on a system without `libfribidi`, Pillow quietly falls back
+to a basic layout. Nothing errors, and an English library looks perfectly fine.
+
+What it costs, if it happens to you:
+
+* Right-to-left scripts (Arabic, Hebrew) are drawn in logical order with
+  isolated letterforms — reversed and disconnected — wherever the client bakes
+  text into the picture: tile captions, Cast & Crew, the heading over a
+  backdrop. The same text drawn as an overlay is correct, because MPV carries
+  its own copy.
+* No script gets kerning, Latin included. That also makes captions *measure*
+  slightly wide, so they get shortened with a "…" a little earlier than they
+  should.
+
+You can ask Pillow directly:
+
+```bash
+python3 -c "from PIL import features; print(features.check('raqm'))"
+```
+
+`True` and there is nothing to do — which is the normal case, because most
+desktops already have FriBiDi (Pango needs it). If it prints `False`:
+
+* install FriBiDi — `libfribidi0` on Debian/Ubuntu, `fribidi` on Fedora and
+  Arch — and check again;
+* and if pip had to **build Pillow from source** rather than use a wheel (no
+  wheel for your platform, an unusual architecture, or `--no-binary`), Pillow
+  needs libraqm's development files *at build time* too: `libraqm-dev` on
+  Debian/Ubuntu, `libraqm-devel` on Fedora, `libraqm` on Arch. Install those,
+  then `pip3 install --force-reinstall --no-binary=pillow pillow`.
+
+The Flatpak and the Windows installer both ship what they need for this.
+
 ## <h2 id="osx-installation">macOS Installation</h2>
 Currently on macOS only the external MPV backend seems to be working. I cannot test on macOS, so please report any issues you find.
 
@@ -495,6 +533,10 @@ If you'd like the menu bar icon as well:
 6. Run `jellyfin-mpv-shim`.
 
 Display mirroring is not tested on macOS, but may be installable with 'pipx install 'jellyfin-mpv-shim[mirror]'`.
+
+macOS installs the same Pillow wheels as Linux, so the FriBiDi note under
+[Linux Installation](#linux-installation) applies here too — worth checking if
+Arabic or Hebrew titles look wrong.
 
 ## Building on Windows
 

--- a/docs/RELEASE_SHAPE_POST_3.0.0.md
+++ b/docs/RELEASE_SHAPE_POST_3.0.0.md
@@ -571,6 +571,47 @@ accurate. **This is the trade CLAUDE.md names** — a platform-resolved default
 stack was three guards mirroring state (Flathub's publish state) owned
 elsewhere.
 
+#### The same platform probe answers a second question: SteamOS → gamepad on
+
+**[iw], recorded for 3.1.0 and deliberately not started now: do this when the
+Flatpak detection and the notifier disable are done, because it is the same
+probe and the same migration step.**
+
+Jellyfin Media Player already does this detection and it is worth copying rather
+than re-deriving — `jellyfin-media-player/src/system/SystemComponent.cpp`:
+
+```cpp
+QFile flatpakOsFile {"/run/host/os-release"};
+if (flatpakOsFile.exists()) {
+  // ... read it, then:
+  if (flatpakOsFileString.contains("NAME=\"SteamOS\"")) {
+```
+
+The mechanism is the part to keep: inside a Flatpak, `/etc/os-release` describes
+the *runtime*, so the host's identity is only at **`/run/host/os-release`**. That
+makes it the same file the Flathub-vs-elsewhere question is already reading, so
+the probe is written once and asked twice.
+
+**The decision, and it is narrower than the notifier's:** on SteamOS, force
+`input_gamepad` **on**. `conf.py:505` defaults it `False`, and a Steam Deck is a
+machine where the gamepad is the only pointing device most users have — so the
+default being off is simply wrong there.
+
+- **Not tri-state.** The notifier needed three states because "on" is a real
+  preference the platform default would otherwise silently overrule. Gamepad
+  input is additive — enabling it takes nothing away and breaks no other input
+  path — so there is nothing to protect and no `default`/`enabled`/`disabled`
+  distinction to carry. A plain `bool` forced on in the migration is the whole
+  change. **Do not copy the tri-state here just because it is next door.**
+- **Force it in the migration**, in the same `CONFIG_VERSION` step, for the
+  reason that section already establishes: `SettingsBase.dict()` writes every
+  field, so every existing conf.json already carries `input_gamepad: false`
+  explicitly and a changed default alone would reach nobody.
+- **A gamepad capability probe is not needed for the decision** — the shim
+  already has one at 0.34 ms and mpv's `sdl2-gamepad` can be disabled at build
+  time, so the setting being on is not a promise that a pad is present. That is
+  the existing behaviour on every other platform and needs no change here.
+
 ### 5.4 Hand-delivered builds are a real distribution channel
 
 **[iw] and this is the practice for user-facing issues now:** hand a CI build to

--- a/docs/RELEASE_SHAPE_POST_3.0.0.md
+++ b/docs/RELEASE_SHAPE_POST_3.0.0.md
@@ -248,8 +248,8 @@ are the ones a 3.0.1 could also have carried; 8-11 are what waiting buys.
 | 4 | The four wrong claims still in the repo | all CONFIRMED — see the table below | **None.** |
 | 5 | Strike ISSUES's "delete the dead branch" instruction (postmortem §2 C3); write the owed `do-not-fix.md` entries for #726 and #727 item 1 | CONFIRMED absent: `grep -n '726\|727' docs/do-not-fix.md` returns nothing | **None.** |
 | 6 | #736 stopgap: document `JELLYFIN_MPV_SHIM_UI_FONT` in `docs/configuration.md` — **DONE**; the reply to the issue is Izzie's to post (see the policy note below) | `pilfont.py:739`; was CONFIRMED in no `.md` file | **None.** The docs state the cost: `_env_extra` prepends the path to **every** candidate list including emoji, so the workaround trades colour emoji away. Covers Korean and Traditional Chinese too, which have the same cause. |
-| 7 | #688: **verify locally rather than waiting** — [iw] asked for a retest and got no response. Linux is expected fixed; **Windows needs a renderer check** against the packaged build, since that is where FriBiDi actually has to be present | `7ed41bce` is contained in the tag | **None to ship**, but it is a test task rather than a doc task, and it shares the Windows-artifact gap with #736 (§5.4): the shipped PyInstaller build has its own Pillow wheel and its own DLL set. |
-| 8 | **#736 properly**: coverage-based face selection — keep the opened faces in candidate order and pick per run by what the run's codepoints actually draw as, with a per-face covered/missing memo | The `.notdef` mask comparison is validated: measured **39.4 us** cold per codepoint and **20 ns** cached, stable across 14 faces, never equal to the space glyph. No new dependency. §6 has the control. | **Moderate** — it lands in the cluster that produced five of the postmortem's top ten generators, and the site count (`strips.py`, `components/banner.py`, `cast.py`, `epub/paint.py`, `epub/fonts.py`) must be done **before** the first patch. It removes an authority: list order stops deciding. |
+| 7 | #688: **verify locally rather than waiting** — [iw] asked for a retest and got no response. Linux verified live (2026-09-08: RAQM and BASIC render Arabic and Hebrew differently, so shaping is on). **Windows is BLOCKED and the block is itself the finding** — see below | `7ed41bce` is contained in the tag | **None to ship**, but it is a test task rather than a doc task, and it shares the Windows-artifact gap with #736 (§5.4): the shipped PyInstaller build has its own Pillow wheel and its own DLL set. |
+| 8 | **#736 properly**: coverage-based face selection — **DONE** (`cc3660e5`, branch `fix-font-selection`) | Measured 45 us/codepoint on Linux and 7.5 us on Windows, ~20 ns memoized, verdict size-independent 8→96 px. On the VM: zh-Hans `msgothic`→`msyh`, ko →`malgun`, both with zero tofu; ja and zh-Hant unchanged. 5781 tests / 214 modules green on both platforms. | The site count was done first and came out smaller than this row assumed: `strips.py`, `banner.py`, `cast.py` and `epub/paint.py` all reach selection through `_split`'s two resolvers, so there was **one** chokepoint plus `epub/fonts.face`. Two corrections to this row's own evidence: notdef **can** be blank (`simsun.ttc`) and **can** equal the space glyph (`NotoColorEmoji.ttf`), so "never equal to the space glyph" was false and an assertion resting on it fails on stock Debian. |
 | 9 | **#739**: bounded async paste (`command_native_async` + `mp.abort_async_command` + a timer) **together with** the concatenated `clip_tools()` list and `wl-clipboard` in the manifest | §1.1 | **Moderate, and indivisible.** Shipping the packaging half alone extends a present-tense hang to Flatpak users. Gated on the measurement in §6. |
 | 10 | **Make `notify_updates` tri-state** (`default` / `enabled` / `disabled`), resolve `default` by platform — off inside a Flathub Flatpak, on elsewhere — and add a `CONFIG_VERSION` 6 migration | §5.3 | **Low-moderate.** The risk is the migration, not the setting: conf.json persists every key, so a stored `true` is indistinguishable between "never touched" and "explicitly wanted", and migrating it to `default` silently loses the second. Migrate a stored `false` to `disabled` so a deliberate opt-out is never stomped. |
 | 10a | **Retarget the notice's action inside Flatpak** — say `flatpak update`, drop the [Open] link — for the users who switch it back on, and for hand-delivered builds marked `JMS_UPDATE_CHECK=1` | §5.3 | **Low.** Independent of 10; the banner still exists wherever it is enabled, and [Open] on a Flathub install has never been the right action. |
@@ -268,6 +268,26 @@ The four wrong claims, each re-verified for this document:
 trace to items 1-3, and none of them carries code risk.
 
 ---
+
+**#688 on Windows cannot be checked from the VM as it stands, and that is worth
+more than the check would have been.** Measured 2026-09-08: the VM's venv has
+`features.check("raqm")` **False** and no FriBiDi at all, so `ImageFont.truetype`
+silently returns a Basic-layout font — right-to-left text draws unreordered and
+unjoined and nothing gets GPOS kerning. That is *expected* for a bare venv
+rather than a defect: Pillow's Windows wheel carries libraqm and HarfBuzz but
+loads FriBiDi at runtime, and only the packaged build ships `fribidi-0.dll`
+beside the exe.
+
+The consequence is bigger than #688. **Every Windows leg of every suite has
+been running without text shaping**, so a green RTL test there is not evidence
+about what ships — it is Codex's "there is an owner for `pilfont.py` but none
+for the shipped artifact rendering a multilingual corpus" (§4 of the postmortem
+handoff) made concrete and measurable. Closing it needs a `fribidi-0.dll` on the
+VM, and `tools/build_win_fribidi.py` targets MSVC through meson `--vsenv`, which
+**this VM cannot run** — it has no C++ workload, the same gap that blocks the
+Vulkan loader. So the options are a mingw cross-build from the Linux box, the VS
+C++ workload, or testing a real PyInstaller artifact; all three are a decision
+rather than a step.
 
 ## 3. Held out of the release
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -1138,16 +1138,18 @@ Set it to the full path of a font file and that font is tried *first* for every
 piece of text the client bakes into the picture — library tiles, the playback
 HUD, the cast screen, the built-in book reader.
 
-It exists for hosts where the automatic choice picks a face that cannot draw
-your language. The client picks the first installed font from a per-script list
-and does not check that the font actually covers the text, so a system whose
-fonts are laid out unusually can end up with boxes (tofu) instead of
-characters.
+It exists for hosts where the automatic choice is still not the font you want.
+The client checks, character by character, that a font can actually draw the
+text before using it, and moves on to the next candidate when it cannot — so
+boxes (tofu) should be rare, and this override is an appearance preference more
+often than a repair.
 
-**Known case: Simplified Chinese, Korean and Traditional Chinese on Windows.**
-The client finds MS Gothic — a *Japanese* font — before the Chinese and Korean
-ones, and MS Gothic can draw only part of those scripts, so some characters
-render and others become boxes. Until this is fixed properly, set:
+**Simplified Chinese, Korean and Traditional Chinese on Windows no longer need
+it.** The client used to take MS Gothic — a *Japanese* font — for every CJK
+script, and MS Gothic can draw only part of Chinese and none of Korean, so some
+characters rendered and others became boxes. Chinese text now resolves Microsoft
+YaHei and Korean resolves Malgun Gothic on their own. If you would rather pick
+the font yourself, these are the ones to name:
 
 ```
 JELLYFIN_MPV_SHIM_UI_FONT=C:\Windows\Fonts\msyh.ttc      Simplified Chinese
@@ -1155,15 +1157,21 @@ JELLYFIN_MPV_SHIM_UI_FONT=C:\Windows\Fonts\msjh.ttc      Traditional Chinese
 JELLYFIN_MPV_SHIM_UI_FONT=C:\Windows\Fonts\malgun.ttf    Korean
 ```
 
+Traditional Chinese is the case where naming a font still buys something real:
+Chinese and Japanese share most of their characters but draw some of them
+differently, and the client cannot tell which language a title is in — so a
+Traditional Chinese library is drawn with Japanese letterforms unless you point
+this at `msjh.ttc`.
+
 On Linux and macOS the automatic choice is normally right; if it is not, point
 this at any font file with the coverage you need (for example
 `/usr/share/fonts/opentype/noto/NotoSansCJK-Regular.ttc`).
 
-**What it costs.** The override goes in front of *every* font list, including
-the one used for emoji and symbols — so with it set, colour emoji and some
-symbols are drawn by whatever your chosen font has for them, which is usually
-nothing. It is a workaround for unreadable text, not a general appearance
-setting; unset it once the underlying problem is fixed.
+**What it costs.** The override is offered ahead of *every* built-in font list,
+including the one used for emoji and symbols, but it is only used for text it can
+actually draw — so colour emoji still work if your chosen font has no emoji in
+it. What you do give up is the client's own preference for anything the font
+*can* draw: name a Chinese font and Japanese titles are drawn with it too.
 
 ## Other Configuration Options
 

--- a/docs/packaging.md
+++ b/docs/packaging.md
@@ -59,6 +59,60 @@ worse than not shipping it — a 32-bit user was downloading something official-
 that failed cryptically instead of reading "not supported".
 
 
+### The Flatpak needs libraqm, and its absence was silent too
+
+Same fault as FriBiDi below, at the other end of the stack, and it shipped in
+3.0.0. **Flathub installs Pillow from its sdist** (`pillow-12.3.0.tar.gz`, via
+`pip3 install 'jellyfin-mpv-shim[all]'`), so Raqm is compiled in only if
+`raqm.pc` is present at build time — and **`org.gnome.Sdk` 50 has harfbuzz,
+fribidi and freetype but no raqm at all** (verified: no `raqm.pc`, no
+`libraqm.so`). Pillow says nothing about it; it just produces an `_imagingft`
+that links freetype and nothing else.
+
+Measured on the shipped 3.0.0 Flatpak:
+
+```
+raqm = False,  libraqm = None,  fribidi = None,  harfbuzz = None
+arabic: RAQM vs BASIC identical, advance 125.0 vs 125.0   -> unshaped
+latin:  AVATAR 111.88 vs 111.88                           -> UNKERNED
+```
+
+So every baked string was laid out with `Layout.BASIC`: right-to-left text in
+logical order with isolated letterforms, and no GPOS kerning for any script —
+which `mpvtk.metrics` then feeds to every ellipsize and wrap decision.
+
+The fix is a `libraqm` module **ordered before** the module that pip-installs
+the app. Verified with a real `flatpak-builder` run of that module plus the
+same sdist:
+
+```
+PKG_CONFIG_PATH=/app/lib/pkgconfig:/app/share/pkgconfig:/usr/lib/pkgconfig:/usr/share/pkgconfig
+pkg-config --modversion raqm -> 0.11.0
+_imagingft NEEDED: libfreetype.so.6, libraqm.so.0, libc.so.6
+raqm = True, libraqm = 0.11.0
+AVATAR: RAQM 105.25 vs BASIC 111.88  -> KERNED
+arabic: differ, advance 95.4 vs 125.0 -> joining active
+```
+
+Three things that cost a test each, so they are worth knowing:
+
+- **`flatpak run` is not the build environment.** In a bare `flatpak run` of the
+  SDK `PKG_CONFIG_PATH` is unset and `/app/lib/pkgconfig` is not searched, so a
+  hand-rolled probe finds no raqm and "proves" the fix does not work.
+  `flatpak-builder` exports the path above; test with it, not around it.
+- **`/app` is fresh per `flatpak run`**, so a two-invocation test (install, then
+  build) silently loses the install between them.
+- **`features.version("fribidi")` and `("harfbuzz")` stay `None`** with a system
+  raqm — Pillow only knows raqm's own version. Do not read that as a partial
+  fix; the kerning and joining numbers above are what answer the question.
+
+The **PyPI** path is different and mostly fine: Pillow publishes 86 wheels
+(manylinux/musllinux x86_64+aarch64, macOS, Windows, iOS) with raqm and
+harfbuzz compiled in. What those wheels do *not* carry is FriBiDi — see below —
+which is why a pip install on Windows measures `raqm=False` while the same
+wheel on a desktop Linux measures `True`. README's Linux Installation section
+carries the user-facing version of this.
+
 ### FriBiDi is required, and its absence is silent
 
 `fribidi-0.dll` must sit beside the batch file. `python tools/build_win_fribidi.py`

--- a/flatpak/com.github.iwalton3.jellyfin-mpv-shim.json
+++ b/flatpak/com.github.iwalton3.jellyfin-mpv-shim.json
@@ -254,6 +254,28 @@
         },
         "shared-modules/libayatana-appindicator/libayatana-appindicator-gtk3.json",
         {
+            "//": "Pillow is installed from its SDIST below, and it enables Raqm -- bidi reorder, Arabic joining and GPOS kerning -- only if it finds libraqm at BUILD time. org.gnome.Sdk 50 ships harfbuzz, fribidi and freetype but NO raqm, and Pillow's build says nothing when it is absent: it just produces a _imagingft with no Raqm support, and every baked string is then laid out with Layout.BASIC. Measured on the shipped 3.0.0 Flatpak: right-to-left text unjoined and unreordered, and nothing kerned anywhere -- which mpvtk.metrics then feeds to every ellipsize and wrap decision. MUST stay ahead of the module that pip-installs the app.",
+            "name": "libraqm",
+            "buildsystem": "meson",
+            "config-opts": [
+                "-Dtests=false",
+                "-Ddocs=false"
+            ],
+            "sources": [
+                {
+                    "type": "archive",
+                    "url": "https://github.com/HOST-Oman/libraqm/releases/download/v0.11.0/raqm-0.11.0.tar.xz",
+                    "sha256": "3d0add115f7d4a9410d3377462ed3c05e86342193ef984183e4380e3787b2d4c",
+                    "x-checker-data": {
+                        "type": "json",
+                        "url": "https://api.github.com/repos/HOST-Oman/libraqm/releases/latest",
+                        "version-query": ".tag_name | sub(\"^v\"; \"\")",
+                        "url-query": "\"https://github.com/HOST-Oman/libraqm/releases/download/v\" + $version + \"/raqm-\" + $version + \".tar.xz\""
+                    }
+                }
+            ]
+        },
+        {
             "name": "jellyfin-mpv-shim",
             "buildsystem": "simple",
             "//note": "Built from the checkout this manifest lives in, with network access, so the dependencies come straight from PyPI. That is deliberately NOT what Flathub publishes -- Flathub forbids network in the build and pins every wheel in flathub/com.github.iwalton3.jellyfin-mpv-shim's pypi-dependencies.json. This manifest is for CI and local test bundles of the working tree.",

--- a/jellyfin_mpv_shim/epub/fonts.py
+++ b/jellyfin_mpv_shim/epub/fonts.py
@@ -106,7 +106,7 @@ def _resolve_family(kind):
     return None
 
 
-def face(kind, size, bold=False, italic=False, script="latin"):
+def face(kind, size, bold=False, italic=False, script="latin", text=None):
     """A PIL font. Never None, never raises.
 
     ``kind`` is "serif", "sans" or "mono"; ``script`` is a
@@ -118,12 +118,27 @@ def face(kind, size, bold=False, italic=False, script="latin"):
     legal answers here and are the faces for a star or a 🎬 in the prose --
     they would be catastrophic as a whole book's face, and the caller that
     picks that one keeps them out: see :class:`~.layout.Measurer`.
+
+    ``text`` is the run itself, and it is not optional in spirit: this is the
+    second site of #736's rule. Routing a script name into ``pilfont.font``
+    and letting the candidate order decide gave a Simplified Chinese book the
+    Japanese face that happened to open first, exactly as the library did.
+    It stays keyword-optional only so the Latin branch, which has its own
+    families, need not pass one.
     """
     size = max(6, int(size))
     key = (kind, size, bool(bold), bool(italic), script)
-    hit = _font_cache.get(key)
-    if hit is not None:
-        return hit
+    # **The cache is bypassed in both directions when ``text`` decides**, and
+    # reading it unconditionally was a defect: the key holds no text, and the
+    # book's own base face is resolved first and *without* text
+    # (`layout.Measurer.font`), so every later run was answered from that
+    # entry and the coverage check below never ran. Every test in this file
+    # still passed. See `test_epub_layout.py:TestCjkFaceCoverageInTheReader`.
+    cacheable = text is None or script in ("latin", "", None)
+    if cacheable:
+        hit = _font_cache.get(key)
+        if hit is not None:
+            return hit
     font = None
     if script not in ("latin", "", None):
         from ..mpvtk import pilfont
@@ -131,7 +146,7 @@ def face(kind, size, bold=False, italic=False, script="latin"):
         # No italic: pilfont's per-script lists are regular and bold, and a
         # synthesised slant is not something Pillow offers. Drawing the
         # upright face is the same choice every CJK-capable reader makes.
-        font = pilfont.font(script, size, bold)
+        font = pilfont.font(script, size, bold, text=text)
     else:
         family = _resolve_family(kind)
         if family:
@@ -149,7 +164,8 @@ def face(kind, size, bold=False, italic=False, script="latin"):
         from PIL import ImageFont
 
         font = ImageFont.load_default()
-    _font_cache[key] = font
+    if cacheable:
+        _font_cache[key] = font
     return font
 
 

--- a/jellyfin_mpv_shim/epub/layout.py
+++ b/jellyfin_mpv_shim/epub/layout.py
@@ -119,7 +119,25 @@ class Measurer:
     def size_for(self, span_style):
         return max(8, int(round(self.style.font_px * span_style.scale)))
 
-    def _face(self, span_style, script):
+    def _face(self, span_style, script, text=None):
+        """``text`` is the run, when there is one, and it decides the face
+        for a non-Latin script: #736's rule, whose second site was this
+        module reaching `pilfont` through a script name alone.
+
+        **Not cached with ``text`` in play**, because the key cannot hold it
+        and a cache without it hands the next run whatever the first run
+        needed. `pilfont` memoizes the faces and the per-glyph coverage, so
+        the uncached path is a dict lookup rather than a font open. The
+        text-free calls -- the book's own base face, and the line-height
+        reservation in `_metrics` -- still hit this cache and pay nothing.
+        """
+        if text is not None:
+            from . import fonts
+
+            kind = "mono" if span_style.mono else self.style.font_kind
+            return fonts.face(kind, self.size_for(span_style),
+                              span_style.bold, span_style.italic, script,
+                              text=text)
         key = (span_style.key(), script)
         hit = self._fonts.get(key)
         if hit is None:
@@ -150,8 +168,8 @@ class Measurer:
         key = span_style.key()
         hit = self._resolvers.get(key)
         if hit is None:
-            def hit(script, _style=span_style):
-                return self._face(_style, script)
+            def hit(script, text=None, _style=span_style):
+                return self._face(_style, script, text)
             self._resolvers[key] = hit
         return hit
 

--- a/jellyfin_mpv_shim/mpvtk/GUIDE.md
+++ b/jellyfin_mpv_shim/mpvtk/GUIDE.md
@@ -980,7 +980,86 @@ still → `msgothic.ttc`. A zh-Hant library gets Japanese shapes for the Han it
 shares, which is the one case left open and needs a language the server is never
 asked for.
 
-### 12.7 Where the Unicode data actually is
+### 12.7 A Flatpak sees the runtime's fonts, not the user's
+
+**Pillow does not use fontconfig.** It searches a fixed list of directories,
+which is the whole reason the sandbox needs anything said about it: inside a
+Flatpak that list finds the *runtime's* `/usr/share/fonts`, and the user's fonts
+are bind-mounted somewhere Pillow has never heard of.
+
+Measured 2026-09-08 against the shipped 3.0.0 Flatpak, on a host with the full
+Noto set installed:
+
+| | files | has CJK / Thai / Indic |
+|---|---|---|
+| runtime `/usr/share/fonts` (`org.freedesktop.Platform` 25.08) | 95 | **none of them** |
+| host, at `/run/host/fonts` | 4243 | all of them |
+
+So **Chinese, Japanese, Korean, Thai and Hindi libraries drew as a screen of
+boxes**, and `NotoSansCJK-Regular.ttc` — verified in the sandbox to draw 莲 —
+was on the disk the whole time. Absolute candidates made it worse rather than
+better: `/usr/share/fonts/opentype/noto/NotoSansCJK-Regular.ttc` names the
+runtime's tree inside the sandbox, so the entry that looks most specific is the
+one guaranteed to miss.
+
+`_load` therefore tries each candidate's **basename** under
+`_HOST_FONT_DIRS` (`/run/host/fonts`, `/run/host/local-fonts`,
+`/run/host/user-fonts`). Basename, because it has to carry over for an absolute
+candidate as much as a bare one. It is `_resolutions`' second yield, so the walk
+is only reached once a name has failed at every size — 2656 files in 3 ms, once
+per process, and never on a host that has no such directory.
+
+Two things worth knowing before touching it:
+
+- **The index being built is not the same as a directory being walked.** On
+  Windows the first Latin candidate (`DejaVuSans.ttf`) does not exist, so the
+  lookup *is* reached and the index is built empty: three `isdir` calls. A test
+  asserting "the index is None off-Flatpak" passes on Linux for an accidental
+  reason and fails on Windows for a correct one.
+- `/run/host/os-release` is the same trick from the other direction — it is the
+  only place a Flatpak can read the *host's* identity, which is what the
+  SteamOS detection in `docs/RELEASE_SHAPE_POST_3.0.0.md` §5.3 uses.
+
+### 12.8 One bucket per family of faces, not per script
+
+`script_of_char` buckets a codepoint, and the right granularity is **however
+many buckets the available faces justify** — not one per script and not one for
+everything.
+
+Seventeen scripts had no bucket at all until 2026-09-08, so every codepoint in
+them answered `"latin"`, took the Latin face and drew as boxes: Bengali,
+Gurmukhi, Gujarati, Oriya, Tamil, Telugu, Kannada, Malayalam, Sinhala, Lao,
+Tibetan, Myanmar, Georgian, Ethiopic, Cherokee, Khmer, Mongolian. Both platforms
+ship a face for every one of them. Georgian and Armenian were in exactly the
+same position and were invisible, because DejaVu happens to cover them — which
+is what made the whole set read as a platform limit instead of a bug.
+
+**The ten Indic scripts share one `"indic"` bucket, and that is only correct
+because of 12.6's coverage check.** They share no codepoints, so unlike CJK
+there is no regional-form problem: Noto ships a file per script, Windows ships
+`Nirmala.ttf` for all ten, and `font()` picks per run by what the run's
+codepoints actually draw as. Measured: from one list, Bengali resolves
+`NotoSansBengali`, Tamil `NotoSansTamil`, Telugu `NotoSansTelugu`; on Windows all
+ten resolve `Nirmala.ttf`.
+
+**Cost is one comparison**, because every added range lives inside
+U+0980..U+18AF and a single band test sits in front of `_BAND_SCRIPTS`. The
+scripts in it got *faster*: they used to traverse the whole chain to reach
+`"latin"` (147 ns measured) instead of returning at the gate. Thai and
+Devanagari sit inside that band, keep their own buckets and are answered
+*before* it — and a codepoint the table does not claim falls through rather than
+being taken, so the two orderings cannot silently swap. A test holds both ends.
+
+**Measure the font name on a host that has it.** `mangal.ttf` was Devanagari's
+only Windows entry for years and Mangal is not on Windows 10 — it became an
+optional feature — so Hindi drew in Arial. `NotoSansTibetan` does not exist
+either; Noto ships Serif only for that script. Both were caught by
+`TestTheHostsOwnInventory`, which walks the platform's font directories and
+fails when the host owns a face the shim did not find, naming the file. That
+test is the only thing here that can catch an *incomplete* list, because
+completeness cannot be checked against the file — only against a machine.
+
+### 12.9 Where the Unicode data actually is
 
 Debian's `unicode-data` package ships
 `/usr/share/unicode/emoji/emoji-data.txt` — the authoritative

--- a/jellyfin_mpv_shim/mpvtk/GUIDE.md
+++ b/jellyfin_mpv_shim/mpvtk/GUIDE.md
@@ -882,7 +882,81 @@ Arial's (19, 5) at 20px.
   lands on), NotoSansThai and NotoSansArabic all draw the letter A as `.notdef`,
   so "進撃の巨人 (2013)" came out with the year as four tofu boxes.
 
-### 12.6 Where the Unicode data actually is
+### 12.6 One CJK bucket, four languages, and no face that covers it
+
+`script_of_char` folds Han, kana and Hangul into the single script `"cjk"`,
+because there is no way to tell zh-Hans from zh-Hant from ja by codepoint —
+they share the Unified Han block, and the shim has no per-item language to ask
+the server for. One bucket is the right answer. **One face for the bucket is
+not**, and that was #736: a Simplified Chinese library drawn half in glyphs and
+half in tofu.
+
+Coverage measured 2026-09-08, per face, against the codepoints of each
+language's sample (#736's own title `莲花 电视剧 第一季` for zh-Hans):
+
+| face | host | zh-Hans | zh-Hant | ja | ko | ASCII |
+|---|---|---|---|---|---|---|
+| `NotoSansCJK-Regular.ttc` | Debian | ✓ | ✓ | ✓ | ✓ | ✓ |
+| `DroidSansFallbackFull.ttf` | Debian | ✓ | ✓ | ✓ | ✗ | **✗** |
+| `fonts-japanese-gothic.ttf` (IPAGothic) | Debian | **✗ 4/8** | ✗ 嬛 | ✓ | ✗ | ✓ |
+| `VL-Gothic-Regular.ttf` | Debian | **✗ 4/8** | ✓ | ✓ | ✗ | ✓ |
+| `msgothic.ttc` (MS Gothic) | Windows 10 | **✗ 4/8** | ✓ | ✓ | ✗ | ✓ |
+| `YuGothM.ttc` / `YuGothR.ttc` | Windows 10 | **✗ 4/8** | ✓ | ✓ | ✗ | ✓ |
+| `msyh.ttc` (YaHei) / `msjh.ttc` (JhengHei) | Windows 10 | ✓ | ✓ | ✓ | ✗ | ✓ |
+| `simsun.ttc` | Windows 10 | ✓ | ✓ | ✓ | ✗ | ✓ |
+| `malgun.ttf` | Windows 10 | ✗ 4/8 | ✓ | ✗ 撃 | ✓ | ✓ |
+| `arial.ttf` / `segoeui.ttf` / `seguisym.ttf` | Windows 10 | ✗ | ✗ | ✗ | ✗ | ✓ |
+
+**Nothing on a stock Windows 10 covers all four.** The Chinese faces have no
+Hangul at all; the Korean face is missing most Han; the Japanese faces are
+missing a quarter of #736's own title. So no ordering of `_CANDIDATES["cjk"]`
+can be correct, and the fix cannot be a reordering — it has to be **per-run
+selection by coverage**, which is what `font(script, size, bold, text=...)`
+does. `_load` answers "the first name that opens"; that was never the same
+question as "the first name that works".
+
+**How coverage is measured, and why it is a render comparison.** Pillow exposes
+no cmap — `FreeTypeFont` has `getmask`, `getbbox`, `getlength` and `getname`,
+and nothing mapping a character to a glyph id — so `_draws` renders the
+character and compares it against what that same face renders for a codepoint
+Unicode guarantees will never be assigned. That is a real answer for **39–45 µs
+on Linux and 7.5 µs on Windows**, memoized per (face, codepoint) at ~20 ns, and
+it needs no new dependency. The verdict is **identical at 8 px and at 96 px** on
+every face tried, which is why the memo is keyed by the face's *name* and shared
+across sizes.
+
+Three results that look like the probe failing and are not:
+
+- `simsun.ttc` renders a **blank** no-glyph mark, and `NotoColorEmoji.ttf`
+  renders one **identical to its space**. Both are harmless, because the only
+  glyphs that render blank are whitespace and `_covers` skips it. Do not add an
+  assertion that the mark is non-blank or differs from a space — it is false on
+  a stock Debian box.
+- `DroidSansFallbackFull.ttf` covers three CJK languages and **has no ASCII at
+  all**, not even digits. It is a legitimate candidate anyway: a mixed title
+  splits into runs and the Latin run resolves its own face.
+- Several entries on this list cover none of it. The Latin chain is appended to
+  every script for the tofu-rather-than-crash backstop, and it correctly never
+  satisfies a CJK run.
+
+**Only the selecting script's codepoints are required.** Asking a face to cover
+the whole *string* would overturn 12.1's two measured decisions — Noto Arabic is
+kept first although it has no ASCII, and the Hebrew list is ordered backwards
+precisely for the neutrals. Requiring just the codepoints that chose the list
+leaves both exactly as they were.
+
+**What coverage still cannot decide is regional glyph form.** Han unification
+means one codepoint has different shapes in Japanese and Chinese typography, and
+`msyh.ttc` covers Japanese perfectly well — so promoting it to fix Simplified
+Chinese would give every Japanese title Chinese shapes. The Japanese entries
+therefore keep their position and the Chinese ones are *appended*: order in that
+list is now preference, and only correctness was taken away from it. On the
+Windows VM the result is zh-Hans → `msyh.ttc`, ko → `malgun.ttf`, ja and zh-Hant
+still → `msgothic.ttc`. A zh-Hant library gets Japanese shapes for the Han it
+shares, which is the one case left open and needs a language the server is never
+asked for.
+
+### 12.7 Where the Unicode data actually is
 
 Debian's `unicode-data` package ships
 `/usr/share/unicode/emoji/emoji-data.txt` — the authoritative

--- a/jellyfin_mpv_shim/mpvtk/GUIDE.md
+++ b/jellyfin_mpv_shim/mpvtk/GUIDE.md
@@ -806,6 +806,14 @@ have Arabic — 165/256, with `arab` shaping in both GSUB and GPOS — but only
 249/772 presentation forms, and Arabic is a script of presentation forms. That
 is the wrong three quarters to give up for the occasional Latin word.
 
+**RTL also outranks every other script in `script_of`, wherever it appears in
+the string.** That answer becomes the whole line's face, and "first non-Latin
+wins" gave "進撃の巨人 مسلسل" to a CJK face — which draws all five Arabic
+characters as boxes, unjoined and in logical order. The trade is already
+settled by the rule above: reordered text is a *wrong* line where tofu is only
+an ugly one, so the CJK is what degrades. A line with no RTL in it is
+unaffected, and two control tests pin that.
+
 When adding or reordering an RTL candidate, check ASCII coverage and the
 OpenType script tags, not just the letters.
 
@@ -862,6 +870,22 @@ A symbol only wins a whole string when there is nothing else in it. Segoe UI
 Symbol's Latin is not Arial's and it carries no Arabic or Hebrew at all, so one
 star choosing it would re-typeset whole paragraphs — and for an RTL line, which
 cannot be split at all, draw every word as a box.
+
+**A symbol the symbol faces lack falls to the emoji chain, and that is the
+only cross-script fallback edge in the file.** Measured 2026-09-08 on Debian:
+of the 1108 codepoints `_SYMBOL_RANGES` claims, **223 are drawn by nothing in
+the symbol chain or the Latin one behind it, and the emoji chain draws 219** —
+`Symbola` is on that list and is a symbol face in every respect except which
+bucket it sits in. The colour faces are not reachable this way and need not
+be: `_load` probes strikes only for the emoji script, so a CBDT face that opens
+at one fixed size is skipped here. #713's star still comes from the symbol
+chain's own first answer.
+
+Two edges were measured and **not** declared, which is the point of measuring:
+a `cjk` edge rescues 22 symbol codepoints and all 22 are already among the 219,
+and the 33 Latin codepoints nothing draws are the C0/C1 controls, which must not
+be rescued by anything. An entry in `_FALLBACK_SCRIPTS` that no run has needed
+pre-authorises a face for a case nobody has seen.
 
 Mixed lines cost a little vertical room: PIL's default vertical anchor is the
 *ascender* and two faces do not share one, so runs are drawn from a shared

--- a/jellyfin_mpv_shim/mpvtk/GUIDE.md
+++ b/jellyfin_mpv_shim/mpvtk/GUIDE.md
@@ -799,12 +799,50 @@ still stack. That is why the Hebrew list is ordered the opposite way from every
 other list in the file: putting Noto Hebrew first drew "שלום עולם." with the
 stop as a box and every year in a title as four more.
 
-**Arabic has no such face, and that is a knowing loss.** `NotoSansArabic` is
-255/256 of the block and 751/772 presentation forms but has no A-Z, so an
-Arabic line with a Latin word in it draws that word as boxes. DejaVu *does*
-have Arabic — 165/256, with `arab` shaping in both GSUB and GPOS — but only
-249/772 presentation forms, and Arabic is a script of presentation forms. That
-is the wrong three quarters to give up for the occasional Latin word.
+**Arabic had no such face, and the loss was knowing — until the choice stopped
+having to be global.** `NotoSansArabic` is 255/256 of the block and 751/772
+presentation forms but has no A-Z, so an Arabic line with a Latin word in it
+drew that word as boxes. DejaVu *does* have Arabic — 165/256, with `arab`
+shaping in both GSUB and GPOS — but only 249/772 presentation forms, and Arabic
+is a script of presentation forms. That was the wrong three quarters to give up
+for the occasional Latin word.
+
+**That trade was between one face and every Arabic line. It is now per line.**
+Coverage-based selection (12.6) means `font(whole=True)` can ask first for a
+face that carries *this* line and fall back to the script-only question, so:
+
+| line | face | why |
+|---|---|---|
+| `مسلسل الحلقة الأولى` | `NotoSansArabic` | nothing else in it; keeps 737/773 forms |
+| `مسلسل Netflix الأصلي` | `FreeSerif` | Noto has no A-Z, and this line needs it |
+| `مسلسل (2013)` | `FreeSerif` | Noto has the *digits* and not the brackets — measured |
+| Arabic + presentation forms + Latin | `NotoSansArabic` | no face carries both, so the script wins and the Latin degrades |
+
+`FreeSerif` is a real Arabic face rather than a Latin one with a few Arabic
+glyphs: measured 2026-09-08, it **joins** (its advance for مسلسل drops from 103
+to 70 under Raqm, which is what joining does) and has full ASCII including
+brackets, at 345/773 presentation forms. Only a line Noto cannot carry reaches
+it, so every other Arabic title is unaffected — which is the difference between
+this and reordering the list, and it is why the row above that gives up the
+Latin is still the right answer when no face can have both.
+
+**Windows never had this gap.** Measured: no Arabic face in a default Windows
+install exceeds 376/773 presentation forms (Courier New; Arial and Segoe UI are
+312) and all of them have full ASCII, so the face the shim already picks there
+carries the whole line.
+
+**Hebrew has always worked this way, by accident** — Liberation Sans covers both,
+so it satisfied the whole-line question before there was one. `whole=True` makes
+that deliberate for both scripts.
+
+**What is still lost: an RTL line mixed with CJK, Thai or Indic.** No installed
+face covers Arabic *and* CJK (unifont aside, which is not a candidate and is not
+a UI face), so the line keeps its RTL face and the other script degrades — and
+that is the right way round, per the rule above. Splitting such a line is not a
+font problem at all: it needs UAX#9 run reordering, whose paired-bracket rule
+(BD16) is the fiddliest part of the algorithm and covers one of the very cases
+this section is about, so a hand-rolled subset would be wrong exactly where it
+was needed. A test asserts this loss rather than leaving it to be rediscovered.
 
 **RTL also outranks every other script in `script_of`, wherever it appears in
 the string.** That answer becomes the whole line's face, and "first non-Latin

--- a/jellyfin_mpv_shim/mpvtk/pilfont.py
+++ b/jellyfin_mpv_shim/mpvtk/pilfont.py
@@ -85,6 +85,19 @@ _CANDIDATES = {
         "NotoSansArabic-Regular.ttf",
         "/usr/share/fonts/truetype/noto/NotoSansArabic-Regular.ttf",
         "/System/Library/Fonts/GeezaPro.ttc",
+        # For the LINE, not for the script. Measured 2026-09-08: FreeSerif
+        # joins Arabic (its advance for مسلسل drops 103 -> 70 under Raqm,
+        # which is joining) and has full ASCII including the brackets, at
+        # 345/773 presentation forms against Noto's 737. `font(whole=True)`
+        # reaches it only for a line Noto cannot carry, so every other
+        # Arabic line still gets Noto -- which is what makes this a
+        # different answer from reordering the list.
+        "FreeSerif.ttf",
+        "/usr/share/fonts/truetype/freefont/FreeSerif.ttf",
+        # Windows has no high-coverage Arabic face at all: measured, the
+        # best in a default install is Courier New at 376/773 and Arial is
+        # 312 -- but both have full ASCII, so the gap this list closes for
+        # Noto-first hosts never opens there.
         "arial.ttf",
     ],
     # **The order here is load-bearing and is the opposite of every other
@@ -528,6 +541,21 @@ _JOINERS = frozenset((0x200D,            # zero width joiner
                       0xFE0E, 0xFE0F,    # text / emoji variation selectors
                       0x20E3))           # combining enclosing keycap
 
+#: Combining enclosing keycap, which ends a ``base [U+FE0F] U+20E3``
+#: sequence and is the one joiner that decides its run's *script*.
+#:
+#: **A keycap has no text presentation.** Only a colour emoji face composes
+#: the sequence; a Latin face has U+20E3 and draws a dotted box around the
+#: digit, which is why no coverage check can see this -- the glyph is not
+#: missing, it is the wrong picture. Measured: the emoji face and the Latin
+#: face draw ``1️⃣`` differently, and the Latin one is what the sheet showed
+#: as ``1□``.
+#:
+#: **U+FE0F is deliberately not in here.** Rerouting on the variation
+#: selector alone would send ``★️`` to a colour face, and no colour face
+#: draws U+2605 -- #713's tofu, straight back (see :data:`_EMOJI_RANGES`).
+_KEYCAP = 0x20E3
+
 
 def runs(text):
     """``[(script, chunk), ...]`` in order, adjacent same-script chars merged.
@@ -553,6 +581,23 @@ def runs(text):
     """
     out = []
     for ch in text or "":
+        if ord(ch) == _KEYCAP and out:
+            # Peel the sequence's base off the run it joined and give it to
+            # the emoji face. **Peel, not relabel**: relabelling the run
+            # would draw "Season 1️⃣" entirely in a 109px colour face.
+            chunk = out[-1][1]
+            peeled = []
+            if chunk and ord(chunk[-1]) == 0xFE0F:
+                peeled.insert(0, chunk.pop())
+            if chunk:
+                peeled.insert(0, chunk.pop())
+            if not chunk:
+                out.pop()
+            if out and out[-1][0] == "emoji":
+                out[-1][1].extend(peeled + [ch])
+            else:
+                out.append(["emoji", peeled + [ch]])
+            continue
         if ord(ch) in _JOINERS:
             script = None
         elif ch.isspace():
@@ -736,7 +781,8 @@ def _draws(fnt, name, ch):
 
 
 def _covers(fnt, name, text, script):
-    """Whether ``fnt`` can draw the part of ``text`` that chose ``script``.
+    """Whether ``fnt`` can draw the part of ``text`` that chose ``script``,
+    or **all** of it when ``script`` is None.
 
     **Only that part, and that is the whole design of this check.** Asking
     a face to cover the whole *string* would quietly overturn two decisions
@@ -751,9 +797,17 @@ def _covers(fnt, name, text, script):
 
     Everything else in the string is somebody else's run: ``runs`` splits a
     mixed title and each piece resolves its own face.
+
+    **Except for an RTL line, which has no other run to fall to** -- there
+    the whole line is one draw call, so ``script`` is passed as None and
+    every codepoint is required. `font` asks for that first and falls back
+    to the script-only question, so the stricter answer is a preference and
+    never a way to end up with no face at all.
     """
     for ch in text or "":
-        if ch.isspace() or script_of_char(ord(ch)) != script:
+        if ch.isspace():
+            continue
+        if script is not None and script_of_char(ord(ch)) != script:
             continue
         if not _draws(fnt, name, ch):
             return False
@@ -819,10 +873,27 @@ def font_for(text, size, bold=False):
     """A PIL font able to render ``text`` at ``size``. Falls back to the Latin
     face (and finally Pillow's bitmap default) when nothing better is
     installed."""
-    return font(script_of(text), size, bold, text=text)
+    # `has_rtl`, because that is exactly the condition under which the
+    # face has to carry the whole line: `_split` gives an RTL string one
+    # draw call and there is no second run to fall back to.
+    return font(script_of(text), size, bold, text=text, whole=has_rtl(text))
 
 
-def font(script, size, bold=False, text=None):
+def _pick(script, size, bold, text, require):
+    """First face in candidate order satisfying ``require`` (a script name,
+    or None for "every codepoint in ``text``"). None if the chain runs out."""
+    index = 0
+    while True:
+        entry = _opened(script, size, bold, index)
+        if entry is None:
+            return None
+        name, fnt = entry
+        if name is None or _covers(fnt, name, text, require):
+            return fnt
+        index += 1
+
+
+def font(script, size, bold=False, text=None, whole=False):
     """A PIL face for ``script``, able to draw ``text`` if it is given.
 
     **"The first candidate that opens" is not the same question as "the
@@ -860,15 +931,17 @@ def font(script, size, bold=False, text=None):
         _cache[key] = primary
     if not text:
         return primary
-    index = 0
-    while True:
-        entry = _opened(script, size, bold, index)
-        if entry is None:
-            return primary
-        name, fnt = entry
-        if name is None or _covers(fnt, name, text, script):
-            return fnt
-        index += 1
+    if whole:
+        # An RTL line is drawn in ONE call, so prefer a face that carries
+        # all of it -- the Latin word, the brackets, the year. Only a
+        # preference: `_pick` returning None falls through to the
+        # script-only question below, so a line whose Latin cannot be had
+        # without losing the script keeps the script.
+        got = _pick(script, size, bold, text, None)
+        if got is not None:
+            return got
+    got = _pick(script, size, bold, text, script)
+    return got if got is not None else primary
 
 
 def _scale_of(fnt):
@@ -919,7 +992,8 @@ def _same_size(fnt, script, text=None):
     nobody: the worst case is a bold run drawn regular.
     """
     return font(script, getattr(fnt, "_jms_size", getattr(fnt, "size", 12)),
-                getattr(fnt, "_jms_bold", False), text=text)
+                getattr(fnt, "_jms_bold", False), text=text,
+                whole=has_rtl(text))
 
 
 def _run_face(fnt, script, text=None):

--- a/jellyfin_mpv_shim/mpvtk/pilfont.py
+++ b/jellyfin_mpv_shim/mpvtk/pilfont.py
@@ -466,6 +466,65 @@ def _strike_order(size):
             + [s for s in reversed(_STRIKES) if s < size])
 
 
+#: Where a Flatpak's *host* fonts are bind-mounted. **This is the whole of
+#: why the sandbox needs special handling**: Pillow does not use fontconfig
+#: -- it searches a fixed list of directories -- so inside a Flatpak it sees
+#: only the runtime's own ``/usr/share/fonts``, and the user's fonts are
+#: over here instead.
+#:
+#: Measured 2026-09-08 against the shipped 3.0.0 Flatpak: the
+#: ``org.freedesktop.Platform`` 25.08 runtime carries **95 font files and no
+#: CJK, Thai or Indic face at all** (DejaVu, Liberation, FreeSans, Adwaita,
+#: Caladea, Carlito, Cantarell, plus NotoColorEmoji), while the host's 4243
+#: fonts -- including ``NotoSansCJK-Regular.ttc``, verified to draw 莲 --
+#: were sitting in here unreachable. Every Flatpak user with a Chinese,
+#: Japanese, Korean, Thai or Hindi library saw a screen of boxes.
+_HOST_FONT_DIRS = ("/run/host/fonts", "/run/host/local-fonts",
+                   "/run/host/user-fonts")
+
+#: ``basename.lower() -> path`` over :data:`_HOST_FONT_DIRS`, or ``{}``.
+#: Built at most once, and only when a candidate has already failed to load
+#: by its own name, so a host that is not a Flatpak never walks anything.
+_host_index = None
+
+
+def _host_fonts():
+    global _host_index
+    if _host_index is None:
+        _host_index = {}
+        for directory in _HOST_FONT_DIRS:
+            if not os.path.isdir(directory):
+                continue
+            for root, _dirs, files in os.walk(directory):
+                for filename in files:
+                    if filename.lower().endswith((".ttf", ".otf", ".ttc",
+                                                  ".otc")):
+                        # First wins, so the earlier directory in the tuple
+                        # takes precedence over a later duplicate.
+                        _host_index.setdefault(filename.lower(),
+                                               os.path.join(root, filename))
+    return _host_index
+
+
+def _resolutions(name):
+    """The paths to try for one candidate: its own name, then the same
+    **basename** under the host's font tree.
+
+    A generator because the second half must not be reached on a normal
+    host: `_load` only advances it when the name has already failed at
+    every size, so the walk in :func:`_host_fonts` is paid by a Flatpak and
+    by nobody else.
+
+    The basename is what carries over, for absolute candidates as much as
+    bare ones -- ``/usr/share/fonts/opentype/noto/NotoSansCJK-Regular.ttc``
+    does not exist inside the sandbox, and the file it names does.
+    """
+    yield name
+    alt = _host_fonts().get(os.path.basename(name).lower())
+    if alt and alt != name:
+        yield alt
+
+
 def _load(names, size, strikes=False):
     """``(font, name, native)``. ``native`` is the size it actually opened
     at, which is ``size`` for every scalable face and the strike for a
@@ -480,11 +539,13 @@ def _load(names, size, strikes=False):
     from PIL import ImageFont
 
     for name in names:
-        for want in [size] + (_strike_order(size) if strikes else []):
-            try:
-                return ImageFont.truetype(name, want), name, want
-            except (OSError, IOError):
-                continue
+        for candidate in _resolutions(name):
+            for want in [size] + (_strike_order(size) if strikes else []):
+                try:
+                    return (ImageFont.truetype(candidate, want), candidate,
+                            want)
+                except (OSError, IOError):
+                    continue
     return None, None, size
 
 
@@ -958,6 +1019,9 @@ def draw_text(draw, xy, text, fnt, fill=None, anchor=None, faces=None):
 
 
 def clear_cache():
+    global _host_index
+
+    _host_index = None
     _cache.clear()
     _chains.clear()
     _coverage.clear()

--- a/jellyfin_mpv_shim/mpvtk/pilfont.py
+++ b/jellyfin_mpv_shim/mpvtk/pilfont.py
@@ -39,6 +39,21 @@ _CANDIDATES = {
         "Arial.ttf",
         "arial.ttf",
     ],
+    # **Order here is preference, not correctness** -- `font()` rejects a
+    # candidate that cannot draw the run in hand, so nothing below depends on
+    # its position for a string to render. What it still decides is *regional
+    # glyph form*, and that is why the Japanese entries are deliberately NOT
+    # demoted: Han unification means one codepoint has different shapes in
+    # Japanese and Chinese typography, coverage cannot tell them apart, and
+    # the shim has no per-item language to ask. Promoting `msyh.ttc` would
+    # fix Simplified Chinese by giving every Japanese title Chinese shapes.
+    #
+    # Measured 2026-09-08 on a stock Windows 10 -- and it is the reason no
+    # ordering of this list was ever going to be right: `msgothic.ttc` has
+    # zh-Hant and ja and misses four of #736's eight codepoints; `msyh.ttc`
+    # and `simsun.ttc` have the Chinese and no Hangul at all; `malgun.ttf`
+    # has the Hangul and misses most Han. Four languages, one bucket, no
+    # single face. See mpvtk/GUIDE.md section 12.6.
     "cjk": [
         "NotoSansCJK-Regular.ttc",
         "/usr/share/fonts/opentype/noto/NotoSansCJK-Regular.ttc",
@@ -50,6 +65,13 @@ _CANDIDATES = {
         "msgothic.ttc",
         "meiryo.ttc",
         "YuGothM.ttc",
+        # Microsoft YaHei and JhengHei -- the Simplified and Traditional
+        # Chinese UI faces, shipped with Windows since Vista/7. Appended
+        # rather than promoted, for the reason above: with the coverage
+        # check they are what a Chinese title reaches once the Japanese
+        # faces decline it, which is a modern face instead of `simsun.ttc`.
+        "msyh.ttc",
+        "msjh.ttc",
         "simsun.ttc",
         "malgun.ttf",
     ],
@@ -149,8 +171,22 @@ _BOLD = {
             "/usr/share/fonts/opentype/noto/NotoSansCJK-Bold.ttc"],
 }
 
-_cache = {}          # (script, size, bold) -> ImageFont
+_cache = {}          # (script, size, bold) -> the face asked for with no text
+_chains = {}         # (script, size, bold) -> [(name, face), ...] opened so far
+# (font name, char) -> whether that face has a glyph. Unbounded on purpose:
+# the ceiling is the codepoints actually drawn times the faces asked, and a
+# bounded clear would re-pay 45 us per entry to save a few hundred KB.
+_coverage = {}
+_notdef = {}         # (font name, open size) -> that face's no-glyph renders
 _resolved = {}       # (script, bold) -> path/name that loaded, or None
+
+#: Codepoints Unicode guarantees will never be assigned, so what a face
+#: renders for one is that face's own "no glyph" mark. Three rather than
+#: one because a face that maps one anyway would make everything look
+#: covered; they are required to agree, which
+#: `tests/test_mpvtk_pilfont.py:TestCjkCoverage` holds against every
+#: candidate installed on the host.
+_NOTDEF_PROBES = ("\U000FFFFF", "\U0010FFFF", "\U000FFFFE")
 
 
 #: Blocks a text face is not expected to cover: arrows, media and geometric
@@ -406,44 +442,132 @@ def _load(names, size, strikes=False):
     return None, None, size
 
 
-def font_for(text, size, bold=False):
-    """A PIL font able to render ``text`` at ``size``. Falls back to the Latin
-    face (and finally Pillow's bitmap default) when nothing better is
-    installed."""
-    return font(script_of(text), size, bold)
+def _notdef_refs(fnt, name):
+    """What ``fnt`` renders for a codepoint that cannot exist.
+
+    Memoized per (name, open size) because the *bitmap* is size-dependent
+    even though the coverage verdict below is not: three renders cost 105 us
+    on Linux and 19 us on Windows (measured), which is worth paying once per
+    face rather than once per batch of characters.
+    """
+    key = (name, getattr(fnt, "size", None))
+    hit = _notdef.get(key)
+    if hit is None:
+        hit = []
+        for probe in _NOTDEF_PROBES:
+            mask = fnt.getmask(probe, mode="L")
+            hit.append((mask.size, bytes(mask)))
+        _notdef[key] = hit
+    return hit
 
 
-def font(script, size, bold=False):
+def _draws(fnt, name, ch):
+    """Whether ``fnt`` has a glyph for ``ch``, by rendering it and comparing
+    against that face's own no-glyph mark.
+
+    **A render comparison because Pillow exposes no cmap.** A
+    ``FreeTypeFont`` offers ``getmask``, ``getbbox``, ``getlength`` and
+    ``getname`` and nothing that maps a character to a glyph id, so the
+    alternative is a fontTools dependency for a check this cheap.
+
+    Measured 2026-09-08: 45 us per codepoint on Linux, 7.5 us on Windows,
+    paid once per (face, codepoint) for the session. **The verdict is the
+    same at 8px and at 96px on every face tried**, which is why the memo is
+    keyed by the face's name and shared across every size it is opened at.
+
+    Two faces measured here answer in ways that look wrong and are not.
+    ``simsun.ttc`` renders a *blank* no-glyph mark, and
+    ``NotoColorEmoji.ttf`` renders one identical to its space -- both are
+    harmless because the only glyphs that render blank are whitespace, and
+    :func:`_covers` skips it. Do not "fix" this by requiring the mark to be
+    non-blank; that assertion fails on a stock Debian box.
+    """
+    key = (name, ch)
+    hit = _coverage.get(key)
+    if hit is None:
+        try:
+            mask = fnt.getmask(ch, mode="L")
+            hit = (mask.size, bytes(mask)) not in _notdef_refs(fnt, name)
+        except (OSError, ValueError, AttributeError):
+            # Pillow's bitmap default, or a face that will not render this
+            # at all. "Covered" is the answer that keeps the behaviour
+            # there was before this check existed, which for an
+            # unanswerable face is the right one.
+            hit = True
+        _coverage[key] = hit
+    return hit
+
+
+def _covers(fnt, name, text, script):
+    """Whether ``fnt`` can draw the part of ``text`` that chose ``script``.
+
+    **Only that part, and that is the whole design of this check.** Asking
+    a face to cover the whole *string* would quietly overturn two decisions
+    this module made on measured evidence and wrote down:
+    ``NotoSansArabic-Regular.ttf`` is kept first for Arabic although it has
+    no ASCII at all (:data:`_CANDIDATES`, and the comment above it says
+    why), and the Hebrew list is ordered the opposite way round for
+    precisely the neutrals an RTL line cannot split off. Requiring only the
+    selecting script's codepoints leaves both answering exactly as they did,
+    while a Japanese face stops being handed a Simplified Chinese title
+    (#736).
+
+    Everything else in the string is somebody else's run: ``runs`` splits a
+    mixed title and each piece resolves its own face.
+    """
+    for ch in text or "":
+        if ch.isspace() or script_of_char(ord(ch)) != script:
+            continue
+        if not _draws(fnt, name, ch):
+            return False
+    return True
+
+
+def _opened(script, size, bold, index):
+    """``(name, face)`` at ``index`` in this script's candidate order, or
+    None past the end. Candidates are opened lazily and kept, so the common
+    case is still one ``ImageFont.truetype`` per (script, size, weight).
+
+    Measured 2026-09-08 on the Windows VM, where the walk is longest: a
+    Korean title reaches ``malgun.ttf`` on the fourth candidate for 1.81 ms
+    all in, once per chain.
+    """
     key = (script, size, bool(bold))
-    hit = _cache.get(key)
-    if hit is not None:
-        return hit
-    names = []
-    if bold:
-        names += _BOLD.get(script, [])
-    names += _CANDIDATES.get(script, [])
-    for other in _FALLBACK_SCRIPTS.get(script, ()):
-        names += _CANDIDATES.get(other, [])
-    if script != "latin":
-        # Better a Latin face than Pillow's 11px bitmap default.
+    state = _chains.get(key)
+    if state is None:
+        names = []
         if bold:
-            names += _BOLD["latin"]
-        names += _CANDIDATES["latin"]
-    fnt, name, native = _load(names, size, strikes=(script == "emoji"))
-    if fnt is None:
-        from PIL import ImageFont
+            names += _BOLD.get(script, [])
+        names += _CANDIDATES.get(script, [])
+        for other in _FALLBACK_SCRIPTS.get(script, ()):
+            names += _CANDIDATES.get(other, [])
+        if script != "latin":
+            # Better a Latin face than Pillow's 11px bitmap default. It will
+            # not satisfy `_covers` for a non-Latin run, which is correct:
+            # it is the tofu backstop, not a candidate.
+            if bold:
+                names += _BOLD["latin"]
+            names += _CANDIDATES["latin"]
+        state = {"names": names, "next": 0, "faces": []}
+        _chains[key] = state
+    while len(state["faces"]) <= index and state["next"] < len(state["names"]):
+        name = state["names"][state["next"]]
+        state["next"] += 1
+        fnt, got, native = _load([name], size, strikes=(script == "emoji"))
+        if fnt is not None:
+            _stamp(fnt, script, size, bold, native)
+            state["faces"].append((got, fnt))
+    if index < len(state["faces"]):
+        return state["faces"][index]
+    return None
 
-        fnt = ImageFont.load_default()
-        name, native = None, size
-    if _resolved.get((script, bool(bold))) != name:
-        _resolved[(script, bool(bold))] = name
-        if name is None and script != "latin":
-            log.info("no font found for script %r; text may not render", script)
-    # What it was asked for, so draw_text can ask for the same in another
-    # script. `size` is on FreeTypeFont already but the weight is not, and
-    # the bitmap default has neither. The script rides along too, so a face
-    # can be asked whether it is the right one for the run in hand -- see
-    # _run_face.
+
+def _stamp(fnt, script, size, bold, native):
+    """What it was asked for, so ``draw_text`` can ask for the same in
+    another script. ``size`` is on ``FreeTypeFont`` already but the weight is
+    not, and the bitmap default has neither. The script rides along too, so
+    a face can be asked whether it is the right one for the run in hand --
+    see :func:`_run_face`."""
     try:
         fnt._jms_size, fnt._jms_bold = size, bool(bold)
         fnt._jms_script = script
@@ -452,8 +576,62 @@ def font(script, size, bold=False):
         fnt._jms_native = native
     except AttributeError:         # a face that will not be annotated
         pass
-    _cache[key] = fnt
-    return fnt
+
+
+def font_for(text, size, bold=False):
+    """A PIL font able to render ``text`` at ``size``. Falls back to the Latin
+    face (and finally Pillow's bitmap default) when nothing better is
+    installed."""
+    return font(script_of(text), size, bold, text=text)
+
+
+def font(script, size, bold=False, text=None):
+    """A PIL face for ``script``, able to draw ``text`` if it is given.
+
+    **"The first candidate that opens" is not the same question as "the
+    first candidate that works", and the difference is #736.** A stock
+    Windows 10 resolves ``msgothic.ttc`` for every CJK string, and MS Gothic
+    is a *Japanese* face: measured, it is missing four of the eight
+    codepoints in that issue's own title, so half a Simplified Chinese
+    library drew as tofu. No ordering of :data:`_CANDIDATES` fixes that,
+    because no face on that host covers all four CJK languages -- msyh and
+    simsun have the Chinese and no Hangul, malgun has the Hangul and little
+    Han. So ``text`` decides, and the list only expresses preference.
+
+    Without ``text`` this answers exactly what it always did, from the same
+    one-lookup cache: the first candidate that opens. That is the answer for
+    a caller who wants a face's *metrics* rather than its glyphs
+    (`components/banner.py` reserving a line), and it is the fallback when
+    nothing in the chain covers the string -- tofu, but never a crash.
+    """
+    key = (script, size, bool(bold))
+    primary = _cache.get(key)
+    if primary is None:
+        entry = _opened(script, size, bold, 0)
+        if entry is None:
+            from PIL import ImageFont
+
+            fnt = ImageFont.load_default()
+            _stamp(fnt, script, size, bold, size)
+            entry = (None, fnt)
+        name, primary = entry
+        if _resolved.get((script, bool(bold))) != name:
+            _resolved[(script, bool(bold))] = name
+            if name is None and script != "latin":
+                log.info("no font found for script %r; text may not render",
+                         script)
+        _cache[key] = primary
+    if not text:
+        return primary
+    index = 0
+    while True:
+        entry = _opened(script, size, bold, index)
+        if entry is None:
+            return primary
+        name, fnt = entry
+        if name is None or _covers(fnt, name, text, script):
+            return fnt
+        index += 1
 
 
 def _scale_of(fnt):
@@ -494,7 +672,7 @@ def metrics(fnt):
     return int(round(ascent * scale)), int(round(descent * scale))
 
 
-def _same_size(fnt, script):
+def _same_size(fnt, script, text=None):
     """The face for ``script`` at the size and weight ``fnt`` was made with.
 
     Callers hold a font, not a (size, bold) pair -- they need its metrics for
@@ -504,10 +682,10 @@ def _same_size(fnt, script):
     nobody: the worst case is a bold run drawn regular.
     """
     return font(script, getattr(fnt, "_jms_size", getattr(fnt, "size", 12)),
-                getattr(fnt, "_jms_bold", False))
+                getattr(fnt, "_jms_bold", False), text=text)
 
 
-def _run_face(fnt, script):
+def _run_face(fnt, script, text=None):
     """The face to draw a run of ``script`` with, given the font a caller
     chose — possibly for a longer string this run was wrapped out of.
 
@@ -527,7 +705,7 @@ def _run_face(fnt, script):
     stamped = getattr(fnt, "_jms_script", None)
     if stamped is None or stamped == script:
         return fnt
-    return _same_size(fnt, script)
+    return _same_size(fnt, script, text)
 
 
 def _face_pickers(fnt, faces):
@@ -545,8 +723,8 @@ def _face_pickers(fnt, faces):
     """
     if faces is not None:
         return faces, faces
-    return ((lambda script: _run_face(fnt, script)),
-            (lambda script: _same_size(fnt, script)))
+    return ((lambda script, text=None: _run_face(fnt, script, text)),
+            (lambda script, text=None: _same_size(fnt, script, text)))
 
 
 def _split(text, fnt, faces):
@@ -562,9 +740,11 @@ def _split(text, fnt, faces):
     parts = runs(text)
     single, per_run = _face_pickers(fnt, faces)
     if has_rtl(text):
-        return parts, single(script_of(text)), per_run
+        # The whole line, so the face is chosen against every codepoint in
+        # it that belongs to the line's script -- see `_covers`.
+        return parts, single(script_of(text), text), per_run
     if len(parts) == 1 and parts[0][0] != "emoji":
-        return parts, single(parts[0][0]), per_run
+        return parts, single(parts[0][0], parts[0][1]), per_run
     return parts, None, per_run
 
 
@@ -576,7 +756,7 @@ def _measure(text, fnt, faces, measure):
         return measure(text, whole) * _scale_of(whole)
     total = 0.0
     for script, chunk in parts:
-        face = per_run(script)
+        face = per_run(script, chunk)
         total += measure(chunk, face) * _scale_of(face)
     return total
 
@@ -684,7 +864,7 @@ def draw_text(draw, xy, text, fnt, fill=None, anchor=None, faces=None):
         draw.text(xy, text, font=whole, fill=fill, anchor=anchor)
         return
 
-    fonts = [per_run(script) for script, _chunk in parts]
+    fonts = [per_run(script, chunk) for script, chunk in parts]
     scales = [_scale_of(f) for f in fonts]
     # Through `metrics`, or a 109px emoji strike would decide the baseline
     # for a 20px line and push the whole thing five lines down.
@@ -724,6 +904,9 @@ def draw_text(draw, xy, text, fnt, fill=None, anchor=None, faces=None):
 
 def clear_cache():
     _cache.clear()
+    _chains.clear()
+    _coverage.clear()
+    _notdef.clear()
     _resolved.clear()
 
 

--- a/jellyfin_mpv_shim/mpvtk/pilfont.py
+++ b/jellyfin_mpv_shim/mpvtk/pilfont.py
@@ -147,7 +147,7 @@ _CANDIDATES = {
     # Flatpak runtime, which matters on a host with no Indic font at all.
     #
     # **One bucket for the ten Indic scripts, and the coverage check is why
-    # that works.** They share no codepoints, so unlike CJK there is no
+    # that works** (mpvtk/GUIDE.md section 12.8). They share no codepoints, so unlike CJK there is no
     # regional-form problem; Noto has a file per script and Windows has one
     # face for all of them, and `font()` picks per run by what the run's
     # codepoints actually draw as. Order here is preference only.
@@ -599,6 +599,8 @@ def _strike_order(size):
 #: -- it searches a fixed list of directories -- so inside a Flatpak it sees
 #: only the runtime's own ``/usr/share/fonts``, and the user's fonts are
 #: over here instead.
+#:
+#: Full account and the measured inventory: mpvtk/GUIDE.md section 12.7.
 #:
 #: Measured 2026-09-08 against the shipped 3.0.0 Flatpak: the
 #: ``org.freedesktop.Platform`` 25.08 runtime carries **95 font files and no

--- a/jellyfin_mpv_shim/mpvtk/pilfont.py
+++ b/jellyfin_mpv_shim/mpvtk/pilfont.py
@@ -123,7 +123,106 @@ _CANDIDATES = {
     "thai": [
         "NotoSansThai-Regular.ttf",
         "/usr/share/fonts/truetype/noto/NotoSansThai-Regular.ttf",
+        # Leelawadee UI is Windows' own Thai face; tahoma also has it and
+        # stays behind it. `FreeSerif` is the one the Flatpak runtime has.
+        "LeelawUI.ttf",
         "tahoma.ttf",
+        "FreeSerif.ttf",
+        "/usr/share/fonts/truetype/freefont/FreeSerif.ttf",
+    ],
+    # Nine scripts that had **no bucket at all** until now: every codepoint
+    # in them answered "latin", got the Latin face and drew as boxes -- on
+    # Linux boxes with the whole Noto set installed and on a stock Windows
+    # 10, both of which ship a face for every one of them. Georgian and
+    # Armenian were in the same position and were invisible because DejaVu
+    # happens to cover them, which is what made this look like nothing.
+    #
+    # Every name below was **measured on the host that has it**, never
+    # guessed -- `mangal.ttf` above is what guessing costs. Windows 10
+    # inventory, measured 2026-09-08: `Nirmala.ttf` covers all ten Indic
+    # scripts by itself, `LeelawUI.ttf` covers Lao and Khmer (and Thai),
+    # `mmrtext.ttf` Myanmar, `himalaya.ttf` Tibetan, `ebrima.ttf` Ethiopic,
+    # `gadugi.ttf` Cherokee, `monbaiti.ttf` Mongolian, `sylfaen.ttf` and
+    # Calibri Georgian. `FreeSerif` is a broad Indic backstop and is in the
+    # Flatpak runtime, which matters on a host with no Indic font at all.
+    #
+    # **One bucket for the ten Indic scripts, and the coverage check is why
+    # that works.** They share no codepoints, so unlike CJK there is no
+    # regional-form problem; Noto has a file per script and Windows has one
+    # face for all of them, and `font()` picks per run by what the run's
+    # codepoints actually draw as. Order here is preference only.
+    "indic": [
+        "NotoSansBengali-Regular.ttf",
+        "/usr/share/fonts/truetype/noto/NotoSansBengali-Regular.ttf",
+        "NotoSansGurmukhi-Regular.ttf",
+        "/usr/share/fonts/truetype/noto/NotoSansGurmukhi-Regular.ttf",
+        "NotoSansGujarati-Regular.ttf",
+        "/usr/share/fonts/truetype/noto/NotoSansGujarati-Regular.ttf",
+        "NotoSansOriya-Regular.ttf",
+        "/usr/share/fonts/truetype/noto/NotoSansOriya-Regular.ttf",
+        "NotoSansTamil-Regular.ttf",
+        "/usr/share/fonts/truetype/noto/NotoSansTamil-Regular.ttf",
+        "NotoSansTelugu-Regular.ttf",
+        "/usr/share/fonts/truetype/noto/NotoSansTelugu-Regular.ttf",
+        "NotoSansKannada-Regular.ttf",
+        "/usr/share/fonts/truetype/noto/NotoSansKannada-Regular.ttf",
+        "NotoSansMalayalam-Regular.ttf",
+        "/usr/share/fonts/truetype/noto/NotoSansMalayalam-Regular.ttf",
+        "NotoSansSinhala-Regular.ttf",
+        "/usr/share/fonts/truetype/noto/NotoSansSinhala-Regular.ttf",
+        # One face for all ten on Windows.
+        "Nirmala.ttf",
+        "FreeSerif.ttf",
+        "/usr/share/fonts/truetype/freefont/FreeSerif.ttf",
+    ],
+    "lao": [
+        "NotoSansLao-Regular.ttf",
+        "/usr/share/fonts/truetype/noto/NotoSansLao-Regular.ttf",
+        "LeelawUI.ttf",
+        "DejaVuSans.ttf",
+    ],
+    # **Serif, not Sans**: Noto ships no `NotoSansTibetan`, and the guessed
+    # name was caught by `TestTheHostsOwnInventory` on the first run rather
+    # than by a bug report -- the same way `mangal.ttf` was.
+    "tibetan": [
+        "NotoSerifTibetan-Regular.ttf",
+        "/usr/share/fonts/truetype/noto/NotoSerifTibetan-Regular.ttf",
+        "himalaya.ttf",
+    ],
+    "myanmar": [
+        "NotoSansMyanmar-Regular.ttf",
+        "/usr/share/fonts/truetype/noto/NotoSansMyanmar-Regular.ttf",
+        "mmrtext.ttf",
+    ],
+    "georgian": [
+        "NotoSansGeorgian-Regular.ttf",
+        "/usr/share/fonts/truetype/noto/NotoSansGeorgian-Regular.ttf",
+        # DejaVu has Georgian, which is why this script never looked broken.
+        "DejaVuSans.ttf",
+        "/usr/share/fonts/truetype/dejavu/DejaVuSans.ttf",
+        "sylfaen.ttf",
+    ],
+    "ethiopic": [
+        "NotoSansEthiopic-Regular.ttf",
+        "/usr/share/fonts/truetype/noto/NotoSansEthiopic-Regular.ttf",
+        "ebrima.ttf",
+        "FreeSerif.ttf",
+    ],
+    "cherokee": [
+        "NotoSansCherokee-Regular.ttf",
+        "/usr/share/fonts/truetype/noto/NotoSansCherokee-Regular.ttf",
+        "gadugi.ttf",
+        "FreeSans.ttf",
+    ],
+    "khmer": [
+        "NotoSansKhmer-Regular.ttf",
+        "/usr/share/fonts/truetype/noto/NotoSansKhmer-Regular.ttf",
+        "LeelawUI.ttf",
+    ],
+    "mongolian": [
+        "NotoSansMongolian-Regular.ttf",
+        "/usr/share/fonts/truetype/noto/NotoSansMongolian-Regular.ttf",
+        "monbaiti.ttf",
     ],
     # Stars, ticks, arrows, media glyphs. Not a script anybody writes in, and
     # on Linux it resolves to the same DejaVu the Latin text does -- it earns
@@ -320,6 +419,14 @@ def script_of_char(cp):
         return "devanagari"
     if 0x0E00 <= cp <= 0x0E7F:
         return "thai"
+    # One comparison for the nine table-driven scripts. Deliberately after
+    # thai and devanagari, which are inside this band and have their own
+    # buckets, and deliberately falling through rather than returning when
+    # nothing matches.
+    if 0x0980 <= cp <= 0x18AF:
+        for lo, hi, script in _BAND_SCRIPTS:
+            if lo <= cp <= hi:
+                return script
     # Before the CJK catch-all, because most of this table is above it.
     if cp in _EMOJI_CPS:
         return "emoji"
@@ -390,6 +497,27 @@ def script_of(text):
     # redundant condition would read as load-bearing.
     return "symbol" if saw_symbol and not saw_word else "latin"
 
+
+#: ``(lo, hi, script)`` for the scripts that need nothing but a range and a
+#: candidate list. Reached through **one** comparison in
+#: :func:`script_of_char` -- every entry lives inside U+0980..U+18AF, so a
+#: single band test in front of this loop keeps the cost off Latin, CJK,
+#: emoji and symbols entirely.
+#:
+#: Thai (U+0E00..U+0E7F) and Devanagari (U+0900..U+097F) sit inside that
+#: band and are deliberately **not** here: they have their own buckets and
+#: are answered before the gate. A codepoint in the band that matches
+#: nothing here falls through to the rest of the chain rather than being
+#: claimed, so the two orderings cannot silently swap.
+_BAND_SCRIPTS = ((0x0980, 0x0DFF, "indic"),      # Bengali..Sinhala
+                 (0x0E80, 0x0EFF, "lao"),
+                 (0x0F00, 0x0FFF, "tibetan"),
+                 (0x1000, 0x109F, "myanmar"),
+                 (0x10A0, 0x10FF, "georgian"),
+                 (0x1200, 0x137F, "ethiopic"),
+                 (0x13A0, 0x13FF, "cherokee"),
+                 (0x1780, 0x17FF, "khmer"),
+                 (0x1800, 0x18AF, "mongolian"))
 
 #: Characters that join what is around them into one glyph and must never
 #: start a run of their own, because **shaping does not cross a run

--- a/jellyfin_mpv_shim/mpvtk/pilfont.py
+++ b/jellyfin_mpv_shim/mpvtk/pilfont.py
@@ -149,12 +149,30 @@ _CANDIDATES = {
     ],
 }
 
-#: Where a script's face falls back to *before* the Latin one. Only emoji
-#: has an entry, and it matters: with no emoji font at all, "⭐" drawn by
-#: the Latin face is a box, and drawn by the symbol face is the monochrome
-#: star it has always been. Falling straight to Latin would make this
-#: change a regression on exactly the hosts it cannot help.
-_FALLBACK_SCRIPTS = {"emoji": ("symbol",)}
+#: Where a script's face falls back to *before* the Latin one, and both
+#: entries are measured rather than offered.
+#:
+#: **emoji -> symbol**: with no emoji font at all, "⭐" drawn by the Latin
+#: face is a box and drawn by the symbol face is the monochrome star it has
+#: always been. Falling straight to Latin would make the emoji bucket a
+#: regression on exactly the hosts it cannot help.
+#:
+#: **symbol -> emoji**: measured 2026-09-08 on Debian, of the 1108
+#: codepoints :data:`_SYMBOL_RANGES` claims, **223 are drawn by nothing in
+#: the symbol chain or the Latin one behind it, and the emoji chain draws
+#: 219 of them** -- `Symbola` is on that list and is a symbol face in every
+#: respect except the bucket it sits in. The colour faces are not reachable
+#: this way and do not need to be: `_load` only probes strikes for the emoji
+#: script, so a CBDT face that opens at one fixed size is simply skipped
+#: here, and #713's star still comes from the symbol chain's own first
+#: answer (a control test holds that).
+#:
+#: **No other edge is declared, because no other edge changed an answer.**
+#: A `cjk` edge would rescue 22 symbol codepoints and all 22 are already in
+#: the 219; the 33 Latin codepoints nothing draws are the C0/C1 controls,
+#: which must not be rescued by anything. A speculative entry here
+#: pre-authorises a face for a run nobody has seen.
+_FALLBACK_SCRIPTS = {"emoji": ("symbol",), "symbol": ("emoji",)}
 
 #: Pixel sizes a bitmap-strike face may be available at, tried in
 #: `_strike_order` when the asked-for size is refused. The Apple entries are
@@ -305,6 +323,14 @@ def script_of(text):
     the first character outside the Latin face's coverage wins, so
     "進撃の巨人 (2013)" resolves to cjk.
 
+    **Except that RTL outranks everything, wherever it appears.** This
+    answer becomes the *whole line's* face when `has_rtl` says so, and
+    "first non-Latin wins" handed "進撃の巨人 مسلسل" to a CJK face -- which
+    draws the Arabic as boxes, unjoined, in logical order. The trade is
+    already decided at :data:`_RTL_RANGES`: *reordered text is a wrong line
+    where tofu is only an ugly one*. So the CJK is what becomes tofu here,
+    and a line with no RTL in it is untouched.
+
     **A symbol only wins when there is nothing else in the string.** It is a
     face for the odd glyph, not for words, and this answer is used for two
     things that would be wrong for: the line height a caller reserves
@@ -330,14 +356,22 @@ def script_of(text):
     caller should be handed.
     """
     saw_symbol = saw_word = False
+    first = None
     for ch in text or "":
         script = script_of_char(ord(ch))
+        if script in ("hebrew", "arabic"):
+            # Returned rather than remembered: no later character can
+            # outrank it, so there is nothing left to scan for.
+            return script
         if script in ("symbol", "emoji"):
             saw_symbol = True
         elif script != "latin":
-            return script            # cjk / arabic / thai / devanagari
+            if first is None:
+                first = script       # cjk / thai / devanagari
         elif not ch.isspace():
             saw_word = True
+    if first is not None:
+        return first
     # No ``has_rtl`` guard needed and none added: every RTL codepoint maps
     # to hebrew or arabic and has returned above (an invariant a test
     # holds), so anything reaching here has no RTL in it at all. A

--- a/jellyfin_mpv_shim/mpvtk/pilfont.py
+++ b/jellyfin_mpv_shim/mpvtk/pilfont.py
@@ -695,12 +695,21 @@ def _run_face(fnt, script, text=None):
     it was before any of this existed.
 
     **Single-run only.** The multi-run paths use :func:`_same_size`, which
-    resolves a real face per script unconditionally. For a stamped font the
-    two agree exactly (the stamp came from the same `font()` call the
-    lookup would make), and for an unstamped one they must not: "leave the
-    caller's face alone" is right for a string that face can draw and
-    disastrous for the mixed string this whole path exists to handle,
-    where it puts the tofu straight back.
+    resolves a real face per script unconditionally. For an unstamped font the
+    two must not agree: "leave the caller's face alone" is right for a string
+    that face can draw and disastrous for the mixed string this whole path
+    exists to handle, where it puts the tofu straight back.
+
+    For a stamped font the two agree **as long as the caller resolved the face
+    for the text it goes on to draw** -- every caller here does, and the ones
+    that ellipsize or wrap draw a subset plus a Latin "…", which is its own
+    run. That is the contract now, not an identity: since `font()` picks by
+    coverage, the same (script, size, weight) can legitimately answer with two
+    different faces, so a face resolved for one string and reused for another
+    the first face cannot draw would be returned unchanged. No guard is added
+    for it, because a guard here would be a second place deciding what
+    `font()` already decides -- if a caller ever needs that, it should pass
+    the text it draws.
     """
     stamped = getattr(fnt, "_jms_script", None)
     if stamped is None or stamped == script:

--- a/jellyfin_mpv_shim/mpvtk/pilfont.py
+++ b/jellyfin_mpv_shim/mpvtk/pilfont.py
@@ -103,9 +103,21 @@ _CANDIDATES = {
         "NotoSansHebrew-Regular.ttf",
         "/usr/share/fonts/truetype/noto/NotoSansHebrew-Regular.ttf",
     ],
+    # `mangal.ttf` alone was a Windows entry that is not on Windows:
+    # **Mangal became an optional feature in Windows 10** ("Hindi
+    # Supplemental Fonts"), so on a stock install this list resolved
+    # nothing, fell through to the Latin backstop and drew Hindi as boxes
+    # with Arial. `Nirmala.ttf` (Nirmala UI) ships by default and covers
+    # the script completely -- measured 2026-09-08, 12/12 codepoints.
+    # Mangal stays behind it for the hosts that do have it.
+    #
+    # Found by `TestTheHostsOwnInventory`, which asks the host what it has
+    # rather than trusting this list -- every Devanagari assertion here was
+    # about `script_of` and none could see it.
     "devanagari": [
         "NotoSansDevanagari-Regular.ttf",
         "/usr/share/fonts/truetype/noto/NotoSansDevanagari-Regular.ttf",
+        "Nirmala.ttf",
         "mangal.ttf",
     ],
     "thai": [

--- a/tests/test_epub_layout.py
+++ b/tests/test_epub_layout.py
@@ -476,6 +476,129 @@ class TestPagination(unittest.TestCase):
         self.assertEqual(len(pages), 2)
 
 
+class TestCjkFaceCoverageInTheReader(unittest.TestCase):
+    """#736's second site: `epub/fonts.py` reaching pilfont by script name.
+
+    F32 routed the reader through pilfont so a minority script would get a
+    face that has it. It still asked by *script*, so the reader inherited
+    the library's bug one level down: on a host whose first CJK candidate is
+    a Japanese face, a Simplified Chinese book drew the characters that face
+    happens to share and tofu'd the rest.
+    """
+
+    TITLE = "莲花电视剧"
+
+    def _bitmap(self, font, text):
+        from PIL import Image, ImageDraw
+
+        img = Image.new("L", (90, 60), 0)
+        ImageDraw.Draw(img).text((2, 2), text, font=font, fill=255)
+        return img.tobytes()
+
+    def _missing(self, font, text):
+        tofu = self._bitmap(font, "\U000FFFFF")
+        return [ch for ch in text if not ch.isspace()
+                and self._bitmap(font, ch) == tofu]
+
+    def _pin(self):
+        """Pin the cjk list to (a face that reproduces #736, one that does
+        not) and return the first of them."""
+        from PIL import ImageFont
+        from jellyfin_mpv_shim.epub import fonts
+        from jellyfin_mpv_shim.mpvtk import pilfont
+
+        def opens(name):
+            try:
+                return ImageFont.truetype(name, 21)
+            except (OSError, IOError):
+                return None
+
+        ja_only = None
+        for name in ("/usr/share/fonts/truetype/fonts-japanese-gothic.ttf",
+                     "/usr/share/fonts/truetype/vlgothic/VL-Gothic-Regular.ttf",
+                     "/usr/share/fonts/truetype/takao-gothic/TakaoGothic.ttf",
+                     "msgothic.ttc", "YuGothM.ttc"):
+            face = opens(name)
+            if face is not None and self._missing(face, self.TITLE):
+                ja_only = name
+                break
+        full = None
+        for name in pilfont._CANDIDATES["cjk"]:
+            face = opens(name)
+            if face is not None and not self._missing(face, self.TITLE):
+                full = name
+                break
+        if ja_only is None or full is None:
+            self.skipTest("no face pair on this host reproduces #736")
+
+        saved = list(pilfont._CANDIDATES["cjk"])
+        savedb = list(pilfont._BOLD["cjk"])
+        self.addCleanup(pilfont._CANDIDATES.__setitem__, "cjk", saved)
+        self.addCleanup(pilfont._BOLD.__setitem__, "cjk", savedb)
+        self.addCleanup(fonts.clear_cache)
+        self.addCleanup(pilfont.clear_cache)
+        pilfont._CANDIDATES["cjk"] = [ja_only, full]
+        pilfont._BOLD["cjk"] = []
+        pilfont.clear_cache()
+        fonts.clear_cache()
+        return ja_only
+
+    def test_a_simplified_chinese_run_gets_a_face_that_can_draw_it(self):
+        from jellyfin_mpv_shim.epub import fonts
+
+        self._pin()
+        got = fonts.face("serif", 21, script="cjk", text=self.TITLE)
+        self.assertEqual([], self._missing(got, self.TITLE),
+                         "the reader's CJK face draws part of the run as "
+                         "tofu")
+
+    def test_a_run_does_not_inherit_the_face_the_base_script_cached(self):
+        """The step the unit test above cannot take on its own.
+
+        `fonts.face`'s cache is keyed ``(kind, size, bold, italic, script)``
+        with no text in it, and the *book's own* face is resolved first and
+        without text -- `Measurer.font` asks for it to set the base line.
+        So a lookup that consults that cache before it consults ``text``
+        answers every later run with whatever the base resolved to, and the
+        coverage check never runs. Measured: it did, and every test in this
+        file still passed.
+        """
+        from jellyfin_mpv_shim.epub import fonts
+
+        self._pin()
+        base = fonts.face("serif", 21, script="cjk")          # no text
+        run = fonts.face("serif", 21, script="cjk", text=self.TITLE)
+        self.assertEqual(
+            [], self._missing(run, self.TITLE),
+            "the run was handed the base script's cached face (%s)"
+            % ("the same object" if run is base else "a stale one"))
+
+    def test_the_page_draws_the_chinese_rather_than_repeating_one_box(self):
+        """F32's own detector, on #736's fixture: tofu is one shape
+        repeated, so two pages differing only in characters the pinned face
+        lacks composite identically when that face is the one drawing."""
+        from jellyfin_mpv_shim.epub.paint import render_page
+        from PIL import ImageFont
+
+        ja_only = self._pin()
+        gone = self._missing(ImageFont.truetype(ja_only, 21), self.TITLE)
+        if len(gone) < 2:
+            self.skipTest("need two characters the pinned face lacks")
+
+        def render(text):
+            blocks = blocks_of("<p>%s</p>" % text)
+            m = layout.Measurer(layout.ReaderStyle(font_px=21), "cjk")
+            pages = layout.paginate(blocks, 600, 400, m)
+            return render_page(pages[0], (680, 400), m.style, m,
+                               palette("light"), origin=(40, 30)).tobytes()
+
+        # assertTrue, not assertNotEqual: these are whole-page bitmaps and
+        # unittest prints both operands on failure.
+        self.assertTrue(
+            render(gone[0] * 3) != render(gone[1] * 3),
+            "changing the Chinese changed nothing on the page, so both "
+            "drew as identical .notdef boxes")
+
 class TestDocumentPosition(unittest.TestCase):
     """The offset-is-the-state property, against a real book."""
 

--- a/tests/test_mpvtk_pilfont.py
+++ b/tests/test_mpvtk_pilfont.py
@@ -1248,6 +1248,12 @@ class TestTheHostsOwnInventory(unittest.TestCase):
         "/usr/share/fonts", "/usr/local/share/fonts",
         os.path.expanduser("~/.fonts"),
         os.path.expanduser("~/.local/share/fonts"),
+        # Flatpak: the runtime's own /usr/share/fonts is a 95-file set with
+        # no CJK, Thai or Indic face in it, and the HOST's fonts are
+        # bind-mounted here instead. Pillow does not use fontconfig, so
+        # these are exactly the directories it cannot see -- which is why
+        # they belong in a test about what this host can do.
+        "/run/host/fonts", "/run/host/local-fonts", "/run/host/user-fonts",
         r"C:\Windows\Fonts",
         os.path.join(os.environ.get("LOCALAPPDATA", ""),
                      "Microsoft", "Windows", "Fonts"),
@@ -1306,6 +1312,98 @@ class TestTheHostsOwnInventory(unittest.TestCase):
             "this host has a face for these scripts and pilfont did not "
             "find it -- add it to _CANDIDATES: %s"
             % "; ".join("%s (%r) is covered by %s" % g for g in gaps))
+
+class TestHostFontsInsideAFlatpak(unittest.TestCase):
+    """Pillow does not use fontconfig, so a Flatpak sees the runtime's fonts
+    and not the user's.
+
+    Measured against the shipped 3.0.0 Flatpak: the runtime carries 95 font
+    files and **no CJK, Thai or Indic face at all**, while the host's were
+    bind-mounted at `/run/host/fonts` where Pillow never looks. Chinese,
+    Japanese, Korean, Thai and Hindi libraries were a screen of boxes, and
+    the font that would have drawn them was on the disk the whole time.
+
+    Both halves are tested here without needing a sandbox: that a candidate
+    resolves by **basename** under the host tree, and that a host which is
+    not a Flatpak never walks anything.
+    """
+
+    def _real_font(self):
+        from PIL import ImageFont
+
+        for name in pilfont._CANDIDATES["latin"]:
+            try:
+                return ImageFont.truetype(name, 20).path
+            except (OSError, IOError):
+                continue
+        self.skipTest("no Latin face installed to stand in for a host font")
+
+    def _fake_host(self, real, as_name):
+        """A directory shaped like `/run/host/fonts`, holding ``real``
+        under ``as_name`` in a nested subdirectory -- nested because the
+        host's tree is (`opentype/noto/...`) and a flat scan would pass
+        while the real thing failed."""
+        import shutil
+        import tempfile
+
+        root = tempfile.mkdtemp()
+        self.addCleanup(shutil.rmtree, root, True)
+        nested = os.path.join(root, "opentype", "noto")
+        os.makedirs(nested)
+        shutil.copyfile(real, os.path.join(nested, as_name))
+        self.addCleanup(setattr, pilfont, "_HOST_FONT_DIRS",
+                        pilfont._HOST_FONT_DIRS)
+        self.addCleanup(pilfont.clear_cache)
+        pilfont._HOST_FONT_DIRS = (root,)
+        pilfont.clear_cache()
+        return root
+
+    def test_a_candidate_resolves_by_basename_under_the_host_tree(self):
+        """The candidate names a path that does not exist here -- exactly
+        what `/usr/share/fonts/opentype/noto/NotoSansCJK-Regular.ttc` is
+        inside the sandbox -- and the file it names is on the host."""
+        real = self._real_font()
+        self._fake_host(real, "JmsHostOnly-Regular.ttf")
+
+        saved = list(pilfont._CANDIDATES["cjk"])
+        savedb = list(pilfont._BOLD["cjk"])
+        self.addCleanup(pilfont._CANDIDATES.__setitem__, "cjk", saved)
+        self.addCleanup(pilfont._BOLD.__setitem__, "cjk", savedb)
+        pilfont._CANDIDATES["cjk"] = [
+            "/nonexistent/runtime/tree/JmsHostOnly-Regular.ttf"]
+        pilfont._BOLD["cjk"] = []
+        pilfont.clear_cache()
+
+        got = pilfont.font("cjk", 20)
+        self.assertIsNotNone(getattr(got, "path", None),
+                             "fell back to Pillow's bitmap default")
+        self.assertEqual(os.path.basename(str(got.path)),
+                         "JmsHostOnly-Regular.ttf",
+                         "the host's copy was not found; got %s" % got.path)
+
+    def test_a_host_that_is_not_a_flatpak_never_walks_anything(self):
+        """The laziness is the whole reason this is free off-Flatpak: the
+        index is only consulted once a candidate has failed at every size,
+        so an ordinary resolution must not build it.
+        """
+        self.addCleanup(pilfont.clear_cache)
+        pilfont.clear_cache()
+        self.assertIsNone(pilfont._host_index, "cleared state is not clean")
+        pilfont.font_for("Blade Runner 2049", 20)
+        self.assertIsNone(
+            pilfont._host_index,
+            "resolving a Latin string walked the host font tree, which "
+            "every non-Flatpak host would then pay for")
+
+    def test_the_index_is_empty_rather_than_absent_when_there_is_no_host(self):
+        """`_host_fonts` must answer, not raise, when the directories are
+        not there -- it is on the path of every failed candidate."""
+        self.addCleanup(setattr, pilfont, "_HOST_FONT_DIRS",
+                        pilfont._HOST_FONT_DIRS)
+        self.addCleanup(pilfont.clear_cache)
+        pilfont._HOST_FONT_DIRS = ("/nonexistent/run/host/fonts",)
+        pilfont.clear_cache()
+        self.assertEqual({}, pilfont._host_fonts())
 
 class TestEmojiTable(unittest.TestCase):
     """The classifier half of F31, and the regression it must not cause.

--- a/tests/test_mpvtk_pilfont.py
+++ b/tests/test_mpvtk_pilfont.py
@@ -16,6 +16,7 @@ if __name__ == "__main__":
     sys.path.insert(0, os.path.dirname(
         os.path.dirname(os.path.abspath(__file__))))
 
+import os
 import unittest
 
 from jellyfin_mpv_shim.mpvtk import pilfont
@@ -1214,6 +1215,97 @@ class TestFallbackAcrossSymbolSets(unittest.TestCase):
                     os.path.basename(str(first)),
                     "%r was moved off the symbol chain's own first answer"
                     % ch)
+
+class TestTheHostsOwnInventory(unittest.TestCase):
+    """If this machine HAS a face for a script, the shim must find it.
+
+    Every other test here asks whether the candidate lists behave correctly.
+    This one asks whether they are *complete*, by looking at what is actually
+    installed rather than at what the file claims -- which is the only way a
+    missing entry can be caught, and it is the gap Codex named: there is an
+    owner for `pilfont.py` and none for "the shipped artifact, with its real
+    font inventory, renders a multilingual corpus".
+
+    It found `mangal.ttf` -- the sole Windows entry for Devanagari -- to be
+    **absent from Windows 10**, where Mangal became an optional feature, while
+    `Nirmala.ttf` ships by default and covers the script completely. Hindi drew
+    as boxes with Arial and nothing in the suite could tell, because every
+    Devanagari assertion was about `script_of`.
+
+    Deliberately host-driven and answer-free: it hardcodes no font name, so it
+    reports what *this* machine can do and cannot go stale into a lie.
+    """
+
+    #: Script -> a string that script must be able to draw. Short, because
+    #: each codepoint is a render on every face until one covers them all.
+    SAMPLES = {"cjk": "莲花电视剧", "arabic": "مسلسل", "hebrew": "שלום",
+               "devanagari": "हिन्दी", "thai": "ไทย", "symbol": "★✓",
+               "latin": "Añb"}
+
+    #: Where a system keeps fonts. A missing directory is skipped, so this
+    #: costs nothing on a platform it does not describe.
+    FONT_DIRS = (
+        "/usr/share/fonts", "/usr/local/share/fonts",
+        os.path.expanduser("~/.fonts"),
+        os.path.expanduser("~/.local/share/fonts"),
+        r"C:\Windows\Fonts",
+        os.path.join(os.environ.get("LOCALAPPDATA", ""),
+                     "Microsoft", "Windows", "Fonts"),
+        "/System/Library/Fonts", "/Library/Fonts",
+        "/System/Library/Fonts/Supplemental",
+    )
+
+    @classmethod
+    def _installed(cls):
+        if getattr(cls, "_cache", None) is not None:
+            return cls._cache
+        found = []
+        for directory in cls.FONT_DIRS:
+            if not directory or not os.path.isdir(directory):
+                continue
+            for root, _dirs, files in os.walk(directory):
+                for name in files:
+                    if name.lower().endswith((".ttf", ".otf", ".ttc", ".otc")):
+                        found.append(os.path.join(root, name))
+        cls._cache = found
+        return found
+
+    def _covers(self, face, text):
+        ref = face.getmask("\U000FFFFF", mode="L")
+        for ch in text:
+            mask = face.getmask(ch, mode="L")
+            if (mask.size, bytes(mask)) == (ref.size, bytes(ref)):
+                return False
+        return True
+
+    def test_every_script_this_host_can_draw_is_drawn(self):
+        from PIL import ImageFont
+
+        installed = self._installed()
+        if len(installed) < 5:
+            self.skipTest("no system font directory found here")
+
+        self.addCleanup(pilfont.clear_cache)
+        gaps = []
+        for script, sample in sorted(self.SAMPLES.items()):
+            pilfont.clear_cache()
+            chosen = pilfont.font_for(sample, 24)
+            if self._covers(chosen, sample):
+                continue                    # the shim found a face: fine
+            # The shim cannot draw it. Is that this host's fault or ours?
+            for path in installed:
+                try:
+                    face = ImageFont.truetype(path, 24)
+                except (OSError, IOError, ValueError):
+                    continue
+                if self._covers(face, sample):
+                    gaps.append((script, sample, os.path.basename(path)))
+                    break
+        self.assertEqual(
+            [], gaps,
+            "this host has a face for these scripts and pilfont did not "
+            "find it -- add it to _CANDIDATES: %s"
+            % "; ".join("%s (%r) is covered by %s" % g for g in gaps))
 
 class TestEmojiTable(unittest.TestCase):
     """The classifier half of F31, and the regression it must not cause.

--- a/tests/test_mpvtk_pilfont.py
+++ b/tests/test_mpvtk_pilfont.py
@@ -21,6 +21,42 @@ import unittest
 
 from jellyfin_mpv_shim.mpvtk import pilfont
 
+#: One character per script bucket, and one string per bucket to draw.
+#:
+#: Shared because two tests need it and both used to key a dict inline --
+#: which meant adding a script to `_CANDIDATES` made one of them call
+#: ``getmask(None)`` and raise something unrelated to what it tests.
+#: `test_every_bucket_has_a_sample` turns that into a stated requirement.
+SCRIPT_SAMPLE = {
+    "latin": ("A", "Blade Runner 2049"),
+    "cjk": ("\u4e00", "\u83b2\u82b1\u7535\u89c6\u5267"),
+    "hebrew": ("\u05d0", "\u05e9\u05dc\u05d5\u05dd"),
+    "arabic": ("\u0645", "\u0645\u0633\u0644\u0633\u0644"),
+    "devanagari": ("\u0939", "\u0939\u093f\u0928\u094d\u0926\u0940"),
+    "thai": ("\u0e01", "\u0e44\u0e17\u0e22"),
+    "indic": ("\u0995", "\u0ba4\u0bae\u0bbf\u0bb4\u0bcd"),
+    "lao": ("\u0e81", "\u0ea5\u0eb2\u0ea7"),
+    "tibetan": ("\u0f40", "\u0f56\u0f7c\u0f51"),
+    "myanmar": ("\u1000", "\u1019\u103c\u1014\u103a"),
+    "georgian": ("\u10d0", "\u10e5\u10d0\u10e0\u10d7"),
+    "ethiopic": ("\u1200", "\u12a0\u1218\u122d\u129b"),
+    "cherokee": ("\u13a0", "\u13e3\u13b3\u13a9"),
+    "khmer": ("\u1780", "\u1781\u17d2\u1798\u17c2\u179a"),
+    "mongolian": ("\u1826", "\u182e\u1823\u1829\u182d"),
+    "symbol": ("\u2605", "\u2605\u2713"),
+    "emoji": ("\U0001f3ac", "\U0001f3ac"),
+}
+
+#: Characters used only to ask a face "can you draw ANYTHING?".
+#:
+#: One per bucket is not enough for `indic`, which nine Noto faces share and
+#: each of which covers exactly one of the scripts -- measured:
+#: `NotoSansGurmukhi` draws Gurmukhi and none of the other eight. So the
+#: alphabet is per *script*, not per bucket.
+PROBE_ALPHABET = (
+    "".join(ch for ch, _text in SCRIPT_SAMPLE.values())
+    + "\u0995\u0a15\u0a95\u0b15\u0b95\u0c15\u0c95\u0d15\u0d9a")
+
 
 class TestScriptOf(unittest.TestCase):
     def test_ascii_is_latin(self):
@@ -1039,20 +1075,21 @@ class TestCjkCoverage(unittest.TestCase):
                 # look like notdef. Drawn from the samples the face's own
                 # script list exists for, so a face with a blank notdef is
                 # still held to a real answer.
-                has = {"latin": "A", "cjk": "\u4e00", "hebrew": "\u05d0",
-                       "arabic": "\u0645", "devanagari": "\u0939",
-                       "thai": "\u0e01", "symbol": "\u2605",
-                       "emoji": "\U0001f3ac"}.get(script)
+                has = SCRIPT_SAMPLE[script][0]
                 mask = face.getmask(has, mode="L")
                 if (mask.size, bytes(mask)) != (masks[0].size, first):
                     checked += 1
                     continue
                 # Not every candidate carries its list's script -- the
                 # Latin backstops on the CJK list are there for the tofu
-                # case. Only a face that covers NOTHING is a broken probe.
+                # case, and `NotoSansGurmukhi` on the `indic` list covers
+                # Gurmukhi and none of the other nine (measured), so a
+                # single per-BUCKET character cannot be the control for a
+                # bucket several faces share. Only a face that covers
+                # nothing at all is a broken probe.
                 self.assertTrue(
                     any(bytes(face.getmask(ch, mode="L")) != first
-                        for ch in "A\u4e00\u05d0\u0645\u2605"),
+                        for ch in PROBE_ALPHABET),
                     "%s renders every probe character exactly as it renders "
                     "notdef, so the check cannot answer for it" % name)
                 checked += 1
@@ -1238,9 +1275,13 @@ class TestTheHostsOwnInventory(unittest.TestCase):
 
     #: Script -> a string that script must be able to draw. Short, because
     #: each codepoint is a render on every face until one covers them all.
-    SAMPLES = {"cjk": "莲花电视剧", "arabic": "مسلسل", "hebrew": "שלום",
-               "devanagari": "हिन्दी", "thai": "ไทย", "symbol": "★✓",
-               "latin": "Añb"}
+    #: Every bucket, so a script added without a face on a host that HAS
+    #: one fails here rather than in a bug report. Straight from
+    #: `SCRIPT_SAMPLE`, minus emoji -- `script_of` never answers "emoji"
+    #: (a colour face's metrics would be wrong for a whole line), so
+    #: `font_for` is the wrong question for it.
+    SAMPLES = {script: text for script, (_ch, text)
+               in SCRIPT_SAMPLE.items() if script != "emoji"}
 
     #: Where a system keeps fonts. A missing directory is skipped, so this
     #: costs nothing on a platform it does not describe.
@@ -1381,19 +1422,54 @@ class TestHostFontsInsideAFlatpak(unittest.TestCase):
                          "JmsHostOnly-Regular.ttf",
                          "the host's copy was not found; got %s" % got.path)
 
-    def test_a_host_that_is_not_a_flatpak_never_walks_anything(self):
-        """The laziness is the whole reason this is free off-Flatpak: the
-        index is only consulted once a candidate has failed at every size,
-        so an ordinary resolution must not build it.
+    def test_a_host_that_is_not_a_flatpak_walks_no_directory(self):
+        """Off-Flatpak this must cost nothing, and "nothing" is about
+        directories walked -- not about whether the index object exists.
+
+        The first version asserted `_host_index is None` after resolving a
+        Latin string, which passed on Linux for an accidental reason: the
+        first Latin candidate (`DejaVuSans.ttf`) loads there, so the
+        generator was never advanced. **On Windows it does not exist**, so
+        the lookup is reached and the index is built -- empty, because the
+        `/run/host` directories are not there. That is three `isdir` calls
+        once per process and is the correct behaviour; the assertion was
+        wrong, not the code.
         """
+        self.addCleanup(setattr, pilfont, "_HOST_FONT_DIRS",
+                        pilfont._HOST_FONT_DIRS)
         self.addCleanup(pilfont.clear_cache)
+        pilfont._HOST_FONT_DIRS = ("/nonexistent/run/host/fonts",)
         pilfont.clear_cache()
-        self.assertIsNone(pilfont._host_index, "cleared state is not clean")
         pilfont.font_for("Blade Runner 2049", 20)
+        self.assertFalse(
+            pilfont._host_fonts(),
+            "a host with no /run/host font directory indexed something")
+
+    def test_the_index_is_not_built_while_a_candidate_still_loads(self):
+        """The laziness itself, pinned platform-independently.
+
+        `_resolutions` is a generator whose second yield does the walking,
+        so a candidate that loads must leave it unreached. Asserted against
+        a first candidate that is known to load *here*, rather than against
+        whichever name happens to work on the author's machine.
+        """
+        real = self._real_font()
+        self._fake_host(real, "JmsHostOnly-Regular.ttf")
+
+        saved = list(pilfont._CANDIDATES["latin"])
+        savedb = list(pilfont._BOLD["latin"])
+        self.addCleanup(pilfont._CANDIDATES.__setitem__, "latin", saved)
+        self.addCleanup(pilfont._BOLD.__setitem__, "latin", savedb)
+        pilfont._CANDIDATES["latin"] = [real]      # an absolute path that IS here
+        pilfont._BOLD["latin"] = []
+        pilfont.clear_cache()
+
+        got = pilfont.font_for("Blade Runner 2049", 20)
+        self.assertEqual(str(getattr(got, "path", "")), real)
         self.assertIsNone(
             pilfont._host_index,
-            "resolving a Latin string walked the host font tree, which "
-            "every non-Flatpak host would then pay for")
+            "the host tree was indexed even though the first candidate "
+            "loaded, so every host would pay for the walk")
 
     def test_the_index_is_empty_rather_than_absent_when_there_is_no_host(self):
         """`_host_fonts` must answer, not raise, when the directories are
@@ -1404,6 +1480,72 @@ class TestHostFontsInsideAFlatpak(unittest.TestCase):
         pilfont._HOST_FONT_DIRS = ("/nonexistent/run/host/fonts",)
         pilfont.clear_cache()
         self.assertEqual({}, pilfont._host_fonts())
+
+class TestBucketBookkeeping(unittest.TestCase):
+    """The tables that have to stay in step with each other.
+
+    Both of these existed as implicit assumptions and both broke the moment
+    nine scripts were added: one test keyed a dict by script name and called
+    `getmask(None)` for anything new, and the other silently tested a subset.
+    """
+
+    def test_every_bucket_has_a_sample(self):
+        missing = sorted(set(pilfont._CANDIDATES) - set(SCRIPT_SAMPLE))
+        self.assertEqual(
+            [], missing,
+            "these buckets have no entry in SCRIPT_SAMPLE, so the coverage "
+            "and inventory tests silently skip them: %s" % missing)
+
+    def test_no_sample_is_for_a_bucket_that_does_not_exist(self):
+        extra = sorted(set(SCRIPT_SAMPLE) - set(pilfont._CANDIDATES))
+        self.assertEqual([], extra,
+                         "SCRIPT_SAMPLE names buckets that are gone: %s"
+                         % extra)
+
+    def test_every_sample_resolves_the_bucket_it_is_filed_under(self):
+        """A sample under the wrong key makes both tests assert about the
+        wrong script while still passing."""
+        for script, (ch, text) in sorted(SCRIPT_SAMPLE.items()):
+            if script == "emoji":
+                # `script_of` deliberately never answers emoji; the
+                # character still must.
+                self.assertEqual("emoji", pilfont.script_of_char(ord(ch)))
+                continue
+            self.assertEqual(script, pilfont.script_of_char(ord(ch)),
+                             "%r is not a %s character" % (ch, script))
+            self.assertEqual(script, pilfont.script_of(text),
+                             "%r does not resolve %s" % (text, script))
+
+    def test_every_band_script_is_a_bucket_with_candidates(self):
+        """A range in `_BAND_SCRIPTS` naming a bucket with no candidate list
+        resolves the Latin face and draws boxes -- which is the state all
+        nine of these scripts were in before they had ranges."""
+        for lo, hi, script in pilfont._BAND_SCRIPTS:
+            self.assertIn(script, pilfont._CANDIDATES,
+                          "band %04X-%04X names %r, which has no candidates"
+                          % (lo, hi, script))
+            self.assertTrue(pilfont._CANDIDATES[script],
+                            "%r has an empty candidate list" % script)
+
+    def test_the_band_gate_covers_every_band_range(self):
+        """The gate in `script_of_char` is a single hardcoded comparison in
+        front of the table. A range added outside it is unreachable, and
+        nothing else would say so.
+        """
+        for lo, hi, script in pilfont._BAND_SCRIPTS:
+            for cp in (lo, hi):
+                self.assertEqual(
+                    script, pilfont.script_of_char(cp),
+                    "U+%04X is in the %r range but the band gate does not "
+                    "reach it" % (cp, script))
+
+    def test_the_band_does_not_swallow_thai_or_devanagari(self):
+        """Both sit inside the band and are answered before it. If the gate
+        ever moved above them they would resolve the wrong bucket."""
+        for cp in (0x0E00, 0x0E7F):
+            self.assertEqual("thai", pilfont.script_of_char(cp))
+        for cp in (0x0900, 0x097F):
+            self.assertEqual("devanagari", pilfont.script_of_char(cp))
 
 class TestEmojiTable(unittest.TestCase):
     """The classifier half of F31, and the regression it must not cause.

--- a/tests/test_mpvtk_pilfont.py
+++ b/tests/test_mpvtk_pilfont.py
@@ -773,6 +773,282 @@ class TestSymbolFace(unittest.TestCase):
                             self._bitmap(latin, "2001"))
 
 
+class TestCjkCoverage(unittest.TestCase):
+    """#736: a Simplified Chinese library drawn with a Japanese face.
+
+    The whole class asserts a *drawn glyph is not the face's own tofu*.
+    Every other CJK test in this file asserts a script name or that
+    something non-None came back, which is why none of them could fail
+    while the resolved face could not draw the string.
+
+    Measured 2026-09-08, and it is what makes ordering the list unfixable:
+    no single face on a stock Windows 10 covers all four CJK languages.
+    `msgothic.ttc` (what `_load` picks there today) has zh-Hant and ja and
+    misses 4 of the 8 codepoints in #736's own title; `simsun.ttc` and
+    `msyh.ttc` have the Chinese and no Hangul; `malgun.ttf` has the Hangul
+    and misses most Han. On Linux the same split is IPAGothic / VL Gothic /
+    Takao (ja, no zh-Hans) against NotoSansCJK (all four).
+    """
+
+    #: The title from the issue. Its two halves are the whole point: a
+    #: Japanese face draws 花第一季 and tofus 莲电视剧, which is the partial
+    #: garbling in the screenshot rather than a uniform row of boxes.
+    TITLE = "莲花 电视剧 第一季"
+
+    #: Faces measured to cover Japanese and *not* Simplified Chinese, in
+    #: the order they are worth trying. Not candidate-list entries -- they
+    #: are the fixture, standing in for the host in the issue.
+    JA_ONLY = ("/usr/share/fonts/truetype/fonts-japanese-gothic.ttf",
+               "/usr/share/fonts/truetype/vlgothic/VL-Gothic-Regular.ttf",
+               "/usr/share/fonts/truetype/takao-gothic/TakaoGothic.ttf",
+               "msgothic.ttc", "YuGothM.ttc", "YuGothR.ttc")
+
+    def _bitmap(self, font, text):
+        from PIL import Image, ImageDraw
+
+        img = Image.new("L", (80, 60), 0)
+        ImageDraw.Draw(img).text((2, 2), text, font=font, fill=255)
+        return img.tobytes()
+
+    def _tofu(self, font):
+        return self._bitmap(font, "\U000FFFFF")
+
+    def _missing(self, font, text):
+        tofu = self._tofu(font)
+        return [ch for ch in text if not ch.isspace()
+                and self._bitmap(font, ch) == tofu]
+
+    def _pin(self, names):
+        """Cut the cjk list down to ``names`` for one test."""
+        saved = list(pilfont._CANDIDATES["cjk"])
+        savedb = list(pilfont._BOLD["cjk"])
+        self.addCleanup(pilfont._CANDIDATES.__setitem__, "cjk", saved)
+        self.addCleanup(pilfont._BOLD.__setitem__, "cjk", savedb)
+        self.addCleanup(pilfont.clear_cache)
+        pilfont._CANDIDATES["cjk"] = list(names)
+        # A bold request would otherwise reach NotoSansCJK-Bold and answer
+        # correctly for a reason this test is not about.
+        pilfont._BOLD["cjk"] = []
+        pilfont.clear_cache()
+
+    def _fixture(self, needs=None):
+        """``(ja_only_name, full_name)`` -- a face that reproduces the
+        issue, and one that does not. Skips only where the host has no such
+        pair at all, which no box this runs on is."""
+        from PIL import ImageFont
+
+        def opens(name):
+            try:
+                return ImageFont.truetype(name, 24)
+            except (OSError, IOError):
+                return None
+
+        ja_only = None
+        for name in self.JA_ONLY:
+            face = opens(name)
+            if face is None:
+                continue
+            if self._missing(face, self.TITLE):
+                ja_only = name
+                break
+        full = None
+        for name in pilfont._CANDIDATES["cjk"]:
+            face = opens(name)
+            if face is None:
+                continue
+            if not self._missing(face, (needs or "") + self.TITLE):
+                full = name
+                break
+        if ja_only is None or full is None:
+            self.skipTest("no face pair on this host reproduces #736 "
+                          "(ja_only=%r, full=%r)" % (ja_only, full))
+        return ja_only, full
+
+    def test_a_simplified_chinese_title_is_not_drawn_by_a_japanese_face(self):
+        """#736 itself, through the face `strips._font`/`imageutil.pil_font`
+        hand to a baked caption."""
+        ja_only, full = self._fixture()
+        self._pin([ja_only, full])
+
+        font = pilfont.font_for(self.TITLE, 24)
+        self.assertEqual(
+            [], self._missing(font, self.TITLE),
+            "the caption face draws part of #736's title as tofu; it "
+            "resolved the first name that OPENS, not the first that WORKS")
+
+    def test_the_drawing_path_resolves_a_covering_face_too(self):
+        """`draw_text` re-resolves per run, so it is a second resolver and
+        not the one above -- and it is the one a tile caption goes through
+        (`strips.py:1344`)."""
+        from PIL import Image, ImageDraw
+
+        ja_only, full = self._fixture()
+        self._pin([ja_only, full])
+        font = pilfont.font_for(self.TITLE, 24)
+
+        def drawn(text):
+            img = Image.new("L", (80, 60), 0)
+            pilfont.draw_text(ImageDraw.Draw(img), (2, 2), text, font,
+                              fill=255)
+            return img.tobytes()
+
+        tofu = drawn("\U000FFFFF")
+        bad = [ch for ch in self.TITLE
+               if not ch.isspace() and drawn(ch) == tofu]
+        self.assertEqual([], bad,
+                         "draw_text drew %r as tofu" % "".join(bad))
+
+    def test_a_japanese_title_first_does_not_lock_the_face_for_a_chinese_one(
+            self):
+        """The step that a fix inside `_load` alone would not take.
+
+        `_cache` is keyed ``(script, size, bold)`` with no text in it, so
+        whichever title is drawn *first* in a session decides the face for
+        every later one. A mixed library resolves ja, caches the ja-only
+        face, and the Chinese titles below it are #736 again -- and the
+        session order is not something a one-shot test can see.
+        """
+        ja_only, full = self._fixture(needs="進撃の巨人")
+        self._pin([ja_only, full])
+
+        for step, title in enumerate(("進撃の巨人", self.TITLE,
+                                      "オリジナル", self.TITLE)):
+            font = pilfont.font_for(title, 24)
+            self.assertEqual(
+                [], self._missing(font, title),
+                "step %d (%r) drew tofu: the face cached for an earlier "
+                "title is still being handed to a later one" % (step, title))
+
+    def test_a_korean_title_is_not_drawn_by_a_chinese_face(self):
+        """The sibling the issue did not mention.
+
+        Hangul and Han share the one ``"cjk"`` bucket
+        (`pilfont.py:script_of_char`), and the faces that carry Chinese
+        mostly have no Hangul at all -- measured on `simsun.ttc`,
+        `msyh.ttc`, `msjh.ttc` and `DroidSansFallbackFull.ttf`. So
+        reordering the list for #736 moves the breakage rather than
+        removing it.
+        """
+        from PIL import ImageFont
+
+        korean = "오징어 게임"
+        han_only = full = None
+        for name in ("/usr/share/fonts/truetype/droid/"
+                     "DroidSansFallbackFull.ttf", "simsun.ttc", "msyh.ttc",
+                     "msjh.ttc") + tuple(pilfont._CANDIDATES["cjk"]):
+            try:
+                face = ImageFont.truetype(name, 24)
+            except (OSError, IOError):
+                continue
+            miss = self._missing(face, korean)
+            if miss and not self._missing(face, self.TITLE):
+                han_only = han_only or name
+            elif not miss:
+                full = full or name
+        if han_only is None or full is None:
+            self.skipTest("no Han-without-Hangul face pair on this host")
+        self._pin([han_only, full])
+
+        font = pilfont.font_for(korean, 24)
+        self.assertEqual([], self._missing(font, korean),
+                         "a Korean title resolved a Han-only face")
+
+    def test_the_arabic_face_is_still_chosen_for_a_line_with_ascii_in_it(self):
+        """Negative control for the deliberate decision at `pilfont.py:57`.
+
+        `NotoSansArabic-Regular.ttf` has the Arabic and **no ASCII**
+        (measured), and the list keeps it first knowingly: the face that
+        would draw the Latin word gives up three quarters of the
+        presentation forms. A coverage check that asked the whole *line* to
+        be covered would silently overturn that. It asks only for the
+        codepoints of the script that chose the list.
+        """
+        from PIL import ImageFont
+
+        try:
+            first = pilfont._CANDIDATES["arabic"][0]
+            face = ImageFont.truetype(first, 24)
+        except (OSError, IOError):
+            self.skipTest("the first Arabic candidate is not installed here")
+        if not self._missing(face, "S1"):
+            self.skipTest("%s covers ASCII here, so there is nothing to "
+                          "control for" % first)
+
+        self.addCleanup(pilfont.clear_cache)
+        pilfont.clear_cache()
+        got = pilfont.font_for("مسلسل (2013)", 24)
+        self.assertEqual(
+            [], self._missing(got, "مسلسل"),
+            "the Arabic line lost its Arabic face")
+        self.assertEqual(
+            getattr(got, "path", None), getattr(face, "path", None),
+            "the Arabic line was moved off %s, which is the face "
+            "pilfont.py:57-62 keeps first on purpose" % first)
+
+    def test_the_notdef_probes_agree_on_every_installed_candidate(self):
+        """What the coverage check rests on, asserted against whatever
+        faces this host actually has.
+
+        Two halves, and the second is the one that took a correction.
+        Three noncharacter codepoints must render the *same* thing as each
+        other, or "differs from notdef" names no single reference. And a
+        codepoint the face demonstrably HAS must come back covered, which
+        is the property the check is actually used for.
+
+        What is deliberately **not** asserted is that notdef differs from a
+        space. Measured 2026-09-08: `simsun.ttc` renders a blank notdef and
+        `NotoColorEmoji.ttf` renders notdef and space *identically* (both
+        empty at its 136px strike). That is harmless because the only
+        glyphs that render blank are whitespace and the check skips it --
+        but it is not the invariant, and asserting it fails on a stock
+        Debian box.
+        """
+        from PIL import ImageFont
+
+        probes = ("\U000FFFFF", "\U0010FFFF", "\U000FFFFE")
+        checked = 0
+        for script, names in pilfont._CANDIDATES.items():
+            for name in names:
+                for size in ([24] + list(pilfont._STRIKES)
+                             if script == "emoji" else [24]):
+                    try:
+                        face = ImageFont.truetype(name, size)
+                    except (OSError, IOError):
+                        continue
+                    break
+                else:
+                    continue
+                masks = [face.getmask(p, mode="L") for p in probes]
+                first = bytes(masks[0])
+                for probe, mask in zip(probes[1:], masks[1:]):
+                    self.assertEqual(
+                        (masks[0].size, first), (mask.size, bytes(mask)),
+                        "%s renders %r and %r differently, so neither is a "
+                        "reliable notdef reference" % (name, probes[0], probe))
+                # Positive control, per face: something it has must not
+                # look like notdef. Drawn from the samples the face's own
+                # script list exists for, so a face with a blank notdef is
+                # still held to a real answer.
+                has = {"latin": "A", "cjk": "\u4e00", "hebrew": "\u05d0",
+                       "arabic": "\u0645", "devanagari": "\u0939",
+                       "thai": "\u0e01", "symbol": "\u2605",
+                       "emoji": "\U0001f3ac"}.get(script)
+                mask = face.getmask(has, mode="L")
+                if (mask.size, bytes(mask)) != (masks[0].size, first):
+                    checked += 1
+                    continue
+                # Not every candidate carries its list's script -- the
+                # Latin backstops on the CJK list are there for the tofu
+                # case. Only a face that covers NOTHING is a broken probe.
+                self.assertTrue(
+                    any(bytes(face.getmask(ch, mode="L")) != first
+                        for ch in "A\u4e00\u05d0\u0645\u2605"),
+                    "%s renders every probe character exactly as it renders "
+                    "notdef, so the check cannot answer for it" % name)
+                checked += 1
+        self.assertGreater(checked, 3,
+                           "too few faces installed to be evidence")
+
 class TestEmojiTable(unittest.TestCase):
     """The classifier half of F31, and the regression it must not cause.
 

--- a/tests/test_mpvtk_pilfont.py
+++ b/tests/test_mpvtk_pilfont.py
@@ -696,9 +696,17 @@ class TestSymbolFace(unittest.TestCase):
         `has_rtl` makes `draw_text` take a single draw call with the face it
         was handed -- necessary, because Pillow reorders bidi within a call
         and cannot across several. But "the face it was handed" was chosen
-        for a longer string: wrap "東京 دراما" and the Arabic-only line
-        inherits the CJK face. One draw call is still one draw call with
-        the *right* face, so the bypass must re-resolve rather than skip.
+        for a longer string, so an Arabic-only line can arrive holding a CJK
+        face. One draw call is still one draw call with the *right* face, so
+        the bypass must re-resolve rather than skip.
+
+        **The premise is now stated rather than produced.** It used to be
+        `font_for("東京 دراما")`, asserted to come back CJK-stamped -- and
+        that was the misclassification `TestMixedRtlLine` now forbids: RTL
+        outranks an earlier script precisely because a CJK face draws Arabic
+        as unjoined boxes in logical order. The fixture was the bug. Handing
+        the CJK face in directly tests the same bypass and no longer depends
+        on a caller being wrong first.
         """
         from PIL import Image, ImageDraw
 
@@ -707,8 +715,9 @@ class TestSymbolFace(unittest.TestCase):
         if cjk is latin or arabic is latin or cjk is arabic:
             self.skipTest("this host has no separate CJK and Arabic faces")
 
-        chosen = pilfont.font_for("東京 دراما", 28)
-        self.assertIs(chosen, cjk, "the premise: a CJK-stamped font")
+        chosen = cjk
+        self.assertEqual(getattr(chosen, "_jms_script", None), "cjk",
+                         "the premise: a CJK-stamped font")
 
         line = "دراما"
         got = Image.new("L", (200, 48), 0)
@@ -1048,6 +1057,163 @@ class TestCjkCoverage(unittest.TestCase):
                 checked += 1
         self.assertGreater(checked, 3,
                            "too few faces installed to be evidence")
+
+class TestMixedRtlLine(unittest.TestCase):
+    """An RTL line mixed with another script: which face carries it.
+
+    `has_rtl` gives the whole line to ONE face because Pillow reorders bidi
+    within a draw call and cannot across several. `script_of` decides which,
+    and it used to answer with the *first* non-Latin script it saw -- so a
+    title with Japanese before Arabic handed the line to a CJK face and the
+    Arabic came out as boxes, unjoined and in logical order.
+
+    The module already states which way this trade goes, at `_RTL_RANGES`:
+    *"reordered text is a wrong line where tofu is only an ugly one."* So RTL
+    outranks. The CJK becomes tofu instead, which is the ugly answer rather
+    than the wrong one.
+    """
+
+    def _bitmap(self, font, text):
+        from PIL import Image, ImageDraw
+
+        img = Image.new("L", (110, 60), 0)
+        ImageDraw.Draw(img).text((2, 2), text, font=font, fill=255)
+        return img.tobytes()
+
+    def _missing(self, font, text):
+        tofu = self._bitmap(font, "\U000FFFFF")
+        return [ch for ch in text if not ch.isspace()
+                and self._bitmap(font, ch) == tofu]
+
+    def test_rtl_outranks_an_earlier_script(self):
+        self.assertEqual(pilfont.script_of("進撃の巨人 مسلسل"), "arabic")
+        self.assertEqual(pilfont.script_of("進撃の巨人 שלום"), "hebrew")
+
+    def test_the_line_is_drawn_by_a_face_that_has_the_rtl(self):
+        line = "進撃の巨人 مسلسل"
+        self.addCleanup(pilfont.clear_cache)
+        pilfont.clear_cache()
+        parts, whole, _per_run = pilfont._split(
+            line, pilfont.font_for(line, 24), None)
+        self.assertIsNotNone(whole, "an RTL line must be drawn with one face")
+        arabic = [ch for ch in line if pilfont.has_rtl(ch)]
+        if not self._missing(pilfont.font("arabic", 24), "".join(arabic)):
+            self.assertEqual(
+                [], self._missing(whole, "".join(arabic)),
+                "the Arabic in a CJK-then-Arabic line is still boxes")
+
+    def test_an_rtl_only_line_is_unchanged(self):
+        """Control: the ordinary case must answer exactly as before."""
+        self.assertEqual(pilfont.script_of("مسلسل (2013)"), "arabic")
+        self.assertEqual(pilfont.script_of("שלום עולם."), "hebrew")
+
+    def test_a_line_with_no_rtl_still_follows_the_first_script(self):
+        """Control: RTL outranking must not disturb anything else."""
+        self.assertEqual(pilfont.script_of("進撃の巨人 (2013)"), "cjk")
+        self.assertEqual(pilfont.script_of("進撃 ภาพยนตร์"), "cjk")
+        self.assertEqual(pilfont.script_of("ภาพยนตร์ 進撃"), "thai")
+
+
+class TestFallbackAcrossSymbolSets(unittest.TestCase):
+    """A symbol the symbol faces do not have, drawn by the emoji chain.
+
+    Measured 2026-09-08 on Debian: of the 1108 codepoints `_SYMBOL_RANGES`
+    claims, **223 are drawn by no face in the symbol chain or the Latin one
+    behind it, and the emoji chain draws 219 of them** -- `Symbola` is in that
+    list and is a symbol face in every respect except the bucket it sits in.
+    That is the only cross-script fallback edge the measurement supports; a
+    `cjk` edge rescues 22 and every one of them is already in the 219, and the
+    33 "orphaned" Latin codepoints are the C0/C1 controls, which must not be
+    rescued by anything.
+    """
+
+    def _bitmap(self, font, text):
+        from PIL import Image, ImageDraw
+
+        img = Image.new("L", (60, 60), 0)
+        ImageDraw.Draw(img).text((2, 2), text, font=font, fill=255)
+        return img.tobytes()
+
+    def _draws(self, font, ch):
+        return self._bitmap(font, ch) != self._bitmap(font, "\U000FFFFF")
+
+    def _orphan(self):
+        """A symbol codepoint the symbol chain cannot draw and the emoji
+        chain can, discovered rather than hardcoded."""
+        from PIL import ImageFont
+
+        def faces(script, sizes):
+            out = []
+            for name in pilfont._CANDIDATES[script]:
+                for want in sizes:
+                    try:
+                        out.append(ImageFont.truetype(name, want))
+                        break
+                    except (OSError, IOError):
+                        continue
+            return out
+
+        sym = faces("symbol", [24]) + faces("latin", [24])
+        emo = faces("emoji", [24] + list(pilfont._STRIKES))
+        if not sym or not emo:
+            self.skipTest("no symbol or emoji face installed here")
+        for lo, hi in pilfont._SYMBOL_RANGES:
+            for cp in range(lo, hi + 1):
+                ch = chr(cp)
+                if pilfont.script_of_char(cp) != "symbol":
+                    continue
+                if any(self._draws(f, ch) for f in sym):
+                    continue
+                if any(self._draws(f, ch) for f in emo):
+                    return ch
+        self.skipTest("this host's symbol chain orphans nothing the emoji "
+                      "chain has")
+
+    def test_an_orphaned_symbol_reaches_the_emoji_chain(self):
+        ch = self._orphan()
+        self.addCleanup(pilfont.clear_cache)
+        pilfont.clear_cache()
+        got = pilfont.font("symbol", 24, text=ch)
+        self.assertTrue(
+            self._draws(got, ch),
+            "U+%04X is drawn by no symbol face and by an emoji-chain face, "
+            "and still came back as tofu from %s"
+            % (ord(ch), getattr(got, "path", "?")))
+
+    def test_the_713_star_and_tick_still_come_from_the_symbol_chain(self):
+        """The control that matters: #713 was the rating star drawing as
+        tofu, and the fix was the symbol bucket. No colour face draws U+2605
+        or U+2713, so if the emoji edge ever outranked the symbol chain for
+        these, that regression comes straight back.
+        """
+        from PIL import ImageFont
+
+        self.addCleanup(pilfont.clear_cache)
+        pilfont.clear_cache()
+        for ch in ("★", "✓"):
+            got = pilfont.font("symbol", 24, text=ch)
+            self.assertTrue(self._draws(got, ch),
+                            "%r is tofu again (#713)" % ch)
+            first = None
+            for name in pilfont._CANDIDATES["symbol"]:
+                try:
+                    face = ImageFont.truetype(name, 24)
+                except (OSError, IOError):
+                    continue
+                if self._draws(face, ch):
+                    first = name
+                    break
+            if first is not None:
+                # Basenames: Pillow resolves a bare candidate name through
+                # the platform font path, so `got.path` is absolute and the
+                # candidate string may not be.
+                import os
+
+                self.assertEqual(
+                    os.path.basename(str(getattr(got, "path", ""))),
+                    os.path.basename(str(first)),
+                    "%r was moved off the symbol chain's own first answer"
+                    % ch)
 
 class TestEmojiTable(unittest.TestCase):
     """The classifier half of F31, and the regression it must not cause.

--- a/tests/test_mpvtk_pilfont.py
+++ b/tests/test_mpvtk_pilfont.py
@@ -999,15 +999,24 @@ class TestCjkCoverage(unittest.TestCase):
         self.assertEqual([], self._missing(font, korean),
                          "a Korean title resolved a Han-only face")
 
-    def test_the_arabic_face_is_still_chosen_for_a_line_with_ascii_in_it(self):
-        """Negative control for the deliberate decision at `pilfont.py:57`.
+    def test_the_arabic_face_is_still_chosen_for_a_pure_arabic_line(self):
+        """Negative control for the deliberate decision at `pilfont.py:57`,
+        **narrowed on purpose** once that decision was revisited.
 
-        `NotoSansArabic-Regular.ttf` has the Arabic and **no ASCII**
-        (measured), and the list keeps it first knowingly: the face that
-        would draw the Latin word gives up three quarters of the
-        presentation forms. A coverage check that asked the whole *line* to
-        be covered would silently overturn that. It asks only for the
-        codepoints of the script that chose the list.
+        `NotoSansArabic-Regular.ttf` has the Arabic and **no A-Z**
+        (measured), and the list keeps it first knowingly. The coverage
+        check must not overturn that by asking the whole *line* to be
+        covered as a matter of course -- so the script-only question is
+        what a run asks, and this pins it.
+
+        It used to assert the same thing for a line *with* ASCII in it, and
+        that half was retired deliberately, not because it was
+        inconvenient: `TestAnRtlLineCarriesWhatIsInIt` now prefers a face
+        that carries the whole line **for RTL lines only**, because such a
+        line gets one draw call and has no second run to fall back to. The
+        trade 12.1 refused was global -- one Arabic face for every line -
+        and this one is per line, so a pure Arabic title still keeps Noto's
+        737/773 presentation forms. That is the assertion left here.
         """
         from PIL import ImageFont
 
@@ -1022,13 +1031,13 @@ class TestCjkCoverage(unittest.TestCase):
 
         self.addCleanup(pilfont.clear_cache)
         pilfont.clear_cache()
-        got = pilfont.font_for("مسلسل (2013)", 24)
+        got = pilfont.font_for("مسلسل الحلقة", 24)
         self.assertEqual(
             [], self._missing(got, "مسلسل"),
             "the Arabic line lost its Arabic face")
         self.assertEqual(
             getattr(got, "path", None), getattr(face, "path", None),
-            "the Arabic line was moved off %s, which is the face "
+            "a pure Arabic line was moved off %s, which is the face "
             "pilfont.py:57-62 keeps first on purpose" % first)
 
     def test_the_notdef_probes_agree_on_every_installed_candidate(self):
@@ -1546,6 +1555,222 @@ class TestBucketBookkeeping(unittest.TestCase):
             self.assertEqual("thai", pilfont.script_of_char(cp))
         for cp in (0x0900, 0x097F):
             self.assertEqual("devanagari", pilfont.script_of_char(cp))
+
+class TestAnRtlLineCarriesWhatIsInIt(unittest.TestCase):
+    """An RTL line gets ONE face, so that face has to cover the whole line.
+
+    12.1 chose Noto Arabic's 737/773 presentation forms over having any
+    Latin, and said so: *"that is the wrong three quarters to give up for
+    the occasional Latin word."* **That trade was real when one face had to
+    serve every Arabic line, and coverage-based selection retired it** --
+    the choice is now per line, so a line with a Latin word in it can take
+    a face that carries both while every other Arabic line keeps Noto.
+
+    Measured 2026-09-08: `FreeSerif` joins Arabic (its advance for مسلسل
+    drops from 103 to 70 under Raqm, which is joining) and has full ASCII
+    including brackets, at 345/773 presentation forms. So the fallback is a
+    real Arabic face, not a Latin face with a few Arabic glyphs.
+
+    Hebrew has always behaved this way for an accidental reason -- Liberation
+    Sans happens to carry both -- and these tests make it deliberate for
+    both scripts.
+    """
+
+    def _line_faces(self, text, size=26):
+        """The faces `draw_text` will really use, and whether one covers
+        the whole line."""
+        fnt = pilfont.font_for(text, size)
+        parts, whole, per_run = pilfont._split(text, fnt, None)
+        if whole is not None:
+            return [(whole, text)]
+        return [(per_run(script, chunk)) and (per_run(script, chunk), chunk)
+                for script, chunk in parts]
+
+    def _tofu(self, text):
+        """Characters the line's own face(s) cannot draw.
+
+        **Asked of the face the LINE gets, not of a character drawn alone.**
+        A single Latin character resolves the Latin face on its own, so a
+        per-character `draw_text` reports no tofu for exactly the bug this
+        class is about -- measured, and it cost a probe.
+        """
+        bad = []
+        for face, chunk in self._line_faces(text):
+            ref = face.getmask("\U000FFFFF", mode="L")
+            rt = (ref.size, bytes(ref))
+            for ch in chunk:
+                if ch.isspace():
+                    continue
+                mask = face.getmask(ch, mode="L")
+                if (mask.size, bytes(mask)) == rt:
+                    bad.append(ch)
+        return "".join(bad)
+
+    def _needs_arabic_pair(self):
+        """Skip unless this host both reproduces the gap and can fix it."""
+        from PIL import ImageFont
+
+        first = None
+        for name in pilfont._CANDIDATES["arabic"]:
+            try:
+                face = ImageFont.truetype(name, 26)
+            except (OSError, IOError):
+                continue
+            first = face
+            break
+        if first is None:
+            self.skipTest("no Arabic face installed")
+        ref = first.getmask("\U000FFFFF", mode="L")
+        rt = (ref.size, bytes(ref))
+        if all((lambda m: (m.size, bytes(m)) != rt)(
+                first.getmask(c, mode="L")) for c in "Netflix()"):
+            self.skipTest("this host's first Arabic face already has Latin, "
+                          "so there is no gap to close (Windows is this)")
+
+    def test_an_arabic_line_with_a_latin_word_draws_the_word(self):
+        self._needs_arabic_pair()
+        self.addCleanup(pilfont.clear_cache)
+        pilfont.clear_cache()
+        self.assertEqual(
+            "", self._tofu("مسلسل Netflix الأصلي"),
+            "the Latin word in an Arabic line is boxes, and the line's one "
+            "face is the only one it gets")
+
+    def test_an_arabic_line_keeps_its_brackets(self):
+        self._needs_arabic_pair()
+        self.addCleanup(pilfont.clear_cache)
+        pilfont.clear_cache()
+        # Noto Arabic HAS the digits and lacks the brackets -- measured, so
+        # this is about "(" and ")" specifically and not about numerals.
+        self.assertEqual("", self._tofu("مسلسل (2013) الجزء 2"),
+                         "the brackets around the year are boxes")
+
+    def test_a_pure_arabic_line_still_gets_the_best_arabic_face(self):
+        """The control, and the reason this is a two-pass and not a
+        reordering: giving up presentation forms is only acceptable on the
+        lines that actually need the Latin. A pure Arabic line must keep
+        whatever the candidate order prefers."""
+        from PIL import ImageFont
+
+        self.addCleanup(pilfont.clear_cache)
+        pilfont.clear_cache()
+        first = None
+        for name in pilfont._CANDIDATES["arabic"]:
+            try:
+                ImageFont.truetype(name, 26)
+            except (OSError, IOError):
+                continue
+            first = name
+            break
+        if first is None:
+            self.skipTest("no Arabic face installed")
+        faces = self._line_faces("مسلسل الحلقة الأولى")
+        self.assertEqual(
+            os.path.basename(str(getattr(faces[0][0], "path", ""))),
+            os.path.basename(str(first)),
+            "a pure Arabic line was moved off the preferred Arabic face")
+
+    def test_a_hebrew_line_with_latin_and_punctuation_is_unchanged(self):
+        """Hebrew already passed, by accident. It must keep passing, and
+        for the same reason as before."""
+        self.addCleanup(pilfont.clear_cache)
+        pilfont.clear_cache()
+        self.assertEqual("", self._tofu("הסרט הזה, משנת 2013."))
+
+    def test_a_cjk_and_arabic_line_is_still_the_documented_loss(self):
+        """The case this deliberately does NOT fix, asserted so that a
+        later change cannot quietly claim it.
+
+        No installed face covers Arabic and CJK (unifont aside, which is not
+        a candidate and is not a UI face), so the line keeps its RTL face
+        and the CJK degrades. Splitting it needs UAX#9 run reordering --
+        whose paired-bracket rule is the fiddliest part of the algorithm and
+        one of the very cases above -- so a subset would be wrong exactly
+        where it mattered. jellyfin_mpv_shim/mpvtk/GUIDE.md section 12.1.
+        """
+        self.addCleanup(pilfont.clear_cache)
+        pilfont.clear_cache()
+        line = "進撃の巨人 مسلسل"
+        faces = self._line_faces(line)
+        self.assertEqual(1, len(faces), "an RTL line must be one face")
+        arabic = "".join(c for c in line if pilfont.has_rtl(c))
+        self.assertEqual("", self._tofu(line).replace(
+            "".join(c for c in line if pilfont.script_of_char(ord(c)) == "cjk"),
+            ""), "the Arabic itself must still be drawn")
+        self.assertNotEqual("", arabic)
+
+class TestKeycapSequences(unittest.TestCase):
+    """``1️⃣`` is base + U+FE0F + U+20E3, and only a colour emoji face
+    composes it.
+
+    **Not a coverage fault, which is why the `.notdef` check cannot see
+    it.** DejaVu *has* U+20E3 and draws it as a dotted enclosing box around
+    the digit, so every "is this glyph missing" test says the line is fine
+    while the sheet shows `1□ 2□`. The fault is that U+20E3 is in
+    :data:`_JOINERS` and rides with the digit before it, which made the run
+    "latin" and kept it off the only face that can compose it.
+
+    Only U+20E3 is treated this way. A bare U+FE0F is deliberately left
+    alone: it would move ``★️`` to the emoji face, and no colour face draws
+    U+2605 -- putting #713's tofu straight back (see :data:`_EMOJI_RANGES`).
+    """
+
+    def _draw(self, text, font):
+        from PIL import Image, ImageDraw
+
+        img = Image.new("RGB", (120, 90), (0, 0, 0))
+        pilfont.draw_text(ImageDraw.Draw(img), (2, 2), text, font,
+                          fill=(255, 255, 255))
+        return img.tobytes()
+
+    def _direct(self, text, font):
+        from PIL import Image, ImageDraw
+
+        img = Image.new("RGB", (120, 90), (0, 0, 0))
+        ImageDraw.Draw(img).text((2, 2), text, font=font,
+                                 fill=(255, 255, 255))
+        return img.tobytes()
+
+    def setUp(self):
+        self.addCleanup(pilfont.clear_cache)
+        pilfont.clear_cache()
+        if pilfont.font("emoji", 26) is pilfont.font("latin", 26):
+            self.skipTest("no separate emoji face on this host")
+
+    def test_the_run_is_not_drawn_by_the_latin_face(self):
+        """The effect, not the face name: before the fix `draw_text` and
+        the Latin face drew byte-identical pictures."""
+        latin = pilfont.font("latin", 26)
+        self.assertNotEqual(
+            self._draw("1️⃣", pilfont.font_for("1️⃣", 26)),
+            self._direct("1️⃣", latin),
+            "the keycap is still drawn exactly as the Latin face draws it")
+
+    def test_the_words_around_it_stay_on_their_own_face(self):
+        """The half that a naive fix breaks: the keycap's base has to be
+        peeled off the run it joined, or "Season 1️⃣" draws "Season " in a
+        109px colour-emoji face."""
+        parts = pilfont.runs("Season 1️⃣")
+        self.assertEqual(["latin", "emoji"], [script for script, _c in parts],
+                         "got %r" % (parts,))
+        self.assertEqual("Season ", parts[0][1])
+        self.assertEqual("1️⃣", parts[1][1])
+
+    def test_two_keycaps_in_a_row_are_one_run(self):
+        parts = pilfont.runs("1️⃣2️⃣")
+        self.assertEqual(["emoji"], [script for script, _c in parts],
+                         "got %r" % (parts,))
+
+    def test_a_keycap_with_nothing_before_it_does_not_crash(self):
+        self.assertIsInstance(pilfont.runs("⃣"), list)
+        self.assertIsInstance(pilfont.runs("️⃣"), list)
+
+    def test_a_star_with_a_variation_selector_stays_on_the_symbol_face(self):
+        """The #713 guard. U+FE0F alone must not reroute anything."""
+        parts = pilfont.runs("★️")
+        self.assertEqual(["symbol"], [script for script, _c in parts],
+                         "a variation selector moved the star off the "
+                         "symbol face, which is #713 again: %r" % (parts,))
 
 class TestEmojiTable(unittest.TestCase):
     """The classifier half of F31, and the regression it must not cause.

--- a/tests/test_text_sample_sheet.py
+++ b/tests/test_text_sample_sheet.py
@@ -79,19 +79,32 @@ class SampleSheetTest(unittest.TestCase):
                 any(pilfont.script_of_char(ord(c)) == "cjk" for c in text),
                 "%r has no CJK left to be outranked" % row[1])
 
-    def test_the_expected_boxes_notes_point_at_something_real(self):
-        """A row marked "boxes here are expected" is telling the reader not
-        to investigate, so it has to be true. Each one must cite where the
-        trade is written down."""
+    def test_every_explained_row_says_which_kind_of_expected_it_is(self):
+        """A row that tells the reader not to chase its boxes must say
+        **why not**, and the two reasons are not interchangeable.
+
+        A *documented trade* means stop looking, and has to cite where the
+        decision is written down. A *known gap* means the opposite -- it is
+        a real defect with work behind it -- and the sheet draws it red
+        rather than amber. A note that said neither would read as "fine"
+        for something that is not.
+        """
         tool = self._tool()
         marked = [r for r in tool.SAMPLES if len(r) > 3]
         self.assertTrue(marked, "no rows carry an explanation any more")
         for row in marked:
             note = row[3]
+            trade = "GUIDE" in note or "BY DESIGN" in note
+            gap = note.startswith("KNOWN GAP")
             self.assertTrue(
-                "GUIDE" in note or "BY DESIGN" in note,
-                "%r explains its boxes without citing the decision: %r"
+                trade or gap,
+                "%r explains its boxes as neither a cited trade nor a "
+                "KNOWN GAP, so a reader cannot tell whether to care: %r"
                 % (row[1], note))
+            self.assertFalse(
+                trade and gap,
+                "%r claims to be both a settled trade and a known gap"
+                % row[1])
 
 
 if __name__ == "__main__":

--- a/tests/test_text_sample_sheet.py
+++ b/tests/test_text_sample_sheet.py
@@ -1,0 +1,98 @@
+"""The sample sheet builds, and its sample table stays honest.
+
+`tools/shoot_text_samples.py` exists because no assertion here can see text
+drawn in the wrong order, letters that failed to join, or Traditional Chinese
+set in Japanese letterforms -- a person looking at a picture is the only
+instrument for those. That makes the tool a deliverable rather than a
+convenience, and an unrunnable one is worth nothing when it is next needed.
+
+So this pins the two things about it that can go stale silently: that it still
+builds an image through the real `pilfont` path, and that every row of its
+table still resolves the script it is filed under. It deliberately does **not**
+assert anything about the pixels; that is the whole point of the tool.
+"""
+
+if __name__ == "__main__":
+    import os
+    import sys
+
+    sys.path.insert(0, os.path.dirname(
+        os.path.dirname(os.path.abspath(__file__))))
+
+import unittest
+
+
+class SampleSheetTest(unittest.TestCase):
+    def _tool(self):
+        import importlib
+
+        try:
+            return importlib.import_module("tools.shoot_text_samples")
+        except ImportError as exc:            # pragma: no cover
+            self.skipTest("tool not importable: %s" % exc)
+
+    def test_the_sheet_builds(self):
+        tool = self._tool()
+        img = tool.build(size=18, width=900)
+        self.assertGreater(img.width, 0)
+        self.assertGreater(img.height, 0)
+        # Not a blank canvas: something was drawn on it. The cheapest
+        # possible check that the pilfont path ran at all -- a sheet that
+        # silently drew nothing would still have saved a valid PNG.
+        self.assertGreater(len(img.getcolors(maxcolors=1 << 20) or []), 3,
+                           "the sheet came out effectively blank")
+
+    def test_every_row_is_filed_under_the_script_it_resolves(self):
+        """A row moved to the wrong group, or a sample edited until it no
+        longer exercises what its label claims, is invisible in a picture --
+        the reader trusts the label. `script_of` is what decides the face,
+        so it is what the group has to agree with.
+        """
+        from jellyfin_mpv_shim.mpvtk import pilfont
+
+        tool = self._tool()
+        want = {"Right to left": ("hebrew", "arabic"),
+                "CJK -- one bucket, four languages": ("cjk",),
+                "Latin and neighbours": ("latin",)}
+        for row in tool.SAMPLES:
+            group, label, text = row[0], row[1], row[2]
+            if group not in want:
+                continue
+            self.assertIn(
+                pilfont.script_of(text), want[group],
+                "%r is filed under %r but resolves %r"
+                % (label, group, pilfont.script_of(text)))
+
+    def test_the_rtl_mix_rows_really_do_mix(self):
+        """The rows that demonstrate RTL outranking are only evidence if
+        they contain both scripts. An edit that dropped the CJK would leave
+        a row that looks fine and proves nothing."""
+        from jellyfin_mpv_shim.mpvtk import pilfont
+
+        tool = self._tool()
+        rows = [r for r in tool.SAMPLES if "RTL wins" in r[1]]
+        self.assertTrue(rows, "the RTL-precedence rows are gone")
+        for row in rows:
+            text = row[2]
+            self.assertTrue(pilfont.has_rtl(text), "%r has no RTL" % row[1])
+            self.assertTrue(
+                any(pilfont.script_of_char(ord(c)) == "cjk" for c in text),
+                "%r has no CJK left to be outranked" % row[1])
+
+    def test_the_expected_boxes_notes_point_at_something_real(self):
+        """A row marked "boxes here are expected" is telling the reader not
+        to investigate, so it has to be true. Each one must cite where the
+        trade is written down."""
+        tool = self._tool()
+        marked = [r for r in tool.SAMPLES if len(r) > 3]
+        self.assertTrue(marked, "no rows carry an explanation any more")
+        for row in marked:
+            note = row[3]
+            self.assertTrue(
+                "GUIDE" in note or "BY DESIGN" in note,
+                "%r explains its boxes without citing the decision: %r"
+                % (row[1], note))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tools/shoot_text_samples.py
+++ b/tools/shoot_text_samples.py
@@ -38,9 +38,13 @@ preload()
 from jellyfin_mpv_shim.mpvtk import pilfont  # noqa: E402
 
 #: ``(group, label, text)`` or ``(group, label, text, expected)``.
-#: ``expected`` names the rows where boxes are a **documented trade** rather
-#: than a defect, so a reader is not sent chasing one. Ordered so the plain
-#: cases come first and the ones that have actually broken come last.
+#: ``expected`` explains rows whose boxes a reader should not chase, and it
+#: must say which of two things it is: a **documented trade** (cite it, with
+#: "GUIDE ..." or "BY DESIGN") or a **known gap** (start it "KNOWN GAP"). The
+#: distinction is the whole value -- one means stop looking, the other means
+#: this is a bug with a ticket's worth of work behind it. A test holds the
+#: convention. Ordered so the plain cases come first and the ones that have
+#: actually broken come last.
 SAMPLES = [
     ("Latin and neighbours", "ASCII", "Blade Runner 2049"),
     ("Latin and neighbours", "accents", "Amélie · Señor · Křižík · Æther"),
@@ -74,6 +78,39 @@ SAMPLES = [
 
     ("Other scripts", "Thai", "ภาพยนตร์ไทย"),
     ("Other scripts", "Devanagari", "हिन्दी फ़िल्म"),
+
+    # `script_of_char` has buckets for latin/hebrew/arabic/devanagari/thai/
+    # cjk and nothing else, so everything here answers "latin" and is drawn
+    # by the Latin face -- which mostly does not have it. Measured on a box
+    # with the full Noto set INSTALLED: the faces are present and
+    # unreachable. Georgian and Armenian are in the group because DejaVu
+    # happens to cover them, which is what makes the rest of the group a
+    # gap rather than a platform limit.
+    ("No bucket in script_of_char -- a KNOWN GAP, not a font problem",
+     "Bengali", "বাংলা চলচ্চিত্র",
+     "KNOWN GAP: no bucket, so this resolves \"latin\". Noto has the face "
+     "and nothing can reach it. Needs a range in script_of_char plus a "
+     "candidate list -- not a missing font."),
+    ("No bucket in script_of_char -- a KNOWN GAP, not a font problem",
+     "Tamil", "தமிழ் திரைப்படம்"),
+    ("No bucket in script_of_char -- a KNOWN GAP, not a font problem",
+     "Telugu", "తెలుగు సినిమా"),
+    ("No bucket in script_of_char -- a KNOWN GAP, not a font problem",
+     "Gurmukhi", "ਪੰਜਾਬੀ ਫ਼ਿਲਮ"),
+    ("No bucket in script_of_char -- a KNOWN GAP, not a font problem",
+     "Kannada", "ಕನ್ನಡ ಚಲನಚಿತ್ರ"),
+    ("No bucket in script_of_char -- a KNOWN GAP, not a font problem",
+     "Sinhala", "සිංහල චිත්‍රපටය"),
+    ("No bucket in script_of_char -- a KNOWN GAP, not a font problem",
+     "Ethiopic", "አማርኛ ፊልም"),
+    ("No bucket in script_of_char -- a KNOWN GAP, not a font problem",
+     "Khmer", "ខ្មែរ ភាពយន្ត"),
+    ("No bucket in script_of_char -- a KNOWN GAP, not a font problem",
+     "Myanmar", "မြန်မာ ဇာတ်ကား"),
+    ("No bucket in script_of_char -- a KNOWN GAP, not a font problem",
+     "Georgian (DejaVu has it)", "ქართული ფილმი"),
+    ("No bucket in script_of_char -- a KNOWN GAP, not a font problem",
+     "Armenian (DejaVu has it)", "Հայերեն ֆիլմ"),
 
     ("Symbols and emoji", "symbol face", "★ 8.1 · ✓ · ▶ · ♪ · ⏸ · ⏭"),
     ("Symbols and emoji", "colour emoji", "🎬 🍿 ⭐ 🎵 📺"),
@@ -210,12 +247,16 @@ def build(size=26, width=1500):
                 else:
                     line = (line + " " + w).strip()
             lines.append(line)
-            put(330, y + int(size * 1.05), "boxes here are expected -- "
-                + lines[0], note_size - 1, (200, 170, 110))
+            gap = expected.startswith("KNOWN GAP")
+            # Red for a gap, amber for a trade: a reader must be able to
+            # tell "stop looking" from "this one is real" at a glance.
+            colour = (235, 120, 120) if gap else (200, 170, 110)
+            lead = "" if gap else "boxes here are expected -- "
+            put(330, y + int(size * 1.05), lead + lines[0], note_size - 1,
+                colour)
             for extra in lines[1:]:
                 y += 15
-                put(330, y + int(size * 1.05), extra, note_size - 1,
-                    (200, 170, 110))
+                put(330, y + int(size * 1.05), extra, note_size - 1, colour)
         y += row_h
 
     return img

--- a/tools/shoot_text_samples.py
+++ b/tools/shoot_text_samples.py
@@ -1,0 +1,246 @@
+"""Photograph how this build draws every script the UI has to draw.
+
+    xvfb-run -a python3 -m tools.shoot_text_samples            # Linux
+    "%USERPROFILE%\\jms\\venv\\Scripts\\python.exe" -m tools.shoot_text_samples
+
+**The question no test here can answer.** `tests/test_mpvtk_pilfont.py` can
+prove a glyph is not the face's own `.notdef`, which is the difference between
+a character and a box -- and that is all it can prove. It cannot see text drawn
+in the wrong *order*, an Arabic word whose letters failed to *join*, a line
+sitting on the wrong baseline, kerning that is subtly absent, or a Traditional
+Chinese title drawn with Japanese letterforms. Those are all correct-by-
+assertion and wrong on screen, and short of OCR the only instrument is a person
+looking. This makes the thing to look at.
+
+Everything is drawn through the shipping path -- `pilfont.font_for` for the
+face and `pilfont.draw_text` for the ink, the same two calls
+`mpvtk_browser.strips` makes for a tile caption -- so the sheet is evidence
+about the build it ran in and not about a private reimplementation.
+
+Each row names the face(s) that actually drew it, because "this looks wrong" is
+only actionable with that. The header names the platform, Pillow and whether
+Raqm is live: **without Raqm every right-to-left row below is expected to be
+wrong**, and a sheet that did not say so would look like a font bug.
+"""
+
+import argparse
+import os
+import sys
+
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+
+# Before PIL, always: `load_fribidi` runs once from `PyInit__imagingft`, so
+# this is the last moment it can matter. See win_fribidi.
+from jellyfin_mpv_shim.win_fribidi import preload, describe  # noqa: E402
+
+preload()
+
+from jellyfin_mpv_shim.mpvtk import pilfont  # noqa: E402
+
+#: ``(group, label, text)`` or ``(group, label, text, expected)``.
+#: ``expected`` names the rows where boxes are a **documented trade** rather
+#: than a defect, so a reader is not sent chasing one. Ordered so the plain
+#: cases come first and the ones that have actually broken come last.
+SAMPLES = [
+    ("Latin and neighbours", "ASCII", "Blade Runner 2049"),
+    ("Latin and neighbours", "accents", "Amélie · Señor · Křižík · Æther"),
+    ("Latin and neighbours", "Cyrillic", "Ведьмак · Иван Васильевич"),
+    ("Latin and neighbours", "Greek", "Ελλάδα · Οδύσσεια"),
+    ("Latin and neighbours", "kerning (AV pairs)", "AVATAR WAVY To Ta Ty"),
+
+    ("CJK -- one bucket, four languages", "zh-Hans (#736's title)",
+     "莲花 电视剧 第一季"),
+    ("CJK -- one bucket, four languages", "zh-Hans (more)",
+     "流浪地球 · 三体 · 战狼"),
+    ("CJK -- one bucket, four languages", "zh-Hant",
+     "後宮甄嬛傳 · 臺灣 · 鬼滅之刃"),
+    ("CJK -- one bucket, four languages", "ja (kanji+kana)",
+     "進撃の巨人 · ハウルの動く城"),
+    ("CJK -- one bucket, four languages", "ja (katakana)",
+     "ドラえもん · エヴァンゲリオン"),
+    ("CJK -- one bucket, four languages", "ko (Hangul)",
+     "오징어 게임 · 기생충"),
+    ("CJK -- one bucket, four languages", "fullwidth forms",
+     "（２０１３）　ＡＢＣ　！？"),
+
+    ("Right to left", "Arabic", "مسلسل الحلقة الأولى"),
+    ("Right to left", "Arabic + digits", "مسلسل (2013) الجزء 2",
+     "GUIDE 12.1: Noto Arabic has no ASCII and is first on purpose -- "
+     "the face that would draw the parens gives up 3/4 of the "
+     "presentation forms. Digits render; brackets are boxes."),
+    ("Right to left", "Hebrew", "שלום עולם"),
+    ("Right to left", "Hebrew + punctuation", "הסרט הזה, משנת 2013."),
+    ("Right to left", "Hebrew + niqqud", "בְּרֵאשִׁית"),
+
+    ("Other scripts", "Thai", "ภาพยนตร์ไทย"),
+    ("Other scripts", "Devanagari", "हिन्दी फ़िल्म"),
+
+    ("Symbols and emoji", "symbol face", "★ 8.1 · ✓ · ▶ · ♪ · ⏸ · ⏭"),
+    ("Symbols and emoji", "colour emoji", "🎬 🍿 ⭐ 🎵 📺"),
+    ("Symbols and emoji", "emoji ZWJ (one glyph)", "👩‍💻 👨‍👩‍👧 🏳️‍🌈"),
+    # Not marked expected: the keycap halves ARE boxes here and that is a
+    # real gap, not a trade. U+20E3 is in `_JOINERS` so it rides with the
+    # digit before it, which makes the run "latin" -- so the enclosing mark
+    # never reaches the emoji face. Left for a reader to judge.
+    ("Symbols and emoji", "keycap + variation sel.", "1️⃣ 2️⃣ ☂️ ❤️"),
+    ("Symbols and emoji", "symbol orphans (12.4)", "⌒ ⌓ ⎰ 〈 〉"),
+
+    ("Mixes -- where it breaks", "CJK + Latin year",
+     "進撃の巨人 (2013)"),
+    ("Mixes -- where it breaks", "CJK + Latin words",
+     "君の名は。 your name."),
+    ("Mixes -- where it breaks", "zh + ja in one line",
+     "莲花电视剧 進撃の巨人"),
+    ("Mixes -- where it breaks", "CJK + Arabic (RTL wins)",
+     "進撃の巨人 مسلسل",
+     "BY DESIGN: an RTL line gets ONE face (Pillow cannot reorder bidi "
+     "across draw calls) and RTL outranks, so the CJK is what degrades. "
+     "Reordered text is a wrong line where tofu is only an ugly one."),
+    ("Mixes -- where it breaks", "CJK + Hebrew (RTL wins)",
+     "進撃の巨人 שלום",
+     "BY DESIGN, same as above -- though Liberation Hebrew happens to "
+     "carry the Latin, so only the CJK boxes."),
+    ("Mixes -- where it breaks", "Latin + emoji + star",
+     "Dune ⭐ 8.1 🎬 (2021)"),
+    ("Mixes -- where it breaks", "every script at once",
+     "Aあ莲한مسلسلשלוםไทยहिन्दी★🎬",
+     "BY DESIGN: it contains RTL, so the whole line is one face and "
+     "almost everything else boxes. No face covers this and none can."),
+    ("Mixes -- where it breaks", "Arabic + Latin word",
+     "مسلسل Netflix الأصلي",
+     "GUIDE 12.1, knowingly: the Latin word in an Arabic line is boxes."),
+    ("Mixes -- where it breaks", "CJK + symbol",
+     "進撃の巨人 ★ 8.1"),
+]
+
+#: A codepoint that can never be assigned, so every face draws its own
+#: no-glyph mark for it. Printed once at the top as the reference: anything
+#: below that looks like THIS is tofu.
+TOFU = "\U000FFFFF"
+
+
+def _faces_for(text, size, bold=False):
+    """The face names `draw_text` will actually use, run by run."""
+    fnt = pilfont.font_for(text, size, bold)
+    parts, whole, per_run = pilfont._split(text, fnt, None)
+    if whole is not None:
+        used = [whole]
+    else:
+        used = [per_run(script, chunk) for script, chunk in parts]
+    names = []
+    for f in used:
+        name = os.path.basename(str(getattr(f, "path", "") or "builtin"))
+        if name not in names:
+            names.append(name)
+    return fnt, names
+
+
+def build(size=26, width=1500):
+    from PIL import Image, ImageDraw
+
+    label_size = 15
+    note_size = 13
+    row_h = int(size * 2.4)
+    explained = sum(1 for r in SAMPLES if len(r) > 3)
+    head_h = 150
+    groups = []
+    for row in SAMPLES:
+        if row[0] not in groups:
+            groups.append(row[0])
+    height = (head_h + len(SAMPLES) * row_h
+              + len(groups) * int(size * 1.9) + explained * 34 + 60)
+
+    img = Image.new("RGB", (width, height), (24, 24, 28))
+    draw = ImageDraw.Draw(img)
+
+    def put(x, y, text, px, fill, bold=False):
+        fnt = pilfont.font_for(text, px, bold)
+        pilfont.draw_text(draw, (x, y), text, fnt, fill=fill)
+
+    y = 14
+    put(20, y, "Text rendering sample sheet -- jellyfin-mpv-shim", 24,
+        (255, 255, 255), bold=True)
+    y += 34
+    from PIL import features
+    import PIL
+
+    put(20, y, "platform %s   Pillow %s   %s" % (
+        sys.platform, PIL.__version__, describe()), note_size, (170, 175, 185))
+    y += 20
+    put(20, y, "raqm=%s  fribidi=%s  harfbuzz=%s   <- with raqm=False every "
+        "right-to-left row below is EXPECTED to be wrong (unjoined, "
+        "unreordered) and unkerned" % (
+            features.check("raqm"), features.version("fribidi"),
+            features.version("harfbuzz")), note_size, (170, 175, 185))
+    y += 22
+    put(20, y, "reference: an unassigned codepoint, i.e. what tofu looks "
+        "like here ->", note_size, (170, 175, 185))
+    put(560, y - 4, TOFU * 4, size, (255, 120, 120))
+    y += 28
+    put(20, y, "each row: label / the text as the UI draws it / the face(s) "
+        "that drew it", note_size, (140, 145, 155))
+    y += 30
+
+    current = None
+    for row in SAMPLES:
+        group, label, text = row[0], row[1], row[2]
+        expected = row[3] if len(row) > 3 else None
+        if group != current:
+            current = group
+            y += int(size * 0.7)
+            put(20, y, group, 19, (120, 200, 255), bold=True)
+            draw.line([(20, y + 26), (width - 20, y + 26)],
+                      fill=(60, 62, 70), width=1)
+            y += int(size * 1.2)
+        put(24, y + 6, label, label_size, (150, 155, 165))
+        try:
+            fnt, names = _faces_for(text, size)
+            pilfont.draw_text(draw, (330, y), text, fnt, fill=(240, 240, 245))
+            note = " + ".join(names)
+        except Exception as exc:                     # noqa: BLE001
+            note = "%s: %s" % (type(exc).__name__, exc)
+            put(330, y, "<raised>", size, (255, 90, 90))
+        put(1080, y + 6, note[:58], note_size, (130, 170, 130))
+        if expected:
+            words, line, lines = expected.split(), "", []
+            for w in words:
+                if len(line) + len(w) + 1 > 74:
+                    lines.append(line)
+                    line = w
+                else:
+                    line = (line + " " + w).strip()
+            lines.append(line)
+            put(330, y + int(size * 1.05), "boxes here are expected -- "
+                + lines[0], note_size - 1, (200, 170, 110))
+            for extra in lines[1:]:
+                y += 15
+                put(330, y + int(size * 1.05), extra, note_size - 1,
+                    (200, 170, 110))
+        y += row_h
+
+    return img
+
+
+def main(argv=None):
+    ap = argparse.ArgumentParser(description=__doc__)
+    ap.add_argument("-o", "--out", default=None,
+                    help="output PNG (default: text-samples-<platform>.png "
+                         "in the current directory)")
+    ap.add_argument("--size", type=int, default=26,
+                    help="pixel size for the sample text (default 26)")
+    args = ap.parse_args(argv)
+
+    out = args.out or ("text-samples-%s.png" % sys.platform)
+    img = build(size=args.size)
+    img.save(out)
+    print("wrote %s (%dx%d)" % (out, img.width, img.height))
+    print(describe())
+    for (script, bold), name in sorted(
+            pilfont._resolved.items(), key=lambda kv: str(kv[0])):
+        print("  resolved %-11s bold=%-5s -> %s"
+              % (script, bold, os.path.basename(str(name)) if name else None))
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tools/shoot_text_samples.py
+++ b/tools/shoot_text_samples.py
@@ -178,14 +178,17 @@ def build(size=26, width=1500):
     label_size = 15
     note_size = 13
     row_h = int(size * 2.4)
-    explained = sum(1 for r in SAMPLES if len(r) > 3)
+    # Budget exactly what the row loop adds for an explained row, or the
+    # last rows fall off the bottom of the canvas.
+    explained = sum(12 + max(0, (len(r[3]) // 74)) * 16
+                    for r in SAMPLES if len(r) > 3)
     head_h = 150
     groups = []
     for row in SAMPLES:
         if row[0] not in groups:
             groups.append(row[0])
     height = (head_h + len(SAMPLES) * row_h
-              + len(groups) * int(size * 1.9) + explained * 34 + 60)
+              + len(groups) * int(size * 1.9) + explained + 80)
 
     img = Image.new("RGB", (width, height), (24, 24, 28))
     draw = ImageDraw.Draw(img)
@@ -238,26 +241,31 @@ def build(size=26, width=1500):
             note = "%s: %s" % (type(exc).__name__, exc)
             put(330, y, "<raised>", size, (255, 90, 90))
         put(1080, y + 6, note[:58], note_size, (130, 170, 130))
-        if expected:
-            words, line, lines = expected.split(), "", []
-            for w in words:
-                if len(line) + len(w) + 1 > 74:
-                    lines.append(line)
-                    line = w
-                else:
-                    line = (line + " " + w).strip()
-            lines.append(line)
-            gap = expected.startswith("KNOWN GAP")
-            # Red for a gap, amber for a trade: a reader must be able to
-            # tell "stop looking" from "this one is real" at a glance.
-            colour = (235, 120, 120) if gap else (200, 170, 110)
-            lead = "" if gap else "boxes here are expected -- "
-            put(330, y + int(size * 1.05), lead + lines[0], note_size - 1,
-                colour)
-            for extra in lines[1:]:
-                y += 15
-                put(330, y + int(size * 1.05), extra, note_size - 1, colour)
-        y += row_h
+        if not expected:
+            y += row_h
+            continue
+        words, line, lines = expected.split(), "", []
+        for w in words:
+            if len(line) + len(w) + 1 > 74:
+                lines.append(line)
+                line = w
+            else:
+                line = (line + " " + w).strip()
+        lines.append(line)
+        gap = expected.startswith("KNOWN GAP")
+        # Red for a gap, amber for a trade: a reader must be able to tell
+        # "stop looking" from "this one is real" at a glance.
+        colour = (235, 120, 120) if gap else (200, 170, 110)
+        lead = "" if gap else "boxes here are expected -- "
+        # **Below the sample's descender, not beside it.** `draw_text`
+        # anchors "la", so the sample occupies roughly one full ascent plus
+        # descent from `y`; at `size * 1.05` the note landed on top of the
+        # Arabic it was explaining.
+        note_y = y + int(size * 1.55)
+        put(330, note_y, lead + lines[0], note_size - 1, colour)
+        for i, extra in enumerate(lines[1:], start=1):
+            put(330, note_y + i * 16, extra, note_size - 1, colour)
+        y += row_h + 12 + max(0, len(lines) - 1) * 16
 
     return img
 

--- a/tools/shoot_text_samples.py
+++ b/tools/shoot_text_samples.py
@@ -79,37 +79,36 @@ SAMPLES = [
     ("Other scripts", "Thai", "ภาพยนตร์ไทย"),
     ("Other scripts", "Devanagari", "हिन्दी फ़िल्म"),
 
-    # `script_of_char` has buckets for latin/hebrew/arabic/devanagari/thai/
-    # cjk and nothing else, so everything here answers "latin" and is drawn
-    # by the Latin face -- which mostly does not have it. Measured on a box
-    # with the full Noto set INSTALLED: the faces are present and
-    # unreachable. Georgian and Armenian are in the group because DejaVu
-    # happens to cover them, which is what makes the rest of the group a
-    # gap rather than a platform limit.
-    ("No bucket in script_of_char -- a KNOWN GAP, not a font problem",
-     "Bengali", "বাংলা চলচ্চিত্র",
-     "KNOWN GAP: no bucket, so this resolves \"latin\". Noto has the face "
-     "and nothing can reach it. Needs a range in script_of_char plus a "
-     "candidate list -- not a missing font."),
-    ("No bucket in script_of_char -- a KNOWN GAP, not a font problem",
+    # These had no bucket in `script_of_char` at all, so every codepoint
+    # answered "latin", got the Latin face and drew as boxes -- on a box
+    # with the full Noto set installed and on a stock Windows 10, both of
+    # which ship a face for every one of them. Georgian and Armenian stay
+    # in the group because DejaVu happens to cover them, which is what made
+    # the rest look like a platform limit rather than a bug.
+    #
+    # Armenian still has no bucket and does not need one: nothing measured
+    # draws it that the Latin chain does not already reach.
+    ("Scripts that had no bucket until now",
+     "Bengali", "বাংলা চলচ্চিত্র"),
+    ("Scripts that had no bucket until now",
      "Tamil", "தமிழ் திரைப்படம்"),
-    ("No bucket in script_of_char -- a KNOWN GAP, not a font problem",
+    ("Scripts that had no bucket until now",
      "Telugu", "తెలుగు సినిమా"),
-    ("No bucket in script_of_char -- a KNOWN GAP, not a font problem",
+    ("Scripts that had no bucket until now",
      "Gurmukhi", "ਪੰਜਾਬੀ ਫ਼ਿਲਮ"),
-    ("No bucket in script_of_char -- a KNOWN GAP, not a font problem",
+    ("Scripts that had no bucket until now",
      "Kannada", "ಕನ್ನಡ ಚಲನಚಿತ್ರ"),
-    ("No bucket in script_of_char -- a KNOWN GAP, not a font problem",
+    ("Scripts that had no bucket until now",
      "Sinhala", "සිංහල චිත්‍රපටය"),
-    ("No bucket in script_of_char -- a KNOWN GAP, not a font problem",
+    ("Scripts that had no bucket until now",
      "Ethiopic", "አማርኛ ፊልም"),
-    ("No bucket in script_of_char -- a KNOWN GAP, not a font problem",
+    ("Scripts that had no bucket until now",
      "Khmer", "ខ្មែរ ភាពយន្ត"),
-    ("No bucket in script_of_char -- a KNOWN GAP, not a font problem",
+    ("Scripts that had no bucket until now",
      "Myanmar", "မြန်မာ ဇာတ်ကား"),
-    ("No bucket in script_of_char -- a KNOWN GAP, not a font problem",
+    ("Scripts that had no bucket until now",
      "Georgian (DejaVu has it)", "ქართული ფილმი"),
-    ("No bucket in script_of_char -- a KNOWN GAP, not a font problem",
+    ("Scripts that had no bucket until now",
      "Armenian (DejaVu has it)", "Հայերեն ֆիլմ"),
 
     ("Symbols and emoji", "symbol face", "★ 8.1 · ✓ · ▶ · ♪ · ⏸ · ⏭"),

--- a/tools/shoot_text_samples.py
+++ b/tools/shoot_text_samples.py
@@ -68,10 +68,7 @@ SAMPLES = [
      "（２０１３）　ＡＢＣ　！？"),
 
     ("Right to left", "Arabic", "مسلسل الحلقة الأولى"),
-    ("Right to left", "Arabic + digits", "مسلسل (2013) الجزء 2",
-     "GUIDE 12.1: Noto Arabic has no ASCII and is first on purpose -- "
-     "the face that would draw the parens gives up 3/4 of the "
-     "presentation forms. Digits render; brackets are boxes."),
+    ("Right to left", "Arabic + digits", "مسلسل (2013) الجزء 2"),
     ("Right to left", "Hebrew", "שלום עולם"),
     ("Right to left", "Hebrew + punctuation", "הסרט הזה, משנת 2013."),
     ("Right to left", "Hebrew + niqqud", "בְּרֵאשִׁית"),
@@ -143,8 +140,7 @@ SAMPLES = [
      "BY DESIGN: it contains RTL, so the whole line is one face and "
      "almost everything else boxes. No face covers this and none can."),
     ("Mixes -- where it breaks", "Arabic + Latin word",
-     "مسلسل Netflix الأصلي",
-     "GUIDE 12.1, knowingly: the Latin word in an Arabic line is boxes."),
+     "مسلسل Netflix الأصلي"),
     ("Mixes -- where it breaks", "CJK + symbol",
      "進撃の巨人 ★ 8.1"),
 ]


### PR DESCRIPTION
Contains two fixes:
1. Fixes font selection for runs of glyphs from different character sets
2. Fixes flatpak ci test builds, which didn't get the raqm fix Windows needed