### PR TITLE
Fix Wayland clipboard past on newer WMs

### DIFF
--- a/docs/mpv-backends.md
+++ b/docs/mpv-backends.md
@@ -815,10 +815,23 @@ Measured on an X11 session with `JMS-CLIP-TEST-42` on the clipboard:
 | plain read | `[]` |
 | after `update-clipboard` | `[JMS-CLIP-TEST-42]` |
 
-So every Linux paste fell through to the `wl-paste`/`xclip`/`xsel` helpers.
-That works on a desktop that has them and **inserts nothing in the Flatpak,
-which ships none** — which is why the bug reproduced for some users only and
-looked unexplained.
+So every Linux paste fell through to the `wl-paste`/`xclip`/`xsel` helpers,
+and **which helper it finds is the rest of the bug**:
+
+- **X11 session, any packaging** — `xclip` reads the same clipboard the user
+  copied into. Paste worked, which is why plenty of users saw nothing wrong.
+- **Wayland session, host install** — `wl-paste` is normally present, so it
+  worked there too.
+- **Wayland session, Flatpak** — the manifest ships `xclip` (module at
+  `flatpak/…json:90`) and **not** `wl-clipboard`, so `clip_tools` falls to
+  `xclip`, which talks to **XWayland — a different clipboard from the one the
+  user copied into**. Paste silently inserted the wrong thing or nothing.
+
+That last row is the reported case, and the shape of it — works for some
+users, not others, no error either way — is why it looked unexplained. An
+earlier version of this section said the Flatpak "ships none of them", which
+is wrong: it ships `xclip`, and shipping the *wrong* helper for the session is
+worse than shipping none, because the fallback then appears to succeed.
 
 ### The wait is bounded, and the bound is the only thing protecting the UI
 
@@ -846,9 +859,39 @@ writes to whichever textbox has focus, so a callback can land after focus moved
 or the scene was rebuilt, which is the stale-capture class `docs/browser-shell.md`
 exists to warn about. A 20 ms ceiling is the cheaper correctness.
 
-Shipping `wl-clipboard` in the Flatpak is still worth doing, but it is the belt:
-with the refresh in place the helpers are a fallback again rather than the only
-path that ever worked.
+### The Flatpak does not need `wl-clipboard` — measured
+
+The obvious conclusion from the above is to ship `wl-clipboard` so the Wayland
+fallback is the *right* clipboard. **Measured, and it is not needed**, because
+with mpv from master there is no Wayland gap left for a helper to fill:
+
+| compositor | mpv backend | how the data arrives | refresh needed? |
+|---|---|---|---|
+| has `ext-data-control-v1` | `wayland` | it has `update_data` | yes — and `clip_get` sends it |
+| lacks it | `vo` | compositor pushes the selection offer | **no** |
+
+The second row is the one worth measuring, and it was: under a **headless**
+sway 1.10.1 (which advertises only `zwlr_data_control_manager_v1`, so mpv falls
+to `vo`), `clipboard/text` read `WL-CLIP-VALUE` immediately, with no
+`update-clipboard` and with mpv's own `focused` property reporting `no`. The
+`vo` backend has no `update_data` hook precisely because it does not need one.
+
+**A nested sway on X11 cannot test this and will tell you the opposite.** The
+first attempt ran sway with `WLR_BACKENDS=x11`; its host window never had
+keyboard focus from a non-interactive shell, so the seat had *no* focus at all
+(`swaymsg -t get_tree` reported zero focused nodes before mpv even started) and
+the property read `nil` forever. Use `WLR_BACKENDS=headless WLR_RENDERER=pixman`
+with `--vo=wlshm`, which owns its own seat.
+
+So the helpers stay a fallback for **mpv <= 0.41 only** — no `update-clipboard`,
+and `clipboard-x11.c` declines under Wayland unless `--clipboard-xwayland=yes`.
+The Flatpak pins master, so that case cannot arise there, and adding a
+dependency to cover it would be paying for a configuration the package cannot
+be in.
+
+The `wayland` backend path itself was **not** exercised here (sway 1.10.1 is
+wlroots 0.18 and has no `ext-data-control-v1`); it is the same code path as
+`x11` — both declare `update_data` — and the x11 half is measured above.
 
 ## 12. The on-screen controls, and the user's own OSC
 

--- a/docs/mpv-backends.md
+++ b/docs/mpv-backends.md
@@ -889,9 +889,27 @@ The Flatpak pins master, so that case cannot arise there, and adding a
 dependency to cover it would be paying for a configuration the package cannot
 be in.
 
-The `wayland` backend path itself was **not** exercised here (sway 1.10.1 is
-wlroots 0.18 and has no `ext-data-control-v1`); it is the same code path as
-`x11` — both declare `update_data` — and the x11 half is measured above.
+### Every branch of the fork, measured
+
+The `wayland` backend needed a compositor with `ext-data-control-v1`, which
+nothing wlroots-0.18 has. **Hyprland has it** — measured by grepping the
+binaries, and it is the only such compositor packaged for Debian trixie
+(`ext_data_control_manager_v1` present in `/usr/bin/Hyprland`; absent from
+mutter 48.7, KWin 6.3.6, and everything on Debian's wlroots 0.18). Run it
+nested inside a headless sway, because aquamarine needs a seat and there is
+no logind session in a test shell.
+
+| session | mpv backend | before refresh | after refresh |
+|---|---|---|---|
+| X11 | `x11` | `[]` | correct |
+| Wayland, **no** `ext-data-control` (sway 1.10.1, KWin 6.3.6) | `vo` | **already correct** | n/a — `vo` has no `update_data` |
+| Wayland, **with** `ext-data-control` (Hyprland 0.55.2) | `wayland` | `[]` for 4.9 s straight | correct, refresh took 0.62 ms |
+
+The third row is #739's reported case. KWin gained `ext-data-control` after
+6.3.6, so a Plasma new enough to have it puts mpv on the `wayland` backend and
+the property is stale — while an older KWin lands on `vo` and works, which is
+why the same build pasted fine when smoke-tested on Debian's KWin 6.3.6 and
+failed for a reporter on Fedora KDE 44.
 
 ## 12. The on-screen controls, and the user's own OSC
 

--- a/docs/mpv-backends.md
+++ b/docs/mpv-backends.md
@@ -792,6 +792,64 @@ Two scope limits, both load-bearing:
 The suspend does nothing at all on an mpv without the option (built without
 gpu-next, or too old) — reading it is how we find that out.
 
+## 11a. The clipboard property is outdated until you ask for it
+
+**`clipboard/text` is not a live value on Linux**, and reading it as if it were
+is the whole of #739 — paste inserted nothing, for a reason that had nothing to
+do with which backends were enabled.
+
+Three facts from mpv's own source at our pin (`182fa6ca49`):
+
+- **Only `x11` and `wayland` implement `update_data`** — the two Linux backends.
+  `win32` and `mac` do not need it.
+- **`--clipboard-monitor` defaults to `no`** (`player/clipboard/clipboard.c`
+  sets no default in `clipboard_conf.defaults`), so nothing polls for changes.
+- mpv's commit adding the command (`f7f7cf18f3`, an ancestor of our pin) states
+  the contract outright: *"The client now needs to run this command to update
+  the clipboard content, otherwise the property value is outdated."*
+
+Measured on an X11 session with `JMS-CLIP-TEST-42` on the clipboard:
+
+| | `clipboard/text` |
+|---|---|
+| plain read | `[]` |
+| after `update-clipboard` | `[JMS-CLIP-TEST-42]` |
+
+So every Linux paste fell through to the `wl-paste`/`xclip`/`xsel` helpers.
+That works on a desktop that has them and **inserts nothing in the Flatpak,
+which ships none** — which is why the bug reproduced for some users only and
+looked unexplained.
+
+### The wait is bounded, and the bound is the only thing protecting the UI
+
+`update-clipboard` is `{type, timeout_ms}`, `.spawn_thread = true`, and
+`cmd_update_clipboard` calls `mp_core_unlock` before waiting — so **playback is
+never affected**; only the caller waits. Measured wall-clock (`mp.get_time()`,
+not `os.clock()`, which is CPU time and reports 0.1ms for any wait):
+
+| clipboard state | timeout | actual block |
+|---|---|---|
+| healthy owner | 1–200 ms | **0.18–0.28 ms** |
+| nothing owns the selection | 10 / 50 ms | 0.27 / 0.28 ms |
+| **owner alive and not answering** | 10 / 50 / 200 ms | **10.1 / 50.1 / 200.1 ms** |
+| any | 0 ms | returns immediately, and **does not fetch** |
+
+The wait ends when the notification arrives, so the timeout is a *ceiling on a
+wedged owner* and not a budget for a working one. The unresponsive case was
+simulated with a `SIGSTOP`ped `xclip` still holding the X selection — that is
+the hang mpv designed the worker thread and `mp_cancel` around, and it is real.
+
+`renderer.lua`'s `clip_get` therefore issues it **synchronously with a 20 ms
+ceiling**: about one frame in the worst case, nothing measurable in the normal
+one. Async was the obvious alternative and is the wrong trade here — `tb_insert`
+writes to whichever textbox has focus, so a callback can land after focus moved
+or the scene was rebuilt, which is the stale-capture class `docs/browser-shell.md`
+exists to warn about. A 20 ms ceiling is the cheaper correctness.
+
+Shipping `wl-clipboard` in the Flatpak is still worth doing, but it is the belt:
+with the refresh in place the helpers are a fallback again rather than the only
+path that ever worked.
+
 ## 12. The on-screen controls, and the user's own OSC
 
 `osc_style` has four values and only three of them are ours. `default` means

--- a/jellyfin_mpv_shim/messages/base.pot
+++ b/jellyfin_mpv_shim/messages/base.pot
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: jellyfin-mpv-shim\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2026-09-07 17:35-0400\n"
+"POT-Creation-Date: 2026-09-08 22:26-0400\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -2548,6 +2548,13 @@ msgstr ""
 msgid ""
 "Install the \"%(package)s\" package (for example \"apt install "
 "%(package)s\"), or use MPV 0.41 or newer."
+msgstr ""
+
+#: jellyfin_mpv_shim/mpvtk_browser/dialogs.py
+#, python-format
+msgid ""
+"Install the \"%(package)s\" package (for example \"apt install "
+"%(package)s\")."
 msgstr ""
 
 #: jellyfin_mpv_shim/mpvtk_browser/dialogs.py

--- a/jellyfin_mpv_shim/mpvtk/renderer.lua
+++ b/jellyfin_mpv_shim/mpvtk/renderer.lua
@@ -398,6 +398,50 @@ local function clip_set(text)
 end
 
 local function clip_get()
+    -- **`clipboard/text` is OUTDATED until we ask for it**, and asking is
+    -- the whole of #739. mpv's x11 and wayland backends are the only two
+    -- with an `update_data` hook, `--clipboard-monitor` defaults to no, and
+    -- mpv's own commit for the command states the contract: "the client now
+    -- needs to run this command to update the clipboard content, otherwise
+    -- the property value is outdated". So on Linux this read returned the
+    -- stale value -- empty -- every time, paste fell through to the helpers
+    -- below, and the Flatpak ships none of them. Measured at our pin on an
+    -- X11 session: empty before the command, correct after.
+    --
+    -- **Synchronous with a ceiling, and both halves are measured.** The wait
+    -- ends when the notification arrives, not when the timeout does: 0.2ms
+    -- for a healthy clipboard and 0.3ms when nothing owns the selection. It
+    -- burns the WHOLE timeout only for an owner that is alive and does not
+    -- answer -- simulated with a SIGSTOPped xclip still holding the
+    -- selection, where 10/50/200ms timeouts blocked 10.1/50.1/200.1ms. 20ms
+    -- caps that at about one frame, and `cmd_update_clipboard` unlocks the
+    -- core before waiting, so playback is untouched either way and only this
+    -- script pauses. docs/mpv-backends.md has the numbers.
+    --
+    -- **Deliberately not async.** `tb_insert` writes to whichever textbox
+    -- has focus, so a callback can land after focus moved or the scene was
+    -- rebuilt -- the stale-capture bug this file warns about everywhere
+    -- else. A 20ms ceiling is the cheaper correctness.
+    --
+    -- **Probed, not just pcall'd, because the command is master-only.** It
+    -- is in neither v0.40.0 nor v0.41.0, and `mp.command_native` does not
+    -- raise for a command mpv lacks -- it returns nil plus "invalid
+    -- parameter" and mpv logs `Command 'update-clipboard' not found.` at
+    -- ERROR level. A pcall would swallow the value and leave the log line,
+    -- once per paste, on a version this client supports. `command-list` is
+    -- 87 entries in 0.6ms, cached like `clip_tools`.
+    if state.clip_update == nil then
+        state.clip_update = false
+        for _, c in ipairs(mp.get_property_native('command-list') or {}) do
+            if c.name == 'update-clipboard' then
+                state.clip_update = true
+                break
+            end
+        end
+    end
+    if state.clip_update then
+        pcall(mp.command_native, { 'update-clipboard', 'text', 20 })
+    end
     local ok, v = pcall(mp.get_property, 'clipboard/text')
     if ok and v and v ~= '' then return v end
     for _, tool in ipairs(clip_tools()) do

--- a/jellyfin_mpv_shim/mpvtk_browser/dialogs.py
+++ b/jellyfin_mpv_shim/mpvtk_browser/dialogs.py
@@ -1053,21 +1053,34 @@ class DialogsMixin:
         the text field being broken; say what to install.
         The renderer raises this at most once per session.
 
-        The default backend list is win32,mac,wayland,**x11**,vo -- this
-        said the x11 entry was absent until it was read from mpv's source.
-        The advice below is still stale for a different reason: on Wayland
-        `--clipboard-xwayland` defaults to no, so a NEWER mpv does not help
-        either, and the flatpak is already on master. Fixing the string is
-        #739's work, not this comment's -- it is translated, so it moves
-        with the .pot."""
+        **The "or use MPV 0.41 or newer" half used to be said to everyone,
+        and on Wayland it is wrong** -- mpv's x11 clipboard backend declines
+        to start whenever WAYLAND_DISPLAY is set unless
+        `--clipboard-xwayland=yes`, which defaults to no, so no upgrade
+        helps there. #739's reporter was on a Flatpak already running master
+        and said as much: *"it is assumed that the mentioned mpv version
+        from the error is already being used ... suggests something more is
+        going on."* They were right, and the advice sent them after the
+        wrong thing.
+
+        `need` carries the session: the renderer picks the package from it
+        (`clip_tools`), so wl-clipboard means Wayland and xclip/xsel mean
+        X11. On X11 the upgrade advice is genuinely useful and stays."""
         if op == "copy":
             text = _("Copying to the clipboard is not available.")
         else:
             text = _("Pasting from the clipboard is not available.")
-        if need:
+        if need in ("xclip", "xsel"):
+            # X11: both remedies are real, and this msgid is unchanged so
+            # its existing translations survive.
             text += " " + (
                 _('Install the "%(package)s" package (for example '
                   '"apt install %(package)s"), or use MPV 0.41 or newer.')
+                % {"package": need})
+        elif need:
+            text += " " + (
+                _('Install the "%(package)s" package (for example '
+                  '"apt install %(package)s").')
                 % {"package": need})
         else:
             text += " " + _("Use MPV 0.41 or newer.")

--- a/tests/lua/fake_mp.lua
+++ b/tests/lua/fake_mp.lua
@@ -240,8 +240,39 @@ function mp.commandv(...)
     return true
 end
 
+--- Model mpv's real clipboard behaviour: the x11 and wayland backends are
+--- the only ones with an `update_data` hook and `--clipboard-monitor`
+--- defaults to **no**, so `clipboard/text` reads EMPTY until the client
+--- issues `update-clipboard`. mpv's own commit for that command says it:
+--- *"the client now needs to run this command to update the clipboard
+--- content, otherwise the property value is outdated."*
+---
+--- **This fake answered the property straight away, which is exactly why
+--- nothing here could see #739.** Set this and the property behaves like
+--- the two Linux backends do.
+M.clipboard_needs_update = false
+local clipboard_fetched = false
+
+--- `command-list`, so a capability probe can find (or miss) a command.
+--- Defaults to having `update-clipboard`; drop it to model mpv <= 0.41,
+--- which does not.
+M.commands_available = { "update-clipboard" }
+
+function M.reset_clipboard()
+    M.clipboard_needs_update = false
+    clipboard_fetched = false
+    -- NOT commands_available: the renderer caches its capability probe for
+    -- the life of the script, so a reset here would claim to change
+    -- something that cannot change and make a test pass for the wrong
+    -- reason. The suite decides it once, up front.
+end
+
 function mp.command_native(t)
     table.insert(M.log.commands, t)
+    if type(t) == "table" and t[1] == "update-clipboard" then
+        clipboard_fetched = true
+        return true
+    end
     if type(t) == "table" and t.name == "subprocess" then
         if M.subprocess then return M.subprocess(t) end
         return { status = -1, stdout = "" }
@@ -274,9 +305,24 @@ function mp.set_property_bool(name, value) M.log.props[name] = value end
 -- the renderer -- so it never reached mpv through any of the paths above and
 -- had no fake at all until the end-of-page interlock needed testing.
 function mp.set_property_number(name, value) M.log.props[name] = value end
-function mp.get_property_native(name, def) return M.log.props[name] or def end
+function mp.get_property_native(name, def)
+    if name == "command-list" then
+        local out = {}
+        for _, n in ipairs(M.commands_available or {}) do
+            out[#out + 1] = { name = n }
+        end
+        return out
+    end
+    return M.log.props[name] or def
+end
 function mp.get_property(name, def)
     if M.unavailable[name] then return nil, "property unavailable" end
+    if name == "clipboard/text" and M.clipboard_needs_update
+            and not clipboard_fetched then
+        -- Outdated, not unavailable: mpv answers with the stale value, and
+        -- for a backend that has never fetched, stale is empty.
+        return ""
+    end
     return M.log.props[name] or def
 end
 function mp.get_property_number(name, def) return M.log.props[name] or def end

--- a/tests/lua/test_renderer.lua
+++ b/tests/lua/test_renderer.lua
@@ -289,6 +289,15 @@ ok(last_event("commit") == nil, "ESC reverts rather than committing")
 -- Copy and paste were pcall'd, and mp.set_property signals failure by
 -- RETURNING nil rather than raising -- so both silently did nothing.
 
+-- The `update-clipboard` capability is probed once and cached for the life
+-- of the script (like `clip_tools`), so it has to be decided before the
+-- first paste below -- not in the #739 block further down, which is where
+-- the first version of this set it and got a warm cache instead.
+-- `test_renderer_lua.py` runs this file again with the flag set.
+if os.getenv("JMS_TEST_NO_CLIP_UPDATE") then
+    fake.commands_available = {}         -- an mpv <= 0.41
+end
+
 local function subprocess_calls()
     local out = {}
     for _, c in ipairs(fake.log.commands) do
@@ -386,6 +395,87 @@ fake.key("mpvtk_k_ctrl_x")
 local cut = last_event("change")
 ok(cut == nil, "cut keeps the text when the copy could not happen",
    cut and cut.value or "")
+
+-- #739: the property is OUTDATED until the client asks for a refresh.
+-- mpv's x11 and wayland backends are the only ones with an `update_data`
+-- hook and `--clipboard-monitor` defaults to no, so a read without
+-- `update-clipboard` returns the stale value -- empty, for a backend that
+-- has never fetched. Measured at our mpv pin on an X11 session: with text
+-- on the clipboard the property read empty before the command and correct
+-- after. So paste fell through to the CLI helpers on *every* Linux paste,
+-- and the Flatpak ships none of them -- which is the whole bug report.
+--
+-- **Two mutually exclusive sessions, because the capability probe is
+-- cached for the life of the script** (as `clip_tools` is). One process
+-- cannot see both answers, so `test_renderer_lua.py` runs this file again
+-- with JMS_TEST_NO_CLIP_UPDATE set -- the same trick it already uses to
+-- pin an X11 and a Wayland session.
+fake.reset_events()
+fake.unavailable = {}
+fake.log.commands = {}
+fake.clipboard_needs_update = true
+
+if os.getenv("JMS_TEST_NO_CLIP_UPDATE") then
+    -- mpv <= 0.41 has no `update-clipboard`; it is master-only. And
+    -- `mp.command_native` does not raise for a command mpv lacks -- it
+    -- returns nil and mpv logs "Command 'update-clipboard' not found." at
+    -- ERROR level. So the probe has to be a probe: issuing it anyway would
+    -- put an error line in the log on every paste, on a supported version.
+    fake.log.props["clipboard/text"] = "unreachable"
+    -- The READ path invokes the tool directly; only copy goes through a
+    -- shell (for the pipe). Same shape as the fallback paste test above.
+    fake.subprocess = function(t)
+        if t.args and t.args[1] == WANT_GET then
+            return { status = 0, stdout = "via helper" }
+        end
+        return { status = -1, stdout = "" }
+    end
+    scene({ textbox("clip739", "") })
+    click("clip739")
+    fake.key("mpvtk_k_ctrl_v")
+    local issued = false
+    for _, c in ipairs(fake.log.commands) do
+        if type(c) == "table" and c[1] == "update-clipboard" then
+            issued = true
+        end
+    end
+    ok(not issued, "an mpv without the command is not asked for it")
+    local chb = last_event("change")
+    ok(chb ~= nil and chb.value == "via helper",
+       "and paste still reaches the desktop helper",
+       chb and chb.value or "no change event")
+else
+    fake.subprocess = nil        -- no helper installed, like the Flatpak
+    fake.log.props["clipboard/text"] = "from the clipboard"
+    scene({ textbox("clip739", "") })
+    click("clip739")
+    fake.key("mpvtk_k_ctrl_v")
+    local ch739 = last_event("change")
+    ok(ch739 ~= nil and ch739.value == "from the clipboard",
+       "ctrl+v refreshes mpv's clipboard before reading it (#739)",
+       ch739 and ch739.value or "no change event")
+
+    -- And the refresh must stay BOUNDED. Measured against a clipboard owner
+    -- that is alive and does not answer (a SIGSTOPped xclip still holding
+    -- the selection): the wait burns the WHOLE timeout -- 10ms, 50ms and
+    -- 200ms timeouts blocked 10.1, 50.1 and 200.1ms. A healthy clipboard
+    -- returns in 0.2ms, so the number is a ceiling on a wedged owner and
+    -- not a budget for a working one.
+    local upd739
+    for _, c in ipairs(fake.log.commands) do
+        if type(c) == "table" and c[1] == "update-clipboard" then
+            upd739 = c
+        end
+    end
+    ok(upd739 ~= nil, "the refresh was actually issued")
+    if upd739 then
+        ok(type(upd739[3]) == "number" and upd739[3] > 0 and upd739[3] <= 50,
+           "the refresh is bounded, or a wedged owner stalls the UI",
+           tostring(upd739[3]))
+    end
+end
+
+fake.reset_clipboard()
 
 fake.unavailable = {}
 fake.subprocess = nil

--- a/tests/test_renderer_lua.py
+++ b/tests/test_renderer_lua.py
@@ -92,6 +92,22 @@ class TestRendererLua(unittest.TestCase):
             self._run("test_renderer.lua",
                       env=self._session_env(WAYLAND_DISPLAY="wayland-0")))
 
+    def test_the_renderer_suite_passes_without_update_clipboard(self):
+        """Third session: an mpv with no `update-clipboard` command.
+
+        It is master-only -- neither v0.40.0 nor v0.41.0 has it -- and the
+        renderer probes `command-list` once and caches the answer, exactly
+        as it caches `clip_tools`. So one process can only ever see one of
+        the two answers, and the case that needs pinning is the one where
+        the command is ABSENT: `mp.command_native` does not raise for a
+        missing command, it returns nil and mpv logs an ERROR line, which
+        would then appear on every paste for those users.
+        """
+        self._assert_suite_passed(
+            self._run("test_renderer.lua",
+                      env=self._session_env(DISPLAY=":0",
+                                            JMS_TEST_NO_CLIP_UPDATE="1")))
+
     def test_the_thumbfast_suite_passes(self):
         """`thumbfast.lua` is the other consumer of the trickplay frame
         file — the compatibility layer every thumbfast-style lua OSC talks

--- a/tests/test_shell_chrome.py
+++ b/tests/test_shell_chrome.py
@@ -48,6 +48,33 @@ class TestClipboardNotice(unittest.TestCase):
         self.assertIn("wl-clipboard", text)
         self.assertIn("apt install wl-clipboard", text)
 
+    def test_a_wayland_session_is_not_told_to_upgrade_mpv(self):
+        """#739's other half. The message said "or use MPV 0.41 or newer" for
+        every session, and the reporter -- on a Flatpak already running master
+        -- said so: *"it is assumed that the mentioned mpv version from the
+        error is already being used ... suggests something more is going on."*
+
+        They were right. On Wayland a newer MPV does **not** help: its x11
+        clipboard backend declines to start whenever WAYLAND_DISPLAY is set
+        unless `--clipboard-xwayland=yes`, which defaults to no. Telling a
+        Wayland user to upgrade sends them after the wrong thing.
+        """
+        b, shown = self._browser()
+        b._on_clipboard_error("paste", "wl-clipboard")
+        text = shown[0][0]
+        self.assertIn("wl-clipboard", text)
+        self.assertNotIn("0.41", text,
+                         "a Wayland session was told to upgrade MPV, which "
+                         "cannot help it")
+
+    def test_an_x11_session_is_still_told_a_newer_mpv_helps(self):
+        """The control: on X11 it genuinely does -- the x11 backend only
+        arrived in 0.41, and there it does start."""
+        b, shown = self._browser()
+        b._on_clipboard_error("paste", "xclip")
+        self.assertIn("xclip", shown[0][0])
+        self.assertIn("0.41", shown[0][0])
+
     def test_it_says_which_operation_failed(self):
         b, shown = self._browser()
         b._on_clipboard_error("copy", "xclip")


### PR DESCRIPTION
Some Wayland WMs require a clipboard pull event, they don't get the clipboard state for free on window focus. This mode isn't present in most Debian Stable WMs yet so I didn't catch it. It needs an mpv build from master to work or wl-clipboard.