### PR TITLE
Implement per-character font fallback

### DIFF
--- a/jellyfin_mpv_shim/mpvtk/GUIDE.md
+++ b/jellyfin_mpv_shim/mpvtk/GUIDE.md
@@ -925,6 +925,12 @@ and the 33 Latin codepoints nothing draws are the C0/C1 controls, which must not
 be rescued by anything. An entry in `_FALLBACK_SCRIPTS` that no run has needed
 pre-authorises a face for a case nobody has seen.
 
+**That last figure is a Debian figure, and 12.9 is what it looks like on
+Windows** — where the Latin face is Arial rather than DejaVu, "the Latin
+codepoints nothing draws" is 6,728 rather than 33. The rule about the controls
+survives unchanged and is now enforced in code: `NotoSansSymbols2` draws a
+*picture* for every one of them.
+
 Mixed lines cost a little vertical room: PIL's default vertical anchor is the
 *ascender* and two faces do not share one, so runs are drawn from a shared
 baseline set by the tallest ascent. A caller reserving from `script_of`'s face
@@ -1097,7 +1103,66 @@ fails when the host owns a face the shim did not find, naming the file. That
 test is the only thing here that can catch an *incomplete* list, because
 completeness cannot be checked against the file — only against a machine.
 
-### 12.9 Where the Unicode data actually is
+### 12.9 A character the run's own face lacks
+
+`runs()` gives each run a face and 12.6 makes that face one that covers the
+run. Neither answers the character that is in **no** bucket's chain: #740 is a
+Simplified Chinese title, "机动战士Z高达Ⅱ：恋人们", whose Roman numeral drew as a
+box on Windows once the Han around it was fixed. U+2161 is neither CJK nor a
+symbol to `script_of_char` — it is below the CJK catch-all and in none of the
+symbol tables — so it lands in a *Latin* run, and the Latin face on Windows is
+Arial.
+
+Measured on the Windows VM, 2026-09-09, through `_draws` (the same test the
+selector uses):
+
+| face | Number Forms | ⅠⅡⅢ | ① | ℃ |
+|---|---|---|---|---|
+| `arial.ttf` | 7/64 | no | no | no |
+| `seguisym.ttf` | 0/64 | no | yes | yes |
+| `msgothic` / `msyh` / `simsun` / `malgun` | 22–52/64 | **yes** | yes | yes |
+| `DejaVuSans.ttf` (Linux, Flatpak) | 55/64 | yes | — | — |
+
+**The class, not the character.** Of the 9,103 assigned codepoints below U+2E80
+that `script_of_char` calls `"latin"`, Arial draws 2,375 and DejaVu 4,669; of
+the 6,728 Arial misses, a CJK face already installed draws 906 — letterlike,
+number forms, enclosed alphanumerics, maths, box drawing and the whole of
+Hangul Jamo, which has no bucket and does not need one now.
+
+**The repair is per character, not per chain.** A `latin -> cjk` entry in
+`_FALLBACK_SCRIPTS` would have fixed the reported title, because there the
+numeral is a run of its own — and re-typeset the whole of "Rocky Ⅱ" in a CJK
+face, because there it is not. So `_peel` splits the run instead: the character
+the face cannot draw moves, and everything beside it is drawn exactly as before.
+`_orphan_face` asks, in order, the faces the **rest of this string** resolved
+(a character with no script of its own belongs with the text around it — U+2161
+in a Chinese title is East Asian wide, and the face drawing the Han beside it is
+the right width and weight), then the run's own chain, then `_ORPHAN_SCRIPTS`.
+
+Three characters are never peeled, and each one has a measurement behind it:
+
+- **Category C.** `NotoSansSymbols2` draws a picture for every C0/C1 control and
+  for U+007F, so a peel that took the first face with a glyph would turn a stray
+  U+0085 in a title into a visible one, and a zero-width space into something
+  with width. This is 12.4's rule, now enforced rather than observed.
+- **Joiners and combining marks.** Shaping does not cross a run boundary (12.3),
+  and the peel *is* a boundary. Segoe UI Symbol has no U+FE0F, so the first
+  version of this drew "☂️" as two pieces — the split `_JOINERS` exists to
+  prevent, one level down. Marks also follow a base that moves, or niqqud and
+  Devanagari stack onto the wrong glyph.
+- **Anything in an RTL line.** It is one draw call and stays one (12.1).
+
+**Cost: about 3µs on a 72µs measure** (three captions, warm memo, Debian
+2026-09-09), because `_draws` is memoized per face and codepoint and the peel
+asks it once per character.
+
+What this does **not** address: a run-level face mix inside one title. The Han
+in #740's own title resolves `msyh` for 机动战士 and `msgothic` for 高达, since
+each run takes the first candidate covering *that run* — so two Han runs of one
+title can carry Chinese and Japanese letterforms. Visible on the sample sheet,
+pre-existing, and a different decision from this one.
+
+### 12.10 Where the Unicode data actually is
 
 Debian's `unicode-data` package ships
 `/usr/share/unicode/emoji/emoji-data.txt` — the authoritative

--- a/jellyfin_mpv_shim/mpvtk/pilfont.py
+++ b/jellyfin_mpv_shim/mpvtk/pilfont.py
@@ -11,6 +11,12 @@ Latin/Cyrillic/Greek range our default face covers, map it to a script, and
 load a system font known to cover that script. Everything is cached, and a
 miss degrades to the default face (tofu, but never a crash).
 
+Three granularities, because each one was a bug: **per string** (this
+module), **per run** of one script (:func:`runs`, so a year beside a Japanese
+title is not four boxes) and **per character** (:func:`_peel`, so a Roman
+numeral in a Chinese title is not one box -- #740, and mpvtk/GUIDE.md
+section 12.9).
+
 Two pseudo-scripts, neither of which is one anywhere else. **"symbol"**,
 because a Latin face is not a symbol face (:data:`_SYMBOL_RANGES`). **"emoji"**,
 the only one where the *face* is awkward rather than the choice of it: it draws
@@ -25,6 +31,7 @@ mpvtk/GUIDE.md section 12.
 
 import logging
 import os
+import unicodedata
 
 log = logging.getLogger("mpvtk.pilfont")
 
@@ -321,6 +328,7 @@ _chains = {}         # (script, size, bold) -> [(name, face), ...] opened so far
 _coverage = {}
 _notdef = {}         # (font name, open size) -> that face's no-glyph renders
 _resolved = {}       # (script, bold) -> path/name that loaded, or None
+_orphans = {}        # (char, script, size, bold) -> a face that draws it
 
 #: Codepoints Unicode guarantees will never be assigned, so what a face
 #: renders for one is that face's own "no glyph" mark. Three rather than
@@ -1047,36 +1055,162 @@ def _face_pickers(fnt, faces):
             (lambda script, text=None: _same_size(fnt, script, text)))
 
 
+#: Chains an orphaned character is looked for in, after the run's own.
+#:
+#: **Not a preference between faces -- a search for one that has the glyph
+#: at all**, asked per character, so the Latin word beside the orphan keeps
+#: the face it had. Measured on the Windows VM 2026-09-09: of the 6,728
+#: codepoints Arial misses among the 9,103 that `script_of_char` calls
+#: "latin", the CJK faces on the same machine draw 906 and Segoe UI Symbol
+#: most of what is left. Latin needs no entry: `_opened` already appends
+#: the Latin backstop to every non-Latin chain (GUIDE section 12.9).
+_ORPHAN_SCRIPTS = ("symbol", "cjk")
+
+
+def _peelable(ch):
+    """Whether a character the run's face lacks may be moved to another.
+
+    **Category C is excluded and it is not a formality**: measured on
+    Debian, `NotoSansSymbols2` draws a *picture* for every C0/C1 control
+    and for U+007F, so a peel that took the first face with a glyph would
+    turn a stray U+0085 in a title into a visible one -- and a zero-width
+    space into something with width. GUIDE section 12.4 names that set as
+    the one nothing may rescue. Whitespace is left alone for the reason
+    :func:`_covers` skips it: it is blank in every face, and moving it
+    would split a run for no glyph.
+    """
+    return not ch.isspace() and unicodedata.category(ch)[0] != "C"
+
+
+def _attaches(ch):
+    """Whether a character joins what is beside it, so it can never be
+    peeled off on its own **or left behind when its base moves**.
+
+    Shaping does not cross a run boundary (GUIDE section 12.3), and the peel
+    is a run boundary. Measured on the Windows VM: Segoe UI Symbol has no
+    U+FE0F, so without this the variation selector was peeled to the emoji
+    face and "☂️" was drawn as two pieces -- the exact split
+    :data:`_JOINERS` exists to prevent, arriving one level down. The
+    combining marks are here for the same reason and for the other
+    direction: an orphaned base takes its marks with it, or Devanagari and
+    niqqud stack onto the wrong glyph.
+    """
+    return ord(ch) in _JOINERS or unicodedata.category(ch)[0] == "M"
+
+
+def _face_draws(fnt, ch):
+    """:func:`_draws` for a face somebody already resolved.
+
+    The name is only a memo key, and it comes off the object here because
+    there is no candidate list in hand. Pillow's bitmap default is the one
+    face reachable without a ``path``; every other one is a file.
+    """
+    return _draws(fnt, getattr(fnt, "path", None), ch)
+
+
+def _orphan_face(ch, script, size, bold, prefer=()):
+    """A face for one character its run's face cannot draw, or None.
+
+    ``prefer`` is the faces the *rest of this string* resolved, and it is
+    asked first because a character with no script of its own belongs with
+    the text around it: U+2161 in a Chinese title is East Asian wide, and
+    taking it from the face already drawing the Han beside it is both the
+    right width and the right weight. Falling to :data:`_ORPHAN_SCRIPTS`
+    after that is what covers the character standing on its own.
+
+    The run's own chain is asked before either, because `font` rejected a
+    candidate for failing *somewhere else in the run* -- a face further
+    down the same list may have exactly this glyph.
+    """
+    for face in prefer:
+        if _face_draws(face, ch):
+            return face
+    key = (ch, script, size, bool(bold))
+    if key not in _orphans:
+        got = None
+        for other in (script,) + tuple(s for s in _ORPHAN_SCRIPTS
+                                       if s != script):
+            got = _pick(other, size, bold, ch, None)
+            if got is not None:
+                break
+        _orphans[key] = got
+    return _orphans[key]
+
+
+def _peel(chunk, face, script, prefer):
+    """``[(chunk, face), ...]`` for one run, splitting off the characters
+    ``face`` cannot draw.
+
+    **This is the fallback Pillow does not have** (#740). A run's face is
+    chosen for the whole run, so one codepoint the chain cannot supply used
+    to make one box; here that character alone moves to a face that has it
+    and everything around it is drawn exactly as before. A character
+    nothing on the host draws stays put -- tofu, as it was.
+    """
+    size = getattr(face, "_jms_size", getattr(face, "size", 12))
+    bold = getattr(face, "_jms_bold", False)
+    out = []
+    for ch in chunk:
+        if out and _attaches(ch):
+            out[-1][0].append(ch)
+            continue
+        use = face
+        if _peelable(ch) and not _face_draws(face, ch):
+            use = _orphan_face(ch, script, size, bold, prefer) or face
+        if out and out[-1][1] is use:
+            out[-1][0].append(ch)
+        else:
+            out.append(([ch], use))
+    return [("".join(chars), used) for chars, used in out]
+
+
 def _split(text, fnt, faces):
-    """``(runs, one_face_or_None, per_run_resolver)`` — the one place the
-    two bypasses live, so measuring and drawing cannot disagree about them.
-    A non-None second element means the whole string is drawn with it.
+    """``(pieces, one_face_or_None)`` — the one place face resolution
+    happens, so measuring and drawing cannot disagree about it. ``pieces``
+    is ``[(script, chunk, face), ...]`` in order; a non-None second element
+    means the whole string is drawn with that face in a single call.
 
     A single **emoji** run does not take the bypass. It has to reach the
     per-run resolver (`_run_face` would hand back the caller's own face,
     which is the face that cannot draw it) and, on a bitmap-strike face,
     the scaling that only the run loop does.
+
+    **An RTL line is never peeled**: Pillow reorders bidi within one draw
+    call and cannot across several, so a missing glyph there stays tofu
+    rather than becoming a reordered line (GUIDE section 12.1).
     """
     parts = runs(text)
     single, per_run = _face_pickers(fnt, faces)
     if has_rtl(text):
         # The whole line, so the face is chosen against every codepoint in
         # it that belongs to the line's script -- see `_covers`.
-        return parts, single(script_of(text), text), per_run
-    if len(parts) == 1 and parts[0][0] != "emoji":
-        return parts, single(parts[0][0], parts[0][1]), per_run
-    return parts, None, per_run
+        script = script_of(text)
+        face = single(script, text)
+        return [(script, text, face)], face
+    resolver = (single if len(parts) == 1 and parts[0][0] != "emoji"
+                else per_run)
+    chosen = [resolver(script, chunk) for script, chunk in parts]
+    pieces = []
+    for (script, chunk), face in zip(parts, chosen):
+        prefer = [other for other in chosen if other is not face]
+        for piece, used in _peel(chunk, face, script, prefer):
+            pieces.append((script, piece, used))
+    # One piece left after the peel is the original path, byte for byte:
+    # every string that needed no fallback still takes one draw call with
+    # the face its caller chose.
+    if len(pieces) == 1 and pieces[0][0] != "emoji":
+        return pieces, pieces[0][2]
+    return pieces, None
 
 
 def _measure(text, fnt, faces, measure):
     if not text:
         return 0.0
-    parts, whole, per_run = _split(text, fnt, faces)
+    pieces, whole = _split(text, fnt, faces)
     if whole is not None:
         return measure(text, whole) * _scale_of(whole)
     total = 0.0
-    for script, chunk in parts:
-        face = per_run(script, chunk)
+    for _script, chunk, face in pieces:
         total += measure(chunk, face) * _scale_of(face)
     return total
 
@@ -1174,7 +1308,7 @@ def draw_text(draw, xy, text, fnt, fill=None, anchor=None, faces=None):
     """
     if not text:
         return
-    parts, whole, per_run = _split(text, fnt, faces)
+    pieces, whole = _split(text, fnt, faces)
     if whole is not None:
         # One draw call covers the line. For an RTL line that is forced --
         # Pillow reorders bidi within a call and cannot across several --
@@ -1184,7 +1318,7 @@ def draw_text(draw, xy, text, fnt, fill=None, anchor=None, faces=None):
         draw.text(xy, text, font=whole, fill=fill, anchor=anchor)
         return
 
-    fonts = [per_run(script, chunk) for script, chunk in parts]
+    fonts = [face for _script, _chunk, face in pieces]
     scales = [_scale_of(f) for f in fonts]
     # Through `metrics`, or a 109px emoji strike would decide the baseline
     # for a 20px line and push the whole thing five lines down.
@@ -1204,7 +1338,7 @@ def draw_text(draw, xy, text, fnt, fill=None, anchor=None, faces=None):
         baseline = y - descent
     else:                          # "s" -- already a baseline
         baseline = y
-    for (script, chunk), face, scale in zip(parts, fonts, scales):
+    for (script, chunk, face), scale in zip(pieces, scales):
         if scale != 1.0:
             _draw_scaled(draw, x, baseline, chunk, face, scale, fill)
         else:
@@ -1229,6 +1363,7 @@ def clear_cache():
     _cache.clear()
     _chains.clear()
     _coverage.clear()
+    _orphans.clear()
     _notdef.clear()
     _resolved.clear()
 

--- a/tests/test_mpvtk_pilfont.py
+++ b/tests/test_mpvtk_pilfont.py
@@ -1140,7 +1140,7 @@ class TestMixedRtlLine(unittest.TestCase):
         line = "進撃の巨人 مسلسل"
         self.addCleanup(pilfont.clear_cache)
         pilfont.clear_cache()
-        parts, whole, _per_run = pilfont._split(
+        _pieces, whole = pilfont._split(
             line, pilfont.font_for(line, 24), None)
         self.assertIsNotNone(whole, "an RTL line must be drawn with one face")
         arabic = [ch for ch in line if pilfont.has_rtl(ch)]
@@ -1261,6 +1261,253 @@ class TestFallbackAcrossSymbolSets(unittest.TestCase):
                     os.path.basename(str(first)),
                     "%r was moved off the symbol chain's own first answer"
                     % ch)
+
+class TestPerCharacterFallback(unittest.TestCase):
+    """A character the run's own face lacks, drawn by a face that has it.
+
+    #740: "机动战士Z高达Ⅱ：恋人们" drew the Roman numeral as a box on
+    Windows once the Han around it was fixed. U+2161 is neither CJK nor a
+    symbol to `script_of_char`, so it lands in a *Latin* run -- and the
+    Latin face on Windows is Arial, which has **7 of the 64 Number Forms**
+    while every CJK face on the same machine has all of them (measured on
+    the Windows VM, 2026-09-09, with `_draws`).
+
+    The class of it, measured the same day: of the 9,103 assigned
+    codepoints below U+2E80 that `script_of_char` calls "latin", Arial
+    draws 2,375 and DejaVu 4,669 -- and of the 6,728 Arial misses, a CJK
+    face already installed draws 906. GUIDE 12.4's "the only orphaned Latin
+    codepoints are the C0/C1 controls" was measured on Debian, where the
+    Latin face is DejaVu.
+    """
+
+    #: The scan below costs a getmask per (codepoint, face); shared so the
+    #: class pays it once rather than once per test.
+    _found = {}
+
+    def setUp(self):
+        self.addCleanup(pilfont.clear_cache)
+        pilfont.clear_cache()
+
+    def _chain(self, script, size):
+        from PIL import ImageFont
+
+        out = []
+        for name in pilfont._CANDIDATES[script]:
+            try:
+                out.append(ImageFont.truetype(name, size))
+            except (OSError, IOError):
+                continue
+        return out
+
+    def _draws(self, face, ch):
+        ref = face.getmask("\U000FFFFF", mode="L")
+        got = face.getmask(ch, mode="L")
+        return (got.size, bytes(got)) != (ref.size, bytes(ref))
+
+    def _scan(self, size):
+        """``(orphan, undrawable)`` for this host, discovered not hardcoded.
+
+        The orphan is a printable character no Latin candidate draws and
+        some other chain does -- U+2161 on Windows, and on Debian the
+        Hangul Jamo and the enclosed alphanumerics, which are the same bug
+        with a different face. The undrawable one is a character *nothing*
+        installed draws, which is the case the peel must leave alone.
+        """
+        import unicodedata
+
+        if size in self._found:
+            return self._found[size]
+        latin = self._chain("latin", size)
+        rescue = self._chain("symbol", size) + self._chain("cjk", size)
+        orphan = undrawable = None
+        if latin and rescue:
+            for lo, hi in ((0x1100, 0x11FF), (0x2000, 0x2E7F)):
+                for cp in range(lo, hi + 1):
+                    ch = chr(cp)
+                    if (pilfont.script_of_char(cp) != "latin" or ch.isspace()
+                            or unicodedata.category(ch)[0] == "C"):
+                        continue
+                    if any(self._draws(f, ch) for f in latin):
+                        continue
+                    if any(self._draws(f, ch) for f in rescue):
+                        if orphan is None:
+                            orphan = ch
+                    elif undrawable is None:
+                        undrawable = ch
+                    if orphan is not None and undrawable is not None:
+                        break
+                if orphan is not None and undrawable is not None:
+                    break
+        self._found[size] = (orphan, undrawable)
+        return self._found[size]
+
+    def _orphan(self, size=24):
+        ch = self._scan(size)[0]
+        if ch is None:
+            self.skipTest("every printable codepoint this host's Latin face "
+                          "misses is missing from every other chain too")
+        return ch
+
+    def _image(self, size=24):
+        from PIL import Image, ImageDraw
+
+        img = Image.new("L", (size * 4, size * 3), 0)
+        return img, ImageDraw.Draw(img)
+
+    def _ink(self, font, text, size=24):
+        """What `draw_text` puts on a plate."""
+        img, draw = self._image(size)
+        pilfont.draw_text(draw, (2, 2), text, font, fill=255)
+        return img.tobytes()
+
+    def _plain(self, font, text, size=24):
+        """What one `draw.text` with that face puts there -- the tofu, for
+        a character the face does not have.
+
+        **Not `draw_text` of a codepoint that cannot exist**: the notdef
+        probes are astral and `script_of_char` sends them to the CJK face,
+        so that reference is a different face's box and the comparison
+        passes whatever happens. Measured, and it cost a mutation run.
+        """
+        img, draw = self._image(size)
+        draw.text((2, 2), text, font=font, fill=255)
+        return img.tobytes()
+
+    def test_an_orphan_is_drawn_by_a_face_that_has_it(self):
+        """The bug itself: the run's face draws a box, and a face on this
+        host draws the character."""
+        ch = self._orphan()
+        fnt = pilfont.font("latin", 24)
+        drawn = self._ink(fnt, ch)
+        self.assertNotEqual(
+            drawn, self._plain(fnt, ch),
+            "U+%04X came back as the Latin face's own tofu" % ord(ch))
+        self.assertNotEqual(drawn, self._ink(fnt, ""),
+                            "U+%04X drew nothing at all" % ord(ch))
+
+    def test_only_the_orphan_moves(self):
+        """The letters around it keep the face they had. A chain that
+        covered the *run* would re-typeset the whole word, which is the
+        trade this peel exists to avoid."""
+        ch = self._orphan()
+        fnt = pilfont.font("latin", 24)
+        pieces, whole = pilfont._split("A" + ch + "B", fnt, None)
+        self.assertIsNone(whole, "the string was drawn with one face")
+        self.assertEqual([chunk for _script, chunk, _face in pieces],
+                         ["A", ch, "B"])
+        self.assertIs(pieces[0][2], fnt)
+        self.assertIs(pieces[2][2], fnt)
+        self.assertTrue(self._draws(pieces[1][2], ch))
+
+    def test_a_control_character_is_never_rescued(self):
+        """GUIDE 12.4's rule, and it is not theoretical:
+        `NotoSansSymbols2` draws a *picture* for every C0/C1 control, so a
+        peel that took the first face with a glyph would turn a stray
+        U+0085 in a title into a visible one."""
+        fnt = pilfont.font("latin", 24)
+        for ch in ("\x7f", "\x85", "\u200b"):
+            pieces, whole = pilfont._split("A" + ch + "B", fnt, None)
+            self.assertIsNotNone(
+                whole, "%r was peeled off the run's own face" % ch)
+
+    def test_a_character_nothing_draws_stays_where_it_was(self):
+        """No face on the host has it, so there is nothing to move it to
+        and the answer is the tofu there always was -- not a crash, and not
+        a second face in the middle of a word."""
+        ch = self._scan(24)[1]
+        if ch is None:
+            self.skipTest("this host draws every printable codepoint tried")
+        fnt = pilfont.font("latin", 24)
+        pieces, whole = pilfont._split("A" + ch + "B", fnt, None)
+        self.assertIsNotNone(whole)
+
+    def test_a_combining_character_is_never_split_from_its_base(self):
+        """Shaping does not cross a run boundary, and the peel is one.
+
+        Measured on the Windows VM: Segoe UI Symbol has no U+FE0F, so the
+        first version of this peeled the variation selector onto the emoji
+        face and drew "☂️" as two pieces -- which is the split `_JOINERS`
+        exists to prevent, arriving one level down. Asked of a face that
+        draws nothing at all, so every character is an orphan on every
+        host.
+        """
+        class _Blank:
+            size = (1, 1)
+
+            def __bytes__(self):
+                return b"\x00"
+
+        class _NoGlyphFace:
+            size = 24
+            path = "<test: draws nothing>"
+
+            def getmask(self, text, mode="L"):
+                return _Blank()
+
+        # Named here rather than asked of `_attaches`, and the rescue is
+        # offered **only** for the joining characters: a test that asks the
+        # function under test what counts as joining agrees with it however
+        # it is broken, and one where the base moves to the same face as
+        # its mark cannot see the split either. Both versions of this
+        # passed with `_attaches` stubbed to False before it was built this
+        # way.
+        joins = {0xFE0F, 0xFE0E, 0x200D, 0x20E3, 0x0301}
+        moved = _NoGlyphFace()
+
+        def only_joiners(ch, script, size, bold, prefer=()):
+            return moved if ord(ch) in joins else None
+
+        real = pilfont._orphan_face
+        self.addCleanup(setattr, pilfont, "_orphan_face", real)
+        pilfont._orphan_face = only_joiners
+
+        face = _NoGlyphFace()
+        text = "1\ufe0f\u20e3 A\u0301 \u2602\ufe0f"
+        pieces = pilfont._peel(text, face, "latin", ())
+        self.assertTrue(pieces)
+        for chunk, used in pieces:
+            self.assertNotIn(
+                ord(chunk[0]), joins,
+                "a piece starts with U+%04X, which joins what is before it"
+                % ord(chunk[0]))
+            self.assertIs(used, face,
+                          "%r was moved to a face offered only to the "
+                          "characters that join" % chunk)
+
+    def test_measuring_and_drawing_agree_after_a_peel(self):
+        """Both go through `_split`, and a caption ellipsized against a
+        width it is not drawn at is the failure this pins."""
+        from PIL import Image, ImageDraw
+
+        ch = self._orphan()
+        draw = ImageDraw.Draw(Image.new("RGBA", (10, 10)))
+        for text in ("A" + ch + "B", ch, ch + ch, "A " + ch):
+            fnt = pilfont.font_for(text, 24)
+            self.assertAlmostEqual(pilfont.text_length(draw, text, fnt),
+                                   pilfont.length(text, fnt), places=3,
+                                   msg=repr(text))
+
+    def test_the_740_title_has_no_tofu_left_in_it(self):
+        """The issue's own string, drawn the way the browser draws it."""
+        title = "机动战士Z高达Ⅱ：恋人们"
+        size = 24
+        installed = (self._chain("latin", size) + self._chain("cjk", size)
+                     + self._chain("symbol", size))
+        if not installed:
+            self.skipTest("no fonts at all on this host")
+        fnt = pilfont.font_for(title, size)
+        pieces, whole = pilfont._split(title, fnt, None)
+        if whole is not None:
+            pieces = [(None, title, whole)]
+        for _script, chunk, face in pieces:
+            for ch in chunk:
+                if not any(self._draws(f, ch) for f in installed):
+                    continue        # nothing here can draw it; not our bug
+                self.assertTrue(
+                    self._draws(face, ch),
+                    "U+%04X drew as tofu from %s"
+                    % (ord(ch), getattr(face, "path", "?")))
+
 
 class TestTheHostsOwnInventory(unittest.TestCase):
     """If this machine HAS a face for a script, the shim must find it.
@@ -1580,11 +1827,10 @@ class TestAnRtlLineCarriesWhatIsInIt(unittest.TestCase):
         """The faces `draw_text` will really use, and whether one covers
         the whole line."""
         fnt = pilfont.font_for(text, size)
-        parts, whole, per_run = pilfont._split(text, fnt, None)
+        pieces, whole = pilfont._split(text, fnt, None)
         if whole is not None:
             return [(whole, text)]
-        return [(per_run(script, chunk)) and (per_run(script, chunk), chunk)
-                for script, chunk in parts]
+        return [(face, chunk) for _script, chunk, face in pieces]
 
     def _tofu(self, text):
         """Characters the line's own face(s) cannot draw.

--- a/tools/shoot_text_samples.py
+++ b/tools/shoot_text_samples.py
@@ -143,6 +143,42 @@ SAMPLES = [
      "مسلسل Netflix الأصلي"),
     ("Mixes -- where it breaks", "CJK + symbol",
      "進撃の巨人 ★ 8.1"),
+
+    # #740: the character the run's face does not have. `script_of_char`
+    # calls all of these "latin" -- they are below the CJK catch-all and in
+    # none of the symbol tables -- so they are drawn by the Latin face,
+    # which on Windows is Arial: 7 of the 64 Number Forms and none of the
+    # 160 enclosed alphanumerics, against every CJK face on the same box
+    # having them all. The peel moves the one character and leaves the
+    # words around it alone, so what a reader is checking here is that the
+    # numeral appears AND that nothing beside it changed typeface.
+    ("Characters the run's own face lacks", "#740's title",
+     "机动战士Z高达Ⅱ：恋人们"),
+    ("Characters the run's own face lacks", "Roman numerals, CJK context",
+     "高达Ⅱ · 第Ⅲ部 · Ⅳ"),
+    ("Characters the run's own face lacks", "Roman numerals, Latin context",
+     "Rocky Ⅱ · Final Fantasy Ⅶ"),
+    ("Characters the run's own face lacks", "enclosed alphanumerics",
+     "① ② ③ ⑩ ⓐ"),
+    ("Characters the run's own face lacks", "letterlike and units",
+     "№ 5 · 25℃ · ℡ · ™"),
+    ("Characters the run's own face lacks", "Hangul jamo (no bucket)",
+     "ᄀ ᄁ ᄂ ᅡ ᆨ"),
+    ("Characters the run's own face lacks", "orphan inside a Latin word",
+     "Blade Runner Ⅱ 2049"),
+    ("Characters the run's own face lacks", "orphan beside an emoji",
+     "Ⅶ 🎬 ① ⭐"),
+    ("Characters the run's own face lacks", "orphan in an RTL line",
+     "مسلسل Ⅱ الجزء",
+     "BY DESIGN: an RTL line is one draw call and nothing is peeled off "
+     "its face -- Pillow reorders bidi within a call and cannot across "
+     "several (GUIDE section 12.1)."),
+    ("Characters the run's own face lacks", "controls and zero-width",
+     "A\u0085B\u200bC\u007fD",
+     "BY DESIGN: category C is never peeled, so these draw as whatever the "
+     "line's own face does with them, which is nothing. NotoSansSymbols2 "
+     "has a picture for every C0/C1 control and must not be handed them "
+     "(GUIDE section 12.4)."),
 ]
 
 #: A codepoint that can never be assigned, so every face draws its own
@@ -154,11 +190,11 @@ TOFU = "\U000FFFFF"
 def _faces_for(text, size, bold=False):
     """The face names `draw_text` will actually use, run by run."""
     fnt = pilfont.font_for(text, size, bold)
-    parts, whole, per_run = pilfont._split(text, fnt, None)
+    pieces, whole = pilfont._split(text, fnt, None)
     if whole is not None:
         used = [whole]
     else:
-        used = [per_run(script, chunk) for script, chunk in parts]
+        used = [face for _script, _chunk, face in pieces]
     names = []
     for f in used:
         name = os.path.basename(str(getattr(f, "path", "") or "builtin"))


### PR DESCRIPTION
The pilfont subsystem does support splitting fonts per run of characters by grouping, but "Ⅱ" is not in the Latin grouping in the Windows font set used by default, and so, needs a fallback selected. This implements fallback for missed characters in runs, so the remaining gap is now RTL/LTR mixed in one run of text.