### PR TITLE
Fix right click bindings

### DIFF
--- a/docs/RELEASE_SHAPE_POST_3.0.0.md
+++ b/docs/RELEASE_SHAPE_POST_3.0.0.md
@@ -640,22 +640,78 @@ than asking for a restart. So the row belongs in `RESTART_REQUIRED`
 22, and the rest would repaint into the new language on the next draw, which is
 the ugly middle state the flag exists to prevent.
 
-Three things to settle when it is built, in `docs/settings-curation.md` terms:
+##### What to list — measured 2026-09-08
 
-- **Which tab.** It is a "look" setting applied at startup, which is the group
-  `browse` already collects.
-- **What to list.** There are **86 locales** under `jellyfin_mpv_shim/messages/`,
-  most of them partial — Weblate fills them and completeness moves. A picker
-  listing all 86 offers mostly-English UIs under native names; a filtered list
-  needs a completeness threshold computed from the `.po` files at build time,
-  and that number then has to be regenerated with the translations. Decide
-  which before writing the enum, because the two have different build stories.
-  `window_controls` (`config.py:532`) is the structural precedent for a
-  three-way whose first option resolves at runtime — here that first option is
-  **"Use the system language"**, which is what `lang = None` already means.
-- **The display name for each entry** should be the language's own endonym, not
-  its English name: a user who cannot read the current UI language is exactly
-  the person reaching for this control.
+86 locales, 1075 msgids in the template. Completeness, counting non-fuzzy
+translated entries:
+
+| completeness | locales |
+|---|---|
+| 95–100% | **3** — `zh_Hans`, `it`, `ca` |
+| 75–95% | 2 — `pt_PT`, `pt` |
+| 50–75% | 7 — `de`, `es`, `da`, `ar`, `lt`, `nl`, `en_GB` |
+| **25–50%** | **41** |
+| 5–25% | 19 |
+| 0–5% | 14 |
+
+**That 41-locale cluster is the jellyfin-web seed line** ([iw]: the seeded
+strings "don't cover a lot of the UI"), and it is what makes a threshold the
+wrong instrument: put the bar at 50% and the picker offers twelve languages,
+excluding French, Russian, Polish, Japanese and most of the list a user would
+actually look for. Put it at 25% and it means nothing.
+
+So **list them all and show the number** — "Deutsch — 62%" — computed from the
+`.po` files at build time and regenerated with the translations. It is honest,
+it needs no arbitrary bar, and it tells a would-be translator where the gaps
+are, which is the population most likely to open this menu. `window_controls`
+(`config.py:532`) is the structural precedent for a three-way whose first
+option resolves at runtime; here that option is **"Use the system language"**,
+which is exactly what `lang = None` already means.
+
+**Endonyms, not English names.** Someone reaching for this control is by
+definition someone who cannot read the current one.
+
+##### Where — and why further than jellyfin-web goes
+
+[iw]: **top of the settings landing page**, because a user may be pointing a
+phone camera at the screen to read it.
+
+**jellyfin-web does not have one on its login page** — checked: the login
+controllers reference no language or localization at all, and the selector
+lives in Display preferences (`LabelDisplayLanguage`). The setup wizard's
+`selectLanguage` is `HeaderPreferredMetadataLanguage`, i.e. metadata language,
+a server setting.
+
+**Our case is not theirs, and the difference is measured.** jellyfin-web runs
+in a browser, which reports the user's language reliably. We ask Python, and on
+Linux that is wrong three different ways — see below. So a user whose desktop
+*is* German can still get an English UI with no indication why, and the control
+that fixes it has to be findable without reading anything. That argues for the
+login screen too, since a first run reaches login before settings.
+
+##### Locale detection on Linux is unreliable — three measured faults
+
+`i18n.configure()` uses `locale.getdefaultlocale()`, chosen because it
+"supports Windows correctly" (the comment says so). On Linux it is wrong in
+three separate ways, all measured on this box:
+
+- **`LANGUAGE` is ignored.** With `LANG=en_US.UTF-8 LANGUAGE=de_DE:en` it
+  answers `('en_US','UTF-8')`. `LANGUAGE` is the variable GNOME and KDE set for
+  UI language, and gettext's *own* lookup honours it first.
+- **`LANG` only works if the locale has been generated.** `LANG=de_DE.UTF-8`
+  answers `('C','UTF-8')` on a box where only `C.utf8` and `en_US.utf8` exist —
+  and generating locales is opt-in on Debian/Ubuntu and absent in most
+  containers. The user's language is simply discarded.
+- **It is deprecated**, with removal in **Python 3.15**
+  (`DeprecationWarning` today on 3.13). This will stop working, not degrade.
+
+With no environment at all — a systemd service — it answers `('C','UTF-8')`,
+which falls back to English rather than crashing.
+
+**That is arguably a bug in its own right and worth fixing with the selector**:
+on non-Windows, defer to gettext's own environment handling (`LANGUAGE`,
+`LC_ALL`, `LC_MESSAGES`, `LANG`, no generated-locale requirement) and keep the
+`getdefaultlocale` path only where it earns its keep.
 
 
 ### 5.4 Hand-delivered builds are a real distribution channel

--- a/docs/RELEASE_SHAPE_POST_3.0.0.md
+++ b/docs/RELEASE_SHAPE_POST_3.0.0.md
@@ -708,10 +708,54 @@ three separate ways, all measured on this box:
 With no environment at all — a systemd service — it answers `('C','UTF-8')`,
 which falls back to English rather than crashing.
 
-**That is arguably a bug in its own right and worth fixing with the selector**:
-on non-Windows, defer to gettext's own environment handling (`LANGUAGE`,
-`LC_ALL`, `LC_MESSAGES`, `LANG`, no generated-locale requirement) and keep the
-`getdefaultlocale` path only where it earns its keep.
+##### The translations have been largely inert, and that is the headline
+
+[iw]: *"surprised no one ever reported the locale detection issues — most of
+the translations were inert."* Measured, and it holds for two large
+populations for two different reasons:
+
+- **KDE, on any packaging.** Plasma splits *formats* from *translations*:
+  `~/.config/plasma-localerc` carries `[Formats] LANG=...`, while the display
+  language a user picks in **Region & Language** goes to `LANGUAGE` —
+  `kcm_regionandlang` and both `startplasma-x11` / `startplasma-wayland`
+  reference it. We ignore `LANGUAGE`, so **changing the display language on
+  KDE does nothing to this app**. That is #737's reporter's platform family.
+- **The Flatpak, for almost everyone.** Measured inside the shipped sandbox,
+  the generated locales are `C`, `POSIX` and **twenty English variants — and
+  nothing else**: `en_AG en_AU en_BW en_CA en_DK en_GB en_HK en_IE en_IL en_IN
+  en_NG en_NZ en_PH en_SG en_US en_ZA en_ZM en_ZW`. No `de`, `fr`, `es`, `zh`.
+  So `LANG=de_DE.UTF-8` resolves to `C` for want of a generated locale, and
+  `LANGUAGE=de` is ignored — **both paths fail**, and the UI is English
+  whatever the user asked for. (Flatpak *does* forward `LANGUAGE` into the
+  sandbox — verified — so this is our detection and not the sandbox.)
+  Locales arrive with the per-language `.Locale` extension, which is installed
+  according to the user's configured languages; none is present here.
+
+**This reframes the 25-50% translation cluster.** It is not only that the
+jellyfin-web seed did not cover our UI — it is that a large share of users
+could never see their own language, so nobody was moved to finish it. Fixing
+detection is the input to the feedback loop, not a footnote to it.
+
+##### The fix, and the deadline
+
+On non-Windows, defer to gettext's own environment handling (`LANGUAGE`,
+`LC_ALL`, `LC_MESSAGES`, `LANG`, in that order, and **no generated-locale
+requirement**) and keep the `getdefaultlocale` path only where it earns its
+keep — the Windows case the comment cites. `gettext.translation(languages=...)`
+already accepts an explicit list, so the change is confined to
+`i18n.configure()`.
+
+**There is a deadline attached**: `locale.getdefaultlocale()` is removed in
+**Python 3.15**. This is not drift we can absorb — it stops working. Doing it
+alongside the selector means one round of translator-facing testing rather than
+two.
+
+Together that makes a localization package rather than a feature:
+
+1. fix detection (a bug, with a Python-3.15 deadline);
+2. the selector, so a user can override it when it is still wrong;
+3. surface completeness in the picker, so the people most able to help can see
+   where the gaps are.
 
 
 ### 5.4 Hand-delivered builds are a real distribution channel

--- a/docs/RELEASE_SHAPE_POST_3.0.0.md
+++ b/docs/RELEASE_SHAPE_POST_3.0.0.md
@@ -750,12 +750,74 @@ already accepts an explicit list, so the change is confined to
 alongside the selector means one round of translator-facing testing rather than
 two.
 
-Together that makes a localization package rather than a feature:
+##### Crashing translations must be filtered out at build time — 3.1.0
+
+**Four locales currently ship translations that raise when formatted, and the
+build does not notice.** Verified end to end 2026-09-09: `msgfmt` exits 0 with
+no stderr, the broken msgstr lands in the `.mo`, and gettext hands it back to
+be formatted and raise.
+
+| locale | msgstr | raises |
+|---|---|---|
+| `ar` | `صفحة %(page)d من %(total)ات` | `ValueError: unsupported format character` |
+| `gl` | `Páxina %(page) de %(total)` | `ValueError: incomplete format` |
+| `ms` | `Halaman %(page) daripada %(total)` | `ValueError: incomplete format` |
+| `sk` | `Používateľ {0} sa pripojil` | `TypeError` — brace syntax for a `%s` msgid |
+
+`ar` has a second at `base.po:5027` (`Downloading %(name)s — %(n)d remaining`).
+`Page %(page)d of %(total)d` is `reader.py:748` inside `_bottom_bar`, so in
+Galician, Malay and Arabic the epub/comic reader raises **on every repaint**.
+The `ru` `{0: 0.1f}` entry that `--check-format` also flags does **not** raise —
+a space is a valid format-spec flag — so a checker that only diffs placeholder
+sets over-reports.
+
+**The requirement: filter, do not gate.** [iw]: a crashing translation must
+never reach a build, and the way to guarantee that is to **drop the offending
+entry at compile time**, not to fail the build. gettext then returns the msgid,
+so that one string falls back to English and the rest of the locale is
+unaffected. Failing the build instead would hand Weblate volunteers a way to
+break our release, and would need fixing `.po` files by hand — which is
+Weblate's job, not ours (`docs/i18n.md`).
+
+Design, and the parts that are not obvious:
+
+- **Validate by attempting the substitution, not by parsing placeholders.**
+  Format each non-fuzzy msgstr with synthesized arguments and drop it if it
+  raises. That is what distinguishes the four real crashers from the `ru`
+  cosmetic case, and it cannot false-positive on a literal `%` in "125%" or a
+  stray brace in prose — both of which a placeholder-diff heuristic trips on.
+- **Both compile paths, or it is the usual one-of-two.** `gen_pkg.sh:85-89`
+  uses GNU `msgfmt` when present and falls back to `tools/msgfmt.py`
+  otherwise (Windows without MSYS2). The filter has to cover both, or the
+  guarantee holds only on the machine that happens to have gettext installed.
+  This repo's recurring defect shape is exactly that — see
+  `docs/do-not-fix.md` and the risk map's §2.
+- **Report what it dropped.** A silent filter turns a crash into a mystery
+  gap in the translation. Print the locale, the msgid and the exception, so a
+  dropped string is visible in the build log and can be sent upstream.
+- **Test the filter, not the catalog.** A test asserting the catalogs are
+  clean fails whenever a volunteer types a bad placeholder, which is both
+  inevitable and not our bug. Assert instead that the filter drops a crafted
+  bad entry, keeps a good one, and keeps the `ru`-style cosmetic case — with
+  the four real msgstrs above as fixtures.
+- Fuzzy entries are already excluded by both compilers, so only non-fuzzy
+  entries need checking.
+
+**Out of scope for 3.1.0, explicitly: LLM/generated translation of the
+application.** [iw] — community translation velocity in Jellyfin is good, and
+the generated-translation question stays open and unbuilt. See
+[[translation-landscape]] for the measured state if it is ever revisited.
+
+Together that makes a localization package rather than a feature, scoped for
+**3.1.0**:
 
 1. fix detection (a bug, with a Python-3.15 deadline);
-2. the selector, so a user can override it when it is still wrong;
-3. surface completeness in the picker, so the people most able to help can see
+2. **filter crashing translations at build time** (a shipped crash today);
+3. the selector, so a user can override detection when it is still wrong;
+4. surface completeness in the picker, so the people most able to help can see
    where the gaps are.
+
+Generated/LLM translation is **not** in it.
 
 
 ### 5.4 Hand-delivered builds are a real distribution channel

--- a/docs/RELEASE_SHAPE_POST_3.0.0.md
+++ b/docs/RELEASE_SHAPE_POST_3.0.0.md
@@ -803,6 +803,41 @@ Design, and the parts that are not obvious:
 - Fuzzy entries are already excluded by both compilers, so only non-fuzzy
   entries need checking.
 
+###### `regen_pot.sh` marks them fuzzy — and that IS the filter
+
+[iw]: running the regen should mark broken translations however Weblate needs
+to flag them. It does not need a new mechanism, because **fuzzy already does
+both jobs**:
+
+- **Weblate** shows a fuzzy entry as **"Needs editing"** — it leaves the
+  translated count, appears in the translator's queue, and clears itself when
+  someone fixes it.
+- **Both compilers already exclude fuzzy**, verified: `tools/msgfmt.py:164`
+  emits an entry only `if value and (is_header or not entry.fuzzy)`, and GNU
+  `msgfmt` requires an opt-in `-f`/`--use-fuzzy` to include them.
+
+So one surgical edit flags it upstream *and* keeps it out of the `.mo` on both
+paths. `tools/msgfmt.py`'s own docstring documents the header-emitted-even-when
+-fuzzy exception precisely because a tool writing fuzzy flags into `.po` files
+was expected.
+
+**This makes the regen touch `.po` files, and that is a deliberate, bounded
+exception rather than a relaxation of the `--merge` prohibition.** The
+difference is the diff: adding `#, fuzzy` to the offending entries is **5
+entries across 4 files** and leaves every other byte alone, where `--merge`
+rewrites references and re-wraps whatever it touches for **~10k lines across
+86 files** (`docs/i18n.md`). Keep `--merge` forbidden; this is not it.
+
+Two constraints:
+
+- **Mark only what actually raises.** The `ru` `{0: 0.1f}` entry must stay
+  translated — same reason the validator formats rather than diffs.
+- **The build-time filter still earns its place**, as defence for an entry
+  that arrives *after* the last regen: broken translations land on Weblate's
+  schedule, not ours, and a release cut between regens would otherwise ship
+  one. Which also argues for the check being runnable standalone, not only as
+  a side effect of a string change.
+
 **Out of scope for 3.1.0, explicitly: LLM/generated translation of the
 application.** [iw] — community translation velocity in Jellyfin is good, and
 the generated-translation question stays open and unbuilt. See

--- a/docs/RELEASE_SHAPE_POST_3.0.0.md
+++ b/docs/RELEASE_SHAPE_POST_3.0.0.md
@@ -612,6 +612,52 @@ default being off is simply wrong there.
   time, so the setting being on is not a promise that a pad is present. That is
   the existing behaviour on every other platform and needs no change here.
 
+#### An interface language selector — [iw], recorded for later
+
+**The mechanism already exists; the work is exposing it.** `conf.py:500` has
+`lang: Optional[str] = None`, and `i18n.configure()` already prefers it over
+the system locale:
+
+```python
+if settings.lang is not None:
+    lang = settings.lang
+else:
+    lc = locale.getdefaultlocale()      # robust on Windows, unlike gettext's own
+```
+
+So a user *can* override the language today — by hand-editing `conf.json`.
+`lang` is not in `config.py`'s `TAB_SECTIONS`, so nothing in the UI offers it,
+which is the same "real setting, no way to reach it" shape as the `kb_*` keys.
+
+**It requires a restart, and that is measured rather than assumed.** There are
+**22 module-scope `_()` / `_p()` call sites** (`syncplay.py:21`,
+`video_profile.py:32`, `users.py:36`, `menu.py:29` …). Those evaluate at
+import, so re-running `configure()` live would swap the translation object and
+leave those strings in the old language — a half-translated UI, which is worse
+than asking for a restart. So the row belongs in `RESTART_REQUIRED`
+(`config.py:299`), and that set's own docstring is the standard to meet:
+*"'Requires restart' means literally nothing happened"* — true here for those
+22, and the rest would repaint into the new language on the next draw, which is
+the ugly middle state the flag exists to prevent.
+
+Three things to settle when it is built, in `docs/settings-curation.md` terms:
+
+- **Which tab.** It is a "look" setting applied at startup, which is the group
+  `browse` already collects.
+- **What to list.** There are **86 locales** under `jellyfin_mpv_shim/messages/`,
+  most of them partial — Weblate fills them and completeness moves. A picker
+  listing all 86 offers mostly-English UIs under native names; a filtered list
+  needs a completeness threshold computed from the `.po` files at build time,
+  and that number then has to be regenerated with the translations. Decide
+  which before writing the enum, because the two have different build stories.
+  `window_controls` (`config.py:532`) is the structural precedent for a
+  three-way whose first option resolves at runtime — here that first option is
+  **"Use the system language"**, which is what `lang = None` already means.
+- **The display name for each entry** should be the language's own endonym, not
+  its English name: a user who cannot read the current UI language is exactly
+  the person reaching for this control.
+
+
 ### 5.4 Hand-delivered builds are a real distribution channel
 
 **[iw] and this is the practice for user-facing issues now:** hand a CI build to

--- a/jellyfin_mpv_shim/mpvtk/renderer.lua
+++ b/jellyfin_mpv_shim/mpvtk/renderer.lua
@@ -5962,6 +5962,24 @@ local phud_skip_hide, phud_skip_unbind  -- fwd: summon/hide retune them
 -- routed here as a keypress) skips instead of summoning, and a click
 -- skips on the button / summons elsewhere. While the HUD is up, ENTER
 -- and clicks belong to the scene, whose Skip button is a real node.
+--- Is the pointer on the Skip button? The only thing a click on an
+--- otherwise-hidden HUD can hit; everything else there is bare video.
+---
+--- Shared by all three bindings that can land on it -- `mbtn_left` in
+--- click-to-pause mode, `mbtn_right` in mpv modality, and the skip
+--- button's own `mbtn_left` -- because three copies of one hit test is how
+--- they drift apart.
+--- On `state` rather than a file-scope `local`, like `state.pause_now`:
+--- the main chunk is at Lua's 200-local ceiling and one more would not
+--- compile (tests/test_renderer_lua.py reports the headroom).
+state.hit_skip = function()
+    local r = state.phud.skip_rect
+    local x, y = state.phud.mx, state.phud.my
+    return state.phud.skip_show and r and x >= r.x1 and x <= r.x2
+        and y >= r.y1 and y <= r.y2 and true or false
+end
+
+
 local function phud_skip_bind()
     if state.kb_saved then            -- see bind_nav_keys
         state.kb_saved.skip = true
@@ -5987,10 +6005,7 @@ local function phud_skip_bind()
     -- keyboard-only in that mode, which is not a trade anybody chose.
     if not state.phud.click_pauses then
         mp.add_forced_key_binding('mbtn_left', 'mpvtk_skip_click', function()
-            local r = state.phud.skip_rect
-            local x, y = state.phud.mx, state.phud.my
-            if state.phud.skip_show and r and x >= r.x1 and x <= r.x2
-                and y >= r.y1 and y <= r.y2 then
+            if state.hit_skip() then
                 send({ t = 'hudskip' })
                 phud_skip_hide()
             else
@@ -6085,14 +6100,29 @@ function phud_bind_summon()
     -- even with this bound the two pause toggles cancel and fullscreen
     -- still fires.
     if not state.phud.click_pauses then
+        -- **The right button needs binding here, and used not to.** In mpv
+        -- modality the left button drags the window and the RIGHT one
+        -- pauses -- `on_rclick` does that, but only while the bar is
+        -- `shown`, and the bar is hidden for most of playback. What covered
+        -- the gap was mpv's own default, and our pin move took it away:
+        -- v0.41.0 binds MBTN_RIGHT to `cycle pause`, master binds it to
+        -- `script-binding select/context-menu` (65a1852ba3), and the
+        -- flatpak went to master for an unrelated HDR fix (#687). So right
+        -- click over a hidden HUD did nothing at all.
+        mp.add_forced_key_binding('mbtn_right', 'mpvtk_phud_rclick',
+            function()
+                if state.hit_skip() then
+                    send({ t = 'hudskip' })
+                    phud_skip_hide()
+                else
+                    state.pause_now()
+                end
+            end)
         state.kb_summon = true
         return
     end
     mp.add_forced_key_binding('mbtn_left', 'mpvtk_phud_click', function()
-        local r = state.phud.skip_rect
-        local x, y = state.phud.mx, state.phud.my
-        if state.phud.skip_show and r and x >= r.x1 and x <= r.x2
-            and y >= r.y1 and y <= r.y2 then
+        if state.hit_skip() then
             send({ t = 'hudskip' })
             phud_skip_hide()
         else
@@ -6108,6 +6138,7 @@ local function phud_unbind_summon()
         mp.remove_key_binding('mpvtk_summon_' .. key)
     end
     mp.remove_key_binding('mpvtk_phud_click')
+    mp.remove_key_binding('mpvtk_phud_rclick')
     state.kb_summon = false
 end
 

--- a/jellyfin_mpv_shim/mpvtk/renderer.lua
+++ b/jellyfin_mpv_shim/mpvtk/renderer.lua
@@ -6004,6 +6004,18 @@ end
 -- Give ENTER back to the scene without taking the button down.
 function phud_skip_unbind()
     mp.remove_key_binding('mpvtk_skip_enter')
+    -- **And the mouse half, which `phud_skip_bind` takes only in
+    -- right-click-to-pause mode.** Releasing just ENTER left a forced
+    -- `mbtn_left` behind after every skip segment, and its else-branch
+    -- runs `begin-vo-dragging` -- so once the button was down, every click
+    -- dragged the window instead of reaching the UI, for the rest of the
+    -- session. That is #737: "the UI becomes unresponsive after a few
+    -- videos ... switching back to left click to pause this behavior never
+    -- occurs". Unconditional because `remove_key_binding` on a name that
+    -- was never bound is a no-op, and gating it on `click_pauses` would
+    -- strand the binding for anyone who changes the setting while a skip
+    -- segment is up.
+    mp.remove_key_binding('mpvtk_skip_click')
     state.kb_skip = false
 end
 

--- a/tests/lua/test_renderer.lua
+++ b/tests/lua/test_renderer.lua
@@ -3370,6 +3370,61 @@ eq(fake.log.props["user-data/mpvtk/active"], true,
    "a direction over the Skip button did not bring the bar up")
 fake.send("mpvtk-hud-skip", "")
 
+-- ============================================ #737: the leaked skip click
+--
+-- Reported as "right click to pause causes the UI to become unresponsive":
+-- after a couple of videos no mouse click reaches the UI at all, the
+-- keyboard still works, and quitting playback does not clear it. Only with
+-- right-click-to-pause -- "switching back to left click to pause this
+-- behavior never occurs".
+--
+-- That is exactly the shape of a forced binding nobody released.
+-- `phud_skip_bind` takes `mbtn_left` for the Skip button **only when
+-- click_pauses is off** (with it on, `mpvtk_phud_click` already owns the
+-- button), and `phud_skip_unbind` released only the ENTER half. So every
+-- skip segment left another `mpvtk_skip_click` behind, and once the button
+-- is down that handler's else-branch runs `begin-vo-dragging` for every
+-- click -- which is a UI that ignores the mouse and a window that drags.
+fake.send("mpvtk-hud", "no")
+fake.send("mpvtk-hud", "yes",
+          fake.token({ hide = 4, mode = "hover", click = false }))
+fake.send("mpvtk-hud-skip", "Skip Intro")
+fake.advance(1)
+ok(fake.log.keybinds["mpvtk_skip_click"] ~= nil,
+   "the premise: right-click mode takes mbtn_left while the button is up")
+fake.send("mpvtk-hud-skip", "")
+ok(fake.log.keybinds["mpvtk_skip_click"] == nil,
+   "the Skip button gives mbtn_left back when it hides (#737)")
+
+-- And it must survive the loop that the report describes: several videos,
+-- each with a skip segment. One release that only works the first time
+-- would still strand the button.
+for i = 1, 3 do
+    fake.send("mpvtk-hud", "no")
+    fake.send("mpvtk-hud", "yes",
+              fake.token({ hide = 4, mode = "hover", click = false }))
+    fake.send("mpvtk-hud-skip", "Skip Intro")
+    fake.advance(1)
+    fake.send("mpvtk-hud-skip", "")
+    if fake.log.keybinds["mpvtk_skip_click"] ~= nil then
+        ok(false, "mbtn_left was still bound after skip cycle " .. i)
+        break
+    end
+end
+ok(fake.log.keybinds["mpvtk_skip_click"] == nil,
+   "three skip segments in a row leave nothing bound")
+
+-- The control: with click-to-pause ON, the button is owned by
+-- mpvtk_phud_click and this binding is never taken in the first place.
+fake.send("mpvtk-hud", "no")
+fake.send("mpvtk-hud", "yes", fake.token({ hide = 4, mode = "hover" }))
+fake.send("mpvtk-hud-skip", "Skip Intro")
+fake.advance(1)
+eq(fake.log.keybinds["mpvtk_skip_click"], nil,
+   "left-click-to-pause never takes the second binding")
+fake.send("mpvtk-hud-skip", "")
+fake.send("mpvtk-hud", "no")
+
 -- Auto-repeat. mpv repeats a held key at --input-ar-rate -- 40 a second by
 -- default -- which on a stick is forty library rows a second and is not
 -- something anybody can aim. Held controls are thinned to their own rate.

--- a/tests/lua/test_renderer.lua
+++ b/tests/lua/test_renderer.lua
@@ -2987,6 +2987,58 @@ fake.key("mbtn_right")
 ok(not did("cycle", "pause"),
    "click-to-pause on: right click is not a second way to pause")
 
+-- ...and with the HUD HIDDEN, which is most of playback. A4, and the other
+-- half of #737's right-click story.
+--
+-- `on_rclick`'s bare-video pause requires `state.phud.shown`, and
+-- `phud_bind_summon` binds `mbtn_left` when click_pauses is ON and nothing
+-- at all when it is off -- so with right-click-to-pause and the bar
+-- auto-hidden there was no path to pause by mouse. That used to be covered
+-- by mpv's own default, and our pin move took it away: v0.41.0 binds
+-- MBTN_RIGHT to `cycle pause`, master binds it to
+-- `script-binding select/context-menu` (65a1852ba3), and the flatpak moved
+-- to master for an unrelated HDR fix.
+hud_engage({ hide = 4, mode = "hover", click = false })
+hud_pointer(600, 300)          -- off the controls, onto the picture
+fake.reset_events()
+hud_wait()
+ok(hud_hidden(), "premise: the HUD engaged and then auto-hid")
+-- Asserted through the binding rather than `fake.key("mbtn_right")`,
+-- because the fake dispatches by binding NAME and cannot model mpv's
+-- section stack (fake_mp says so itself) -- `mbtn_right` there reaches the
+-- mouse section's handler, while in real mpv a FORCED binding outranks the
+-- section. So: the binding must exist while the HUD is hidden, and it must
+-- pause.
+ok(fake.log.keybinds["mpvtk_phud_rclick"] ~= nil,
+   "mpv modality: the right button is bound while the HUD is hidden (A4)")
+fake.log.commands = {}
+if fake.log.keybinds["mpvtk_phud_rclick"] then
+    fake.key("mpvtk_phud_rclick")
+end
+ok(did("cycle", "pause"),
+   "mpv modality: right click pauses with the HUD hidden too (A4)")
+
+-- The control, both ways round: click-to-pause on must not gain a second
+-- pause button, and the left button must keep dragging the window in mpv
+-- modality rather than pausing.
+hud_engage({ hide = 4, mode = "hover", click = true })
+hud_pointer(600, 300)
+fake.reset_events()
+hud_wait()
+eq(fake.log.keybinds["mpvtk_phud_rclick"], nil,
+   "click-to-pause on: the right button is not taken with the HUD hidden")
+fake.log.commands = {}
+fake.key("mbtn_right")
+ok(not did("cycle", "pause"),
+   "click-to-pause on: right click is not a second pause with the HUD hidden")
+
+-- And the release, which the pairing lint also insists on: leaving
+-- mpvtk_phud_rclick bound after the HUD disengages would be #737 again
+-- with the other button.
+fake.send("mpvtk-hud", "no")
+eq(fake.log.keybinds["mpvtk_phud_rclick"], nil,
+   "the right-button binding is released when the HUD disengages")
+
 -- ------------- ...but "no node" is not "bare video" while something floats
 --
 -- node_at() answers with clickable SCENE nodes, and a modal's body, a

--- a/tests/test_no_unpaired_bindings.py
+++ b/tests/test_no_unpaired_bindings.py
@@ -1,0 +1,112 @@
+"""Every forced key binding in the renderer is released by something.
+
+`mp.add_forced_key_binding` outranks the user's own input.conf and mpv's
+defaults and stays until something names it to `mp.remove_key_binding`. A
+binding nobody releases does not fail, log or degrade -- it quietly keeps
+eating that key for the rest of the session, and the symptom is "the mouse
+stopped working", which points nowhere near a binding.
+
+#737 was one: the Skip button took `mbtn_left` in right-click-to-pause mode
+and only the ENTER half was released, so every skip segment left another
+handler behind and, once the button was down, every click ran
+`begin-vo-dragging` instead of reaching the UI.
+
+**The renderer suite could not have caught the next one.** It has 400
+assertions and a fake that models the binding registry, so a test *can*
+assert that one name is gone -- and one now does. What no test does is
+enumerate the pairs, which is why this is a lint and not another case.
+
+A finding here is not automatically a bug: release the binding where its
+owner goes away, or add it to `tools/audit_key_bindings.ACCEPTED` with the
+reason it needs no release.
+"""
+
+# Run as a script, this is what puts the repo root on sys.path -- without
+# it `jellyfin_mpv_shim` resolves to whatever is pip-installed. A no-op
+# under `discover`; tests/test_module_paths.py is the guard.
+if __name__ == "__main__":
+    import os
+    import sys
+
+    sys.path.insert(0, os.path.dirname(
+        os.path.dirname(os.path.abspath(__file__))))
+
+import os
+import unittest
+
+ROOT = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+RENDERER = os.path.join(ROOT, "jellyfin_mpv_shim", "mpvtk", "renderer.lua")
+
+
+def _audit():
+    import importlib.util
+
+    spec = importlib.util.spec_from_file_location(
+        "audit_key_bindings", os.path.join(ROOT, "tools",
+                                           "audit_key_bindings.py"))
+    mod = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(mod)
+    return mod
+
+
+class UnpairedBindingsTest(unittest.TestCase):
+    def test_every_binding_is_released(self):
+        mod = _audit()
+        findings = mod.audit(RENDERER)
+        self.assertEqual(
+            [], findings,
+            "forced key bindings with no release: %s"
+            % "; ".join("%s (line %d)" % (n, ln) for ln, n, _k in findings))
+
+    def test_the_lint_can_actually_fail(self):
+        """Guard on the guard. A pairing check that matched everything --
+        an over-broad prefix rule, say -- would pass this file for ever and
+        say nothing. Feed it a binding that is plainly unreleased.
+        """
+        import tempfile
+
+        mod = _audit()
+        src = (
+            "mp.add_forced_key_binding('mbtn_left', 'jms_probe_leak',\n"
+            "    function() end)\n"
+            "mp.remove_key_binding('something_else')\n")
+        with tempfile.NamedTemporaryFile("w", suffix=".lua",
+                                         delete=False) as fh:
+            fh.write(src)
+            path = fh.name
+        self.addCleanup(os.unlink, path)
+        findings = mod.audit(path)
+        self.assertEqual(1, len(findings), findings)
+        self.assertEqual("jms_probe_leak", findings[0][1])
+
+    def test_a_released_binding_is_not_reported(self):
+        """The other direction: a correct pair must not be a finding, or
+        the lint is noise and gets exempted into uselessness."""
+        import tempfile
+
+        mod = _audit()
+        src = (
+            "mp.add_forced_key_binding('mbtn_left', 'jms_probe_ok',\n"
+            "    function() end)\n"
+            "mp.remove_key_binding('jms_probe_ok')\n"
+            "mp.add_forced_key_binding(key, 'jms_pre_' .. key, fn)\n"
+            "mp.remove_key_binding('jms_pre_' .. key)\n")
+        with tempfile.NamedTemporaryFile("w", suffix=".lua",
+                                         delete=False) as fh:
+            fh.write(src)
+            path = fh.name
+        self.addCleanup(os.unlink, path)
+        self.assertEqual([], mod.audit(path))
+
+    def test_accepted_entries_name_a_mechanism(self):
+        """An exemption is only worth having if it says *how* the binding
+        is released -- otherwise it is a silenced finding."""
+        mod = _audit()
+        for name, reason in mod.ACCEPTED.items():
+            self.assertGreater(
+                len(reason), 40,
+                "%s is exempted without explaining the release" % name)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tools/audit_key_bindings.py
+++ b/tools/audit_key_bindings.py
@@ -1,0 +1,132 @@
+#!/usr/bin/env python3
+"""Find forced key bindings that nothing ever releases.
+
+`mp.add_forced_key_binding` installs a binding that outranks the user's own
+input.conf and mpv's defaults, and it stays until something names it to
+`mp.remove_key_binding`. A binding whose owner goes away without releasing
+it does not fail, log, or degrade -- it silently keeps eating that key for
+the rest of the session, and the symptom is "the mouse stopped working"
+rather than anything pointing at the binding.
+
+That is #737. `phud_skip_bind` took `mbtn_left` for the Skip button -- but
+only in right-click-to-pause mode, since with click-to-pause on
+`mpvtk_phud_click` already owns the button -- and `phud_skip_unbind`
+released only the ENTER half. Every skip segment left another
+`mpvtk_skip_click` behind, and once the button was down its else-branch ran
+`begin-vo-dragging`, so every click dragged the window instead of reaching
+the UI. The reporter's account is the exact shape: "the UI becomes
+unresponsive after a few videos ... keyboard shortcuts still work ...
+switching back to left click to pause this behavior never occurs".
+
+**Why a lint and not a test.** The binding registry is real, so a Lua test
+*can* assert one name is gone -- and one such test now does. What it cannot
+do is notice the next binding somebody adds. The leak lived through a
+release with a suite of 400 renderer assertions around it, because nothing
+enumerated the pairs. This does.
+
+A finding is not automatically a bug. Either release the binding where its
+owner goes away, or add the name to `ACCEPTED` with the reason it does not
+need releasing -- which is documentation either way.
+"""
+
+import argparse
+import os
+import re
+import sys
+
+#: Bindings that are released by something this cannot see, with the
+#: mechanism. Keep the reason concrete: it is the only evidence a reader
+#: gets that the name is not the next #737.
+ACCEPTED = {
+    "mpvtk_text": (
+        "released through the `text_key_names` registry -- `bind_text_keys` "
+        "appends every name it installs and `unbind_text_keys` iterates the "
+        "list calling remove_key_binding, so the release is by variable and "
+        "not by literal."
+    ),
+}
+
+#: `mp.add_forced_key_binding(<key>, <name>, ...)` and its non-forced
+#: sibling. The name is the second argument.
+_ADD = re.compile(
+    r"mp\.add_(?:forced_)?key_binding\s*\(\s*[^,]+,\s*(.+?)\s*,", re.S)
+_REMOVE = re.compile(r"mp\.remove_key_binding\s*\(\s*(.+?)\s*\)", re.S)
+
+#: A name built by concatenation -- `'mpvtk_nav_' .. name`. Only the
+#: literal prefix is knowable statically, and that is enough: the add and
+#: the remove have to agree on it.
+_CONCAT = re.compile(r"^'([^']*)'\s*\.\.")
+_LITERAL = re.compile(r"^'([^']*)'$")
+
+
+def _name_of(expr):
+    """(kind, value) for a binding-name expression, or None if it is a bare
+    variable -- those are released by variable too and carry no literal to
+    match on."""
+    expr = expr.strip()
+    hit = _LITERAL.match(expr)
+    if hit:
+        return ("literal", hit.group(1))
+    hit = _CONCAT.match(expr)
+    if hit:
+        return ("prefix", hit.group(1))
+    return None
+
+
+def audit(path):
+    """[(line, name, kind)] for every added binding with no matching
+    release in the same file."""
+    with open(path, encoding="utf-8") as fh:
+        src = fh.read()
+
+    released_literals, released_prefixes = set(), set()
+    for expr in _REMOVE.findall(src):
+        got = _name_of(expr)
+        if got is None:
+            continue
+        kind, value = got
+        (released_literals if kind == "literal" else
+         released_prefixes).add(value)
+
+    findings = []
+    for hit in _ADD.finditer(src):
+        got = _name_of(hit.group(1))
+        if got is None:
+            continue
+        kind, value = got
+        if value in ACCEPTED:
+            continue
+        if kind == "literal":
+            ok = value in released_literals or any(
+                value.startswith(p) for p in released_prefixes)
+        else:
+            ok = value in released_prefixes or any(
+                lit.startswith(value) for lit in released_literals)
+        if not ok:
+            line = src.count("\n", 0, hit.start()) + 1
+            findings.append((line, value, kind))
+    return findings
+
+
+def main(argv=None):
+    ap = argparse.ArgumentParser(description=__doc__)
+    ap.add_argument("files", nargs="*", help="lua files to audit")
+    args = ap.parse_args(argv)
+    root = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+    files = args.files or [
+        os.path.join(root, "jellyfin_mpv_shim", "mpvtk", "renderer.lua")]
+
+    bad = 0
+    for path in files:
+        for line, name, kind in audit(path):
+            bad += 1
+            print("%s:%d: %s binding %r is never released"
+                  % (os.path.relpath(path, root), line, kind, name))
+    if bad:
+        print("\n%d unreleased binding(s). Release it where its owner goes "
+              "away, or add it to ACCEPTED with the reason." % bad)
+    return 1 if bad else 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
Fixes a bug where if you set the mouse bindings to use the mpv style right click to pause bindings, skipping to the next episode while the skip intro button is displayed breaks all mouse input. Also includes documentation changes.