### PR TITLE
Fix Windows font scale reference

### DIFF
--- a/jellyfin_mpv_shim/mpvtk/GUIDE.md
+++ b/jellyfin_mpv_shim/mpvtk/GUIDE.md
@@ -435,12 +435,22 @@ the fallback outvote the renderer — see `MpvtkApp.scroll_offsets`.
    slots and remove-before-add both showed as scroll flicker).
 3. Text metrics: measured per-char advances (ASCII) shared by layout
    and renderer + `\fn` for the same font. **libass scales `\fs` to the
-   font's ascender+descender height, not the em** (VSFilter compat) —
-   metrics.py folds the correction factor (em/(asc+desc), ≈0.859 for
-   DejaVu Sans) into the table; `calibrate.py` verifies pixel-wise
-   (ratios ~1.00). Without the factor, widths run ~16% wide and
-   click/selection lands on the wrong letter. **Pair kerning** is also
-   measured (`getlength(ab) - a - b`, ~220 non-zero ASCII pairs for
+   font's ascender+descender height, not the em** (VSFilter compat), and
+   that box is font-relative — 150 for DejaVu Sans at a 128px em, 172 for
+   Segoe UI, both measured. Two consequences, and only the first was
+   handled for a long time. Widths are a fraction of the nominal size, so
+   metrics.py folds the constant `_WIDTH_FACTOR` (≈0.853) into the table;
+   without it they run ~16% wide and click/selection lands on the wrong
+   letter, and `calibrate.py` verifies that pixel-wise (ratios ~1.00).
+   **And the rendered size is font-relative unless something cancels the
+   face out**: the renderer multiplies every `\fs` by `state.fs_mul`
+   (metrics.py `_fs_multiplier`, sent as the `fs` key), which is the face's
+   own box over DejaVu Sans'. Linux is the reference, so it is 1.0 there
+   and 1.147 on Windows — where the whole UI drew 13% small, with every box
+   around it the right size, because the width model carried the same
+   per-face factor and predicted the smaller text correctly. `calibrate.py`
+   cannot see that: it compares two models that shared the error.
+   **Pair kerning** is also measured (`getlength(ab) - a - b`, ~220 non-zero ASCII pairs for
    DejaVu, e.g. "Ta" = -0.14em) and applied in every width/boundary
    path — advances alone drift badly on strings like "TaTaTa".
    Caret/selection boundaries include the kern INTO the next glyph

--- a/jellyfin_mpv_shim/mpvtk/metrics.py
+++ b/jellyfin_mpv_shim/mpvtk/metrics.py
@@ -16,7 +16,7 @@ import tempfile
 log = logging.getLogger("mpvtk")
 
 # Bump when the measurement logic changes (invalidates disk caches).
-_METRICS_VERSION = 1
+_METRICS_VERSION = 2
 
 # Candidates per platform; Pillow searches the system font paths.
 _CANDIDATES = [
@@ -27,6 +27,28 @@ _CANDIDATES = [
 ]
 
 _MEASURE_SIZE = 128
+
+#: DejaVu Sans' ascender+descender box at ``_MEASURE_SIZE``, and the size
+#: the whole app is drawn at.
+#:
+#: libass reads ``\fs`` as that box rather than as the em (VSFilter compat),
+#: and the box is font-relative -- 150 for DejaVu Sans, 172 for Segoe UI,
+#: both measured. Feeding the nominal size straight in therefore drew a
+#: 14.5px em on Linux and a 12.7px em on Windows for the same 17, with every
+#: box around it identical, because the width table carried the same
+#: per-face factor and predicted the smaller text correctly.
+#:
+#: **Linux is the reference**, so every face is stretched to the size this
+#: box would have drawn (:func:`_fs_multiplier`, applied by the renderer)
+#: and the width table is a fraction of the nominal size on every platform.
+#: Conforming to the nominal number instead would have been the same fix
+#: with every string on every platform 17% larger.
+_REFERENCE_HEIGHT = 150.0
+
+#: Nominal size -> the em libass ends up drawing. A constant, because the
+#: renderer now cancels the face out; folding a face into this as well would
+#: apply the correction twice.
+_WIDTH_FACTOR = _MEASURE_SIZE / _REFERENCE_HEIGHT
 
 
 def _load_font():
@@ -47,6 +69,20 @@ def _load_font():
     return None
 
 
+def _fs_multiplier(font):
+    """What to multiply a nominal size by before it reaches ``\\fs``.
+
+    1.0 for a face with the reference box, more for a taller one. The only
+    place a face's own metrics are read -- see ``_REFERENCE_HEIGHT``.
+    """
+    try:
+        ascent, descent = font.getmetrics()
+    except AttributeError:  # Pillow too old to measure anything
+        return 1.0
+    box = float(ascent + descent)
+    return box / _REFERENCE_HEIGHT if box > 0 else 1.0
+
+
 def measure_kerning():
     """Pair-kerning adjustments as {2-char string: em fraction}, only
     non-zero pairs, with the libass fs factor folded in. ~9k getlength
@@ -56,8 +92,6 @@ def measure_kerning():
     if font is None:
         return None
     try:
-        ascent, descent = font.getmetrics()
-        factor = _MEASURE_SIZE / float(ascent + descent)
         chars = [chr(i) for i in range(32, 127)]
         single = {c: font.getlength(c) for c in chars}
         kern = {}
@@ -66,7 +100,7 @@ def measure_kerning():
             for b in chars:
                 d = font.getlength(a + b) - la - single[b]
                 if abs(d) > 0.6:  # font units of noise at 128px
-                    kern[a + b] = round(d / _MEASURE_SIZE * factor, 4)
+                    kern[a + b] = round(d / _MEASURE_SIZE * _WIDTH_FACTOR, 4)
         log.info("mpvtk metrics: %d kerning pairs", len(kern))
         return kern
     except AttributeError:
@@ -75,23 +109,14 @@ def measure_kerning():
 
 # session state for on-demand measurement (extend_metrics)
 _session_font = None
-_session_factor = None
 _seen_pairs = set()
 
 
 def _dyn_font():
-    global _session_font, _session_factor
+    global _session_font
     if _session_font is None:
-        f = _load_font()
-        if f is None:
-            return None, None
-        try:
-            ascent, descent = f.getmetrics()
-        except AttributeError:
-            return None, None
-        _session_factor = _MEASURE_SIZE / float(ascent + descent)
-        _session_font = f
-    return _session_font, _session_factor
+        _session_font = _load_font()
+    return _session_font
 
 
 def extend_metrics(m, texts):
@@ -101,7 +126,7 @@ def extend_metrics(m, texts):
     real UI text actually uses. Limited to codepoints below U+2E80, which
     is what the base font covers; CJK keeps the ~1em heuristic because
     libass draws it with a fallback font Pillow is not measuring."""
-    font, factor = _dyn_font()
+    font = _dyn_font()
     if font is None or not m:
         return False
     widths = m["widths"]
@@ -115,20 +140,15 @@ def extend_metrics(m, texts):
                 prev = None
                 continue
             if c not in widths:
-                widths[c] = round(
-                    font.getlength(c) / _MEASURE_SIZE * factor, 4
-                )
+                widths[c] = round(font.getlength(c) / _MEASURE_SIZE * _WIDTH_FACTOR, 4)
                 added = True
             if prev is not None and (ord(prev) > 0x7E or o > 0x7E):
                 p = prev + c
                 if p not in _seen_pairs:
                     _seen_pairs.add(p)
-                    d = (font.getlength(p) - font.getlength(prev)
-                         - font.getlength(c))
+                    d = font.getlength(p) - font.getlength(prev) - font.getlength(c)
                     if abs(d) > 0.6:
-                        kern[p] = round(
-                            d / _MEASURE_SIZE * factor, 4
-                        )
+                        kern[p] = round(d / _MEASURE_SIZE * _WIDTH_FACTOR, 4)
                         added = True
             prev = c
     return added
@@ -138,9 +158,7 @@ def _cache_path():
     if sys.platform.startswith("win"):
         base = os.environ.get("LOCALAPPDATA") or tempfile.gettempdir()
     else:
-        base = os.environ.get("XDG_CACHE_HOME") or os.path.expanduser(
-            "~/.cache"
-        )
+        base = os.environ.get("XDG_CACHE_HOME") or os.path.expanduser("~/.cache")
     return os.path.join(base, "mpvtk-metrics.json")
 
 
@@ -202,33 +220,32 @@ def measure_font():
         except (OSError, ValueError, KeyError):
             pass
         try:
-            # libass scales \fs to ascender+descender, not the em, so the
-            # correction factor is folded in HERE and every width consumer
-            # inherits it (GUIDE.md section 6.3; calibrate.py verifies).
-            ascent, descent = font.getmetrics()
-            factor = _MEASURE_SIZE / float(ascent + descent)
             # printable ASCII + Latin-1 supplement (é, ü, ñ, …); other
             # scripts use the fallback widths (fullwidth heuristic for
             # CJK)
             chars = [chr(i) for i in range(32, 127)]
             chars += [chr(i) for i in range(0xA1, 0x100)]
             widths = {
-                c: round(font.getlength(c) / _MEASURE_SIZE * factor, 4)
+                c: round(font.getlength(c) / _MEASURE_SIZE * _WIDTH_FACTOR, 4)
                 for c in chars
             }
-            mask_w = font.getlength("•") / _MEASURE_SIZE * factor
+            mask_w = font.getlength("•") / _MEASURE_SIZE * _WIDTH_FACTOR
+            stretch = _fs_multiplier(font)
             if not 0.1 < mask_w < 1.5:  # glyph missing/degenerate
                 mask_w = 0.55
             family = font.getname()[0]
         except AttributeError:  # Pillow < 8: no getlength
             return None
         log.info(
-            "mpvtk metrics: measured %s (libass factor %.3f)",
+            "mpvtk metrics: measured %s (\\fs stretch %.3f)",
             family,
-            factor,
+            stretch,
         )
         data = {
             "font": family,
+            # The renderer multiplies every \fs by this, which is what makes
+            # a nominal size mean one physical size on every platform.
+            "fs": round(stretch, 6),
             "widths": widths,
             "mask_w": round(mask_w, 4),
             "kern": measure_kerning() or {},

--- a/jellyfin_mpv_shim/mpvtk/renderer.lua
+++ b/jellyfin_mpv_shim/mpvtk/renderer.lua
@@ -63,6 +63,17 @@ local state = {
     nodes = {},
     byid = {},
     w = 0, h = 0,
+    -- What to multiply a font size by before it reaches `\fs`. libass reads
+    -- `\fs` as the face's ascender+descender box rather than as its em, and
+    -- that box is font-relative, so the same size draws smaller in a face
+    -- with a taller box -- 13% smaller in Segoe UI than in DejaVu Sans,
+    -- measured, which is what made the whole UI look small on Windows.
+    -- mpvtk/metrics.py computes it against DejaVu Sans. 1.0 until the
+    -- metrics arrive, and 1.0 forever where Pillow cannot measure, which
+    -- is the size this drew before. NOT applied to `\fsp`: letter spacing
+    -- is already in drawn pixels. (On `state` rather than a local of its
+    -- own only because this chunk is at the 200-local ceiling.)
+    fs_mul = 1.0,
     -- Design tokens, replaced wholesale by the mpvtk-theme message (see
     -- theme.py, which owns the names and the stock values). Everything the
     -- renderer draws for itself -- text fields, dropdowns and their popups,
@@ -847,7 +858,7 @@ local function draw_text(ass, node, ex, ey, clip, text, color, extra,
         -- paragraph used to overrun its column on a fractional UI scale.
         '{\\q2\\an%d\\pos(%.1f,%.1f)\\fs%.2f\\bord0\\shad0' ..
         '\\1c%s\\1a&H00&%s%s%s%s%s}',
-        an, px, ey + node.h / 2, node.size,
+        an, px, ey + node.h / 2, node.size * state.fs_mul,
         ass_color(color), glow, node.bold and '\\b1' or '',
         ui_font and ('\\fn' .. ui_font) or '',
         clip_tag(clip), extra or ''))
@@ -2399,7 +2410,8 @@ render = function()
         ass:append(string.format(
             '{\\q2\\an5\\pos(%.1f,%.1f)\\fs%.2f\\bord0\\shad0\\1c%s' ..
             '\\1a&H00&\\b0%s}',
-            x1 + bw / 2, y1 + bh / 2, fs, ass_color(PHUD_SKIP_FG),
+            x1 + bw / 2, y1 + bh / 2, fs * state.fs_mul,
+            ass_color(PHUD_SKIP_FG),
             ui_font and ('\\fn' .. ui_font) or ''))
         ass:append(esc(label))
     else
@@ -5562,6 +5574,7 @@ mp.register_script_message('mpvtk-metrics', function(json)
     measured_widths = m.widths
     kern_table = m.kern
     ui_font = m.font
+    state.fs_mul = tonumber(m.fs) or 1.0
     if m.mask_w then MASK_W = m.mask_w end
     request_render()
 end)

--- a/tests/lua/fake_mp.lua
+++ b/tests/lua/fake_mp.lua
@@ -420,7 +420,8 @@ mp.msg = { error = function() end, warn = function() end,
            debug = function() end, log = mp.log }
 mp.utils = utils
 
--- assdraw: only ass_new() and the builder methods the renderer chains.
+-- assdraw: ass_new() and the builder methods the renderer chains, with the
+-- text it builds kept rather than discarded.
 --
 -- The methods used to be swallowed outright. They are recorded now, because
 -- a class of bug lives entirely in the drawing and nowhere in the state the
@@ -482,9 +483,23 @@ local function rect(_s, x1, y1, x2, y2, radius)
 end
 
 local Ass = {}
+-- `text` is accumulated, not just swallowed. The renderer publishes it as
+-- `osd.data`, so leaving it empty made every tag it writes unreachable --
+-- including the font size, which is how a UI that drew 13% small on
+-- Windows had a green renderer suite. `new_event` separates with a
+-- newline, as real assdraw does (one libass event per line).
 local ASS_METHODS = {
-    new_event = function(s) pending = {}; return s end,
-    append = function(s, t) pending[#pending + 1] = tostring(t or ""); return s end,
+    new_event = function(s)
+        pending = {}
+        if #s.text > 0 then s.text = s.text .. "\n" end
+        return s
+    end,
+    append = function(s, t)
+        t = tostring(t or "")
+        pending[#pending + 1] = t
+        s.text = s.text .. t
+        return s
+    end,
     rect_cw = function(s, ...) rect(s, ...); return s end,
     round_rect_cw = function(s, ...) rect(s, ...); return s end,
 }

--- a/tests/lua/test_renderer.lua
+++ b/tests/lua/test_renderer.lua
@@ -3827,6 +3827,44 @@ ok(fake.log.keybinds["mpvtk_nav_ENTER"] ~= nil,
    "a cleared select key left nothing bound")
 ok(fake.log.keybinds["mpvtk_nav_j"] == nil, "the old select key was left bound")
 
+-- ================================================ libass \fs stretch
+--
+-- libass reads `\fs` as the face's ascender+descender box rather than as
+-- its em, and that box is font-relative -- 150 for DejaVu Sans, 172 for
+-- Segoe UI, both measured. Feeding the size straight in drew every string
+-- 13% smaller on Windows, with every box around it the same size, because
+-- the width table carried the same per-face factor and predicted the
+-- smaller text correctly. mpvtk/metrics.py sends the stretch; this is the
+-- half that applies it.
+
+--- The `\fs` in the ASS the renderer last published. The render is paced
+--- by a timer, so it has to be let run before there is anything to read.
+local function fs_in_ass()
+    fake.advance(1)
+    fake.fire_timers()
+    return tonumber((fake.osd.data or ""):match("\\fs([%d%.]+)"))
+end
+
+scene({ { id = "t", t = "text", x = 10, y = 10, w = 200, h = 30,
+          size = 20, c = "ffffff", text = "Hxg" } })
+eq(fs_in_ass(), 20, "an unmeasured face was stretched anyway")
+
+fake.send("mpvtk-metrics", fake.token(
+    { font = "Segoe UI", fs = 1.146667, widths = {}, kern = {} }))
+scene({ { id = "t", t = "text", x = 10, y = 10, w = 200, h = 30,
+          size = 20, c = "ffffff", text = "Hxg" } })
+ok(math.abs((fs_in_ass() or 0) - 22.93) < 0.01,
+   "a taller face was not stretched to draw at the reference size",
+   tostring(fs_in_ass()))
+
+-- Nothing to stretch by is the size this drew before, not a crash and not
+-- a zero: a machine with no Pillow gets no metrics message at all.
+fake.send("mpvtk-metrics", fake.token(
+    { font = "Segoe UI", widths = {}, kern = {} }))
+scene({ { id = "t", t = "text", x = 10, y = 10, w = 200, h = 30,
+          size = 20, c = "ffffff", text = "Hxg" } })
+eq(fs_in_ass(), 20, "a metrics message with no stretch changed the size")
+
 -- ========================================================== teardown
 
 scene({})

--- a/tests/test_libass_font_size.py
+++ b/tests/test_libass_font_size.py
@@ -1,0 +1,163 @@
+"""What size libass actually draws, which is not the size we asked for.
+
+libass reads ``\\fs`` as the font's **ascender+descender height**, not its em
+(VSFilter compatibility). That box is font-relative, so one ``\\fs`` renders a
+different em per face. Measured at a 128px em: DejaVu Sans' box is 150 and
+Segoe UI's is 172, and those are the faces libass draws on Linux and on
+Windows. Every string in the browser therefore came out 13% smaller on
+Windows, with every box around it identical -- the width model carried the
+same per-face factor, so it stayed self-consistent and predicted the smaller
+text correctly.
+
+**Linux is the reference.** Every face is asked for the size DejaVu Sans
+would have drawn at that nominal size, so the number means one physical size
+everywhere. `tests/lua/test_renderer.lua` holds the renderer's half.
+"""
+
+# Run as a script, this is what puts the repo root on sys.path -- without
+# it `jellyfin_mpv_shim` resolves to whatever is pip-installed. A no-op
+# under `discover`; tests/test_module_paths.py is the guard.
+if __name__ == "__main__":
+    import os
+    import sys
+
+    sys.path.insert(0, os.path.dirname(
+        os.path.dirname(os.path.abspath(__file__))))
+
+import os
+import re
+import sys
+import tempfile
+import unittest
+from unittest import mock
+
+sys.argv = ["test"]
+
+from jellyfin_mpv_shim.mpvtk import metrics  # noqa: E402
+
+#: Ascent+descent at `metrics._MEASURE_SIZE`, both measured with Pillow.
+DEJAVU = 150      # what libass draws on Linux -- the reference
+SEGOE = 172       # what it draws on Windows
+
+
+class Face:
+    """A font with a chosen ascender+descender box and flat advances."""
+
+    def __init__(self, ascent, descent, advance=64.0):
+        self._metrics = (ascent, descent)
+        self._advance = advance
+        self.path = os.path.join(tempfile.gettempdir(), "fake-face.ttf")
+
+    def getmetrics(self):
+        return self._metrics
+
+    def getlength(self, text):
+        return self._advance * len(text)
+
+    def getname(self):
+        return ("Fake Face", "Regular")
+
+
+def measured(face):
+    """`measure_font()` for a face, with the disk cache pointed at a
+    scratch file -- the real one is keyed on a real font path."""
+    with tempfile.TemporaryDirectory() as tmp:
+        with mock.patch.object(metrics, "_load_font", lambda: face), \
+                mock.patch.object(
+                    metrics, "_cache_path",
+                    lambda: os.path.join(tmp, "metrics.json")):
+            return metrics.measure_font()
+
+
+def rendered_em(nominal, data, face):
+    """The em libass ends up drawing, in px.
+
+    The second factor is libass, not us: it scales ``\\fs`` so the face's
+    ascender+descender box comes out that tall, which is the whole bug.
+    """
+    ascent, descent = face.getmetrics()
+    return (nominal * data["fs"]) * (metrics._MEASURE_SIZE
+                                     / float(ascent + descent))
+
+
+class RenderedSize(unittest.TestCase):
+    def test_one_nominal_size_is_one_physical_size(self):
+        """The property the whole change exists for. Before it, the same
+        17 drew a 14.5px em on Linux and a 12.7px em on Windows."""
+        dejavu, segoe = Face(120, 30), Face(138, 34)
+        on_linux = rendered_em(17, measured(dejavu), dejavu)
+        on_windows = rendered_em(17, measured(segoe), segoe)
+        # 4 places, not exact: `fs` is rounded on its way through JSON.
+        self.assertAlmostEqual(on_linux, on_windows, places=4)
+
+    def test_and_it_is_the_size_linux_already_drew(self):
+        """Conforming Windows up to Linux, not both to the nominal number:
+        the reference face is the one whose rendering nobody complained
+        about, and matching the nominal number instead would have grown
+        every string on every platform."""
+        dejavu = Face(120, 30)
+        self.assertAlmostEqual(
+            rendered_em(17, measured(dejavu), dejavu),
+            17 * metrics._MEASURE_SIZE / float(DEJAVU), places=4)
+
+    def test_the_reference_face_is_not_stretched_at_all(self):
+        self.assertEqual(measured(Face(120, 30))["fs"], 1.0)
+
+    def test_a_taller_box_is_stretched_to_compensate(self):
+        self.assertAlmostEqual(measured(Face(138, 34))["fs"],
+                               SEGOE / float(DEJAVU), places=4)
+
+
+class WidthTable(unittest.TestCase):
+    """Widths are a fraction of the NOMINAL size, so they cannot carry the
+    face's own box any more -- the renderer's `\\fs` stretch does that now,
+    and folding it in twice would predict a width nothing draws."""
+
+    def test_the_table_does_not_move_with_the_face(self):
+        wide, narrow = measured(Face(120, 30)), measured(Face(138, 34))
+        self.assertEqual(wide["widths"]["M"], narrow["widths"]["M"])
+
+    def test_and_it_still_predicts_what_libass_draws(self):
+        """A width is `nominal * widths[c]`; libass draws `em * advance_em`.
+        They have to be the same number or clicks land on the wrong letter.
+        2 places: the width table is stored to 4 decimals, which is a
+        thousandth of a pixel at these sizes and the tolerance this can
+        have without asserting on the rounding instead.
+        """
+        for face in (Face(120, 30), Face(138, 34)):
+            with self.subTest(box=sum(face.getmetrics())):
+                data = measured(face)
+                predicted = 17 * data["widths"]["M"]
+                drawn = rendered_em(17, data, face) * (
+                    face.getlength("M") / metrics._MEASURE_SIZE)
+                self.assertAlmostEqual(predicted, drawn, places=2)
+
+
+class OnePlace(unittest.TestCase):
+    """The per-face box was computed at three sites and folded into four
+    tables. That is the shape that made this survive: a rule spelled out
+    in one place and applied in all of them, with nothing tying them
+    together."""
+
+    def test_the_face_box_is_read_in_exactly_one_place(self):
+        src = open(metrics.__file__, encoding="utf-8").read()
+        hits = re.findall(r"ascent \+ descent|ascent\+descent", src)
+        self.assertEqual(
+            len(hits), 1,
+            "the face's ascender+descender box is read %d times; it belongs "
+            "in _fs_multiplier alone, or the next face divides them again"
+            % len(hits))
+
+    def test_a_cache_written_before_this_is_not_reused(self):
+        """The stored table carries the old per-face factor and no `fs`
+        key, so a warm launch would keep drawing small forever."""
+        face = Face(138, 34)
+        with mock.patch.object(metrics, "_METRICS_VERSION", 1):
+            old = metrics._cache_key(face)
+        with mock.patch.object(metrics, "_METRICS_VERSION", 2):
+            new = metrics._cache_key(face)
+        self.assertNotEqual(old, new)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Windows font scaling was noticeably smaller on Windows than on Linux, which was the QA reference. Text under settings on Windows was too small at the default size, the fixed reference resolves the issue.