### PR TITLE
Improve translation accuracy & context

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -338,8 +338,11 @@ volunteer work.
 **One word, two meanings: use `_p(context, string)`.** gettext keys on the English, so
 a string reused in two senses collapses to one entry and no language can tell them
 apart. A context is part of the key, so adding one to a string that did not need it
-discards every existing translation of it. Known cases: `Record`, `Channels`,
-`Download`, `None`. Extraction rationale and seeding: `docs/i18n.md`.
+discards every existing translation of it — **`tools/po_recontext.py` is what carries
+them across instead**, and it is the one other thing besides `po_lint.py --fuzzy` that
+may write to a `.po`. Known cases: `Record`, `Channels`, `Download`, `None`, `Default`,
+`Later`, `Confirm`, `Repeat`, `Top`/`Bottom`. Extraction rationale, the two ways a
+two-sense msgid gets found, and the rescue: `docs/i18n.md` §6 and §10.
 
 ## Documentation Reference
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -314,7 +314,12 @@ the audit tooling are in `docs/testing.md`.
 User-facing strings use gettext via `i18n.py`'s `_()`. After adding or changing them:
 
 1. `./regen_pot.sh` — updates `base.pot` and nothing else. Commit it.
-2. `./gen_pkg.sh --skip-build` compiles `.po` → `.mo`. `.mo` files are gitignored.
+2. **Write the new string's `#.` translator context into `base.pot`.**
+   `tests/test_pot_context.py` fails until you do, and the regeneration
+   preserves what is there. A Weblate translator sees the English and a
+   filename, so say where the string is, what kind of control it labels, and
+   what each placeholder holds. `docs/i18n.md` §9.
+3. `./gen_pkg.sh --skip-build` compiles `.po` → `.mo`. `.mo` files are gitignored.
 
 **Never run `./regen_pot.sh --merge`, and never touch the per-locale `.po` files,
 unless explicitly asked.** The `.pot` is the template Weblate reads; filling the 86

--- a/docs/i18n.md
+++ b/docs/i18n.md
@@ -250,3 +250,66 @@ miss a bad entry and never drop a good one.
 `tests/test_po_lint.py` tests **the filter, not the catalogs** — asserting the
 shipped catalogs are clean would fail the day a volunteer types a bad
 placeholder, which is inevitable and not a defect here.
+
+## 9. Every string carries translator context, and the `.pot` is where it lives
+
+A translator on Weblate sees the English string and a **filename**. That is
+all: §2 removed line numbers on purpose, only eleven entries carry a
+`msgctxt`, and no screenshots are attached. So "Off" arrived as three letters
+that have to serve five different settings dropdowns, and `%s` arrived holding
+nothing in particular. A model reading the call site — the function, the
+widget, the neighbouring strings — had strictly more to go on than the person
+doing the work.
+
+The `#.` comments in `base.pot` close that gap, and `tests/test_pot_context.py`
+keeps it closed: a new `_()` call fails the suite until somebody writes down
+what it means, which is the only moment anyone is thinking about that string.
+
+**The comments are hand-written into `base.pot`, and `tools/pot_context.py`
+carries them across each regeneration.** xgettext can lift `# TRANSLATORS:`
+comments out of Python with `--add-comments`, which is the idiomatic answer
+and was not taken:
+
+- 158 msgids are extracted from **more than one file**. Identical comments at
+  every site collapse to one `#.` line and differing ones stack, so the source
+  form is only correct while every site is edited together — and the one that
+  drifts reads to a translator as a second sense to reconcile.
+- It is ~1,100 comments across 65 files, dwarfing the code comments in the
+  ones that hold a lot of strings (`config.py` alone has 234).
+
+The cost is a generated file with hand-written content in it, and `--check`
+plus that test are what make the cost safe: a comment silently lost is loud
+rather than invisible.
+
+**Entries are keyed on `(msgctxt, msgid)`, which is gettext's own key**, so a
+reworded string *loses* its note and `--restore` names every note it dropped.
+That direction is deliberate — §5 records the opposite failure, where msgmerge
+carried a note across a reword and left `Blend Frames` credited to the key for
+`Dropped frames`. A dropped note is a line in the report; a retained one is
+wrong in a file nobody rereads.
+
+`msgmerge` takes `#.` from the template and translator `#` comments from the
+catalogue, so the context reaches all 86 locales on Weblate's next update and
+the `# seeded from jellyfin-web:` markers are untouched.
+
+### What a good comment says
+
+Not what the string means in English — the translator has the string. What the
+screen cannot be guessed from:
+
+- **Where it is and what kind of control it is.** "Choice in the Debanding
+  dropdown", "tooltip of the heart button", "column heading". A checkbox label
+  and an imperative button are different grammar in most languages.
+- **What every placeholder holds.** `%s` is a package name, `%(size)s` is
+  already formatted, `{0:0.1f}` must keep its format spec or the app raises.
+- **Which words are names.** MPV options, filenames, shell commands, Jellyfin
+  feature names and product names are not to be translated.
+- **When one msgid serves several senses**, say so and say which — the
+  translator cannot see it, and the single translation has to carry both.
+
+That last one is also how this pass found new work. `Later` is the update
+banner's "put it off" *and* the Live TV guide's "forward a few hours";
+`Confirm` is a field label and a dialog title; `Repeat` is a guide badge and
+the loop button. None has a `msgctxt`, and adding one discards every existing
+translation of the string (§6), so they are recorded in the comment and left
+for a deliberate decision.

--- a/docs/i18n.md
+++ b/docs/i18n.md
@@ -100,17 +100,34 @@ and no language can tell them apart.
 
 A context is **part of the key**, so adding one to a string that did not need it
 discards every existing translation of it. Only do it where the senses genuinely
-differ.
+differ — and when you do, `tools/po_recontext.py` is what stops the discarding
+(§10).
 
-The known cases in this codebase, each confirmed against jellyfin-web needing separate
-keys for the same pair:
+| string | the two senses | found by |
+|---|---|---|
+| `Record` | picker label vs button verb | canary |
+| `Channels` | picker label vs Live TV tab | canary |
+| `Download` | button verb vs dialog heading | canary |
+| `None` | no track vs no home section — a gender-agreement problem in Italian | canary |
+| `Default` | settings dropdown choice vs Media Info stream flag | canary |
+| `Later` | guide "forward a few hours" vs update banner "put it off" | call sites |
+| `Confirm` | Set PIN field label (a verb) vs yes/no dialog title (a noun) | call sites |
+| `Repeat` | guide badge (an adjective) vs loop button (a verb) | call sites |
+| `Top`, `Bottom` | where subtitles sit on screen vs where a row moves in a list | call sites |
 
-| string | the two senses |
-|---|---|
-| `Record` | picker label vs button verb |
-| `Channels` | picker label vs Live TV tab |
-| `Download` | button verb vs dialog heading |
-| `None` | no track vs no home section — a gender-agreement problem in Italian |
+**Two ways in, and neither finds what the other does.** The canary
+(§5's mining of jellyfin-web) is mechanical and rerunnable: group jellyfin-web's keys
+by their English, and a fork in any of its 106 languages means our single msgid
+collapses two senses. Rerun over the current template it narrowed 1,083 msgids to 45
+candidates, of which reading our own call sites left exactly one real — `Default`,
+which our own translators had already split (`ar`/`es`/`lt`/`pt`/`pt_PT` took the
+media-info sense, `tr` the other).
+
+It cannot see the other five, because jellyfin-web has one key or none for each of
+those English words: it never had to disambiguate what it never says twice. Those came
+out of writing §9's translator comments, where saying *where* a string appears forces
+you to notice it appears in two unrelated places. Both methods are worth running, and
+the second is a by-product of work worth doing anyway.
 
 ## 7. Which language the app runs in
 
@@ -313,3 +330,51 @@ banner's "put it off" *and* the Live TV guide's "forward a few hours";
 the loop button. None has a `msgctxt`, and adding one discards every existing
 translation of the string (§6), so they are recorded in the comment and left
 for a deliberate decision.
+
+## 10. Splitting a msgid without discarding its translations
+
+`tools/po_recontext.py` moves a catalogue's existing translations onto the new keys a
+`msgctxt` creates. Weblate cannot: it sees a new msgid and an obsolete one with nothing
+connecting them, so without this a split costs every translation the string had — 60
+locales for `Default`, 66 for `Top`. That price is why two-sense msgids sat unsplit.
+
+It **writes to the `.po` files**, which CLAUDE.md otherwise forbids. Same standing as
+`tools/po_lint.py --fuzzy` (§8): a bounded, deliberate exception, run once per split
+and touching only the entries a plan names. The plans live in
+`tools/recontext_plans/`, each one recording why the split happened and what the
+evidence for it was, because that is the part nobody can reconstruct later.
+
+Every entry it writes lands in one of three states, and which one is a claim about
+evidence rather than a default:
+
+- **as-is** — we know the translation carries this sense, so it moves over unmarked and
+  the locale keeps working. Either the entry has a `# seeded from jellyfin-web:` marker
+  (which the seeder only writes where every jellyfin-web key for that English agreed in
+  that language, so both senses are that word), or it was already in the catalogue at
+  the commit where the *second* sense reached the source, so it cannot have been
+  written for it.
+- **seeded** — jellyfin-web has a key of its own for this sense and this language
+  translates it, so we take that rather than guess. Only `Default` qualifies, and it is
+  the case worth having: Spanish now gets `Predeterminado` for the setting and
+  `Por defecto` for the stream flag, which is what jellyfin-web's own translators
+  decided.
+- **fuzzy** — the words are carried over but flagged. Both compilers drop fuzzy
+  entries, so the string falls back to English until a human looks, and Weblate lists it
+  as "Needs editing" with the old wording in front of them.
+
+There is deliberately **no "drop it, we know it is wrong" state**. Knowing that a
+language distinguishes the senses means holding jellyfin-web's translation of both
+keys — and holding them means there is a right word to seed, so the drop never has a
+case of its own. What looked like one was jellyfin-web having translated only the
+sibling key, which is silence and not evidence; reading it as evidence cost fourteen
+locales a working translation before the rule was fixed.
+
+The 2026-09 split of six msgids wrote 552 entries: 346 as-is, 10 seeded, 196 fuzzy.
+
+**One bug fell out of doing this, in `tools/msgfmt.py`.** msgmerge writes the
+`#, fuzzy` of a fuzzy *obsolete* entry on the line above its `#~` run, and nothing
+flushes during that run, so the flag survived to the next **live** entry and dropped it
+from the `.mo` without a word. It was latent for as long as obsolete entries were the
+last thing in every catalogue. `tests/test_msgfmt.py` now pins it, and `po_recontext`
+inserts ahead of the obsolete tail regardless, which is where msgmerge would have put
+the entries anyway.

--- a/jellyfin_mpv_shim/menu.py
+++ b/jellyfin_mpv_shim/menu.py
@@ -567,8 +567,10 @@ class OSDMenu(object):
         self.put_menu(
             _("Select Subtitle Position"),
             [
-                (_("Bottom"), self.sub_settings_handle, "subtitle_position", "bottom"),
-                (_("Top"), self.sub_settings_handle, "subtitle_position", "top"),
+                (_p("subtitle position", "Bottom"),
+                 self.sub_settings_handle, "subtitle_position", "bottom"),
+                (_p("subtitle position", "Top"),
+                 self.sub_settings_handle, "subtitle_position", "top"),
                 (_("Middle"), self.sub_settings_handle, "subtitle_position", "middle"),
             ],
         )

--- a/jellyfin_mpv_shim/messages/af/LC_MESSAGES/base.po
+++ b/jellyfin_mpv_shim/messages/af/LC_MESSAGES/base.po
@@ -5437,6 +5437,32 @@ msgstr "Video Weergawe Profiele"
 msgid "Select Shader Profile"
 msgstr "Selekteer Shaderprofiel"
 
+msgctxt "setting value"
+msgid "Default"
+msgstr "Standaard"
+
+msgctxt "media stream flag"
+msgid "Default"
+msgstr "Standaard"
+
+msgctxt "subtitle position"
+msgid "Top"
+msgstr "Bokant"
+
+#, fuzzy
+msgctxt "list position"
+msgid "Top"
+msgstr "Bokant"
+
+msgctxt "subtitle position"
+msgid "Bottom"
+msgstr "Onderkant"
+
+#, fuzzy
+msgctxt "list position"
+msgid "Bottom"
+msgstr "Onderkant"
+
 #, fuzzy
 #~| msgid ""
 #~| "Could not add server.\n"

--- a/jellyfin_mpv_shim/messages/ar/LC_MESSAGES/base.po
+++ b/jellyfin_mpv_shim/messages/ar/LC_MESSAGES/base.po
@@ -5345,6 +5345,52 @@ msgstr "ملف تشغيل الفيديو"
 msgid "Select Shader Profile"
 msgstr "تحديد وضع التظليل"
 
+# seeded from jellyfin-web: Default
+msgctxt "setting value"
+msgid "Default"
+msgstr "الافتراضي"
+
+# seeded from jellyfin-web: MediaInfoDefault
+msgctxt "media stream flag"
+msgid "Default"
+msgstr "افتراضي"
+
+msgctxt "playback control"
+msgid "Repeat"
+msgstr "تكرار"
+
+msgctxt "guide badge"
+msgid "Repeat"
+msgstr "تكرار"
+
+#, fuzzy
+msgctxt "form label"
+msgid "Confirm"
+msgstr "تأكيد"
+
+#, fuzzy
+msgctxt "dialog heading"
+msgid "Confirm"
+msgstr "تأكيد"
+
+msgctxt "subtitle position"
+msgid "Top"
+msgstr "الأعلى"
+
+#, fuzzy
+msgctxt "list position"
+msgid "Top"
+msgstr "الأعلى"
+
+msgctxt "subtitle position"
+msgid "Bottom"
+msgstr "الأسفل"
+
+#, fuzzy
+msgctxt "list position"
+msgid "Bottom"
+msgstr "الأسفل"
+
 #~ msgid "MPV UI with thumbnails"
 #~ msgstr "واجهة MPV مع صور مصغرة"
 

--- a/jellyfin_mpv_shim/messages/base.pot
+++ b/jellyfin_mpv_shim/messages/base.pot
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: jellyfin-mpv-shim\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2026-09-09 11:34-0400\n"
+"POT-Creation-Date: 2026-09-09 12:00-0400\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -571,21 +571,19 @@ msgstr ""
 msgid "Select Subtitle Position"
 msgstr ""
 
-#. Two uses. Where subtitles are drawn, on the in-player menu and in the
-#. Subtitle Position setting; and a button on the queue and playlist
-#. editors that moves the selected rows to the end of the list.
-#: jellyfin_mpv_shim/menu.py
-#: jellyfin_mpv_shim/mpvtk_browser/pages/queue_edit.py
-#: jellyfin_mpv_shim/osc_bridge.py
+#. Where subtitles are drawn on screen, on the in-player menu and in the
+#. Subtitle Position setting. A position in the picture. Split from the
+#. queue editor's button of the same English word.
+#: jellyfin_mpv_shim/menu.py jellyfin_mpv_shim/osc_bridge.py
+msgctxt "subtitle position"
 msgid "Bottom"
 msgstr ""
 
-#. Two uses. Where subtitles are drawn, on the in-player menu and in the
-#. Subtitle Position setting; and a button on the queue and playlist
-#. editors that moves the selected rows to the start of the list.
-#: jellyfin_mpv_shim/menu.py
-#: jellyfin_mpv_shim/mpvtk_browser/pages/queue_edit.py
-#: jellyfin_mpv_shim/osc_bridge.py
+#. Where subtitles are drawn on screen, on the in-player menu and in the
+#. Subtitle Position setting. A position in the picture. Split from the
+#. queue editor's button of the same English word.
+#: jellyfin_mpv_shim/menu.py jellyfin_mpv_shim/osc_bridge.py
+msgctxt "subtitle position"
 msgid "Top"
 msgstr ""
 
@@ -942,12 +940,11 @@ msgstr ""
 msgid "New PIN"
 msgstr ""
 
-#. One English word, two senses. The label of the field in the Set PIN
-#. dialog asking for the new passcode a second time, where it is a verb;
-#. and the default title of the yes/no dialog, where it is a noun naming
-#. the dialog.
+#. Label of the field in the Set PIN dialog asking for the new passcode a
+#. second time, to check it was typed correctly. A verb. Split from the
+#. yes/no dialog's title of the same English word.
 #: jellyfin_mpv_shim/mpvtk_browser/auth.py
-#: jellyfin_mpv_shim/mpvtk_browser/dialogs.py
+msgctxt "form label"
 msgid "Confirm"
 msgstr ""
 
@@ -1467,14 +1464,12 @@ msgstr ""
 msgid "Rotation"
 msgstr ""
 
-#. One English word, two senses, and Jellyfin Web needs two separate keys
-#. for them. A choice in a settings dropdown meaning "change nothing, let
-#. MPV decide"; and a flag in the Media Info panel marking the stream a
-#. player picks when the viewer has expressed no preference. Several
-#. languages have translated the two differently here, so the single
-#. translation has to carry both.
+#. Flag row in the Media Info panel, marking the stream a player picks when
+#. the viewer has expressed no preference. Split from the settings dropdown
+#. choice of the same English word, which is a different sense; jellyfin-
+#. web calls this one MediaInfoDefault.
 #: jellyfin_mpv_shim/mpvtk_browser/components/media_info.py
-#: jellyfin_mpv_shim/mpvtk_browser/config.py
+msgctxt "media stream flag"
 msgid "Default"
 msgstr ""
 
@@ -2140,6 +2135,16 @@ msgstr ""
 #: jellyfin_mpv_shim/mpvtk_browser/config.py
 #: jellyfin_mpv_shim/mpvtk_browser/pages/comic.py
 msgid "Fit Page"
+msgstr ""
+
+#. Choice in the "Shading Behind the Player Controls" dropdown (Settings >
+#. Playback > Player Controls), meaning change nothing and let MPV decide.
+#. Split from the Media Info flag of the same English word: jellyfin-web
+#. needs two keys for that pair and 15 of its languages translate them
+#. differently.
+#: jellyfin_mpv_shim/mpvtk_browser/config.py
+msgctxt "setting value"
+msgid "Default"
 msgstr ""
 
 #. Choice in the "Shading Behind the Player Controls" dropdown (Settings >
@@ -3772,6 +3777,14 @@ msgstr ""
 msgid "Clipboard"
 msgstr ""
 
+#. Default title of the yes/no dialog, used when the caller supplied none.
+#. A noun naming the dialog, not an instruction to the reader. Split from
+#. the Set PIN dialog's field label of the same English word.
+#: jellyfin_mpv_shim/mpvtk_browser/dialogs.py
+msgctxt "dialog heading"
+msgid "Confirm"
+msgstr ""
+
 #. Shown in the Reading Progress dialog. %s is another application's name.
 #. Jellyfin stores an ebook position as a fraction of the whole book, not
 #. as a page of this file, so it cannot be typed in.
@@ -4801,13 +4814,12 @@ msgstr ""
 msgid "New"
 msgstr ""
 
-#. One English word, two senses. A badge on a Live TV guide cell marking an
-#. episode shown before, where it is an adjective; and the tooltip of the
-#. loop button on the now-playing bar, where it is a verb. Both must stay
-#. short.
+#. Badge on a Live TV guide cell: this episode has been shown before. An
+#. adjective describing the programme, not an instruction to repeat
+#. anything. Must stay short; the cell is about 120 pixels wide.
 #: jellyfin_mpv_shim/mpvtk_browser/live_tv.py
-#: jellyfin_mpv_shim/mpvtk_browser/music.py
 #: jellyfin_mpv_shim/mpvtk_browser/pages/livetv.py
+msgctxt "guide badge"
 msgid "Repeat"
 msgstr ""
 
@@ -4902,6 +4914,15 @@ msgstr ""
 #: jellyfin_mpv_shim/mpvtk_browser/pages/livetv.py
 #: jellyfin_mpv_shim/mpvtk_browser/tiles.py
 msgid "Add to favorites"
+msgstr ""
+
+#. Tooltip of the loop button on the now-playing bar, in the state where
+#. nothing repeats. A verb, and the family word behind "Repeat all" and
+#. "Repeat one". Split from the Live TV guide badge of the same English
+#. word.
+#: jellyfin_mpv_shim/mpvtk_browser/music.py
+msgctxt "playback control"
+msgid "Repeat"
 msgstr ""
 
 #. Tooltip of the loudness slider on the now-playing bar.
@@ -5295,12 +5316,12 @@ msgstr ""
 msgid "Earlier"
 msgstr ""
 
-#. One English word, two senses. A button on the Live TV guide that scrolls
-#. forward a few hours; and a button on the update banner that puts the
-#. notice off for now. A third use, on the restart banner, carries a
-#. context of its own.
+#. Tooltip of the button that scrolls the Live TV guide forward a few
+#. hours. Later in time, and the counterpart of "Earlier" beside it. A
+#. different sense from the update banner's "Later", which postpones a
+#. notice.
 #: jellyfin_mpv_shim/mpvtk_browser/pages/livetv.py
-#: jellyfin_mpv_shim/mpvtk_browser/window_chrome.py
+msgctxt "guide navigation"
 msgid "Later"
 msgstr ""
 
@@ -5533,6 +5554,14 @@ msgstr ""
 msgid "Play Queue"
 msgstr ""
 
+#. Button on the queue and playlist editors that moves the selected rows to
+#. the start of the list. The beginning of an ordering, not a place on
+#. screen. Split from the subtitle position of the same English word.
+#: jellyfin_mpv_shim/mpvtk_browser/pages/queue_edit.py
+msgctxt "list position"
+msgid "Top"
+msgstr ""
+
 #. Button on the queue and playlist editors that moves the selected rows
 #. one place earlier. A direction.
 #: jellyfin_mpv_shim/mpvtk_browser/pages/queue_edit.py
@@ -5543,6 +5572,14 @@ msgstr ""
 #. one place later. A direction.
 #: jellyfin_mpv_shim/mpvtk_browser/pages/queue_edit.py
 msgid "Down"
+msgstr ""
+
+#. Button on the queue and playlist editors that moves the selected rows to
+#. the end of the list. The end of an ordering, not a place on screen.
+#. Split from the subtitle position of the same English word.
+#: jellyfin_mpv_shim/mpvtk_browser/pages/queue_edit.py
+msgctxt "list position"
+msgid "Bottom"
 msgstr ""
 
 #. Caption on the queue and playlist editors, counting how many rows are
@@ -6566,6 +6603,14 @@ msgstr ""
 #. means it opens something else.
 #: jellyfin_mpv_shim/mpvtk_browser/window_chrome.py
 msgid "Details…"
+msgstr ""
+
+#. Button on the update banner that puts the notice off for now, so it
+#. returns next time. "Not now", not a direction in time. Two other buttons
+#. use the same English word in other senses and carry their own contexts.
+#: jellyfin_mpv_shim/mpvtk_browser/window_chrome.py
+msgctxt "update banner"
+msgid "Later"
 msgstr ""
 
 #. Button on the update banner that hides it for this version for good. An

--- a/jellyfin_mpv_shim/messages/base.pot
+++ b/jellyfin_mpv_shim/messages/base.pot
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: jellyfin-mpv-shim\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2026-09-09 03:57-0400\n"
+"POT-Creation-Date: 2026-09-09 11:34-0400\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -16,257 +16,381 @@ msgstr ""
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 
+#. Stands in for a book's file format when the server did not say what it
+#. is. Shown where EPUB or PDF would otherwise appear.
 #: jellyfin_mpv_shim/books.py
 msgid "Unknown format"
 msgstr ""
 
+#. Position in a book or comic, shown in the reader's bottom bar and in the
+#. Reading Progress dialog. Both placeholders are page numbers.
 #: jellyfin_mpv_shim/books.py jellyfin_mpv_shim/mpvtk_browser/dialogs.py
 #: jellyfin_mpv_shim/mpvtk_browser/pages/reader.py
 #, python-format
 msgid "Page %(page)d of %(total)d"
 msgstr ""
 
+#. Position in a book whose length is unknown, so no total can be given. %d
+#. is the page number.
 #: jellyfin_mpv_shim/books.py jellyfin_mpv_shim/mpvtk_browser/dialogs.py
 #, python-format
 msgid "Page %d"
 msgstr ""
 
+#. How far through a book the reader has got, as a percentage. Shown under
+#. the book's tile.
 #: jellyfin_mpv_shim/books.py
 #, python-format
 msgid "%d%% read"
 msgstr ""
 
+#. Heading of the on-screen report drawn over the video while audio and
+#. subtitle tracks are being set for every episode of a series. The lines
+#. below it are appended as each episode is done.
 #: jellyfin_mpv_shim/bulk_subtitle.py
 msgid "Selecting Tracks..."
 msgstr ""
 
+#. One line of the bulk track-selection report. {0} is an episode's name;
+#. the episode has no subtitle track to pick.
 #: jellyfin_mpv_shim/bulk_subtitle.py
 #, python-brace-format
 msgid "{0}: No Subtitles"
 msgstr ""
 
+#. One line of the bulk track-selection report. {0} is an episode's name;
+#. nothing suitable could be chosen for it.
 #: jellyfin_mpv_shim/bulk_subtitle.py
 #, python-brace-format
 msgid "{0}: Fail"
 msgstr ""
 
+#. Final line of the bulk track-selection report after choosing original
+#. audio with subtitles. {0} and {1} are counts of episodes.
 #: jellyfin_mpv_shim/bulk_subtitle.py
 #, python-brace-format
 msgid "Set Subbed: {0} ok, {1} fail"
 msgstr ""
 
+#. Final line of the bulk track-selection report after choosing dubbed
+#. audio. The three placeholders count episodes that succeeded, that got
+#. audio but no matching subtitles, and that failed.
 #: jellyfin_mpv_shim/bulk_subtitle.py
 #, python-brace-format
 msgid "Set Dubbed: {0} ok, {1} audio only, {2} fail"
 msgstr ""
 
+#. Final line of the bulk track-selection report after choosing tracks by
+#. index. {0} and {1} are counts of episodes.
 #: jellyfin_mpv_shim/bulk_subtitle.py
 #, python-brace-format
 msgid "Manual: {0} ok, {1} fail"
 msgstr ""
 
+#. Shown over the video while the chosen tracks are applied to the episode
+#. playing now.
 #: jellyfin_mpv_shim/bulk_subtitle.py
 msgid "Setting Current..."
 msgstr ""
 
+#. Instruction printed in the terminal when signing in without a window.
+#. The arrow is a menu path; "Quick Connect" is the Jellyfin feature name.
 #: jellyfin_mpv_shim/clients.py
 msgid ""
 "Open Jellyfin, go to your user menu -> Quick Connect, and enter this code:"
 msgstr ""
 
+#. Printed in the terminal while Quick Connect waits for someone to accept
+#. the code in another Jellyfin app.
 #: jellyfin_mpv_shim/clients.py
 msgid "Waiting for authorization..."
 msgstr ""
 
+#. Printed in the terminal when the saved logins are being discarded before
+#. signing in again.
 #: jellyfin_mpv_shim/clients.py
 msgid "Clearing all existing accounts."
 msgstr ""
 
+#. Printed in the terminal after a server was signed in to.
 #: jellyfin_mpv_shim/clients.py
 msgid "Successfully added server."
 msgstr ""
 
+#. Printed in the terminal when signing in to a server failed.
 #: jellyfin_mpv_shim/clients.py
 msgid "Adding server failed."
 msgstr ""
 
+#. Printed in the terminal when the server being added is one already
+#. saved, so its saved login is replaced.
 #: jellyfin_mpv_shim/clients.py
 msgid "Account already exists. Updating credentials."
 msgstr ""
 
+#. Printed in the terminal after a saved login was replaced.
 #: jellyfin_mpv_shim/clients.py
 msgid "Successfully updated server credentials."
 msgstr ""
 
+#. Printed in the terminal when replacing a saved login failed.
 #: jellyfin_mpv_shim/clients.py
 msgid "Updating server credentials failed."
 msgstr ""
 
+#. Terminal prompt asking for the Jellyfin server's web address. The
+#. trailing space separates it from what is typed; keep it.
 #: jellyfin_mpv_shim/clients.py
 msgid "Server URL: "
 msgstr ""
 
+#. Terminal prompt asking for the Jellyfin account name. The trailing space
+#. separates it from what is typed; keep it.
 #: jellyfin_mpv_shim/clients.py
 msgid "Username: "
 msgstr ""
 
+#. Terminal prompt asking for the Jellyfin account password. The trailing
+#. space separates it from what is typed; keep it.
 #: jellyfin_mpv_shim/clients.py
 msgid "Password: "
 msgstr ""
 
+#. Terminal prompt asking whether to sign in to a further server.
 #: jellyfin_mpv_shim/clients.py
 msgid "Add another server?"
 msgstr ""
 
+#. Printed in the terminal when the Jellyfin server could not be reached.
 #: jellyfin_mpv_shim/clients.py
 msgid "Could not connect to the server."
 msgstr ""
 
+#. Printed in the terminal when the server administrator has turned the
+#. Quick Connect feature off.
 #: jellyfin_mpv_shim/clients.py
 msgid "Quick Connect is not enabled on this server."
 msgstr ""
 
+#. Printed in the terminal when requesting a Quick Connect code failed.
 #: jellyfin_mpv_shim/clients.py
 msgid "Could not start Quick Connect."
 msgstr ""
 
+#. Label of the dropdown for the "segment_outro" setting (Settings >
+#. Playback > Skip Intro / Credits).
 #: jellyfin_mpv_shim/media.py
 msgid "Skip Credits"
 msgstr ""
 
+#. Confirmation drawn over the video after the closing credits were jumped
+#. past. Past tense.
 #: jellyfin_mpv_shim/media.py
 msgid "Skipped Credits"
 msgstr ""
 
+#. Prompt drawn over the video offering to jump past the closing credits,
+#. shown when the viewer seeks into them.
 #: jellyfin_mpv_shim/media.py
 msgid "Seek to Skip Credits"
 msgstr ""
 
+#. Button drawn over the video during an advertisement break. Pressing it
+#. jumps past it. An imperative verb phrase.
 #: jellyfin_mpv_shim/media.py
 msgid "Skip Commercial"
 msgstr ""
 
+#. Confirmation drawn over the video after an advertisement break was
+#. jumped past. Past tense.
 #: jellyfin_mpv_shim/media.py
 msgid "Skipped Commercial"
 msgstr ""
 
+#. Prompt drawn over the video offering to jump past an advertisement
+#. break, shown when the viewer seeks into it.
 #: jellyfin_mpv_shim/media.py
 msgid "Seek to Skip Commercial"
 msgstr ""
 
+#. Button drawn over the video during a preview of a coming episode.
+#. Pressing it jumps past it. An imperative verb phrase.
 #: jellyfin_mpv_shim/media.py
 msgid "Skip Preview"
 msgstr ""
 
+#. Confirmation drawn over the video after a preview was jumped past. Past
+#. tense.
 #: jellyfin_mpv_shim/media.py
 msgid "Skipped Preview"
 msgstr ""
 
+#. Prompt drawn over the video offering to jump past a preview, shown when
+#. the viewer seeks into it.
 #: jellyfin_mpv_shim/media.py
 msgid "Seek to Skip Preview"
 msgstr ""
 
+#. Button drawn over the video during a "previously on" recap. Pressing it
+#. jumps past it. An imperative verb phrase.
 #: jellyfin_mpv_shim/media.py
 msgid "Skip Recap"
 msgstr ""
 
+#. Confirmation drawn over the video after a recap was jumped past. Past
+#. tense.
 #: jellyfin_mpv_shim/media.py
 msgid "Skipped Recap"
 msgstr ""
 
+#. Prompt drawn over the video offering to jump past a recap, shown when
+#. the viewer seeks into it.
 #: jellyfin_mpv_shim/media.py
 msgid "Seek to Skip Recap"
 msgstr ""
 
+#. Button drawn over the video while an episode's opening titles play.
+#. Pressing it jumps past them. An imperative verb phrase.
 #: jellyfin_mpv_shim/media.py
 msgid "Skip Intro"
 msgstr ""
 
+#. Confirmation drawn over the video after the opening titles were jumped
+#. past. Past tense.
 #: jellyfin_mpv_shim/media.py
 msgid "Skipped Intro"
 msgstr ""
 
+#. Prompt drawn over the video offering to jump past the opening titles,
+#. shown when the viewer seeks into them. "Seek" here means moving the
+#. playback position.
 #: jellyfin_mpv_shim/media.py
 msgid "Seek to Skip Intro"
 msgstr ""
 
+#. Appended to a quality option's name when choosing it would make the
+#. server re-encode the video. The leading space separates it from the name
+#. before it; keep it.
 #: jellyfin_mpv_shim/media.py
 msgid " (Transcode)"
 msgstr ""
 
+#. Subtitle colour, on the in-player menu MPV draws over the video (press M
+#. during playback). Also the Subtitle Color setting.
 #: jellyfin_mpv_shim/menu.py
 msgid "White"
 msgstr ""
 
+#. Subtitle colour, on the in-player menu MPV draws over the video. Also
+#. the Subtitle Color setting.
 #: jellyfin_mpv_shim/menu.py
 msgid "Yellow"
 msgstr ""
 
+#. Subtitle colour, on the in-player menu MPV draws over the video. Also
+#. the Subtitle Color setting.
 #: jellyfin_mpv_shim/menu.py
 msgid "Black"
 msgstr ""
 
+#. Subtitle colour, on the in-player menu MPV draws over the video. Also
+#. the Subtitle Color setting.
 #: jellyfin_mpv_shim/menu.py
 msgid "Cyan"
 msgstr ""
 
+#. Subtitle colour, on the in-player menu MPV draws over the video. Also
+#. the Subtitle Color setting.
 #: jellyfin_mpv_shim/menu.py
 msgid "Blue"
 msgstr ""
 
+#. Subtitle colour, on the in-player menu MPV draws over the video. Also
+#. the Subtitle Color setting.
 #: jellyfin_mpv_shim/menu.py
 msgid "Green"
 msgstr ""
 
+#. Subtitle colour, on the in-player menu MPV draws over the video. Also
+#. the Subtitle Color setting.
 #: jellyfin_mpv_shim/menu.py
 msgid "Magenta"
 msgstr ""
 
+#. Subtitle colour, on the in-player menu MPV draws over the video. Also
+#. the Subtitle Color setting.
 #: jellyfin_mpv_shim/menu.py
 msgid "Red"
 msgstr ""
 
+#. Subtitle colour, on the in-player menu MPV draws over the video. Also
+#. the Subtitle Color setting.
 #: jellyfin_mpv_shim/menu.py
 msgid "Gray"
 msgstr ""
 
+#. Subtitle size on the in-player menu and in the Subtitle Size setting.
+#. Smallest of Tiny, Small, Normal, Large, Huge.
 #: jellyfin_mpv_shim/menu.py
 msgid "Tiny"
 msgstr ""
 
+#. One English word, two settings. A subtitle size on the in-player menu
+#. and in the Subtitle Size setting; and a cover size in the theme settings
+#. and a library's View menu. Both are one of a size ladder.
 #: jellyfin_mpv_shim/menu.py jellyfin_mpv_shim/mpvtk_browser/config.py
 msgid "Small"
 msgstr ""
 
+#. Subtitle size on the in-player menu and in the Subtitle Size setting,
+#. meaning the standard size. One of Tiny, Small, Normal, Large, Huge.
 #: jellyfin_mpv_shim/menu.py
 msgid "Normal"
 msgstr ""
 
+#. One English word, two settings. A subtitle size on the in-player menu
+#. and in the Subtitle Size setting; and a cover size in the theme settings
+#. and a library's View menu. Both are one of a size ladder.
 #: jellyfin_mpv_shim/menu.py jellyfin_mpv_shim/mpvtk_browser/config.py
 msgid "Large"
 msgstr ""
 
+#. Subtitle size on the in-player menu and in the Subtitle Size setting.
+#. Largest of Tiny, Small, Normal, Large, Huge.
 #: jellyfin_mpv_shim/menu.py
 msgid "Huge"
 msgstr ""
 
+#. Title of the in-player menu MPV draws over the video, reached by
+#. pressing M during playback.
 #: jellyfin_mpv_shim/menu.py
 msgid "Main Menu"
 msgstr ""
 
+#. Entry on the in-player menu that opens the audio track chooser. An
+#. imperative verb.
 #: jellyfin_mpv_shim/menu.py
 msgid "Change Audio"
 msgstr ""
 
+#. Entry on the in-player menu that opens the subtitle track chooser. An
+#. imperative verb.
 #: jellyfin_mpv_shim/menu.py
 msgid "Change Subtitles"
 msgstr ""
 
+#. Opens the chooser that limits how much bandwidth the server may use for
+#. this video. On the in-player menu and on the settings menu of the
+#. playback controls.
 #: jellyfin_mpv_shim/menu.py jellyfin_mpv_shim/mpvtk_browser/hud.py
 #: jellyfin_mpv_shim/osc_bridge.py
 msgid "Change Video Quality"
 msgstr ""
 
+#. The Jellyfin feature for watching in sync with other people. Used as a
+#. dialog title, a navigation button, and the heading of the group list.
+#. Other Jellyfin clients keep the name untranslated; follow whatever they
+#. do in this language.
 #: jellyfin_mpv_shim/menu.py jellyfin_mpv_shim/mpvtk_browser/dialogs.py
 #: jellyfin_mpv_shim/mpvtk_browser/hud.py
 #: jellyfin_mpv_shim/mpvtk_browser/window_chrome.py
@@ -274,248 +398,387 @@ msgstr ""
 msgid "SyncPlay"
 msgstr ""
 
+#. Entry on the in-player menu, shown when a newer release exists. {0} is
+#. the version number. "MPV Shim" is this application's short name; leave
+#. it as-is.
 #: jellyfin_mpv_shim/menu.py
 #, python-brace-format
 msgid "MPV Shim v{0} Release Info/Download"
 msgstr ""
 
+#. Opens the video profile chooser. A video profile is a saved set of MPV
+#. shader and rendering options. On the in-player menu and on the settings
+#. menu of the playback controls.
 #: jellyfin_mpv_shim/menu.py jellyfin_mpv_shim/mpvtk_browser/hud.py
 #: jellyfin_mpv_shim/osc_bridge.py
 msgid "Change Video Playback Profile"
 msgstr ""
 
+#. Stops playback and tells the server the item has not been watched,
+#. discarding the resume position. On the in-player menu and on the
+#. settings menu of the playback controls.
 #: jellyfin_mpv_shim/menu.py jellyfin_mpv_shim/mpvtk_browser/hud.py
 #: jellyfin_mpv_shim/osc_bridge.py
 msgid "Quit and Mark Unplayed"
 msgstr ""
 
+#. Saves a still of the current frame. On the in-player menu and on the
+#. settings menu of the playback controls. An imperative verb here.
 #: jellyfin_mpv_shim/menu.py jellyfin_mpv_shim/mpvtk_browser/hud.py
 #: jellyfin_mpv_shim/osc_bridge.py
 msgid "Screenshot"
 msgstr ""
 
+#. Entry on the in-player menu that opens the list of saved video profiles.
+#. A video profile is a saved set of MPV shader and rendering options.
 #: jellyfin_mpv_shim/menu.py
 msgid "Video Playback Profiles"
 msgstr ""
 
+#. Entry on the in-player menu that opens the SmoothVideo Project options.
+#. SVP is a third-party frame interpolation product; leave the abbreviation
+#. as-is.
 #: jellyfin_mpv_shim/menu.py
 msgid "SVP Settings"
 msgstr ""
 
+#. Entry on the in-player menu, and the title of the submenu it opens,
+#. holding subtitle and transcoding options.
 #: jellyfin_mpv_shim/menu.py
 msgid "Video Preferences"
 msgstr ""
 
+#. Entry on the in-player menu, and the title of the submenu it opens,
+#. holding playback behaviour options.
 #: jellyfin_mpv_shim/menu.py
 msgid "Player Preferences"
 msgstr ""
 
+#. Entry that dismisses the in-player menu. An imperative verb.
 #: jellyfin_mpv_shim/menu.py
 msgid "Close Menu"
 msgstr ""
 
+#. Title of the in-player submenu listing the item's audio tracks.
 #: jellyfin_mpv_shim/menu.py
 msgid "Select Audio Track"
 msgstr ""
 
+#. Title of the in-player submenu listing the item's subtitle tracks.
 #: jellyfin_mpv_shim/menu.py
 msgid "Select Subtitle Track"
 msgstr ""
 
+#. Entry at the top of a subtitle or audio track list, meaning no track at
+#. all. Used on the in-player menu and in the browser's track pickers. It
+#. agrees with the word the language uses for "track", which is why the
+#. home-screen sense of "None" is a separate entry with a context on it.
 #: jellyfin_mpv_shim/menu.py jellyfin_mpv_shim/mpvtk_browser/pages/detail.py
 #: jellyfin_mpv_shim/osc_bridge.py
 msgid "None"
 msgstr ""
 
+#. Title of the in-player submenu that limits how much bandwidth the server
+#. may use for this video.
 #: jellyfin_mpv_shim/menu.py
 msgid "Select Transcode Quality"
 msgstr ""
 
+#. Entry in the transcode quality menus, meaning the server should send the
+#. file untouched rather than re-encoding it to fit a bitrate.
 #: jellyfin_mpv_shim/menu.py jellyfin_mpv_shim/osc_bridge.py
 msgid "No Transcode"
 msgstr ""
 
+#. Entry in the transcode quality menu, meaning the highest quality on
+#. offer.
 #: jellyfin_mpv_shim/menu.py jellyfin_mpv_shim/osc_bridge.py
 msgid "Maximum"
 msgstr ""
 
+#. Title of the in-player submenu that sets audio and subtitle tracks for
+#. every episode of the series at once.
 #: jellyfin_mpv_shim/menu.py
 msgid "Select Audio/Subtitle for Series"
 msgstr ""
 
+#. Entry in the series track menu: prefer an English dub for every episode.
+#. Names the language itself, so it stays "English" whatever the interface
+#. language is.
 #: jellyfin_mpv_shim/menu.py
 msgid "English Audio"
 msgstr ""
 
+#. Entry in the series track menu: prefer the original Japanese audio with
+#. English subtitles for every episode. "w/" abbreviates "with". Names the
+#. languages themselves, so both stay as they are whatever the interface
+#. language is.
 #: jellyfin_mpv_shim/menu.py
 msgid "Japanese Audio w/ English Subtitles"
 msgstr ""
 
+#. Entry in the series track menu: pick tracks by their position in the
+#. file rather than by language. Less reliable because episodes need not
+#. order their tracks the same way.
 #: jellyfin_mpv_shim/menu.py
 msgid "Manual by Track Index (Less Reliable)"
 msgstr ""
 
+#. Choice shared by the "Tell Me About Updates", "Window Buttons in the Top
+#. Bar", "Skip Intros", "Skip Credits", "Skip Commercials", "Skip
+#. Previews", "Skip Recaps" dropdowns (Settings > General > This Device,
+#. Settings > General > Window, Settings > Playback > Skip Intro /
+#. Credits). One translation has to serve all of them.
 #: jellyfin_mpv_shim/menu.py jellyfin_mpv_shim/mpvtk_browser/config.py
 msgid "Never"
 msgstr ""
 
+#. Choice shared by the "Skip Intros", "Skip Credits", "Skip Commercials",
+#. "Skip Previews", "Skip Recaps" dropdowns (Settings > Playback > Skip
+#. Intro / Credits). One translation has to serve all of them.
 #: jellyfin_mpv_shim/menu.py jellyfin_mpv_shim/mpvtk_browser/config.py
 msgid "Ask"
 msgstr ""
 
+#. Choice shared by the "Tell Me About Updates", "Window Buttons in the Top
+#. Bar", "Skip Intros", "Skip Credits", "Skip Commercials", "Skip
+#. Previews", "Skip Recaps" dropdowns (Settings > General > This Device,
+#. Settings > General > Window, Settings > Playback > Skip Intro /
+#. Credits). One translation has to serve all of them.
 #: jellyfin_mpv_shim/menu.py jellyfin_mpv_shim/mpvtk_browser/config.py
 msgid "Always"
 msgstr ""
 
+#. Title of the in-player submenu that sets the bandwidth limit used for
+#. remote playback from then on.
 #: jellyfin_mpv_shim/menu.py
 msgid "Select Default Transcode Profile"
 msgstr ""
 
+#. Title of the in-player submenu listing subtitle colours.
 #: jellyfin_mpv_shim/menu.py
 msgid "Select Subtitle Color"
 msgstr ""
 
+#. Title of the in-player submenu listing subtitle sizes.
 #: jellyfin_mpv_shim/menu.py
 msgid "Select Subtitle Size"
 msgstr ""
 
+#. Title of the in-player submenu listing where on screen subtitles are
+#. drawn.
 #: jellyfin_mpv_shim/menu.py
 msgid "Select Subtitle Position"
 msgstr ""
 
+#. Two uses. Where subtitles are drawn, on the in-player menu and in the
+#. Subtitle Position setting; and a button on the queue and playlist
+#. editors that moves the selected rows to the end of the list.
 #: jellyfin_mpv_shim/menu.py
 #: jellyfin_mpv_shim/mpvtk_browser/pages/queue_edit.py
 #: jellyfin_mpv_shim/osc_bridge.py
 msgid "Bottom"
 msgstr ""
 
+#. Two uses. Where subtitles are drawn, on the in-player menu and in the
+#. Subtitle Position setting; and a button on the queue and playlist
+#. editors that moves the selected rows to the start of the list.
 #: jellyfin_mpv_shim/menu.py
 #: jellyfin_mpv_shim/mpvtk_browser/pages/queue_edit.py
 #: jellyfin_mpv_shim/osc_bridge.py
 msgid "Top"
 msgstr ""
 
+#. Where subtitles are drawn, on the in-player menu and in the Subtitle
+#. Position setting: vertically centred.
 #: jellyfin_mpv_shim/menu.py jellyfin_mpv_shim/osc_bridge.py
 msgid "Middle"
 msgstr ""
 
+#. Entry on the in-player Video Preferences menu, showing the current
+#. bandwidth limit. {0:0.1f} is a number with one decimal; keep the whole
+#. placeholder including the colon and the formatting after it, or the app
+#. raises when it draws this line.
 #: jellyfin_mpv_shim/menu.py
 #, python-brace-format
 msgid "Remote Transcode Quality: {0:0.1f} Mbps"
 msgstr ""
 
+#. Entry on the in-player Video Preferences menu, showing the current
+#. setting. {0} is one of Tiny, Small, Normal, Large, Huge.
 #: jellyfin_mpv_shim/menu.py
 #, python-brace-format
 msgid "Subtitle Size: {0}"
 msgstr ""
 
+#. Entry on the in-player Video Preferences menu, showing the current
+#. setting. {0} is one of Bottom, Top, Middle.
 #: jellyfin_mpv_shim/menu.py
 #, python-brace-format
 msgid "Subtitle Position: {0}"
 msgstr ""
 
+#. Entry on the in-player Video Preferences menu, showing the current
+#. setting. {0} is a colour name.
 #: jellyfin_mpv_shim/menu.py
 #, python-brace-format
 msgid "Subtitle Color: {0}"
 msgstr ""
 
+#. Toggle on the in-player Video Preferences menu. Hi10p is ten-bit video;
+#. leave both format names as-is.
 #: jellyfin_mpv_shim/menu.py
 msgid "Transcode Hi10p to 8bit"
 msgstr ""
 
+#. Toggle on the in-player Video Preferences menu, asking the server to
+#. convert high dynamic range video before sending it.
 #: jellyfin_mpv_shim/menu.py
 msgid "Transcode HDR"
 msgstr ""
 
+#. Toggle on the in-player Video Preferences menu. Reads media straight
+#. from a shared network folder instead of streaming it from the server.
 #: jellyfin_mpv_shim/menu.py
 msgid "Direct Paths"
 msgstr ""
 
+#. Toggle on the in-player Video Preferences menu, forcing the server to
+#. re-encode rather than send the file untouched.
 #: jellyfin_mpv_shim/menu.py
 msgid "Disable Direct Play"
 msgstr ""
 
+#. Entry on the in-player Video Preferences menu. {0} is the current shader
+#. profile subtype.
 #: jellyfin_mpv_shim/menu.py
 #, python-brace-format
 msgid "Video Profile Subtype: {0}"
 msgstr ""
 
+#. Title of the in-player submenu choosing which subtype of the shader
+#. profile to use.
 #: jellyfin_mpv_shim/menu.py
 msgid "Video Profile Subtype"
 msgstr ""
 
+#. Toggle on the in-player Player Preferences menu: start the next episode
+#. by itself.
 #: jellyfin_mpv_shim/menu.py
 msgid "Auto Play"
 msgstr ""
 
+#. Toggle on the in-player Player Preferences menu: go full screen when
+#. playback starts.
 #: jellyfin_mpv_shim/menu.py
 msgid "Auto Fullscreen"
 msgstr ""
 
+#. Toggle on the in-player Player Preferences menu: let the keyboard's
+#. media keys skip within a video rather than between items.
 #: jellyfin_mpv_shim/menu.py
 msgid "Media Key Seek"
 msgstr ""
 
+#. Toggle on the in-player Player Preferences menu: take the skip-forward
+#. and skip-back amounts from the server's web client settings. "Pref"
+#. abbreviates "preference".
 #: jellyfin_mpv_shim/menu.py
 msgid "Use Web Seek Pref"
 msgstr ""
 
+#. Toggle on the in-player Player Preferences menu.
 #: jellyfin_mpv_shim/menu.py
 msgid "Write Logs to File"
 msgstr ""
 
+#. Toggle on the in-player Player Preferences menu: look for a newer
+#. release of this application.
 #: jellyfin_mpv_shim/menu.py
 msgid "Check for Updates"
 msgstr ""
 
+#. Toggle on the in-player Player Preferences menu, and the name of the
+#. setting that shows what you are watching in Discord. A Discord feature
+#. name; leave it as Discord does in this language.
 #: jellyfin_mpv_shim/menu.py
 msgid "Discord Rich Presence"
 msgstr ""
 
+#. What to do when an episode's opening titles start: Never, Ask or Always.
+#. A toggle on the in-player Player Preferences menu and a dropdown under
+#. Settings > Playback > Skip Intro / Credits.
 #: jellyfin_mpv_shim/menu.py jellyfin_mpv_shim/mpvtk_browser/config.py
 msgid "Skip Intros"
 msgstr ""
 
+#. Toggle on the in-player Player Preferences menu, and a settings
+#. dropdown: what to do when an episode's closing credits start. Set to
+#. Never, Ask or Always. Carries a context because "Skip Credits" is also
+#. the name of a button on the video itself.
 #: jellyfin_mpv_shim/menu.py jellyfin_mpv_shim/mpvtk_browser/config.py
 msgctxt "setting"
 msgid "Skip Credits"
 msgstr ""
 
+#. What to do at an advertisement break: Never, Ask or Always. A toggle on
+#. the in-player Player Preferences menu and a dropdown under Settings >
+#. Playback > Skip Intro / Credits.
 #: jellyfin_mpv_shim/menu.py jellyfin_mpv_shim/mpvtk_browser/config.py
 msgid "Skip Commercials"
 msgstr ""
 
+#. What to do at a preview of a coming episode: Never, Ask or Always. A
+#. toggle on the in-player Player Preferences menu and a dropdown under
+#. Settings > Playback > Skip Intro / Credits.
 #: jellyfin_mpv_shim/menu.py jellyfin_mpv_shim/mpvtk_browser/config.py
 msgid "Skip Previews"
 msgstr ""
 
+#. What to do at a "previously on" recap: Never, Ask or Always. A toggle on
+#. the in-player Player Preferences menu and a dropdown under Settings >
+#. Playback > Skip Intro / Credits.
 #: jellyfin_mpv_shim/menu.py jellyfin_mpv_shim/mpvtk_browser/config.py
 msgid "Skip Recaps"
 msgstr ""
 
+#. Toggle on the in-player Player Preferences menu: show a preview frame
+#. while seeking.
 #: jellyfin_mpv_shim/menu.py
 msgid "Enable thumbnail previews"
 msgstr ""
 
+#. Evens out loud effects against quiet dialogue. A toggle on the in-player
+#. Player Preferences menu, the settings menu of the playback controls, and
+#. a checkbox under Settings > Playback > Audio. "Adj" abbreviates
+#. "adjustment".
 #: jellyfin_mpv_shim/menu.py jellyfin_mpv_shim/mpvtk_browser/config.py
 #: jellyfin_mpv_shim/mpvtk_browser/hud.py
 msgid "Night Mode (Auto Volume Adj)"
 msgstr ""
 
+#. Title of the screen shown when the application is locked behind a
+#. passcode.
 #: jellyfin_mpv_shim/mpvtk_browser/app.py
 #: jellyfin_mpv_shim/mpvtk_browser/auth.py
 msgid "Locked"
 msgstr ""
 
+#. Status message when a page's content could not be fetched from the
+#. server.
 #: jellyfin_mpv_shim/mpvtk_browser/app.py
 msgid "Failed to load. Check the connection."
 msgstr ""
 
+#. Label beside the number field in the Reading Progress dialog, where a
+#. page to jump to is typed.
 #: jellyfin_mpv_shim/mpvtk_browser/app.py
 #: jellyfin_mpv_shim/mpvtk_browser/dialogs.py
 msgid "Page"
 msgstr ""
 
+#. Follows a page-number field, giving the total, as in "of 240". In the
+#. Reading Progress dialog, the comic reader and a paged library grid.
 #: jellyfin_mpv_shim/mpvtk_browser/app.py
 #: jellyfin_mpv_shim/mpvtk_browser/dialogs.py
 #: jellyfin_mpv_shim/mpvtk_browser/pages/comic.py
@@ -523,43 +786,60 @@ msgstr ""
 msgid "of %d"
 msgstr ""
 
+#. Tooltip of the paging button that jumps to the first page of a library
+#. grid.
 #: jellyfin_mpv_shim/mpvtk_browser/app.py
 msgid "First page"
 msgstr ""
 
+#. Tooltip of the button that goes back one page: in a library grid, and in
+#. the book and comic readers.
 #: jellyfin_mpv_shim/mpvtk_browser/app.py
 #: jellyfin_mpv_shim/mpvtk_browser/pages/comic.py
 #: jellyfin_mpv_shim/mpvtk_browser/pages/reader.py
 msgid "Previous page"
 msgstr ""
 
+#. Tooltip of the button that goes forward one page: in a library grid, and
+#. in the book and comic readers.
 #: jellyfin_mpv_shim/mpvtk_browser/app.py
 #: jellyfin_mpv_shim/mpvtk_browser/pages/comic.py
 #: jellyfin_mpv_shim/mpvtk_browser/pages/reader.py
 msgid "Next page"
 msgstr ""
 
+#. Tooltip of the paging button that jumps to the last page of a library
+#. grid.
 #: jellyfin_mpv_shim/mpvtk_browser/app.py
 msgid "Last page"
 msgstr ""
 
+#. Status message when the server refused an edit, such as marking an item
+#. watched or removing it from a playlist.
 #: jellyfin_mpv_shim/mpvtk_browser/app.py
 #: jellyfin_mpv_shim/mpvtk_browser/item_actions.py
 #: jellyfin_mpv_shim/mpvtk_browser/tiles.py
 msgid "The change could not be applied."
 msgstr ""
 
+#. Name of the broadcast television area of Jellyfin, used as a library
+#. tile, a home-screen section and a page title. A Jellyfin feature name;
+#. follow whatever Jellyfin Web uses in this language.
 #: jellyfin_mpv_shim/mpvtk_browser/app.py
 #: jellyfin_mpv_shim/mpvtk_browser/home_sections.py
 #: jellyfin_mpv_shim/mpvtk_browser/pages/home.py
 msgid "Live TV"
 msgstr ""
 
+#. Status message naming what was just picked, when picking it does not
+#. open anything. %s is the item's name.
 #: jellyfin_mpv_shim/mpvtk_browser/app.py
 #, python-format
 msgid "Selected: %s"
 msgstr ""
 
+#. Shown in a dialog or page while its content is being fetched from the
+#. server.
 #: jellyfin_mpv_shim/mpvtk_browser/app.py
 #: jellyfin_mpv_shim/mpvtk_browser/livetv_dialogs.py
 #: jellyfin_mpv_shim/mpvtk_browser/load_feedback.py
@@ -568,17 +848,23 @@ msgstr ""
 msgid "Loading…"
 msgstr ""
 
+#. Status message when starting an item failed.
 #: jellyfin_mpv_shim/mpvtk_browser/app.py
 #: jellyfin_mpv_shim/mpvtk_browser/item_actions.py
 #: jellyfin_mpv_shim/mpvtk_browser/load_feedback.py
 msgid "Playback could not be started."
 msgstr ""
 
+#. Tooltip of the button on the now-playing bar that opens the list of what
+#. is queued to play. A noun.
 #: jellyfin_mpv_shim/mpvtk_browser/app.py
 #: jellyfin_mpv_shim/mpvtk_browser/music.py
 msgid "Queue"
 msgstr ""
 
+#. Button that tries a failed operation again: reaching a server at
+#. startup, an offline banner, a page that would not load, an item that
+#. would not play. An imperative verb.
 #: jellyfin_mpv_shim/mpvtk_browser/app.py
 #: jellyfin_mpv_shim/mpvtk_browser/auth.py
 #: jellyfin_mpv_shim/mpvtk_browser/load_feedback.py
@@ -587,25 +873,35 @@ msgstr ""
 msgid "Retry"
 msgstr ""
 
+#. Status message when the Restart Now button could not relaunch the
+#. application.
 #: jellyfin_mpv_shim/mpvtk_browser/app.py
 msgid ""
 "Could not restart automatically — quit and start the app again to apply your "
 "changes."
 msgstr ""
 
+#. Status message when a retry after a connection failure also failed.
 #: jellyfin_mpv_shim/mpvtk_browser/app.py
 msgid "Still can't reach the server."
 msgstr ""
 
+#. Title of the dialog that changes to another user of this server. %s is
+#. that user's name.
 #: jellyfin_mpv_shim/mpvtk_browser/auth.py
 #, python-format
 msgid "Switch to %s"
 msgstr ""
 
+#. Placeholder in the empty field where a numeric passcode is typed, on the
+#. switch-user and lock screens. The abbreviation is widely kept as-is; use
+#. whatever word the local Jellyfin apps use for a numeric passcode.
 #: jellyfin_mpv_shim/mpvtk_browser/auth.py
 msgid "PIN"
 msgstr ""
 
+#. Button that dismisses a dialog without doing what it asked about. The
+#. counterpart of OK or of the action button beside it.
 #: jellyfin_mpv_shim/mpvtk_browser/auth.py
 #: jellyfin_mpv_shim/mpvtk_browser/dialogs.py
 #: jellyfin_mpv_shim/mpvtk_browser/livetv_dialogs.py
@@ -614,189 +910,276 @@ msgstr ""
 msgid "Cancel"
 msgstr ""
 
+#. Button that changes to the other user, on the switch-user dialog and the
+#. lock screen. An imperative verb.
 #: jellyfin_mpv_shim/mpvtk_browser/auth.py
 #: jellyfin_mpv_shim/mpvtk_browser/settings/servers.py
 msgid "Switch"
 msgstr ""
 
+#. Error shown when the passcode typed to switch user or unlock does not
+#. match.
 #: jellyfin_mpv_shim/mpvtk_browser/auth.py
 msgid "Incorrect PIN."
 msgstr ""
 
+#. Title of the dialog that gives a user a numeric passcode. %s is that
+#. user's name.
 #: jellyfin_mpv_shim/mpvtk_browser/auth.py
 #, python-format
 msgid "Set PIN for %s"
 msgstr ""
 
+#. Label of the field asking for the passcode already in use, in the Set
+#. PIN dialog.
 #: jellyfin_mpv_shim/mpvtk_browser/auth.py
 msgid "Current PIN"
 msgstr ""
 
+#. Label of the field asking for the passcode to change to, in the Set PIN
+#. dialog.
 #: jellyfin_mpv_shim/mpvtk_browser/auth.py
 msgid "New PIN"
 msgstr ""
 
+#. One English word, two senses. The label of the field in the Set PIN
+#. dialog asking for the new passcode a second time, where it is a verb;
+#. and the default title of the yes/no dialog, where it is a noun naming
+#. the dialog.
 #: jellyfin_mpv_shim/mpvtk_browser/auth.py
 #: jellyfin_mpv_shim/mpvtk_browser/dialogs.py
 msgid "Confirm"
 msgstr ""
 
+#. Checkbox in the Set PIN dialog. When on, the passcode is asked for every
+#. time the application opens.
 #: jellyfin_mpv_shim/mpvtk_browser/auth.py
 msgid "Require this PIN at startup"
 msgstr ""
 
+#. Button in the Set PIN dialog that takes the passcode off this user. An
+#. imperative verb.
 #: jellyfin_mpv_shim/mpvtk_browser/auth.py
 msgid "Remove PIN"
 msgstr ""
 
+#. Button in the Set PIN dialog that stores the new passcode. An imperative
+#. verb.
 #: jellyfin_mpv_shim/mpvtk_browser/auth.py
 #: jellyfin_mpv_shim/mpvtk_browser/livetv_dialogs.py
 msgid "Save"
 msgstr ""
 
+#. Error in the Set PIN dialog when the existing passcode was typed
+#. wrongly.
 #: jellyfin_mpv_shim/mpvtk_browser/auth.py
 msgid "Current PIN is incorrect."
 msgstr ""
 
+#. Error in the Set PIN dialog when the new-passcode field was left empty.
 #: jellyfin_mpv_shim/mpvtk_browser/auth.py
 msgid "Enter a new PIN."
 msgstr ""
 
+#. Error in the Set PIN dialog when the passcode and its confirmation
+#. differ.
 #: jellyfin_mpv_shim/mpvtk_browser/auth.py
 msgid "The PINs don't match."
 msgstr ""
 
+#. Error in the Set PIN dialog when the server refused to take the passcode
+#. off.
 #: jellyfin_mpv_shim/mpvtk_browser/auth.py
 msgid "The PIN could not be removed."
 msgstr ""
 
+#. Error in the Set PIN dialog when the server refused to store the
+#. passcode.
 #: jellyfin_mpv_shim/mpvtk_browser/auth.py
 msgid "The PIN could not be saved."
 msgstr ""
 
+#. Title of the page that connects this application to a Jellyfin server.
 #: jellyfin_mpv_shim/mpvtk_browser/auth.py
 #: jellyfin_mpv_shim/mpvtk_browser/settings/servers.py
 msgid "Add Server"
 msgstr ""
 
+#. Main heading of the sign-in page. "Jellyfin" is the product name; leave
+#. it as-is.
 #: jellyfin_mpv_shim/mpvtk_browser/auth.py
 msgid "Connect to Jellyfin"
 msgstr ""
 
+#. Heading above the list of servers already signed in to, on the sign-in
+#. page.
 #: jellyfin_mpv_shim/mpvtk_browser/auth.py
 msgid "Previously added servers"
 msgstr ""
 
+#. Button beside a remembered server on the sign-in page, choosing that
+#. server. An imperative verb.
 #: jellyfin_mpv_shim/mpvtk_browser/auth.py
 msgid "Use"
 msgstr ""
 
+#. A Jellyfin feature that signs a device in by typing a short code into an
+#. already-signed-in app. Used as a button on the sign-in page and as the
+#. heading of the panel showing the code. Other Jellyfin clients keep the
+#. feature's name; follow whatever they use in this language.
 #: jellyfin_mpv_shim/mpvtk_browser/auth.py
 msgid "Quick Connect"
 msgstr ""
 
+#. Instruction above the Quick Connect code on the sign-in page.
 #: jellyfin_mpv_shim/mpvtk_browser/auth.py
 msgid "Enter this code in the Jellyfin app or web client:"
 msgstr ""
 
+#. Stands in for the Quick Connect code while it is being fetched from the
+#. server.
 #: jellyfin_mpv_shim/mpvtk_browser/auth.py
 msgid "Requesting…"
 msgstr ""
 
+#. Label of the field on the sign-in page where the Jellyfin server's web
+#. address is typed.
 #: jellyfin_mpv_shim/mpvtk_browser/auth.py
 msgid "Server URL"
 msgstr ""
 
+#. Label of the field on the sign-in page where the Jellyfin account name
+#. is typed.
 #: jellyfin_mpv_shim/mpvtk_browser/auth.py
 msgid "Username"
 msgstr ""
 
+#. Label of the field on the sign-in page where the Jellyfin account
+#. password is typed.
 #: jellyfin_mpv_shim/mpvtk_browser/auth.py
 msgid "Password"
 msgstr ""
 
+#. Button on the sign-in page that signs in with a code instead of a
+#. password. "Quick Connect" is the Jellyfin feature name; keep it matching
+#. the entry of that name.
 #: jellyfin_mpv_shim/mpvtk_browser/auth.py
 msgid "Use Quick Connect"
 msgstr ""
 
+#. Button on the sign-in page that signs in with the details typed above.
+#. An imperative verb.
 #: jellyfin_mpv_shim/mpvtk_browser/auth.py
 msgid "Connect"
 msgstr ""
 
+#. Error on the sign-in page when Quick Connect was pressed with the server
+#. address left empty.
 #: jellyfin_mpv_shim/mpvtk_browser/auth.py
 msgid "Enter the server URL first."
 msgstr ""
 
+#. Status shown while the Quick Connect code is being requested.
 #: jellyfin_mpv_shim/mpvtk_browser/auth.py
 msgid "Contacting the server…"
 msgstr ""
 
+#. Status shown while Quick Connect waits for someone to accept the code in
+#. another Jellyfin app.
 #: jellyfin_mpv_shim/mpvtk_browser/auth.py
 msgid "Waiting for approval…"
 msgstr ""
 
+#. Error shown when the Quick Connect code expired or was refused.
 #: jellyfin_mpv_shim/mpvtk_browser/auth.py
 msgid "Quick Connect was not approved."
 msgstr ""
 
+#. Status shown on the sign-in page while the server is being contacted.
 #: jellyfin_mpv_shim/mpvtk_browser/auth.py
 msgid "Connecting…"
 msgstr ""
 
+#. Error on the sign-in page when signing in failed, most often a wrong
+#. address, name or password.
 #: jellyfin_mpv_shim/mpvtk_browser/auth.py
 msgid "Could not connect. Please check your details."
 msgstr ""
 
+#. Heading of the startup screen shown while the saved servers are being
+#. reached.
 #: jellyfin_mpv_shim/mpvtk_browser/auth.py
 #: jellyfin_mpv_shim/mpvtk_browser/pages/home.py
 msgid "Connecting to your server…"
 msgstr ""
 
+#. Button on the startup screen. Browses what has been downloaded to this
+#. device instead of waiting for the server. An imperative verb.
 #: jellyfin_mpv_shim/mpvtk_browser/auth.py
 msgid "Work Offline"
 msgstr ""
 
+#. Button on the startup screen that opens the sign-in page. An imperative
+#. verb.
 #: jellyfin_mpv_shim/mpvtk_browser/auth.py
 msgid "Sign In"
 msgstr ""
 
+#. Shown when Work Offline was pressed but nothing has been downloaded to
+#. this device.
 #: jellyfin_mpv_shim/mpvtk_browser/auth.py
 msgid "There is nothing downloaded to browse."
 msgstr ""
 
+#. Error on the startup screen when none of the remembered servers
+#. answered. The bracketed plural is because there may be one server or
+#. several.
 #: jellyfin_mpv_shim/mpvtk_browser/auth.py
 msgid "Couldn't reach your saved server(s)."
 msgstr ""
 
+#. Heading of the lock screen, asking for the numeric passcode.
 #: jellyfin_mpv_shim/mpvtk_browser/auth.py
 msgid "Enter your PIN"
 msgstr ""
 
+#. Shown under the lock screen's heading. %s is the locked user's name.
 #: jellyfin_mpv_shim/mpvtk_browser/auth.py
 #, python-format
 msgid "%s is locked."
 msgstr ""
 
+#. Button on the lock screen that opens the application with the passcode
+#. typed above. An imperative verb.
 #: jellyfin_mpv_shim/mpvtk_browser/auth.py
 msgid "Unlock"
 msgstr ""
 
+#. Heading above the list of other accounts on the lock screen.
 #: jellyfin_mpv_shim/mpvtk_browser/auth.py
 msgid "Or switch to another user"
 msgstr ""
 
+#. Heading of the idle screen shown when this application is waiting to be
+#. sent something from another Jellyfin app.
 #: jellyfin_mpv_shim/mpvtk_browser/cast.py
 msgid "Ready to cast"
 msgstr ""
 
+#. Instruction under the idle cast screen's heading.
 #: jellyfin_mpv_shim/mpvtk_browser/cast.py
 msgid "Select your media in Jellyfin and play it here."
 msgstr ""
 
+#. Heading over the actors and film-makers on an item's page. Jellyfin Web
+#. uses the same phrase.
 #: jellyfin_mpv_shim/mpvtk_browser/components/detail.py
 msgid "Cast & Crew"
 msgstr ""
 
+#. Button in the Download modal that starts fetching the selected items. An
+#. imperative verb. The modal's own title uses the same English word as a
+#. noun and carries a context to keep the two apart.
 #: jellyfin_mpv_shim/mpvtk_browser/components/detail.py
 #: jellyfin_mpv_shim/mpvtk_browser/dialogs.py
 #: jellyfin_mpv_shim/mpvtk_browser/pages/books.py
@@ -804,73 +1187,109 @@ msgstr ""
 msgid "Download"
 msgstr ""
 
+#. Button on an item's page that deletes the copy downloaded to this
+#. device. The item stays on the server. An imperative verb phrase.
 #: jellyfin_mpv_shim/mpvtk_browser/components/detail.py
 #: jellyfin_mpv_shim/mpvtk_browser/pages/books.py
 msgid "Remove Download"
 msgstr ""
 
+#. Button on an item's page that marks it as watched, drawn ticked when it
+#. already is. Must not read the same as "Watch": in one language it did,
+#. and the play button came out saying "Seen".
 #: jellyfin_mpv_shim/mpvtk_browser/components/detail.py
 msgid "Watched"
 msgstr ""
 
+#. Tooltip of the heart button that marks what is playing or being viewed
+#. as a favourite. A verb here.
 #: jellyfin_mpv_shim/mpvtk_browser/components/detail.py
 #: jellyfin_mpv_shim/mpvtk_browser/hud.py
 #: jellyfin_mpv_shim/mpvtk_browser/pages/books.py
 msgid "Favorite"
 msgstr ""
 
+#. Button on an item's page that opens the same item in Jellyfin's browser
+#. client. Short for the web client, since the button sits in a row of
+#. narrow buttons.
 #: jellyfin_mpv_shim/mpvtk_browser/components/detail.py
 msgid "Web"
 msgstr ""
 
+#. Heading over the video stream's rows in the Media Info panel. A stream
+#. kind, alongside Audio, Subtitle, Lyric and Image.
 #: jellyfin_mpv_shim/mpvtk_browser/components/media_info.py
 msgid "Video"
 msgstr ""
 
+#. One English word, three places. A group heading on the Playback tab of
+#. Settings; the heading over an audio stream's rows in the Media Info
+#. panel, where it is a stream kind alongside Video and Subtitle; and the
+#. label of the audio-track dropdown on an item's page.
 #: jellyfin_mpv_shim/mpvtk_browser/components/media_info.py
 #: jellyfin_mpv_shim/mpvtk_browser/config.py
 #: jellyfin_mpv_shim/mpvtk_browser/pages/detail.py
 msgid "Audio"
 msgstr ""
 
+#. Heading over a subtitle stream's rows in the Media Info panel. A stream
+#. kind, singular.
 #: jellyfin_mpv_shim/mpvtk_browser/components/media_info.py
 #: jellyfin_mpv_shim/mpvtk_browser/pages/detail.py
 msgid "Subtitle"
 msgstr ""
 
+#. Heading over a lyrics stream's rows in the Media Info panel. A stream
+#. kind, singular: the timed words of a song.
 #: jellyfin_mpv_shim/mpvtk_browser/components/media_info.py
 msgid "Lyric"
 msgstr ""
 
+#. Heading over an embedded image stream's rows in the Media Info panel,
+#. such as cover art inside an audio file. A stream kind, singular.
 #: jellyfin_mpv_shim/mpvtk_browser/components/media_info.py
 msgid "Image"
 msgstr ""
 
+#. Row label in the Media Info panel: the file format wrapping the streams,
+#. such as MKV or MP4.
 #: jellyfin_mpv_shim/mpvtk_browser/components/media_info.py
 msgid "Container"
 msgstr ""
 
+#. Row label in the Media Info panel, listing the formats the file also
+#. identifies as.
 #: jellyfin_mpv_shim/mpvtk_browser/components/media_info.py
 msgid "Format"
 msgstr ""
 
+#. Row label in the Media Info panel: where the file sits on the server's
+#. disk.
 #: jellyfin_mpv_shim/mpvtk_browser/components/media_info.py
 msgid "Path"
 msgstr ""
 
+#. Row label in the Media Info panel: how large the file is on disk.
 #: jellyfin_mpv_shim/mpvtk_browser/components/media_info.py
 msgid "Size"
 msgstr ""
 
+#. Value of a yes/no row in the Media Info panel, such as Anamorphic or
+#. Interlaced.
 #: jellyfin_mpv_shim/mpvtk_browser/components/media_info.py
 msgid "Yes"
 msgstr ""
 
+#. Value of a yes/no row in the Media Info panel, such as Anamorphic or
+#. Interlaced.
 #: jellyfin_mpv_shim/mpvtk_browser/components/media_info.py
 #: jellyfin_mpv_shim/mpvtk_browser/hud.py
 msgid "No"
 msgstr ""
 
+#. Two uses. A row in the Media Info panel giving the name a stream
+#. carries, such as "English (SDH)"; and a column heading over item names
+#. in the queue, playlist and chapter tables.
 #: jellyfin_mpv_shim/mpvtk_browser/components/media_info.py
 #: jellyfin_mpv_shim/mpvtk_browser/pages/books.py
 #: jellyfin_mpv_shim/mpvtk_browser/pages/queue_edit.py
@@ -878,974 +1297,1461 @@ msgstr ""
 msgid "Title"
 msgstr ""
 
+#. One English word, two places. The label of the interface-language row at
+#. the top of Settings; and a row in the Media Info panel giving which
+#. language an audio or subtitle stream is in.
 #: jellyfin_mpv_shim/mpvtk_browser/components/media_info.py
 #: jellyfin_mpv_shim/mpvtk_browser/config.py
 msgid "Language"
 msgstr ""
 
+#. Row label in the Media Info panel: the compression format of this
+#. stream, such as H264 or AAC.
 #: jellyfin_mpv_shim/mpvtk_browser/components/media_info.py
 msgid "Codec"
 msgstr ""
 
+#. Row label in the Media Info panel: the four-character code the container
+#. files this codec under.
 #: jellyfin_mpv_shim/mpvtk_browser/components/media_info.py
 msgid "Codec tag"
 msgstr ""
 
+#. Row label in the Media Info panel: the codec profile, such as High or
+#. Main 10.
 #: jellyfin_mpv_shim/mpvtk_browser/components/media_info.py
 msgid "Profile"
 msgstr ""
 
+#. Row label in the Media Info panel: the codec level, a number bounding
+#. resolution and bitrate.
 #: jellyfin_mpv_shim/mpvtk_browser/components/media_info.py
 msgid "Level"
 msgstr ""
 
+#. Row label in the Media Info panel: the picture size in pixels, shown as
+#. width by height.
 #: jellyfin_mpv_shim/mpvtk_browser/components/media_info.py
 msgid "Resolution"
 msgstr ""
 
+#. Row label in the Media Info panel: the shape of the picture, such as
+#. 16:9.
 #: jellyfin_mpv_shim/mpvtk_browser/components/media_info.py
 msgid "Aspect ratio"
 msgstr ""
 
+#. Row label in the Media Info panel: whether the picture is stored
+#. squeezed and stretched back out on playback.
 #: jellyfin_mpv_shim/mpvtk_browser/components/media_info.py
 msgid "Anamorphic"
 msgstr ""
 
+#. Row label in the Media Info panel: whether the video is stored as
+#. interlaced fields rather than whole frames.
 #: jellyfin_mpv_shim/mpvtk_browser/components/media_info.py
 msgid "Interlaced"
 msgstr ""
 
+#. Row label in the Media Info panel: how many frames a second the video
+#. runs at.
 #: jellyfin_mpv_shim/mpvtk_browser/components/media_info.py
 #: jellyfin_mpv_shim/mpvtk_browser/hud.py
 msgid "Framerate"
 msgstr ""
 
+#. Row label in the Media Info panel: how the audio channels are arranged,
+#. such as 5.1.
 #: jellyfin_mpv_shim/mpvtk_browser/components/media_info.py
 msgid "Layout"
 msgstr ""
 
+#. Row label in the Media Info panel: how many audio channels the track
+#. has. A count, not the Live TV channels this word means elsewhere, which
+#. is why it carries a context.
 #: jellyfin_mpv_shim/mpvtk_browser/components/media_info.py
 msgctxt "audio channel count"
 msgid "Channels"
 msgstr ""
 
+#. Value beside the audio channel-count row in the Media Info panel. The
+#. abbreviation is for "channels"; %d is how many.
 #: jellyfin_mpv_shim/mpvtk_browser/components/media_info.py
 #, python-format
 msgid "%d ch"
 msgstr ""
 
+#. Row label in the Media Info panel: how much data a second this stream
+#. uses.
 #: jellyfin_mpv_shim/mpvtk_browser/components/media_info.py
 msgid "Bitrate"
 msgstr ""
 
+#. Value of the Bitrate row in the Media Info panel. Kilobits per second;
+#. the unit is normally left as-is.
 #: jellyfin_mpv_shim/mpvtk_browser/components/media_info.py
 #, python-format
 msgid "%d kbps"
 msgstr ""
 
+#. Row label in the Media Info panel: how many audio samples a second, such
+#. as 48 kHz.
 #: jellyfin_mpv_shim/mpvtk_browser/components/media_info.py
 msgid "Sample rate"
 msgstr ""
 
+#. Value of the Sample rate row in the Media Info panel. Hertz; the unit is
+#. normally left as-is.
 #: jellyfin_mpv_shim/mpvtk_browser/components/media_info.py
 #, python-format
 msgid "%d Hz"
 msgstr ""
 
+#. Row label in the Media Info panel: how many bits each sample or colour
+#. uses.
 #: jellyfin_mpv_shim/mpvtk_browser/components/media_info.py
 msgid "Bit depth"
 msgstr ""
 
+#. Value of the Bit depth row in the Media Info panel, as in "10 bit".
 #: jellyfin_mpv_shim/mpvtk_browser/components/media_info.py
 #, python-format
 msgid "%d bit"
 msgstr ""
 
+#. Row label in the Media Info panel: whether the picture is standard
+#. dynamic range or high.
 #: jellyfin_mpv_shim/mpvtk_browser/components/media_info.py
 msgid "Video range"
 msgstr ""
 
+#. Row label in the Media Info panel: which high dynamic range system the
+#. video uses, such as HDR10 or Dolby Vision.
 #: jellyfin_mpv_shim/mpvtk_browser/components/media_info.py
 msgid "Video range type"
 msgstr ""
 
+#. Row label in the Media Info panel: the colour space the video is encoded
+#. in, such as BT.709.
 #: jellyfin_mpv_shim/mpvtk_browser/components/media_info.py
 msgid "Color space"
 msgstr ""
 
+#. Row label in the Media Info panel: the transfer function, the curve
+#. relating stored values to light.
 #: jellyfin_mpv_shim/mpvtk_browser/components/media_info.py
 msgid "Color transfer"
 msgstr ""
 
+#. Row label in the Media Info panel: which red, green and blue the
+#. encoding is measured against.
 #: jellyfin_mpv_shim/mpvtk_browser/components/media_info.py
 msgid "Color primaries"
 msgstr ""
 
+#. Row label in the Media Info panel: how the pixels are laid out in
+#. memory, such as yuv420p.
 #: jellyfin_mpv_shim/mpvtk_browser/components/media_info.py
 msgid "Pixel format"
 msgstr ""
 
+#. Row label in the Media Info panel: how many earlier frames the codec may
+#. refer back to. Short for "reference frames".
 #: jellyfin_mpv_shim/mpvtk_browser/components/media_info.py
 msgid "Ref frames"
 msgstr ""
 
+#. Row label in the Media Info panel: how far the picture must be turned to
+#. be upright, in degrees.
 #: jellyfin_mpv_shim/mpvtk_browser/components/media_info.py
 msgid "Rotation"
 msgstr ""
 
+#. One English word, two senses, and Jellyfin Web needs two separate keys
+#. for them. A choice in a settings dropdown meaning "change nothing, let
+#. MPV decide"; and a flag in the Media Info panel marking the stream a
+#. player picks when the viewer has expressed no preference. Several
+#. languages have translated the two differently here, so the single
+#. translation has to carry both.
 #: jellyfin_mpv_shim/mpvtk_browser/components/media_info.py
 #: jellyfin_mpv_shim/mpvtk_browser/config.py
 msgid "Default"
 msgstr ""
 
+#. Flag row in the Media Info panel, marking a subtitle track meant to be
+#. shown even when subtitles are off, such as translations of on-screen
+#. signs.
 #: jellyfin_mpv_shim/mpvtk_browser/components/media_info.py
 msgid "Forced"
 msgstr ""
 
+#. Flag row in the Media Info panel, marking a stream that lives in a
+#. separate file beside the video rather than inside it.
 #: jellyfin_mpv_shim/mpvtk_browser/components/media_info.py
 #: jellyfin_mpv_shim/osc_bridge.py
 msgid "External"
 msgstr ""
 
+#. Row label in the Media Info panel: where in the container the timestamps
+#. are stored.
 #: jellyfin_mpv_shim/mpvtk_browser/components/media_info.py
 msgid "Timestamp"
 msgstr ""
 
+#. Row label in the Media Info panel. "DV" is Dolby Vision; the
+#. abbreviation is normally kept.
 #: jellyfin_mpv_shim/mpvtk_browser/components/media_info.py
 msgid "DV title"
 msgstr ""
 
+#. Row label in the Media Info panel: the major part of the Dolby Vision
+#. version number.
 #: jellyfin_mpv_shim/mpvtk_browser/components/media_info.py
 msgid "DV version major"
 msgstr ""
 
+#. Row label in the Media Info panel: the minor part of the Dolby Vision
+#. version number.
 #: jellyfin_mpv_shim/mpvtk_browser/components/media_info.py
 msgid "DV version minor"
 msgstr ""
 
+#. Row label in the Media Info panel: which Dolby Vision profile the video
+#. uses.
 #: jellyfin_mpv_shim/mpvtk_browser/components/media_info.py
 msgid "DV profile"
 msgstr ""
 
+#. Row label in the Media Info panel: which Dolby Vision level the video
+#. uses.
 #: jellyfin_mpv_shim/mpvtk_browser/components/media_info.py
 msgid "DV level"
 msgstr ""
 
+#. Row label in the Media Info panel: whether the Dolby Vision reference
+#. processing unit data is present. Technical field names taken from the
+#. server; several languages keep them as-is.
 #: jellyfin_mpv_shim/mpvtk_browser/components/media_info.py
 msgid "DV rpu preset flag"
 msgstr ""
 
+#. Row label in the Media Info panel: whether the Dolby Vision enhancement
+#. layer is present. Technical field names taken from the server; several
+#. languages keep them as-is.
 #: jellyfin_mpv_shim/mpvtk_browser/components/media_info.py
 msgid "DV el preset flag"
 msgstr ""
 
+#. Row label in the Media Info panel: whether the Dolby Vision base layer
+#. is present. Technical field names taken from the server; several
+#. languages keep them as-is.
 #: jellyfin_mpv_shim/mpvtk_browser/components/media_info.py
 msgid "DV bl preset flag"
 msgstr ""
 
+#. Row label in the Media Info panel: which ordinary format the Dolby
+#. Vision base layer is also readable as. Taken from the server; several
+#. languages keep it as-is.
 #: jellyfin_mpv_shim/mpvtk_browser/components/media_info.py
 msgid "DV bl signal compatibility id"
 msgstr ""
 
+#. One-line media summary. Megabits per second; the unit is normally left
+#. as-is.
 #: jellyfin_mpv_shim/mpvtk_browser/components/media_info.py
 #: jellyfin_mpv_shim/mpvtk_browser/hud.py
 #, python-format
 msgid "%.1f Mbps"
 msgstr ""
 
+#. How the video is reaching this device: the server is sending the
+#. original file untouched. Shown on the playback information panel.
+#. Jellyfin Web uses the same four words.
 #: jellyfin_mpv_shim/mpvtk_browser/components/media_info.py
 msgid "Direct playing"
 msgstr ""
 
+#. How the video is reaching this device: the server is repackaging the
+#. file but not re-encoding the picture. Shown on the playback information
+#. panel.
 #: jellyfin_mpv_shim/mpvtk_browser/components/media_info.py
 msgid "Direct streaming"
 msgstr ""
 
+#. How the video is reaching this device: the streams are being put into a
+#. different container, with no re-encoding. Shown on the playback
+#. information panel.
 #: jellyfin_mpv_shim/mpvtk_browser/components/media_info.py
 msgid "Remuxing"
 msgstr ""
 
+#. One English word, two senses. A group heading on the Playback tab of
+#. Settings, over the options that decide when the server may re-encode;
+#. and, on the playback information panel, the state meaning the server is
+#. re-encoding this video right now.
 #: jellyfin_mpv_shim/mpvtk_browser/components/media_info.py
 #: jellyfin_mpv_shim/mpvtk_browser/config.py
 msgid "Transcoding"
 msgstr ""
 
+#. One reason the server gives for having to re-encode, listed on the
+#. playback information panel. This and the ones like it are sentence
+#. fragments completing "Reason:".
 #: jellyfin_mpv_shim/mpvtk_browser/components/media_info.py
 msgid "The container is not supported"
 msgstr ""
 
+#. One reason the server gives for having to re-encode, listed on the
+#. playback information panel.
 #: jellyfin_mpv_shim/mpvtk_browser/components/media_info.py
 msgid "The video codec is not supported"
 msgstr ""
 
+#. One reason the server gives for having to re-encode, listed on the
+#. playback information panel.
 #: jellyfin_mpv_shim/mpvtk_browser/components/media_info.py
 msgid "The audio codec is not supported"
 msgstr ""
 
+#. One reason the server gives for having to re-encode, listed on the
+#. playback information panel.
 #: jellyfin_mpv_shim/mpvtk_browser/components/media_info.py
 msgid "The subtitle codec is not supported"
 msgstr ""
 
+#. One reason the server gives for having to re-encode: the audio is in a
+#. separate file from the video.
 #: jellyfin_mpv_shim/mpvtk_browser/components/media_info.py
 msgid "The audio stream is external"
 msgstr ""
 
+#. One reason the server gives for having to re-encode, listed on the
+#. playback information panel.
 #: jellyfin_mpv_shim/mpvtk_browser/components/media_info.py
 msgid "Secondary audio tracks are not supported"
 msgstr ""
 
+#. One reason the server gives for having to re-encode. "Profile" is a
+#. codec feature set, such as High or Main 10.
 #: jellyfin_mpv_shim/mpvtk_browser/components/media_info.py
 msgid "The video codec's profile is not supported"
 msgstr ""
 
+#. One reason the server gives for having to re-encode. "Level" is a codec
+#. limit on resolution and bitrate.
 #: jellyfin_mpv_shim/mpvtk_browser/components/media_info.py
 msgid "The video codec's level is not supported"
 msgstr ""
 
+#. One reason the server gives for having to re-encode, listed on the
+#. playback information panel.
 #: jellyfin_mpv_shim/mpvtk_browser/components/media_info.py
 msgid "The video's resolution is not supported"
 msgstr ""
 
+#. One reason the server gives for having to re-encode, listed on the
+#. playback information panel.
 #: jellyfin_mpv_shim/mpvtk_browser/components/media_info.py
 msgid "The video's bit depth is not supported"
 msgstr ""
 
+#. One reason the server gives for having to re-encode, listed on the
+#. playback information panel.
 #: jellyfin_mpv_shim/mpvtk_browser/components/media_info.py
 msgid "The video's framerate is not supported"
 msgstr ""
 
+#. One reason the server gives for having to re-encode: how many earlier
+#. frames the codec refers back to.
 #: jellyfin_mpv_shim/mpvtk_browser/components/media_info.py
 msgid "Reference frames are not supported"
 msgstr ""
 
+#. One reason the server gives for having to re-encode: the picture is
+#. stored squeezed and stretched back out on playback.
 #: jellyfin_mpv_shim/mpvtk_browser/components/media_info.py
 msgid "Anamorphic video is not supported"
 msgstr ""
 
+#. One reason the server gives for having to re-encode, listed on the
+#. playback information panel.
 #: jellyfin_mpv_shim/mpvtk_browser/components/media_info.py
 msgid "Interlaced video is not supported"
 msgstr ""
 
+#. One reason the server gives for having to re-encode, listed on the
+#. playback information panel.
 #: jellyfin_mpv_shim/mpvtk_browser/components/media_info.py
 msgid "The number of audio channels is not supported"
 msgstr ""
 
+#. One reason the server gives for having to re-encode, listed on the
+#. playback information panel.
 #: jellyfin_mpv_shim/mpvtk_browser/components/media_info.py
 msgid "The audio codec's profile is not supported"
 msgstr ""
 
+#. One reason the server gives for having to re-encode, listed on the
+#. playback information panel.
 #: jellyfin_mpv_shim/mpvtk_browser/components/media_info.py
 msgid "The audio's sample rate is not supported"
 msgstr ""
 
+#. One reason the server gives for having to re-encode, listed on the
+#. playback information panel.
 #: jellyfin_mpv_shim/mpvtk_browser/components/media_info.py
 msgid "The audio's bit depth is not supported"
 msgstr ""
 
+#. One reason the server gives for having to re-encode, listed on the
+#. playback information panel.
 #: jellyfin_mpv_shim/mpvtk_browser/components/media_info.py
 msgid "The video's bitrate exceeds the limit"
 msgstr ""
 
+#. One reason the server gives for having to re-encode, listed on the
+#. playback information panel.
 #: jellyfin_mpv_shim/mpvtk_browser/components/media_info.py
 msgid "The video's bitrate is not supported"
 msgstr ""
 
+#. One reason the server gives for having to re-encode, listed on the
+#. playback information panel.
 #: jellyfin_mpv_shim/mpvtk_browser/components/media_info.py
 msgid "The audio's bitrate is not supported"
 msgstr ""
 
+#. One reason the server gives for having to re-encode: it could not read
+#. the video stream's details.
 #: jellyfin_mpv_shim/mpvtk_browser/components/media_info.py
 msgid "The video stream info is unknown"
 msgstr ""
 
+#. One reason the server gives for having to re-encode: it could not read
+#. the audio stream's details.
 #: jellyfin_mpv_shim/mpvtk_browser/components/media_info.py
 msgid "The audio stream info is unknown"
 msgstr ""
 
+#. One reason the server gives for having to re-encode, listed on the
+#. playback information panel.
 #: jellyfin_mpv_shim/mpvtk_browser/components/media_info.py
 msgid "There was an error starting direct playback"
 msgstr ""
 
+#. One reason the server gives for having to re-encode: which high dynamic
+#. range system the video uses.
 #: jellyfin_mpv_shim/mpvtk_browser/components/media_info.py
 msgid "The video's range type is not supported"
 msgstr ""
 
+#. Heading of a group of settings on the General tab of Settings.
 #: jellyfin_mpv_shim/mpvtk_browser/config.py
 msgid "This Device"
 msgstr ""
 
+#. Heading of a group of settings on the General tab of Settings.
 #: jellyfin_mpv_shim/mpvtk_browser/config.py
 msgid "Input"
 msgstr ""
 
+#. Heading of a group of settings on the General tab of Settings.
 #: jellyfin_mpv_shim/mpvtk_browser/config.py
 msgid "Window"
 msgstr ""
 
+#. Heading of a group of settings on the Browse tab of Settings. Label of
+#. the text field for the "theme" setting (Settings > Browse > Theme).
 #: jellyfin_mpv_shim/mpvtk_browser/config.py
 msgid "Theme"
 msgstr ""
 
+#. Heading of a group of settings on the Browse tab of Settings.
 #: jellyfin_mpv_shim/mpvtk_browser/config.py
 msgid "Library Browser"
 msgstr ""
 
+#. Heading of a group of settings on the Browse tab of Settings.
 #: jellyfin_mpv_shim/mpvtk_browser/config.py
 msgid "Reading"
 msgstr ""
 
+#. Content fetched to this device for offline use. A group heading under
+#. Settings > Browse, the name of the Downloads settings page, and the
+#. title of the page listing what is on disk.
 #: jellyfin_mpv_shim/mpvtk_browser/config.py
 #: jellyfin_mpv_shim/mpvtk_browser/settings/downloads.py
 #: jellyfin_mpv_shim/mpvtk_browser/settings/__init__.py
 msgid "Downloads"
 msgstr ""
 
+#. Heading of a group of settings on the Browse tab of Settings.
 #: jellyfin_mpv_shim/mpvtk_browser/config.py
 msgid "Download Tuning"
 msgstr ""
 
+#. Heading of a group of settings on the Playback tab of Settings.
 #: jellyfin_mpv_shim/mpvtk_browser/config.py
 msgid "Player Controls"
 msgstr ""
 
+#. One English word, three places. A group heading on the Playback tab of
+#. Settings; the name of that tab's own section; and the heading of the
+#. block in the Playback Info panel holding the media type and how the
+#. video is reaching this device.
 #: jellyfin_mpv_shim/mpvtk_browser/config.py
 #: jellyfin_mpv_shim/mpvtk_browser/hud.py
 #: jellyfin_mpv_shim/mpvtk_browser/settings/__init__.py
 msgid "Playback"
 msgstr ""
 
+#. Heading of a group of settings on the Playback tab of Settings.
 #: jellyfin_mpv_shim/mpvtk_browser/config.py
 msgid "Subtitles & Languages"
 msgstr ""
 
+#. Heading of a group of settings on the Playback tab of Settings.
 #: jellyfin_mpv_shim/mpvtk_browser/config.py
 msgid "Video Enhancement"
 msgstr ""
 
+#. Heading of a group of settings on the Playback tab of Settings.
 #: jellyfin_mpv_shim/mpvtk_browser/config.py
 msgid "Skip Intro / Credits"
 msgstr ""
 
+#. Heading of the group in Settings holding every row not sorted into a
+#. named group.
 #: jellyfin_mpv_shim/mpvtk_browser/config.py
 msgid "Advanced"
 msgstr ""
 
+#. Choice in the "Hardware Decoding" dropdown (Settings > Playback >
+#. Playback); stored as "no".
 #: jellyfin_mpv_shim/mpvtk_browser/config.py
 msgid "Off (software decoding)"
 msgstr ""
 
+#. Choice in the "Hardware Decoding" dropdown (Settings > Playback >
+#. Playback); stored as "over-1080p".
 #: jellyfin_mpv_shim/mpvtk_browser/config.py
 msgid "Only above 1080p"
 msgstr ""
 
+#. Choice in the "Hardware Decoding" dropdown (Settings > Playback >
+#. Playback); stored as "auto".
 #: jellyfin_mpv_shim/mpvtk_browser/config.py
 msgid "On"
 msgstr ""
 
+#. Choice in the "Hardware Decoding" dropdown (Settings > Playback >
+#. Playback); stored as "auto-copy".
 #: jellyfin_mpv_shim/mpvtk_browser/config.py
 msgid "Copy (advanced)"
 msgstr ""
 
+#. Choice shared by the "Motion Interpolation", "Debanding" dropdowns
+#. (Settings > Playback > Video Enhancement). One translation has to serve
+#. all of them.
 #: jellyfin_mpv_shim/mpvtk_browser/config.py
 msgid "Off"
 msgstr ""
 
+#. Choice in the "Motion Interpolation" dropdown (Settings > Playback >
+#. Video Enhancement); stored as "smooth".
 #: jellyfin_mpv_shim/mpvtk_browser/config.py
 msgid "Smooth Motion"
 msgstr ""
 
+#. Choice in the "Motion Interpolation" dropdown (Settings > Playback >
+#. Video Enhancement); stored as "blend".
 #: jellyfin_mpv_shim/mpvtk_browser/config.py
 msgid "Blend Frames"
 msgstr ""
 
+#. Choice in the "Motion Interpolation" dropdown (Settings > Playback >
+#. Video Enhancement); stored as "hq".
 #: jellyfin_mpv_shim/mpvtk_browser/config.py
 msgid "Smooth (high quality)"
 msgstr ""
 
+#. Choice in the "Debanding" dropdown (Settings > Playback > Video
+#. Enhancement); stored as "light".
 #: jellyfin_mpv_shim/mpvtk_browser/config.py
 msgid "Light (live action)"
 msgstr ""
 
+#. Choice in the "Debanding" dropdown (Settings > Playback > Video
+#. Enhancement); stored as "standard".
 #: jellyfin_mpv_shim/mpvtk_browser/config.py
 msgid "Standard (animation)"
 msgstr ""
 
+#. Choice in the "Debanding" dropdown (Settings > Playback > Video
+#. Enhancement); stored as "strong".
 #: jellyfin_mpv_shim/mpvtk_browser/config.py
 msgid "Strong"
 msgstr ""
 
+#. Choice in the "HDR Tone Mapping" dropdown (Settings > Playback > Video
+#. Enhancement); stored as "auto".
 #: jellyfin_mpv_shim/mpvtk_browser/config.py
 msgid "Automatic (MPV decides)"
 msgstr ""
 
+#. Choice in the "HDR Tone Mapping" dropdown (Settings > Playback > Video
+#. Enhancement); stored as "bt.2390".
 #: jellyfin_mpv_shim/mpvtk_browser/config.py
 msgid "BT.2390 (reference)"
 msgstr ""
 
+#. Choice in the "HDR Tone Mapping" dropdown (Settings > Playback > Video
+#. Enhancement); stored as "bt.2446a".
 #: jellyfin_mpv_shim/mpvtk_browser/config.py
 msgid "BT.2446a"
 msgstr ""
 
+#. Choice in the "HDR Tone Mapping" dropdown (Settings > Playback > Video
+#. Enhancement); stored as "spline".
 #: jellyfin_mpv_shim/mpvtk_browser/config.py
 msgid "Spline"
 msgstr ""
 
+#. Choice in the "HDR Tone Mapping" dropdown (Settings > Playback > Video
+#. Enhancement); stored as "hable".
 #: jellyfin_mpv_shim/mpvtk_browser/config.py
 msgid "Hable"
 msgstr ""
 
+#. Choice in the "HDR Tone Mapping" dropdown (Settings > Playback > Video
+#. Enhancement); stored as "reinhard".
 #: jellyfin_mpv_shim/mpvtk_browser/config.py
 msgid "Reinhard"
 msgstr ""
 
+#. Choice in the "HDR Tone Mapping" dropdown (Settings > Playback > Video
+#. Enhancement); stored as "clip".
 #: jellyfin_mpv_shim/mpvtk_browser/config.py
 msgid "Clip (no tone mapping)"
 msgstr ""
 
+#. Choice in the "Rendering Quality" dropdown (Settings > Playback > Video
+#. Enhancement); stored as "default".
 #: jellyfin_mpv_shim/mpvtk_browser/config.py
 msgid "MPV default"
 msgstr ""
 
+#. Choice in the "Rendering Quality" dropdown (Settings > Playback > Video
+#. Enhancement); stored as "high".
 #: jellyfin_mpv_shim/mpvtk_browser/config.py
 msgid "High quality"
 msgstr ""
 
+#. Choice in the "Network Buffer" dropdown (Settings > Playback >
+#. Playback); stored as "default".
 #: jellyfin_mpv_shim/mpvtk_browser/config.py
 msgid "MPV default (1 second)"
 msgstr ""
 
+#. Choice in the "Network Buffer" dropdown (Settings > Playback >
+#. Playback); stored as "large".
 #: jellyfin_mpv_shim/mpvtk_browser/config.py
 msgid "Large (20 seconds)"
 msgstr ""
 
+#. Choice in the "Network Buffer" dropdown (Settings > Playback >
+#. Playback); stored as "huge".
 #: jellyfin_mpv_shim/mpvtk_browser/config.py
 msgid "Very large (60 seconds)"
 msgstr ""
 
+#. Choice in the "Player Controls Style" dropdown (Settings > Playback >
+#. Player Controls); stored as "mpvtk".
 #: jellyfin_mpv_shim/mpvtk_browser/config.py
 msgid "Jellyfin UI"
 msgstr ""
 
+#. Choice in the "Player Controls Style" dropdown (Settings > Playback >
+#. Player Controls); stored as "mpv".
 #: jellyfin_mpv_shim/mpvtk_browser/config.py
 msgid "MPV UI"
 msgstr ""
 
+#. Choice in the "Player Controls Style" dropdown (Settings > Playback >
+#. Player Controls); stored as "custom".
 #: jellyfin_mpv_shim/mpvtk_browser/config.py
 msgid "Custom OSC"
 msgstr ""
 
+#. Choice in the "Player Controls Style" dropdown (Settings > Playback >
+#. Player Controls); stored as "none".
 #: jellyfin_mpv_shim/mpvtk_browser/config.py
 msgid "No player controls"
 msgstr ""
 
+#. Choice in the "Text size" dropdown (Settings > Browse > Theme); stored
+#. as "0.75".
 #: jellyfin_mpv_shim/mpvtk_browser/config.py
 msgid "75%"
 msgstr ""
 
+#. Choice in the "Text size" dropdown (Settings > Browse > Theme); stored
+#. as "0.85".
 #: jellyfin_mpv_shim/mpvtk_browser/config.py
 msgid "85%"
 msgstr ""
 
+#. Choice in the "Text size" dropdown (Settings > Browse > Theme); stored
+#. as "0.9".
 #: jellyfin_mpv_shim/mpvtk_browser/config.py
 msgid "90%"
 msgstr ""
 
+#. Choice shared by the "Text size", "Interface Scale" dropdowns (Settings
+#. > Browse > Theme). One translation has to serve all of them.
 #: jellyfin_mpv_shim/mpvtk_browser/config.py
 msgid "100% (no scaling)"
 msgstr ""
 
+#. Choice in the "Text size" dropdown (Settings > Browse > Theme); stored
+#. as "1.1".
 #: jellyfin_mpv_shim/mpvtk_browser/config.py
 msgid "110%"
 msgstr ""
 
+#. Choice shared by the "Text size", "Interface Scale" dropdowns (Settings
+#. > Browse > Theme). One translation has to serve all of them.
 #: jellyfin_mpv_shim/mpvtk_browser/config.py
 msgid "125%"
 msgstr ""
 
+#. Choice shared by the "Text size", "Interface Scale" dropdowns (Settings
+#. > Browse > Theme). One translation has to serve all of them.
 #: jellyfin_mpv_shim/mpvtk_browser/config.py
 msgid "150%"
 msgstr ""
 
+#. Choice in the "Minimum Text Size" dropdown (Settings > Browse > Theme);
+#. stored as "0".
 #: jellyfin_mpv_shim/mpvtk_browser/config.py
 msgid "No minimum"
 msgstr ""
 
+#. Choice in the "Minimum Text Size" dropdown (Settings > Browse > Theme);
+#. stored as "14".
 #: jellyfin_mpv_shim/mpvtk_browser/config.py
 msgid "14 px"
 msgstr ""
 
+#. Choice in the "Minimum Text Size" dropdown (Settings > Browse > Theme);
+#. stored as "16".
 #: jellyfin_mpv_shim/mpvtk_browser/config.py
 msgid "16 px"
 msgstr ""
 
+#. Choice in the "Minimum Text Size" dropdown (Settings > Browse > Theme);
+#. stored as "18".
 #: jellyfin_mpv_shim/mpvtk_browser/config.py
 msgid "18 px"
 msgstr ""
 
+#. Choice in the "Minimum Text Size" dropdown (Settings > Browse > Theme);
+#. stored as "20".
 #: jellyfin_mpv_shim/mpvtk_browser/config.py
 msgid "20 px"
 msgstr ""
 
+#. Choice in the "Interface Scale" dropdown (Settings > Browse > Theme);
+#. stored as "None".
 #: jellyfin_mpv_shim/mpvtk_browser/config.py
 msgid "Follow display"
 msgstr ""
 
+#. Choice in the "Interface Scale" dropdown (Settings > Browse > Theme);
+#. stored as "2.0".
 #: jellyfin_mpv_shim/mpvtk_browser/config.py
 msgid "200%"
 msgstr ""
 
+#. Choice in the "Scroll Mode" dropdown (Settings > Browse > Library
+#. Browser); stored as "continuous".
 #: jellyfin_mpv_shim/mpvtk_browser/config.py
 msgid "Continuous"
 msgstr ""
 
+#. Choice in the "Scroll Mode" dropdown (Settings > Browse > Library
+#. Browser); stored as "aligned".
 #: jellyfin_mpv_shim/mpvtk_browser/config.py
 msgid "Aligned to rows"
 msgstr ""
 
+#. Choice in the "Scroll Mode" dropdown (Settings > Browse > Library
+#. Browser); stored as "row".
 #: jellyfin_mpv_shim/mpvtk_browser/config.py
 msgid "One row per notch"
 msgstr ""
 
+#. Choice in several settings dropdowns, meaning the application decides
+#. rather than the viewer: whether to announce updates, when to download
+#. episodes, and which SmoothVideo Project profile to use. One translation
+#. serves all three.
 #: jellyfin_mpv_shim/mpvtk_browser/config.py
 #: jellyfin_mpv_shim/mpvtk_browser/downloads.py
 #: jellyfin_mpv_shim/svp_integration.py
 msgid "Automatic"
 msgstr ""
 
+#. Choice in the "Window Buttons in the Top Bar" dropdown (Settings >
+#. General > Window); stored as "auto".
 #: jellyfin_mpv_shim/mpvtk_browser/config.py
 msgid "Only when the window has no title bar"
 msgstr ""
 
+#. Choice in the "Page Colour" dropdown (Settings > Browse > Reading);
+#. stored as "dark".
 #: jellyfin_mpv_shim/mpvtk_browser/config.py
 #: jellyfin_mpv_shim/mpvtk_browser/pages/reader.py
 msgid "Dark"
 msgstr ""
 
+#. Choice in the "Page Colour" dropdown (Settings > Browse > Reading);
+#. stored as "sepia".
 #: jellyfin_mpv_shim/mpvtk_browser/config.py
 #: jellyfin_mpv_shim/mpvtk_browser/pages/reader.py
 msgid "Sepia"
 msgstr ""
 
+#. Choice in the "Page Colour" dropdown (Settings > Browse > Reading);
+#. stored as "light".
 #: jellyfin_mpv_shim/mpvtk_browser/config.py
 #: jellyfin_mpv_shim/mpvtk_browser/pages/reader.py
 msgid "Light"
 msgstr ""
 
+#. Choice in the "Comic Reading Mode" dropdown (Settings > Browse >
+#. Reading); stored as "width".
 #: jellyfin_mpv_shim/mpvtk_browser/config.py
 #: jellyfin_mpv_shim/mpvtk_browser/pages/comic.py
 msgid "Fit Width"
 msgstr ""
 
+#. Choice in the "Comic Reading Mode" dropdown (Settings > Browse >
+#. Reading); stored as "page".
 #: jellyfin_mpv_shim/mpvtk_browser/config.py
 #: jellyfin_mpv_shim/mpvtk_browser/pages/comic.py
 msgid "Fit Page"
 msgstr ""
 
+#. Choice in the "Shading Behind the Player Controls" dropdown (Settings >
+#. Playback > Player Controls); stored as "panel".
 #: jellyfin_mpv_shim/mpvtk_browser/config.py
 msgid "Panel behind the controls"
 msgstr ""
 
+#. Choice in the "Shading Behind the Player Controls" dropdown (Settings >
+#. Playback > Player Controls); stored as "none".
 #: jellyfin_mpv_shim/mpvtk_browser/config.py
 msgid "None (shadowed text)"
 msgstr ""
 
+#. Choice in the "When the Player Controls Hide" dropdown (Settings >
+#. Playback > Player Controls); stored as "hover".
 #: jellyfin_mpv_shim/mpvtk_browser/config.py
 msgid "Hide unless hovered"
 msgstr ""
 
+#. Choice in the "When the Player Controls Hide" dropdown (Settings >
+#. Playback > Player Controls); stored as "always".
 #: jellyfin_mpv_shim/mpvtk_browser/config.py
 msgid "Always hide"
 msgstr ""
 
+#. Choice in the "When the Player Controls Hide" dropdown (Settings >
+#. Playback > Player Controls); stored as "paused".
 #: jellyfin_mpv_shim/mpvtk_browser/config.py
 msgid "Never hide while paused"
 msgstr ""
 
+#. Choice in the "Grid Spacing" dropdown (Settings > Browse > Library
+#. Browser); stored as "justify".
 #: jellyfin_mpv_shim/mpvtk_browser/config.py
 msgid "Widen the gaps"
 msgstr ""
 
+#. Choice in the "Grid Spacing" dropdown (Settings > Browse > Library
+#. Browser); stored as "center".
 #: jellyfin_mpv_shim/mpvtk_browser/config.py
 msgid "Centre the tiles"
 msgstr ""
 
+#. Choice in the "Grid Spacing" dropdown (Settings > Browse > Library
+#. Browser); stored as "off".
 #: jellyfin_mpv_shim/mpvtk_browser/config.py
 msgid "Leave it on the right"
 msgstr ""
 
+#. Choice in the "Cover Size" dropdown (Settings > Browse > Theme); stored
+#. as "None".
 #: jellyfin_mpv_shim/mpvtk_browser/config.py
 msgid "Theme default"
 msgstr ""
 
+#. Choice in the "Cover Size" dropdown (Settings > Browse > Theme); stored
+#. as "0.75".
 #: jellyfin_mpv_shim/mpvtk_browser/config.py
 msgid "Extra Compact"
 msgstr ""
 
+#. Choice in the "Cover Size" dropdown (Settings > Browse > Theme); stored
+#. as "0.85".
 #: jellyfin_mpv_shim/mpvtk_browser/config.py
 msgid "Compact"
 msgstr ""
 
+#. Choice in the "Cover Size" dropdown (Settings > Browse > Theme); stored
+#. as "1.2".
 #: jellyfin_mpv_shim/mpvtk_browser/config.py
 msgid "Medium"
 msgstr ""
 
+#. Choice in the "Cover Size" dropdown (Settings > Browse > Theme); stored
+#. as "1.7".
 #: jellyfin_mpv_shim/mpvtk_browser/config.py
 msgid "Extra Large"
 msgstr ""
 
+#. Choice in the "Graphics API for Shaders" dropdown (Settings > Playback >
+#. Video Enhancement); stored as "auto".
 #: jellyfin_mpv_shim/mpvtk_browser/config.py
 msgid "Automatic (recommended)"
 msgstr ""
 
+#. Choice in the "Graphics API for Shaders" dropdown (Settings > Playback >
+#. Video Enhancement); stored as "vulkan".
 #: jellyfin_mpv_shim/mpvtk_browser/config.py
 msgid "Vulkan"
 msgstr ""
 
+#. Choice in the "Graphics API for Shaders" dropdown (Settings > Playback >
+#. Video Enhancement); stored as "d3d11".
 #: jellyfin_mpv_shim/mpvtk_browser/config.py
 msgid "Direct3D 11 (Windows only)"
 msgstr ""
 
+#. Choice in the "Graphics API for Shaders" dropdown (Settings > Playback >
+#. Video Enhancement); stored as "opengl".
 #: jellyfin_mpv_shim/mpvtk_browser/config.py
 msgid "OpenGL (compatibility)"
 msgstr ""
 
+#. Choice in the "Audio Output Mode" dropdown (Settings > Playback >
+#. Audio); stored as "auto".
 #: jellyfin_mpv_shim/mpvtk_browser/config.py
 msgid "Default (auto)"
 msgstr ""
 
+#. Choice in the "Audio Output Mode" dropdown (Settings > Playback >
+#. Audio); stored as "stereo".
 #: jellyfin_mpv_shim/mpvtk_browser/config.py
 msgid "Force Stereo"
 msgstr ""
 
+#. Choice in the "Audio Output Mode" dropdown (Settings > Playback >
+#. Audio); stored as "optical".
 #: jellyfin_mpv_shim/mpvtk_browser/config.py
 msgid "Optical Surround"
 msgstr ""
 
+#. Choice in the "Audio Output Mode" dropdown (Settings > Playback >
+#. Audio); stored as "hdmi".
 #: jellyfin_mpv_shim/mpvtk_browser/config.py
 msgid "HDMI Passthrough"
 msgstr ""
 
+#. Choice in the "Language Preference" dropdown (Settings > Playback >
+#. Subtitles & Languages); stored as "unset".
 #: jellyfin_mpv_shim/mpvtk_browser/config.py
 msgid "Unset"
 msgstr ""
 
+#. Choice in the "Language Preference" dropdown (Settings > Playback >
+#. Subtitles & Languages); stored as "dubbed_shows".
 #: jellyfin_mpv_shim/mpvtk_browser/config.py
 msgid "Dubbed (shows only)"
 msgstr ""
 
+#. Choice in the "Language Preference" dropdown (Settings > Playback >
+#. Subtitles & Languages); stored as "subbed_shows".
 #: jellyfin_mpv_shim/mpvtk_browser/config.py
 msgid "Subbed (shows only)"
 msgstr ""
 
+#. Choice in the "Language Preference" dropdown (Settings > Playback >
+#. Subtitles & Languages); stored as "dubbed_all".
 #: jellyfin_mpv_shim/mpvtk_browser/config.py
 msgid "Dubbed (all)"
 msgstr ""
 
+#. Choice in the "Language Preference" dropdown (Settings > Playback >
+#. Subtitles & Languages); stored as "subbed_all".
 #: jellyfin_mpv_shim/mpvtk_browser/config.py
 msgid "Subbed (all)"
 msgstr ""
 
+#. Choice in the "Language Preference" dropdown (Settings > Playback >
+#. Subtitles & Languages); stored as "custom".
 #: jellyfin_mpv_shim/mpvtk_browser/config.py
 msgid "Custom (set in config)"
 msgstr ""
 
+#. Label of the dropdown for the "notify_updates" setting (Settings >
+#. General > This Device).
 #: jellyfin_mpv_shim/mpvtk_browser/config.py
 msgid "Tell Me About Updates"
 msgstr ""
 
+#. Label of the checkbox for the "input_gamepad" setting (Settings >
+#. General > Input).
 #: jellyfin_mpv_shim/mpvtk_browser/config.py
 msgid "Game Controller"
 msgstr ""
 
+#. Label of the checkbox for the "gamepad_swap_confirm" setting (Settings >
+#. General > Input).
 #: jellyfin_mpv_shim/mpvtk_browser/config.py
 msgid "Swap Confirm and Back Buttons"
 msgstr ""
 
+#. Label of the text field for the "sync_path" setting (Settings > Browse >
+#. Downloads).
 #: jellyfin_mpv_shim/mpvtk_browser/config.py
 msgid "Download Folder"
 msgstr ""
 
+#. Label of the checkbox for the "prefer_downloaded" setting (Settings >
+#. Browse > Downloads).
 #: jellyfin_mpv_shim/mpvtk_browser/config.py
 msgid "Prefer Downloaded Copy"
 msgstr ""
 
+#. Label of the checkbox for the "mouse_click_pauses" setting (Settings >
+#. Playback > Player Controls).
 #: jellyfin_mpv_shim/mpvtk_browser/config.py
 msgid "Left Click Pauses Playback"
 msgstr ""
 
+#. Label of the checkbox for the "detail_poster" setting (Settings > Browse
+#. > Library Browser).
 #: jellyfin_mpv_shim/mpvtk_browser/config.py
 msgid "Show Posters on Detail Pages"
 msgstr ""
 
+#. Label of the checkbox for the "detail_episode_image" setting (Settings >
+#. Browse > Library Browser).
 #: jellyfin_mpv_shim/mpvtk_browser/config.py
 msgid "Show Episode Thumbnails on Detail Pages"
 msgstr ""
 
+#. Label of the dropdown for the "hwdec" setting (Settings > Playback >
+#. Playback).
 #: jellyfin_mpv_shim/mpvtk_browser/config.py
 msgid "Hardware Decoding"
 msgstr ""
 
+#. Label of the checkbox for the "deinterlace_auto" setting (Settings >
+#. Playback > Video Enhancement).
 #: jellyfin_mpv_shim/mpvtk_browser/config.py
 msgid "Deinterlace Automatically"
 msgstr ""
 
+#. Label of the dropdown for the "motion_interpolation" setting (Settings >
+#. Playback > Video Enhancement).
 #: jellyfin_mpv_shim/mpvtk_browser/config.py
 msgid "Motion Interpolation"
 msgstr ""
 
+#. Label of the dropdown for the "deband" setting (Settings > Playback >
+#. Video Enhancement).
 #: jellyfin_mpv_shim/mpvtk_browser/config.py
 msgid "Debanding"
 msgstr ""
 
+#. Label of the dropdown for the "tone_mapping" setting (Settings >
+#. Playback > Video Enhancement).
 #: jellyfin_mpv_shim/mpvtk_browser/config.py
 msgid "HDR Tone Mapping"
 msgstr ""
 
+#. Label of the dropdown for the "render_quality" setting (Settings >
+#. Playback > Video Enhancement).
 #: jellyfin_mpv_shim/mpvtk_browser/config.py
 msgid "Rendering Quality"
 msgstr ""
 
+#. Label of the dropdown for the "network_buffer" setting (Settings >
+#. Playback > Playback).
 #: jellyfin_mpv_shim/mpvtk_browser/config.py
 msgid "Network Buffer"
 msgstr ""
 
+#. Label of the checkbox for the "auto_download_enable" setting (Settings >
+#. Browse > Downloads).
 #: jellyfin_mpv_shim/mpvtk_browser/config.py
 msgid "Automatically Download Upcoming Episodes"
 msgstr ""
 
+#. Label of the checkbox for the "auto_download_next_up" setting (Settings
+#. > Browse > Downloads).
 #: jellyfin_mpv_shim/mpvtk_browser/config.py
 msgid "Include Next Up"
 msgstr ""
 
+#. Label of the number field for the "auto_download_next_up_limit" setting
+#. (Settings > Browse > Downloads).
 #: jellyfin_mpv_shim/mpvtk_browser/config.py
 msgid "Next Up Entries to Consider"
 msgstr ""
 
+#. Label of the number field for the "auto_download_lookahead" setting
+#. (Settings > Browse > Downloads).
 #: jellyfin_mpv_shim/mpvtk_browser/config.py
 msgid "Episodes to Keep Ahead (0 = off)"
 msgstr ""
 
+#. Label of the number field for the "auto_download_max_gb" setting
+#. (Settings > Browse > Downloads).
 #: jellyfin_mpv_shim/mpvtk_browser/config.py
 msgid "Storage Limit for Automatic Downloads (GB)"
 msgstr ""
 
+#. Label of the checkbox for the "auto_download_delete_watched" setting
+#. (Settings > Browse > Downloads).
 #: jellyfin_mpv_shim/mpvtk_browser/config.py
 msgid "Delete Automatic Downloads Once Watched"
 msgstr ""
 
+#. Label of the number field for the "auto_download_keep_days" setting
+#. (Settings > Browse > Downloads).
 #: jellyfin_mpv_shim/mpvtk_browser/config.py
 msgid "Delete Unwatched After (days, 0 = never)"
 msgstr ""
 
+#. Label of the number field for the "auto_download_interval_mins" setting
+#. (Settings > Browse > Downloads).
 #: jellyfin_mpv_shim/mpvtk_browser/config.py
 msgid "Check Every (minutes)"
 msgstr ""
 
+#. Label of the number field for the "auto_download_lookahead_min" setting
+#. (Settings > Browse > Download Tuning).
 #: jellyfin_mpv_shim/mpvtk_browser/config.py
 msgid "Top Up When Fewer Than (episodes)"
 msgstr ""
 
+#. Label of the number field for the "auto_download_lookahead_max" setting
+#. (Settings > Browse > Download Tuning).
 #: jellyfin_mpv_shim/mpvtk_browser/config.py
 msgid "Top Up To (episodes)"
 msgstr ""
 
+#. Label of the number field for the "auto_download_max_per_pass" setting
+#. (Settings > Browse > Download Tuning).
 #: jellyfin_mpv_shim/mpvtk_browser/config.py
 msgid "Maximum Downloads per Check"
 msgstr ""
 
+#. Label of the checkbox for the "close_to_tray" setting (Settings >
+#. General > Window).
 #: jellyfin_mpv_shim/mpvtk_browser/config.py
 msgid "Close to Tray (keep running)"
 msgstr ""
 
+#. Label of the checkbox for the "allow_background" setting (Settings >
+#. General > Window).
 #: jellyfin_mpv_shim/mpvtk_browser/config.py
 msgid "Keep Running in Background"
 msgstr ""
 
+#. Label of the checkbox for the "remember_window_size" setting (Settings >
+#. General > Window).
 #: jellyfin_mpv_shim/mpvtk_browser/config.py
 msgid "Remember Window Size"
 msgstr ""
 
+#. Label of the dropdown for the "window_controls" setting (Settings >
+#. General > Window).
 #: jellyfin_mpv_shim/mpvtk_browser/config.py
 msgid "Window Buttons in the Top Bar"
 msgstr ""
 
+#. Label of the checkbox for the "window_controls_fullscreen" setting
+#. (Settings > General > Window).
 #: jellyfin_mpv_shim/mpvtk_browser/config.py
 msgid "Keep Window Buttons in Full Screen"
 msgstr ""
 
+#. Label of the checkbox for the "hide_title_bar" setting (Settings >
+#. General > Window).
 #: jellyfin_mpv_shim/mpvtk_browser/config.py
 msgid "Hide the Desktop Title Bar"
 msgstr ""
 
+#. Label of the dropdown for the "osc_style" setting (Settings > Playback >
+#. Player Controls).
 #: jellyfin_mpv_shim/mpvtk_browser/config.py
 msgid "Player Controls Style"
 msgstr ""
 
+#. Label of the checkbox for the "thumbnail_enable" setting (Settings >
+#. Playback > Player Controls).
 #: jellyfin_mpv_shim/mpvtk_browser/config.py
 msgid "Enable Trickplay Thumbnails"
 msgstr ""
 
+#. Label of the checkbox for the "trickplay_fast_mode" setting (Settings >
+#. Playback > Player Controls).
 #: jellyfin_mpv_shim/mpvtk_browser/config.py
 msgid "Load All Seek Previews at Once"
 msgstr ""
 
+#. Label of the checkbox for the "discord_presence" setting (Settings >
+#. General > This Device).
 #: jellyfin_mpv_shim/mpvtk_browser/config.py
 msgid "Show What You're Watching in Discord"
 msgstr ""
 
+#. Label of the dropdown for the "ui_scale" setting (Settings > Browse >
+#. Theme).
 #: jellyfin_mpv_shim/mpvtk_browser/config.py
 msgid "Interface Scale"
 msgstr ""
 
+#. Label of the dropdown for the "ui_text_scale" setting (Settings > Browse
+#. > Theme).
 #: jellyfin_mpv_shim/mpvtk_browser/config.py
 msgid "Text size"
 msgstr ""
 
+#. Label of the dropdown for the "ui_text_min" setting (Settings > Browse >
+#. Theme).
 #: jellyfin_mpv_shim/mpvtk_browser/config.py
 msgid "Minimum Text Size"
 msgstr ""
 
+#. Label of the dropdown for the "poster_scale" setting (Settings > Browse
+#. > Theme).
 #: jellyfin_mpv_shim/mpvtk_browser/config.py
 #: jellyfin_mpv_shim/mpvtk_browser/dialogs.py
 msgid "Cover Size"
 msgstr ""
 
+#. Label of the checkbox for the "backdrop_full_width" setting (Settings >
+#. Browse > Library Browser).
 #: jellyfin_mpv_shim/mpvtk_browser/config.py
 msgid "Full-Width Backdrops"
 msgstr ""
 
+#. Label of the checkbox for the "clock_12h" setting (Settings > Browse >
+#. Library Browser).
 #: jellyfin_mpv_shim/mpvtk_browser/config.py
 msgid "12-Hour Clock"
 msgstr ""
 
+#. Label of the dropdown for the "grid_fill" setting (Settings > Browse >
+#. Library Browser).
 #: jellyfin_mpv_shim/mpvtk_browser/config.py
 msgid "Grid Spacing"
 msgstr ""
 
+#. Label of the checkbox for the "logo_legibility_live_tv" setting
+#. (Settings > Browse > Library Browser).
 #: jellyfin_mpv_shim/mpvtk_browser/config.py
 msgid "Make Live TV logos more legible"
 msgstr ""
 
+#. Label of the checkbox for the "logo_legibility_library" setting
+#. (Settings > Browse > Library Browser).
 #: jellyfin_mpv_shim/mpvtk_browser/config.py
 msgid "Make library logos more legible"
 msgstr ""
 
+#. Label of the number field for the "reader_font_size" setting (Settings >
+#. Browse > Reading).
 #: jellyfin_mpv_shim/mpvtk_browser/config.py
 msgid "Type Size"
 msgstr ""
 
+#. Label of the dropdown for the "reader_theme" setting (Settings > Browse
+#. > Reading).
 #: jellyfin_mpv_shim/mpvtk_browser/config.py
 msgid "Page Colour"
 msgstr ""
 
+#. Label of the checkbox for the "reader_justify" setting (Settings >
+#. Browse > Reading).
 #: jellyfin_mpv_shim/mpvtk_browser/config.py
 msgid "Justify Text"
 msgstr ""
 
+#. Label of the dropdown for the "comic_fit" setting (Settings > Browse >
+#. Reading).
 #: jellyfin_mpv_shim/mpvtk_browser/config.py
 msgid "Comic Reading Mode"
 msgstr ""
 
+#. Label of the checkbox for the "headless" setting (under Advanced on the
+#. General tab of Settings).
 #: jellyfin_mpv_shim/mpvtk_browser/config.py
 msgid "Cast-target mode (no library browsing)"
 msgstr ""
 
+#. Label of the checkbox for the "display_mirror_summon" setting (Settings
+#. > General > Window).
 #: jellyfin_mpv_shim/mpvtk_browser/config.py
 msgid "Casting Opens the Library Browser"
 msgstr ""
 
+#. Label of the checkbox for the "browser_fullscreen" setting (Settings >
+#. General > Window).
 #: jellyfin_mpv_shim/mpvtk_browser/config.py
 msgid "Fullscreen Library Browser"
 msgstr ""
 
+#. Label of the checkbox for the "browse_block_keys" setting (Settings >
+#. General > Input).
 #: jellyfin_mpv_shim/mpvtk_browser/config.py
 msgid "Block Player Keybinds While Browsing"
 msgstr ""
 
+#. Label of the checkbox for the "hud_grab_keys" setting (Settings >
+#. Playback > Player Controls).
 #: jellyfin_mpv_shim/mpvtk_browser/config.py
 msgid "Always Bind Arrow Keys to Player Controls"
 msgstr ""
 
+#. Label of the text field for the "hud_wake_key" setting (Settings >
+#. Playback > Player Controls).
 #: jellyfin_mpv_shim/mpvtk_browser/config.py
 msgid "Player Controls Activation Key"
 msgstr ""
 
+#. Label of the text field for the "ui_select_key" setting (under Advanced
+#. on the General tab of Settings).
 #: jellyfin_mpv_shim/mpvtk_browser/config.py
 msgid "Select Key"
 msgstr ""
 
+#. Label of the dropdown for the "hud_scrim" setting (Settings > Playback >
+#. Player Controls).
 #: jellyfin_mpv_shim/mpvtk_browser/config.py
 msgid "Shading Behind the Player Controls"
 msgstr ""
 
+#. Label of the dropdown for the "hud_autohide" setting (Settings >
+#. Playback > Player Controls).
 #: jellyfin_mpv_shim/mpvtk_browser/config.py
 msgid "When the Player Controls Hide"
 msgstr ""
 
+#. Label of the number field for the "hud_hide_secs" setting (Settings >
+#. Playback > Player Controls).
 #: jellyfin_mpv_shim/mpvtk_browser/config.py
 msgid "Hide the Player Controls After (seconds)"
 msgstr ""
 
+#. Label of the checkbox for the "hud_auto_scale" setting (Settings >
+#. Playback > Player Controls).
 #: jellyfin_mpv_shim/mpvtk_browser/config.py
 msgid "Shrink the Player Controls on a Narrow Window"
 msgstr ""
 
+#. Label of the checkbox for the "mouse_chapter_nav" setting (Settings >
+#. Playback > Player Controls).
 #: jellyfin_mpv_shim/mpvtk_browser/config.py
 msgid "Mouse Back/Forward Buttons Skip Chapters"
 msgstr ""
 
+#. Label of the dropdown for the "audio_mode" setting (Settings > Playback
+#. > Audio).
 #: jellyfin_mpv_shim/mpvtk_browser/config.py
 msgid "Audio Output Mode"
 msgstr ""
 
+#. Label of the text field for the "audio_device" setting (Settings >
+#. Playback > Audio).
 #: jellyfin_mpv_shim/mpvtk_browser/config.py
 msgid "Audio Output Device"
 msgstr ""
 
+#. Label of the checkbox for the "audio_exclusive" setting (Settings >
+#. Playback > Audio).
 #: jellyfin_mpv_shim/mpvtk_browser/config.py
 msgid "Take the Device Exclusively"
 msgstr ""
 
+#. Label of the checkbox for the "shader_pack_enable" setting (Settings >
+#. Playback > Video Enhancement).
 #: jellyfin_mpv_shim/mpvtk_browser/config.py
 msgid "Enable Video Playback Profiles"
 msgstr ""
 
+#. Label of the dropdown for the "shader_pack_subtype" setting (Settings >
+#. Playback > Video Enhancement).
 #: jellyfin_mpv_shim/mpvtk_browser/config.py
 msgid "Profile Group"
 msgstr ""
 
+#. Label of the checkbox for the "shader_pack_remember" setting (Settings >
+#. Playback > Video Enhancement).
 #: jellyfin_mpv_shim/mpvtk_browser/config.py
 msgid "Remember Last Used Profile"
 msgstr ""
 
+#. Label of the dropdown for the "shader_pack_gpu_api" setting (Settings >
+#. Playback > Video Enhancement).
 #: jellyfin_mpv_shim/mpvtk_browser/config.py
 msgid "Graphics API for Shaders"
 msgstr ""
 
+#. Label of the checkbox for the "audio_passthrough_ac3" setting (Settings
+#. > Playback > Audio).
 #: jellyfin_mpv_shim/mpvtk_browser/config.py
 msgid "Pass Through AC3"
 msgstr ""
 
+#. Label of the checkbox for the "audio_passthrough_dts" setting (Settings
+#. > Playback > Audio).
 #: jellyfin_mpv_shim/mpvtk_browser/config.py
 msgid "Pass Through DTS"
 msgstr ""
 
+#. Label of the checkbox for the "audio_passthrough_eac3" setting (Settings
+#. > Playback > Audio).
 #: jellyfin_mpv_shim/mpvtk_browser/config.py
 msgid "Pass Through E-AC3"
 msgstr ""
 
+#. Label of the checkbox for the "audio_passthrough_dts_hd" setting
+#. (Settings > Playback > Audio).
 #: jellyfin_mpv_shim/mpvtk_browser/config.py
 msgid "Pass Through DTS-HD"
 msgstr ""
 
+#. Label of the checkbox for the "audio_passthrough_truehd" setting
+#. (Settings > Playback > Audio).
 #: jellyfin_mpv_shim/mpvtk_browser/config.py
 msgid "Pass Through TrueHD"
 msgstr ""
 
+#. Label of the checkbox for the "audio_optical_encode_ac3" setting
+#. (Settings > Playback > Audio).
 #: jellyfin_mpv_shim/mpvtk_browser/config.py
 msgid "Re-encode Others to AC3"
 msgstr ""
 
+#. Explanation shown under the "Close to Tray (keep running)" setting
+#. (Settings > General > Window). Explanation shown under the "Keep Running
+#. in Background" setting (Settings > General > Window).
 #: jellyfin_mpv_shim/mpvtk_browser/config.py
 msgid ""
 "With \"Start Minimized\" and \"Fullscreen\" this is the classic cast-target "
@@ -1853,6 +2759,8 @@ msgid ""
 "to it, and goes back to waiting when the video ends or you press Q."
 msgstr ""
 
+#. Explanation shown under the "Language" setting (Settings > General >
+#. This Device).
 #: jellyfin_mpv_shim/mpvtk_browser/config.py
 msgid ""
 "The percentage is how much of this app that language has been translated so "
@@ -1860,6 +2768,8 @@ msgid ""
 "translate.jellyfin.org."
 msgstr ""
 
+#. Explanation shown under the "Tell Me About Updates" setting (Settings >
+#. General > This Device).
 #: jellyfin_mpv_shim/mpvtk_browser/config.py
 msgid ""
 "\"Automatic\" turns this off inside a Flatpak, where your desktop already "
@@ -1867,6 +2777,8 @@ msgid ""
 "everywhere else."
 msgstr ""
 
+#. Explanation shown under the "Game Controller" setting (Settings >
+#. General > Input).
 #: jellyfin_mpv_shim/mpvtk_browser/config.py
 msgid ""
 "Move with the d-pad or left stick, seek with the right stick, shoulder "
@@ -1876,12 +2788,16 @@ msgid ""
 "log says so. Any button can be reassigned in your input.conf."
 msgstr ""
 
+#. Explanation shown under the "Swap Confirm and Back Buttons" setting
+#. (Settings > General > Input).
 #: jellyfin_mpv_shim/mpvtk_browser/config.py
 msgid ""
 "Turn this on for a controller whose A button is on the right rather than at "
 "the bottom (Switch Pro, most 8BitDo pads)."
 msgstr ""
 
+#. Explanation shown under the "Block Player Keybinds While Browsing"
+#. setting (Settings > General > Input).
 #: jellyfin_mpv_shim/mpvtk_browser/config.py
 msgid ""
 "Stops MPV's own shortcuts -- picture adjustment, screenshots, subtitle and "
@@ -1890,6 +2806,8 @@ msgid ""
 "there."
 msgstr ""
 
+#. Explanation shown under the "Select Key" setting (under Advanced on the
+#. General tab of Settings).
 #: jellyfin_mpv_shim/mpvtk_browser/config.py
 msgid ""
 "Activates whatever is highlighted, in the library and on the player "
@@ -1897,6 +2815,8 @@ msgid ""
 "controller's Confirm button and a phone's Select follow it."
 msgstr ""
 
+#. Explanation shown under the "Top Up When Fewer Than (episodes)" setting
+#. (Settings > Browse > Download Tuning).
 #: jellyfin_mpv_shim/mpvtk_browser/config.py
 msgid ""
 "Leave these blank unless downloads are waking your disks too often. Set both "
@@ -1904,11 +2824,15 @@ msgid ""
 "series runs low, instead of one at a time."
 msgstr ""
 
+#. Explanation shown under the "Show Episode Thumbnails on Detail Pages"
+#. setting (Settings > Browse > Library Browser).
 #: jellyfin_mpv_shim/mpvtk_browser/config.py
 msgid ""
 "An episode's thumbnail is a frame of an episode you may not have watched yet."
 msgstr ""
 
+#. Explanation shown under the "Left Click Pauses Playback" setting
+#. (Settings > Playback > Player Controls).
 #: jellyfin_mpv_shim/mpvtk_browser/config.py
 msgid ""
 "Off gives MPV's own mouse behaviour instead: drag the video to move the "
@@ -1916,6 +2840,8 @@ msgid ""
 "click is full screen either way."
 msgstr ""
 
+#. Explanation shown under the "Deinterlace Automatically" setting
+#. (Settings > Playback > Video Enhancement).
 #: jellyfin_mpv_shim/mpvtk_browser/config.py
 msgid ""
 "Deinterlace video the file says is interlaced. Off by default, as in MPV "
@@ -1926,6 +2852,8 @@ msgid ""
 "MPV 0.38 or newer."
 msgstr ""
 
+#. Explanation shown under the "Debanding" setting (Settings > Playback >
+#. Video Enhancement).
 #: jellyfin_mpv_shim/mpvtk_browser/config.py
 msgid ""
 "Smooths the blocky steps that appear in gradients — skies, dark scenes, "
@@ -1937,6 +2865,8 @@ msgid ""
 "all, so your values are left alone."
 msgstr ""
 
+#. Explanation shown under the "HDR Tone Mapping" setting (Settings >
+#. Playback > Video Enhancement).
 #: jellyfin_mpv_shim/mpvtk_browser/config.py
 msgid ""
 "How HDR video is fitted to an SDR display. This does nothing when HDR is "
@@ -1946,6 +2876,8 @@ msgid ""
 "rather than bright."
 msgstr ""
 
+#. Explanation shown under the "Rendering Quality" setting (Settings >
+#. Playback > Video Enhancement).
 #: jellyfin_mpv_shim/mpvtk_browser/config.py
 msgid ""
 "High quality applies the same options as MPV's own high-quality preset: "
@@ -1954,6 +2886,8 @@ msgid ""
 "before the shader pack below."
 msgstr ""
 
+#. Explanation shown under the "Network Buffer" setting (Settings >
+#. Playback > Playback).
 #: jellyfin_mpv_shim/mpvtk_browser/config.py
 msgid ""
 "How far ahead of playback to read. MPV's default is one second, which is "
@@ -1962,6 +2896,8 @@ msgid ""
 "memory and make the first few seconds of a file slower to start."
 msgstr ""
 
+#. Explanation shown under the "Motion Interpolation" setting (Settings >
+#. Playback > Video Enhancement).
 #: jellyfin_mpv_shim/mpvtk_browser/config.py
 msgid ""
 "Frame blending (blends frames together, not the same as SVP/DLSS/framegen). "
@@ -1970,6 +2906,8 @@ msgid ""
 "rates."
 msgstr ""
 
+#. Explanation shown under the "Hardware Decoding" setting (Settings >
+#. Playback > Playback).
 #: jellyfin_mpv_shim/mpvtk_browser/config.py
 msgid ""
 "Off by default because some graphics drivers handle it badly. \"Only above "
@@ -1980,6 +2918,8 @@ msgid ""
 "hwdec and change this back."
 msgstr ""
 
+#. Explanation shown under the "Enable GUI" setting (under Advanced on the
+#. General tab of Settings).
 #: jellyfin_mpv_shim/mpvtk_browser/config.py
 msgid ""
 "Off means command-line mode: no window, no system tray and no settings "
@@ -1988,6 +2928,8 @@ msgid ""
 "Interface for that."
 msgstr ""
 
+#. Explanation shown under the "Cast-target mode (no library browsing)"
+#. setting (under Advanced on the General tab of Settings).
 #: jellyfin_mpv_shim/mpvtk_browser/config.py
 msgid ""
 "Show only what is cast to this machine. The library, including this settings "
@@ -1996,6 +2938,8 @@ msgid ""
 "to browse from; for an ordinary cast target, use the Interface settings."
 msgstr ""
 
+#. Explanation shown under the "Window Buttons in the Top Bar" setting
+#. (Settings > General > Window).
 #: jellyfin_mpv_shim/mpvtk_browser/config.py
 msgid ""
 "Some desktops, GNOME on Wayland in particular, draw no title bar on the "
@@ -2005,6 +2949,8 @@ msgid ""
 "window got one, so desktops that draw a title bar are left alone."
 msgstr ""
 
+#. Explanation shown under the "Keep Window Buttons in Full Screen" setting
+#. (Settings > General > Window).
 #: jellyfin_mpv_shim/mpvtk_browser/config.py
 msgid ""
 "Full screen has no title bar anywhere and nothing to move or maximize, so "
@@ -2012,6 +2958,8 @@ msgid ""
 "full screen that is not a keyboard shortcut."
 msgstr ""
 
+#. Explanation shown under the "Hide the Desktop Title Bar" setting
+#. (Settings > General > Window).
 #: jellyfin_mpv_shim/mpvtk_browser/config.py
 msgid ""
 "Asks the desktop for no title bar on the player window, so the top bar above "
@@ -2021,6 +2969,8 @@ msgid ""
 "some desktops."
 msgstr ""
 
+#. Explanation shown under the "Enable Trickplay Thumbnails" setting
+#. (Settings > Playback > Player Controls).
 #: jellyfin_mpv_shim/mpvtk_browser/config.py
 msgid ""
 "Shows a preview frame while you drag the seek bar. Works with every player "
@@ -2029,6 +2979,8 @@ msgid ""
 "memory -- tens of MB for an episode, a few hundred for a long film."
 msgstr ""
 
+#. Explanation shown under the "Load All Seek Previews at Once" setting
+#. (Settings > Playback > Player Controls).
 #: jellyfin_mpv_shim/mpvtk_browser/config.py
 msgid ""
 "Seek previews are normally fetched a few minutes at a time around where you "
@@ -2039,6 +2991,8 @@ msgid ""
 "video."
 msgstr ""
 
+#. Explanation shown under the "Player Controls Style" setting (Settings >
+#. Playback > Player Controls).
 #: jellyfin_mpv_shim/mpvtk_browser/config.py
 msgid ""
 "MPV keybinds are used by default. Press ENTER to drive the player controls "
@@ -2049,6 +3003,8 @@ msgid ""
 "it."
 msgstr ""
 
+#. Explanation shown under the "Scroll Wheel Pixels" setting (Settings >
+#. Browse > Library Browser).
 #: jellyfin_mpv_shim/mpvtk_browser/config.py
 msgid ""
 "Pixels one wheel notch scrolls. Raise it to scroll faster, lower it for "
@@ -2057,6 +3013,8 @@ msgid ""
 "never leaves you a sliver of a row off."
 msgstr ""
 
+#. Explanation shown under the "Scroll Mode" setting (Settings > Browse >
+#. Library Browser).
 #: jellyfin_mpv_shim/mpvtk_browser/config.py
 msgid ""
 "\"Continuous\" scrolls by pixels and lands wherever the wheel puts it, "
@@ -2066,10 +3024,14 @@ msgid ""
 "a whole row, or one home-screen section, at a time."
 msgstr ""
 
+#. Explanation shown under the "Show What You're Watching in Discord"
+#. setting (Settings > General > This Device).
 #: jellyfin_mpv_shim/mpvtk_browser/config.py
 msgid "Discord Rich Presence."
 msgstr ""
 
+#. Explanation shown under the "Audio Output Device" setting (Settings >
+#. Playback > Audio).
 #: jellyfin_mpv_shim/mpvtk_browser/config.py
 msgid ""
 "Leave this to Default unless setting up passthrough. Note some audio servers "
@@ -2078,12 +3040,16 @@ msgid ""
 "silence otherwise, but results may vary."
 msgstr ""
 
+#. Explanation shown under the "Take the Device Exclusively" setting
+#. (Settings > Playback > Audio).
 #: jellyfin_mpv_shim/mpvtk_browser/config.py
 msgid ""
 "Stop anything else using the device while playing. Needed for passthrough on "
 "some systems, and it means other applications will be silent."
 msgstr ""
 
+#. Explanation shown under the "Paginated" setting (Settings > Browse >
+#. Library Browser).
 #: jellyfin_mpv_shim/mpvtk_browser/config.py
 msgid ""
 "Page the library and music tile grids instead of scrolling: each page is one "
@@ -2091,6 +3057,8 @@ msgid ""
 "can type into. Easier than precise scrolling on a trackpad."
 msgstr ""
 
+#. Explanation shown under the "Make Live TV logos more legible" setting
+#. (Settings > Browse > Library Browser).
 #: jellyfin_mpv_shim/mpvtk_browser/config.py
 msgid ""
 "Channel logos are ink on a transparent background, drawn for the white page "
@@ -2100,6 +3068,8 @@ msgid ""
 "card colour and no shadow, as Jellyfin Web does."
 msgstr ""
 
+#. Explanation shown under the "Make library logos more legible" setting
+#. (Settings > Browse > Library Browser).
 #: jellyfin_mpv_shim/mpvtk_browser/config.py
 msgid ""
 "The same treatment for a library set to draw Logo artwork. Off by default: a "
@@ -2108,12 +3078,15 @@ msgid ""
 "yours are dark."
 msgstr ""
 
+#. Explanation shown under the "Theme" setting (Settings > Browse > Theme).
 #: jellyfin_mpv_shim/mpvtk_browser/config.py
 msgid ""
 "Palette, glow, cover style and default cover size. Colours change "
 "immediately; cover and heading sizes take effect after a restart."
 msgstr ""
 
+#. Explanation shown under the "Grid Spacing" setting (Settings > Browse >
+#. Library Browser).
 #: jellyfin_mpv_shim/mpvtk_browser/config.py
 msgid ""
 "Where the width a whole number of covers does not use ends up. Widening the "
@@ -2121,6 +3094,8 @@ msgid ""
 "the covers evenly spaced and moves both margins instead."
 msgstr ""
 
+#. Explanation shown under the "Full-Width Backdrops" setting (Settings >
+#. Browse > Library Browser).
 #: jellyfin_mpv_shim/mpvtk_browser/config.py
 msgid ""
 "Run the backdrop on a detail page to the edges of the window, as the web "
@@ -2128,10 +3103,14 @@ msgid ""
 "space."
 msgstr ""
 
+#. Explanation shown under the "Cover Size" setting (Settings > Browse >
+#. Theme).
 #: jellyfin_mpv_shim/mpvtk_browser/config.py
 msgid "Overrides the theme's cover size. Also on the View menu of any library."
 msgstr ""
 
+#. Explanation shown under the "12-Hour Clock" setting (Settings > Browse >
+#. Library Browser).
 #: jellyfin_mpv_shim/mpvtk_browser/config.py
 msgid ""
 "Show times of day as \"8:30 PM\" rather than \"20:30\" — the Live TV guide "
@@ -2139,24 +3118,32 @@ msgid ""
 "player controls."
 msgstr ""
 
+#. Explanation shown under the "Shading Behind the Player Controls" setting
+#. (Settings > Playback > Player Controls).
 #: jellyfin_mpv_shim/mpvtk_browser/config.py
 msgid ""
 "The controls have to stay legible over any frame. \"None\" gives the text a "
 "drop shadow instead of shading the picture behind it."
 msgstr ""
 
+#. Explanation shown under the "When the Player Controls Hide" setting
+#. (Settings > Playback > Player Controls).
 #: jellyfin_mpv_shim/mpvtk_browser/config.py
 msgid ""
 "\"Hide unless hovered\" keeps them up only while the pointer is on them, "
 "paused or not."
 msgstr ""
 
+#. Explanation shown under the "Hide the Player Controls After (seconds)"
+#. setting (Settings > Playback > Player Controls).
 #: jellyfin_mpv_shim/mpvtk_browser/config.py
 msgid ""
 "0 hides them as soon as the pointer is not on them, and forces \"Hide unless "
 "hovered\"."
 msgstr ""
 
+#. Explanation shown under the "Shrink the Player Controls on a Narrow
+#. Window" setting (Settings > Playback > Player Controls).
 #: jellyfin_mpv_shim/mpvtk_browser/config.py
 msgid ""
 "Narrowing the window shrinks the controls until the smallest button reaches "
@@ -2164,18 +3151,24 @@ msgid ""
 "older, larger floor."
 msgstr ""
 
+#. Explanation shown under the "Mouse Back/Forward Buttons Skip Chapters"
+#. setting (Settings > Playback > Player Controls).
 #: jellyfin_mpv_shim/mpvtk_browser/config.py
 msgid ""
 "During playback only; in the library those buttons stay Back and Forward. "
 "Off by default because they are easy to hit by accident on some mice."
 msgstr ""
 
+#. Explanation shown under the "Interface Scale" setting (Settings > Browse
+#. > Theme).
 #: jellyfin_mpv_shim/mpvtk_browser/config.py
 #, no-python-format
 msgid ""
 "\"Follow display\" uses the scale your desktop reports, which is 100% on X11."
 msgstr ""
 
+#. Explanation shown under the "Text size" setting (Settings > Browse >
+#. Theme).
 #: jellyfin_mpv_shim/mpvtk_browser/config.py
 msgid ""
 "Scales the text only. Interface Scale above resizes everything, artwork and "
@@ -2185,18 +3178,24 @@ msgid ""
 "which is Interface Scale."
 msgstr ""
 
+#. Explanation shown under the "Minimum Text Size" setting (Settings >
+#. Browse > Theme).
 #: jellyfin_mpv_shim/mpvtk_browser/config.py
 msgid ""
 "Nothing renders smaller than this, whatever Text Size works out to. Raises "
 "the smallest labels without enlarging headings, which a percentage cannot do."
 msgstr ""
 
+#. Explanation shown under the "Audio Output Mode" setting (Settings >
+#. Playback > Audio).
 #: jellyfin_mpv_shim/mpvtk_browser/config.py
 msgid ""
 "\"Default\" changes nothing and lets MPV (and your own mpv.conf) decide. "
 "Pick a mode only if you are sending audio to a receiver."
 msgstr ""
 
+#. Explanation shown under the "Re-encode Others to AC3" setting (Settings
+#. > Playback > Audio).
 #: jellyfin_mpv_shim/mpvtk_browser/config.py
 msgid ""
 "Audio your receiver cannot be sent directly is encoded to AC3, the only way "
@@ -2204,29 +3203,39 @@ msgid ""
 "audio delay; those tracks become stereo instead."
 msgstr ""
 
+#. Explanation shown under the "Profile Group" setting (Settings > Playback
+#. > Video Enhancement).
 #: jellyfin_mpv_shim/mpvtk_browser/config.py
 msgid ""
 "\"hq\" offers heavier profiles. Pick it if you have a fast graphics card."
 msgstr ""
 
+#. Explanation shown under the "Graphics API for Shaders" setting (Settings
+#. > Playback > Video Enhancement).
 #: jellyfin_mpv_shim/mpvtk_browser/config.py
 msgid ""
 "Leave on Automatic unless video breaks when a profile is loaded. This only "
 "applies while a profile is active, and OpenGL can cost you HDR output."
 msgstr ""
 
+#. Explanation shown under the "Type Size" setting (Settings > Browse >
+#. Reading).
 #: jellyfin_mpv_shim/mpvtk_browser/config.py
 msgid ""
 "In pixels, before interface scaling. The A- and A+ buttons in the reader "
 "change this too."
 msgstr ""
 
+#. Explanation shown under the "Comic Reading Mode" setting (Settings >
+#. Browse > Reading).
 #: jellyfin_mpv_shim/mpvtk_browser/config.py
 msgid ""
 "How a comic page is fitted to the window when you open it. The reader's own "
 "buttons change this too."
 msgstr ""
 
+#. Explanation shown under the "Night Mode (Auto Volume Adj)" setting
+#. (Settings > Playback > Audio).
 #: jellyfin_mpv_shim/mpvtk_browser/config.py
 msgid ""
 "Evens out loud effects and quiet dialogue. This turns passthrough off while "
@@ -2234,136 +3243,206 @@ msgid ""
 "gets the audio."
 msgstr ""
 
+#. Heading of the first section of the library filter panel, above the
+#. Unplayed / Played / Favorites / Resumable checkboxes.
 #: jellyfin_mpv_shim/mpvtk_browser/dialogs.py
 msgid "Status"
 msgstr ""
 
+#. Checkbox in the filter panel's Status section. Restricts the library to
+#. items the viewer has not watched.
 #: jellyfin_mpv_shim/mpvtk_browser/dialogs.py
 msgid "Unplayed"
 msgstr ""
 
+#. Checkbox in the filter panel's Status section. Restricts the library to
+#. items the viewer has already watched. Must read differently from "Play":
+#. in one language these collapsed and the row read "Not played / Play".
 #: jellyfin_mpv_shim/mpvtk_browser/dialogs.py
 msgid "Played"
 msgstr ""
 
+#. Three uses, all about items the viewer has marked with the heart. A
+#. checkbox in the library filter panel; a button that filters the Live TV
+#. channel list; and the navigation-bar button that opens the Favorites
+#. page.
 #: jellyfin_mpv_shim/mpvtk_browser/dialogs.py
 #: jellyfin_mpv_shim/mpvtk_browser/pages/livetv.py
 #: jellyfin_mpv_shim/mpvtk_browser/window_chrome.py
 msgid "Favorites"
 msgstr ""
 
+#. Checkbox in the filter panel's Status section. Restricts the library to
+#. items that were started and not finished, so playback would resume part
+#. way in.
 #: jellyfin_mpv_shim/mpvtk_browser/dialogs.py
 msgid "Resumable"
 msgstr ""
 
+#. Heading of the library filter panel's genre section, and the label of
+#. the buttons that open the genre list from a library grid or a music
+#. page. A genre is a kind of film, show or music.
 #: jellyfin_mpv_shim/mpvtk_browser/dialogs.py
 #: jellyfin_mpv_shim/mpvtk_browser/pages/grid.py
 #: jellyfin_mpv_shim/mpvtk_browser/pages/music.py
 msgid "Genres"
 msgstr ""
 
+#. Heading of a filter-panel section, above a dropdown listing the release
+#. years in this library.
 #: jellyfin_mpv_shim/mpvtk_browser/dialogs.py
 msgid "Years"
 msgstr ""
 
+#. Heading of a filter-panel section, above a dropdown of age ratings (PG,
+#. TV-14 and so on).
 #: jellyfin_mpv_shim/mpvtk_browser/dialogs.py
 #: jellyfin_mpv_shim/mpvtk_browser/pages/grid.py
 msgid "Parental Rating"
 msgstr ""
 
+#. Heading of a filter-panel section, above a dropdown listing the tags on
+#. items in this library.
 #: jellyfin_mpv_shim/mpvtk_browser/dialogs.py
 msgid "Tags"
 msgstr ""
 
+#. Heading of a filter-panel section, above a dropdown of the spoken
+#. languages available in this library.
 #: jellyfin_mpv_shim/mpvtk_browser/dialogs.py
 msgid "Audio Language"
 msgstr ""
 
+#. Heading of a filter-panel section, above a dropdown of the subtitle
+#. languages available in this library.
 #: jellyfin_mpv_shim/mpvtk_browser/dialogs.py
 msgid "Subtitle Language"
 msgstr ""
 
+#. Heading of a filter-panel section, above checkboxes for extras an item
+#. may have (subtitles, a trailer, a theme song).
 #: jellyfin_mpv_shim/mpvtk_browser/dialogs.py
 msgid "Features"
 msgstr ""
 
+#. Checkbox in the filter panel's Features section. Restricts the library
+#. to items that carry subtitles.
 #: jellyfin_mpv_shim/mpvtk_browser/dialogs.py
 msgid "Has Subtitles"
 msgstr ""
 
+#. Checkbox in the filter panel's Features section. Restricts the library
+#. to items that have a trailer.
 #: jellyfin_mpv_shim/mpvtk_browser/dialogs.py
 msgid "Has Trailer"
 msgstr ""
 
+#. Checkbox in the filter panel's Features section. Restricts the library
+#. to items with bonus material (deleted scenes, featurettes).
 #: jellyfin_mpv_shim/mpvtk_browser/dialogs.py
 msgid "Has Special Features"
 msgstr ""
 
+#. Checkbox in the filter panel's Features section. Restricts the library
+#. to items with a theme song attached.
 #: jellyfin_mpv_shim/mpvtk_browser/dialogs.py
 msgid "Has Theme Song"
 msgstr ""
 
+#. Checkbox in the filter panel's Features section. Restricts the library
+#. to items with a theme video attached.
 #: jellyfin_mpv_shim/mpvtk_browser/dialogs.py
 msgid "Has Theme Video"
 msgstr ""
 
+#. Heading of a filter-panel section, above checkboxes for resolution and
+#. disc format (SD, HD, 4K, 3D, DVD, Blu-ray, ISO).
 #: jellyfin_mpv_shim/mpvtk_browser/dialogs.py
 msgid "Video Types"
 msgstr ""
 
+#. Checkbox in the filter panel's Video Types section: standard definition.
+#. An abbreviation most languages keep as-is.
 #: jellyfin_mpv_shim/mpvtk_browser/dialogs.py
 msgid "SD"
 msgstr ""
 
+#. Checkbox in the filter panel's Video Types section: high definition. An
+#. abbreviation most languages keep as-is.
 #: jellyfin_mpv_shim/mpvtk_browser/dialogs.py
 #: jellyfin_mpv_shim/mpvtk_browser/guide_view.py
 msgid "HD"
 msgstr ""
 
+#. Checkbox in the filter panel's Video Types section: 4K resolution.
+#. Normally left as-is.
 #: jellyfin_mpv_shim/mpvtk_browser/dialogs.py
 msgid "4K"
 msgstr ""
 
+#. Checkbox in the filter panel's Video Types section: stereoscopic 3D
+#. video. Normally left as-is.
 #: jellyfin_mpv_shim/mpvtk_browser/dialogs.py
 msgid "3D"
 msgstr ""
 
+#. Checkbox in the filter panel's Video Types section: video ripped from a
+#. DVD. A format name, normally left as-is.
 #: jellyfin_mpv_shim/mpvtk_browser/dialogs.py
 msgid "DVD"
 msgstr ""
 
+#. Checkbox in the filter panel's Video Types section: video ripped from a
+#. Blu-ray disc. A trademark, left as-is.
 #: jellyfin_mpv_shim/mpvtk_browser/dialogs.py
 msgid "Blu-ray"
 msgstr ""
 
+#. Checkbox in the filter panel's Video Types section: a whole disc image
+#. file. Left as-is.
 #: jellyfin_mpv_shim/mpvtk_browser/dialogs.py
 msgid "ISO"
 msgstr ""
 
+#. Title of the modal that puts the selected item into a playlist.
 #: jellyfin_mpv_shim/mpvtk_browser/dialogs.py
 msgid "Add to Playlist"
 msgstr ""
 
+#. Shown in the Add to Playlist modal when the viewer has no playlists on
+#. the server.
 #: jellyfin_mpv_shim/mpvtk_browser/dialogs.py
 msgid "No playlists yet."
 msgstr ""
 
+#. Placeholder text in the empty text field where a new playlist's name is
+#. typed, in the Add to Playlist modal.
 #: jellyfin_mpv_shim/mpvtk_browser/dialogs.py
 msgid "New playlist name…"
 msgstr ""
 
+#. Button in the Add to Playlist and Add to Collection modals. Makes the
+#. new playlist or collection named in the field beside it. An imperative
+#. verb.
 #: jellyfin_mpv_shim/mpvtk_browser/dialogs.py
 msgid "Create"
 msgstr ""
 
+#. Checkbox in the Add to Playlist modal, deciding whether the new playlist
+#. is visible to other users of the server.
 #: jellyfin_mpv_shim/mpvtk_browser/dialogs.py
 msgid "Private (only you can see it)"
 msgstr ""
 
+#. Button in the Add to Playlist modal that switches to the Add to
+#. Collection modal. The ellipsis means it opens another view.
 #: jellyfin_mpv_shim/mpvtk_browser/dialogs.py
 msgid "Collections…"
 msgstr ""
 
+#. Button that dismisses something without acting. Used on modals (Add to
+#. Playlist, Reading Progress, SyncPlay, the recording dialogs) and as the
+#. tooltip of the window's own close button.
 #: jellyfin_mpv_shim/mpvtk_browser/dialogs.py
 #: jellyfin_mpv_shim/mpvtk_browser/hud.py
 #: jellyfin_mpv_shim/mpvtk_browser/livetv_dialogs.py
@@ -2371,18 +3450,27 @@ msgstr ""
 msgid "Close"
 msgstr ""
 
+#. Title of the modal that puts the selected item into a collection
+#. (Jellyfin's grouping of related items, such as a film series).
 #: jellyfin_mpv_shim/mpvtk_browser/dialogs.py
 msgid "Add to Collection"
 msgstr ""
 
+#. Shown in the Add to Collection modal when the server has no collections.
 #: jellyfin_mpv_shim/mpvtk_browser/dialogs.py
 msgid "No collections yet."
 msgstr ""
 
+#. Placeholder text in the empty text field where a new collection's name
+#. is typed.
 #: jellyfin_mpv_shim/mpvtk_browser/dialogs.py
 msgid "New collection name…"
 msgstr ""
 
+#. Goes one step back. The navigation bar's back button, the row that
+#. leaves a submenu on the playback controls, the button that leaves the
+#. book and comic readers, and the button in the Add to Collection modal
+#. returning to Add to Playlist. Navigation, not "rear".
 #: jellyfin_mpv_shim/mpvtk_browser/dialogs.py
 #: jellyfin_mpv_shim/mpvtk_browser/hud.py
 #: jellyfin_mpv_shim/mpvtk_browser/pages/comic.py
@@ -2391,78 +3479,113 @@ msgstr ""
 msgid "Back"
 msgstr ""
 
+#. Stands in for the name of a media source (a file or version of an item)
+#. that the server did not name, in the Media Info modal.
 #: jellyfin_mpv_shim/mpvtk_browser/dialogs.py
 msgid "Unknown"
 msgstr ""
 
+#. Shown in the Media Info modal when the server returned no video, audio
+#. or subtitle stream details for the item.
 #: jellyfin_mpv_shim/mpvtk_browser/dialogs.py
 msgid "No media information is available."
 msgstr ""
 
+#. The panel listing an item's video, audio and subtitle stream details.
+#. Used as the modal's title and as the action on an item's menu that opens
+#. it.
 #: jellyfin_mpv_shim/mpvtk_browser/dialogs.py
 #: jellyfin_mpv_shim/mpvtk_browser/pages/detail.py
 #: jellyfin_mpv_shim/mpvtk_browser/tiles.py
 msgid "Media Info"
 msgstr ""
 
+#. Button that dismisses a notice, and the default confirming button of a
+#. yes/no dialog. Also closes the Media Info modal.
 #: jellyfin_mpv_shim/mpvtk_browser/dialogs.py
 msgid "OK"
 msgstr ""
 
+#. Error shown in the Download modal when the server could not be asked
+#. which episodes are still missing.
 #: jellyfin_mpv_shim/mpvtk_browser/dialogs.py
 msgid "Could not check what needs downloading."
 msgstr ""
 
+#. Placeholder in the Download modal while the app works out how many items
+#. would be downloaded and how much space they need.
 #: jellyfin_mpv_shim/mpvtk_browser/dialogs.py
 msgid "Estimating…"
 msgstr ""
 
+#. Summary line in the Download modal. %(count)d is a number of items,
+#. %(size)s an already-formatted size such as "4.2 GB". The middle
+#. character is a separator dot.
 #: jellyfin_mpv_shim/mpvtk_browser/dialogs.py
 #: jellyfin_mpv_shim/mpvtk_browser/settings/downloads.py
 #, python-format
 msgid "%(count)d items · %(size)s"
 msgstr ""
 
+#. Part of the Download modal's summary, in a parenthesised list: how many
+#. of the items are on disk already.
 #: jellyfin_mpv_shim/mpvtk_browser/dialogs.py
 #, python-format
 msgid "%d already downloaded"
 msgstr ""
 
+#. Part of the Download modal's summary, in a parenthesised list: how many
+#. of the items have already been watched.
 #: jellyfin_mpv_shim/mpvtk_browser/dialogs.py
 #, python-format
 msgid "%d watched"
 msgstr ""
 
+#. Part of the Download modal's summary, in a parenthesised list: how many
+#. items the server would not give a size for.
 #: jellyfin_mpv_shim/mpvtk_browser/dialogs.py
 #, python-format
 msgid "%d of unknown size"
 msgstr ""
 
+#. Title of the modal that downloads items for offline viewing. A noun
+#. naming the dialog. The button inside it uses the same English word as a
+#. verb, which is why this one carries a context.
 #: jellyfin_mpv_shim/mpvtk_browser/dialogs.py
 msgctxt "dialog heading"
 msgid "Download"
 msgstr ""
 
+#. Checkbox in the Download modal. When off, episodes already watched are
+#. left out of the download.
 #: jellyfin_mpv_shim/mpvtk_browser/dialogs.py
 msgid "Include watched"
 msgstr ""
 
+#. Shown in the Download modal when every item in the selection is already
+#. on disk.
 #: jellyfin_mpv_shim/mpvtk_browser/dialogs.py
 msgid "Nothing left to download."
 msgstr ""
 
+#. Error shown when the Download modal's button failed to queue anything.
 #: jellyfin_mpv_shim/mpvtk_browser/dialogs.py
 msgid "The download could not be started."
 msgstr ""
 
+#. Shown in place of the filter controls when the server offers nothing to
+#. filter this library by.
 #: jellyfin_mpv_shim/mpvtk_browser/dialogs.py
 msgid "This library offers no filters."
 msgstr ""
 
+#. Title of the modal that filters a library grid.
 #: jellyfin_mpv_shim/mpvtk_browser/dialogs.py
 msgid "Filters"
 msgstr ""
 
+#. Counts items: above a library grid, under the Filters modal's title
+#. where it counts what matches, and on the Downloads page.
 #: jellyfin_mpv_shim/mpvtk_browser/dialogs.py
 #: jellyfin_mpv_shim/mpvtk_browser/pages/grid.py
 #: jellyfin_mpv_shim/mpvtk_browser/settings/downloads.py
@@ -2470,85 +3593,129 @@ msgstr ""
 msgid "%d items"
 msgstr ""
 
+#. Button in the Filters modal. Removes every filter that is set.
 #: jellyfin_mpv_shim/mpvtk_browser/dialogs.py
 msgid "Clear All"
 msgstr ""
 
+#. Button that closes the Filters modal, and the View settings modal,
+#. keeping what was chosen. Not "finished" in the sense of a task
+#. completing.
 #: jellyfin_mpv_shim/mpvtk_browser/dialogs.py
 msgid "Done"
 msgstr ""
 
+#. First entry of every filter-panel dropdown, meaning no restriction on
+#. this field. Neuter, since it stands for genre, year, rating, tag or
+#. language alike.
 #: jellyfin_mpv_shim/mpvtk_browser/dialogs.py
 msgid "Any"
 msgstr ""
 
+#. One English word, two senses. The first choice in a library's Artwork
+#. dropdown, where the tile shape is taken from whatever artwork the item
+#. has; and the value shown for Deinterlace and Aspect Ratio on the
+#. playback controls, where it means MPV decides.
 #: jellyfin_mpv_shim/mpvtk_browser/dialogs.py
 #: jellyfin_mpv_shim/mpvtk_browser/hud.py jellyfin_mpv_shim/osc_bridge.py
 msgid "Auto"
 msgstr ""
 
+#. Choice in the Artwork dropdown of a library's View settings: tall
+#. portrait cover art.
 #: jellyfin_mpv_shim/mpvtk_browser/dialogs.py
 msgid "Poster"
 msgstr ""
 
+#. Choice in the Artwork dropdown of a library's View settings: a wide
+#. landscape still.
 #: jellyfin_mpv_shim/mpvtk_browser/dialogs.py
 msgid "Thumbnail"
 msgstr ""
 
+#. Choice in the Artwork dropdown of a library's View settings: a wide,
+#. short banner image.
 #: jellyfin_mpv_shim/mpvtk_browser/dialogs.py
 msgid "Banner"
 msgstr ""
 
+#. Choice in the Artwork dropdown of a library's View settings: the title
+#. treatment artwork, usually white lettering on a transparent background.
 #: jellyfin_mpv_shim/mpvtk_browser/dialogs.py
 msgid "Logo"
 msgstr ""
 
+#. Choice in the Artwork dropdown of a library's View settings: artwork
+#. shaped like a disc label.
 #: jellyfin_mpv_shim/mpvtk_browser/dialogs.py
 msgid "Disc"
 msgstr ""
 
+#. Label of the dropdown in a library's View settings that chooses which
+#. kind of image the tiles show.
 #: jellyfin_mpv_shim/mpvtk_browser/dialogs.py
 #: jellyfin_mpv_shim/mpvtk_browser/settings/home.py
 msgid "Artwork"
 msgstr ""
 
+#. Explanation under the Artwork dropdown in a library's View settings.
+#. "Auto" and "Poster" are two of that dropdown's choices; keep them
+#. matching those translations, curly quotation marks included.
 #: jellyfin_mpv_shim/mpvtk_browser/dialogs.py
 msgid ""
 "“Auto” shapes the tiles from the artwork itself, which usually comes out as "
 "posters. Choose “Poster” to insist on them."
 msgstr ""
 
+#. Checkbox in a library's View settings. Draws each item's name under its
+#. tile.
 #: jellyfin_mpv_shim/mpvtk_browser/dialogs.py
 msgid "Show titles"
 msgstr ""
 
+#. Checkbox in a library's View settings. Draws each item's release year
+#. under its tile.
 #: jellyfin_mpv_shim/mpvtk_browser/dialogs.py
 msgid "Show years"
 msgstr ""
 
+#. Checkbox in a library's View settings, switching the layout from tiles
+#. to a single-column list.
 #: jellyfin_mpv_shim/mpvtk_browser/dialogs.py
 msgid "List instead of a grid"
 msgstr ""
 
+#. Explanation in a library's View settings, saying those choices are saved
+#. to the Jellyfin server rather than to this device, so Jellyfin Web sees
+#. them too. "Jellyfin Web" is the browser client's product name; leave it
+#. as-is.
 #: jellyfin_mpv_shim/mpvtk_browser/dialogs.py
 msgid "These are stored on your server and shared with Jellyfin Web."
 msgstr ""
 
+#. Checkbox in a library's View settings, switching the grid from scrolling
+#. to one screenful at a time with page buttons.
 #: jellyfin_mpv_shim/mpvtk_browser/dialogs.py
 #: jellyfin_mpv_shim/mpvtk_browser/pages/music.py
 msgid "Paginated"
 msgstr ""
 
+#. Explanation under the Paginated checkbox in a library's View settings.
 #: jellyfin_mpv_shim/mpvtk_browser/dialogs.py
 msgid ""
 "Show one page of tiles at a time instead of scrolling. Applies to every "
 "library on this device."
 msgstr ""
 
+#. Title of the modal that chooses how one library's tiles are drawn.
+#. Sentence case in English.
 #: jellyfin_mpv_shim/mpvtk_browser/dialogs.py
 msgid "View settings"
 msgstr ""
 
+#. Explanation under the "Make library logos more legible" checkbox in a
+#. library's View settings. "Plate" here is the solid light rectangle drawn
+#. behind a logo so it stays visible.
 #: jellyfin_mpv_shim/mpvtk_browser/dialogs.py
 msgid ""
 "Backs transparent logos with the light plate they were drawn for, and "
@@ -2556,18 +3723,27 @@ msgid ""
 "colour behind them instead, with no shadows."
 msgstr ""
 
+#. Default title of the plain message dialog, used when the caller supplied
+#. none.
 #: jellyfin_mpv_shim/mpvtk_browser/dialogs.py
 msgid "Notice"
 msgstr ""
 
+#. Message shown when the viewer asked to copy text but this build of MPV
+#. cannot reach the system clipboard.
 #: jellyfin_mpv_shim/mpvtk_browser/dialogs.py
 msgid "Copying to the clipboard is not available."
 msgstr ""
 
+#. Message shown when the viewer asked to paste but this build of MPV
+#. cannot reach the system clipboard.
 #: jellyfin_mpv_shim/mpvtk_browser/dialogs.py
 msgid "Pasting from the clipboard is not available."
 msgstr ""
 
+#. Follows the message saying the clipboard is unavailable. %(package)s is
+#. a software package name and the parenthesis holds a shell command; leave
+#. both untranslated.
 #: jellyfin_mpv_shim/mpvtk_browser/dialogs.py
 #, python-format
 msgid ""
@@ -2575,6 +3751,9 @@ msgid ""
 "%(package)s\"), or use MPV 0.41 or newer."
 msgstr ""
 
+#. Follows the message saying the clipboard is unavailable. %(package)s is
+#. a software package name and the parenthesis holds a shell command; leave
+#. both untranslated.
 #: jellyfin_mpv_shim/mpvtk_browser/dialogs.py
 #, python-format
 msgid ""
@@ -2582,14 +3761,20 @@ msgid ""
 "%(package)s\")."
 msgstr ""
 
+#. Follows the clipboard message above, naming the MPV version that gained
+#. clipboard support.
 #: jellyfin_mpv_shim/mpvtk_browser/dialogs.py
 msgid "Use MPV 0.41 or newer."
 msgstr ""
 
+#. Title of the dialog explaining that copy or paste is unavailable.
 #: jellyfin_mpv_shim/mpvtk_browser/dialogs.py
 msgid "Clipboard"
 msgstr ""
 
+#. Shown in the Reading Progress dialog. %s is another application's name.
+#. Jellyfin stores an ebook position as a fraction of the whole book, not
+#. as a page of this file, so it cannot be typed in.
 #: jellyfin_mpv_shim/mpvtk_browser/dialogs.py
 #, python-format
 msgid ""
@@ -2598,204 +3783,287 @@ msgid ""
 "is still read from the server and shown above."
 msgstr ""
 
+#. Shown in the Reading Progress dialog. %s is another application's name.
 #: jellyfin_mpv_shim/mpvtk_browser/dialogs.py
 #, python-format
 msgid "%s stores no reading position."
 msgstr ""
 
+#. Title of the dialog that reads or writes how far through a book the
+#. viewer is.
 #: jellyfin_mpv_shim/mpvtk_browser/dialogs.py
 msgid "Reading Progress"
 msgstr ""
 
+#. Shown in the Reading Progress dialog while the stored position is being
+#. fetched from the server.
 #: jellyfin_mpv_shim/mpvtk_browser/dialogs.py
 msgid "Reading the position…"
 msgstr ""
 
+#. Button in the Reading Progress dialog. Takes the position stored on the
+#. server and applies it here. An imperative verb, paired with Push.
 #: jellyfin_mpv_shim/mpvtk_browser/dialogs.py
 msgid "Pull"
 msgstr ""
 
+#. Button in the Reading Progress dialog. Sends the position reached here
+#. up to the server. An imperative verb, paired with Pull.
 #: jellyfin_mpv_shim/mpvtk_browser/dialogs.py
 msgid "Push"
 msgstr ""
 
+#. Error in the Reading Progress dialog when the stored reading position
+#. could not be fetched from the server.
 #: jellyfin_mpv_shim/mpvtk_browser/dialogs.py
 msgid "The position could not be read."
 msgstr ""
 
+#. Validation message in the Reading Progress dialog when what was typed in
+#. the page field is not a number.
 #: jellyfin_mpv_shim/mpvtk_browser/dialogs.py
 msgid "Enter a number."
 msgstr ""
 
+#. Validation message in the Reading Progress dialog. %d is the last page
+#. of the book.
 #: jellyfin_mpv_shim/mpvtk_browser/dialogs.py
 #, python-format
 msgid "Enter a page between 1 and %d."
 msgstr ""
 
+#. Validation message in the Reading Progress dialog, used when the book's
+#. length is unknown.
 #: jellyfin_mpv_shim/mpvtk_browser/dialogs.py
 msgid "Enter a page of 1 or more."
 msgstr ""
 
+#. Status message confirming the reading position was sent to the server.
 #: jellyfin_mpv_shim/mpvtk_browser/dialogs.py
 msgid "Reading position saved."
 msgstr ""
 
+#. Error in the Reading Progress dialog when the reading position could not
+#. be sent to the server.
 #: jellyfin_mpv_shim/mpvtk_browser/dialogs.py
 msgid "The position could not be saved."
 msgstr ""
 
+#. One row of the SyncPlay group list. %s is a group's name, and the suffix
+#. marks the group this device is currently in.
 #: jellyfin_mpv_shim/mpvtk_browser/dialogs.py
 #, python-format
 msgid "%s (joined)"
 msgstr ""
 
+#. Stands in for the name of a SyncPlay group the server did not name. A
+#. set of people watching in sync.
 #: jellyfin_mpv_shim/mpvtk_browser/dialogs.py
 msgid "Group"
 msgstr ""
 
+#. Shown in the SyncPlay dialog when nobody on this server has a watch-
+#. together group open.
 #: jellyfin_mpv_shim/mpvtk_browser/dialogs.py
 msgid "No active groups."
 msgstr ""
 
+#. Button that starts a new SyncPlay watch-together group. On the SyncPlay
+#. dialog and on the playback controls.
 #: jellyfin_mpv_shim/mpvtk_browser/dialogs.py
 #: jellyfin_mpv_shim/mpvtk_browser/hud.py jellyfin_mpv_shim/osc_bridge.py
 #: jellyfin_mpv_shim/syncplay.py
 msgid "New Group"
 msgstr ""
 
+#. Button in the SyncPlay dialog. Goes back to playing on this device
+#. alone, out of sync with the group.
 #: jellyfin_mpv_shim/mpvtk_browser/dialogs.py
 msgid "Resume local playback"
 msgstr ""
 
+#. Button in the SyncPlay dialog that takes this device out of the watch-
+#. together group. An imperative verb.
 #: jellyfin_mpv_shim/mpvtk_browser/dialogs.py
 msgid "Leave"
 msgstr ""
 
+#. Button that fetches something again: the SyncPlay group list, the
+#. downloads list, and the log. An imperative verb.
 #: jellyfin_mpv_shim/mpvtk_browser/dialogs.py
 #: jellyfin_mpv_shim/mpvtk_browser/settings/downloads.py
 #: jellyfin_mpv_shim/mpvtk_browser/settings/logs.py
 msgid "Refresh"
 msgstr ""
 
+#. Error shown when joining a watch-together group failed.
 #: jellyfin_mpv_shim/mpvtk_browser/dialogs.py
 msgid "Could not join the SyncPlay group."
 msgstr ""
 
+#. Error shown when starting a watch-together group failed.
 #: jellyfin_mpv_shim/mpvtk_browser/dialogs.py
 msgid "Could not create the SyncPlay group."
 msgstr ""
 
+#. Error shown when leaving a watch-together group failed.
 #: jellyfin_mpv_shim/mpvtk_browser/dialogs.py
 msgid "Could not leave the SyncPlay group."
 msgstr ""
 
+#. Error shown when returning to synchronised playback failed.
 #: jellyfin_mpv_shim/mpvtk_browser/dialogs.py
 msgid "Could not resume SyncPlay playback."
 msgstr ""
 
+#. Heading of a downloads group: episodes fetched automatically because
+#. they are next to watch in a series being followed.
 #: jellyfin_mpv_shim/mpvtk_browser/downloads.py
 msgid "Automatic: Next Up"
 msgstr ""
 
+#. Heading of a downloads group: episodes fetched automatically because the
+#. series is being watched right now.
 #: jellyfin_mpv_shim/mpvtk_browser/downloads.py
 msgid "Automatic: Actively Watched"
 msgstr ""
 
+#. Name of a search-results and library group holding books read aloud.
 #: jellyfin_mpv_shim/mpvtk_browser/downloads.py
 #: jellyfin_mpv_shim/mpvtk_browser/pages/search.py
 #: jellyfin_mpv_shim/mpvtk_browser/repository.py
 msgid "Audiobooks"
 msgstr ""
 
+#. Name of a search-results and library group holding readable books, and
+#. of the offline library of downloaded books.
 #: jellyfin_mpv_shim/mpvtk_browser/downloads.py
 #: jellyfin_mpv_shim/mpvtk_browser/pages/search.py
 #: jellyfin_mpv_shim/mpvtk_browser/repository.py
 msgid "Books"
 msgstr ""
 
+#. Heading of the downloads group holding books that belong to no album or
+#. folder, so there is nothing to file them under.
 #: jellyfin_mpv_shim/mpvtk_browser/downloads.py
 msgid "Ungrouped"
 msgstr ""
 
+#. Name of a search-results and library group holding single episodes of a
+#. series. Also the heading over a season's episode list.
 #: jellyfin_mpv_shim/mpvtk_browser/downloads.py
 #: jellyfin_mpv_shim/mpvtk_browser/pages/search.py
 #: jellyfin_mpv_shim/mpvtk_browser/repository.py
 msgid "Episodes"
 msgstr ""
 
+#. Name of the season holding episodes outside the numbered seasons, such
+#. as Christmas specials. Jellyfin Web uses this word; follow its wording
+#. in this language.
 #: jellyfin_mpv_shim/mpvtk_browser/downloads.py
 #: jellyfin_mpv_shim/mpvtk_browser/repository.py
 msgid "Specials"
 msgstr ""
 
+#. Heading of a downloads group holding one season's episodes. %s is the
+#. season's number or name.
 #: jellyfin_mpv_shim/mpvtk_browser/downloads.py
 #, python-format
 msgid "Season %s"
 msgstr ""
 
+#. State of a download in progress. %d is the percentage finished; the
+#. doubled percent sign prints one.
 #: jellyfin_mpv_shim/mpvtk_browser/downloads.py
 #, python-format
 msgid "Downloading %d%%"
 msgstr ""
 
+#. State of a download that has started but has no progress figure yet.
 #: jellyfin_mpv_shim/mpvtk_browser/downloads.py
 msgid "Downloading"
 msgstr ""
 
+#. State of a download waiting for its turn.
 #: jellyfin_mpv_shim/mpvtk_browser/downloads.py
 msgid "Queued"
 msgstr ""
 
+#. State of a download that did not finish.
 #: jellyfin_mpv_shim/mpvtk_browser/downloads.py
 msgid "Failed"
 msgstr ""
 
+#. Stands in for the name of a downloaded playlist the catalog did not
+#. name.
 #: jellyfin_mpv_shim/mpvtk_browser/downloads.py
 #: jellyfin_mpv_shim/mpvtk_browser/repository.py
 msgid "Playlist"
 msgstr ""
 
+#. Heading of a downloads group whose series could not be identified.
 #: jellyfin_mpv_shim/mpvtk_browser/downloads.py
 msgid "Unknown Series"
 msgstr ""
 
+#. Heading of the downloads group holding films and standalone videos.
 #: jellyfin_mpv_shim/mpvtk_browser/downloads.py
 msgid "Movies & Videos"
 msgstr ""
 
+#. First entry of the audio or video track list on the playback controls:
+#. no explicit choice, so MPV picks. "mpv" is the media player's name,
+#. always lower case.
 #: jellyfin_mpv_shim/mpvtk_browser/gateway/playback.py
 msgid "Default (mpv decides)"
 msgstr ""
 
+#. Shown on the Live TV Channels tab when the server offers no channels.
 #: jellyfin_mpv_shim/mpvtk_browser/guide_view.py
 #: jellyfin_mpv_shim/mpvtk_browser/pages/livetv.py
 msgid "No channels available."
 msgstr ""
 
+#. Choice for a home-screen row, leaving that slot empty. It agrees with
+#. the word the language uses for a section or row, which is why it is a
+#. separate entry from the "None" that means no subtitle track.
 #: jellyfin_mpv_shim/mpvtk_browser/home_sections.py
 msgctxt "home screen section type"
 msgid "None"
 msgstr ""
 
+#. The viewer's own libraries. The name of a home-screen row and the choice
+#. for one in the Home Screen settings. Jellyfin Web uses the same phrase;
+#. follow its wording in this language.
 #: jellyfin_mpv_shim/mpvtk_browser/home_sections.py
 msgid "My Media"
 msgstr ""
 
+#. Films and episodes started and not finished. The name of a home-screen
+#. row and the choice for one in the Home Screen settings. Jellyfin Web
+#. uses the same two words; follow its wording in this language.
 #: jellyfin_mpv_shim/mpvtk_browser/home_sections.py
 #: jellyfin_mpv_shim/mpvtk_browser/repository.py
 msgid "Continue Watching"
 msgstr ""
 
+#. Music and audiobooks started and not finished. The name of a home-screen
+#. row and the choice for one in the Home Screen settings.
 #: jellyfin_mpv_shim/mpvtk_browser/home_sections.py
 #: jellyfin_mpv_shim/mpvtk_browser/repository.py
 msgid "Continue Listening"
 msgstr ""
 
+#. Books opened and not finished. The name of a home-screen row and the
+#. choice for one in the Home Screen settings.
 #: jellyfin_mpv_shim/mpvtk_browser/home_sections.py
 #: jellyfin_mpv_shim/mpvtk_browser/repository.py
 msgid "Continue Reading"
 msgstr ""
 
+#. The next unwatched episode of a series being followed. The name of a
+#. home-screen row, and the heading of the same on a series or season page.
+#. Jellyfin Web uses the same two words.
 #: jellyfin_mpv_shim/mpvtk_browser/home_sections.py
 #: jellyfin_mpv_shim/mpvtk_browser/pages/season.py
 #: jellyfin_mpv_shim/mpvtk_browser/pages/series.py
@@ -2803,24 +4071,35 @@ msgstr ""
 msgid "Next Up"
 msgstr ""
 
+#. Newly added items. The name of a home-screen row and the choice for one
+#. in the Home Screen settings. Jellyfin Web uses the same phrase.
 #: jellyfin_mpv_shim/mpvtk_browser/home_sections.py
 msgid "Recently Added"
 msgstr ""
 
+#. Heading over the Live TV programmes being recorded at this moment. Used
+#. on the Recordings tab and as a home-screen row.
 #: jellyfin_mpv_shim/mpvtk_browser/home_sections.py
 #: jellyfin_mpv_shim/mpvtk_browser/pages/livetv.py
 #: jellyfin_mpv_shim/mpvtk_browser/repository.py
 msgid "Active Recordings"
 msgstr ""
 
+#. Last entry of the subtitle dropdown on the playback controls. Opens a
+#. second list, for a second set of subtitles shown at the same time as the
+#. first. The ellipsis means it opens another menu.
 #: jellyfin_mpv_shim/mpvtk_browser/hud.py
 msgid "Secondary…"
 msgstr ""
 
+#. Tooltip of the subtitle button on the playback controls drawn over the
+#. video.
 #: jellyfin_mpv_shim/mpvtk_browser/hud.py
 msgid "Subtitle Track"
 msgstr ""
 
+#. Stands in for the name of a chapter the file did not name, wherever
+#. chapters are listed. %d is its number.
 #: jellyfin_mpv_shim/mpvtk_browser/hud.py
 #: jellyfin_mpv_shim/mpvtk_browser/music.py
 #: jellyfin_mpv_shim/mpvtk_browser/pages/books.py
@@ -2829,210 +4108,307 @@ msgstr ""
 msgid "Chapter %d"
 msgstr ""
 
+#. The chapter list of what is playing. The tooltip of the chapter button
+#. on the playback controls and the now-playing bar, and the heading over
+#. an audiobook's chapter table.
 #: jellyfin_mpv_shim/mpvtk_browser/hud.py
 #: jellyfin_mpv_shim/mpvtk_browser/music.py
 #: jellyfin_mpv_shim/mpvtk_browser/pages/books.py
 msgid "Chapters"
 msgstr ""
 
+#. Tooltip of the audio button on the playback controls drawn over the
+#. video.
 #: jellyfin_mpv_shim/mpvtk_browser/hud.py
 msgid "Audio Track"
 msgstr ""
 
+#. Tooltip of the quality button on the playback controls, which limits how
+#. much bandwidth the server may use.
 #: jellyfin_mpv_shim/mpvtk_browser/hud.py
 msgid "Video Quality"
 msgstr ""
 
+#. Row on the settings menu of the playback controls, opening a list of
+#. speeds such as 1.5x.
 #: jellyfin_mpv_shim/mpvtk_browser/hud.py jellyfin_mpv_shim/osc_bridge.py
 msgid "Playback Speed"
 msgstr ""
 
+#. Row on the settings menu of the playback controls, opening a list of
+#. picture shapes such as 16:9.
 #: jellyfin_mpv_shim/mpvtk_browser/hud.py jellyfin_mpv_shim/osc_bridge.py
 msgid "Aspect Ratio"
 msgstr ""
 
+#. Row on the settings menu of the playback controls. Turns deinterlacing
+#. on for this video only, for a file that is interlaced without saying so.
+#. An imperative verb.
 #: jellyfin_mpv_shim/mpvtk_browser/hud.py
 msgid "Deinterlace"
 msgstr ""
 
+#. Row on the settings menu of the playback controls, and the title of the
+#. in-player submenu, choosing how large subtitles are drawn.
 #: jellyfin_mpv_shim/mpvtk_browser/hud.py jellyfin_mpv_shim/osc_bridge.py
 msgid "Subtitle Size"
 msgstr ""
 
+#. Row on the settings menu of the playback controls, and the title of the
+#. in-player submenu, choosing where on screen subtitles are drawn.
 #: jellyfin_mpv_shim/mpvtk_browser/hud.py jellyfin_mpv_shim/osc_bridge.py
 msgid "Subtitle Position"
 msgstr ""
 
+#. Row on the settings menu of the playback controls, and the title of the
+#. in-player submenu, choosing the colour subtitles are drawn in. American
+#. spelling of "colour".
 #: jellyfin_mpv_shim/mpvtk_browser/hud.py jellyfin_mpv_shim/osc_bridge.py
 msgid "Subtitle Color"
 msgstr ""
 
+#. Row on the settings menu of the playback controls, and the title of the
+#. panel it opens, listing how the video is reaching this device and what
+#. MPV is doing with it.
 #: jellyfin_mpv_shim/mpvtk_browser/hud.py
 msgid "Playback Info"
 msgstr ""
 
+#. Means "nothing chosen, and the feature is off". The first entry of the
+#. SyncPlay list on the playback controls, and of the video-profile list.
 #: jellyfin_mpv_shim/mpvtk_browser/hud.py jellyfin_mpv_shim/osc_bridge.py
 #: jellyfin_mpv_shim/syncplay.py jellyfin_mpv_shim/video_profile.py
 msgid "None (Disabled)"
 msgstr ""
 
+#. Row in the Playback Info panel: whether the graphics card is decoding
+#. the video, and by which method.
 #: jellyfin_mpv_shim/mpvtk_browser/hud.py
 msgid "Hardware acceleration"
 msgstr ""
 
+#. Row in the Playback Info panel: which MPV video output driver is drawing
+#. the picture.
 #: jellyfin_mpv_shim/mpvtk_browser/hud.py
 msgid "Video output"
 msgstr ""
 
+#. Row in the Playback Info panel: how many frames were skipped rather than
+#. shown.
 #: jellyfin_mpv_shim/mpvtk_browser/hud.py
 msgid "Dropped frames"
 msgstr ""
 
+#. Value of the Dropped frames row in the Playback Info panel. Two counts:
+#. frames dropped by the video output, and frames dropped by the decoder.
 #: jellyfin_mpv_shim/mpvtk_browser/hud.py
 #, python-format
 msgid "%(vo)d output, %(dec)d decoder"
 msgstr ""
 
+#. Row in the Playback Info panel: how far the audio and video have drifted
+#. apart, in seconds. Short for audio/video.
 #: jellyfin_mpv_shim/mpvtk_browser/hud.py
 msgid "A/V sync"
 msgstr ""
 
+#. Row in the Playback Info panel: how many seconds of the stream have been
+#. read ahead.
 #: jellyfin_mpv_shim/mpvtk_browser/hud.py
 msgid "Buffered"
 msgstr ""
 
+#. Value of the Buffered row in the Playback Info panel. The unit is
+#. seconds.
 #: jellyfin_mpv_shim/mpvtk_browser/hud.py
 #, python-format
 msgid "%.1f s"
 msgstr ""
 
+#. Row in the Playback Info panel: how fast the stream is arriving from the
+#. server.
 #: jellyfin_mpv_shim/mpvtk_browser/hud.py
 msgid "Download speed"
 msgstr ""
 
+#. Row in the Playback Info panel: what kind of item is playing, such as
+#. Movie or Episode.
 #: jellyfin_mpv_shim/mpvtk_browser/hud.py
 msgid "Media type"
 msgstr ""
 
+#. Parenthesised after the play method in the Playback Info panel: the file
+#. being played was downloaded to this device earlier.
 #: jellyfin_mpv_shim/mpvtk_browser/hud.py
 msgid "downloaded copy"
 msgstr ""
 
+#. Parenthesised after the play method in the Playback Info panel: the file
+#. is being read from a shared folder rather than streamed.
 #: jellyfin_mpv_shim/mpvtk_browser/hud.py
 msgid "local file"
 msgstr ""
 
+#. Parenthesised after the play method in the Playback Info panel: the file
+#. is arriving over the network from the Jellyfin server.
 #: jellyfin_mpv_shim/mpvtk_browser/hud.py
 msgid "stream from server"
 msgstr ""
 
+#. Row in the Playback Info panel: how the video is reaching this device.
+#. Its value is one of Direct playing, Direct streaming, Remuxing or
+#. Transcoding.
 #: jellyfin_mpv_shim/mpvtk_browser/hud.py
 msgid "Play method"
 msgstr ""
 
+#. Heading of a numbered block in the Playback Info panel, listing why the
+#. server had to re-encode. Do not confuse with "Seasons": an earlier
+#. translation sweep put a translation of that word here.
 #: jellyfin_mpv_shim/mpvtk_browser/hud.py
 msgid "Reasons"
 msgstr ""
 
+#. Heading of a block in the Playback Info panel holding MPV's own
+#. statistics. The player program, not a person.
 #: jellyfin_mpv_shim/mpvtk_browser/hud.py
 msgid "Player"
 msgstr ""
 
+#. Heading of a block in the Playback Info panel holding the media file's
+#. own attributes, such as its container and size.
 #: jellyfin_mpv_shim/mpvtk_browser/hud.py
 msgid "File"
 msgstr ""
 
+#. Shown in the Playback Info panel when nothing is playing.
 #: jellyfin_mpv_shim/mpvtk_browser/hud.py
 msgid "Nothing is playing."
 msgstr ""
 
+#. Tooltip of the button that goes back one: the previous item in the queue
+#. on the playback controls and the now-playing bar, and the previous batch
+#. on a paged row of tiles.
 #: jellyfin_mpv_shim/mpvtk_browser/hud.py
 #: jellyfin_mpv_shim/mpvtk_browser/music.py
 #: jellyfin_mpv_shim/mpvtk_browser/tile_renderer.py
 msgid "Previous"
 msgstr ""
 
+#. Tooltip of the button on the playback controls that jumps to the
+#. previous chapter.
 #: jellyfin_mpv_shim/mpvtk_browser/hud.py
 #: jellyfin_mpv_shim/mpvtk_browser/music.py
 msgid "Previous chapter"
 msgstr ""
 
+#. Tooltip of the rewind button on the playback controls.
 #: jellyfin_mpv_shim/mpvtk_browser/hud.py
 msgid "Back 10 Seconds"
 msgstr ""
 
+#. Tooltip of the fast-forward button on the playback controls.
 #: jellyfin_mpv_shim/mpvtk_browser/hud.py
 msgid "Forward 30 Seconds"
 msgstr ""
 
+#. Tooltip of the button on the playback controls that jumps to the next
+#. chapter.
 #: jellyfin_mpv_shim/mpvtk_browser/hud.py
 #: jellyfin_mpv_shim/mpvtk_browser/music.py
 msgid "Next chapter"
 msgstr ""
 
+#. Tooltip of the button that goes forward one: the next item in the queue
+#. on the playback controls and the now-playing bar, and the next batch on
+#. a paged row of tiles.
 #: jellyfin_mpv_shim/mpvtk_browser/hud.py
 #: jellyfin_mpv_shim/mpvtk_browser/music.py
 #: jellyfin_mpv_shim/mpvtk_browser/tile_renderer.py
 msgid "Next"
 msgstr ""
 
+#. Shown beside the seek bar: the clock time this video will finish at. {0}
+#. is a time of day, already formatted.
 #: jellyfin_mpv_shim/mpvtk_browser/hud.py jellyfin_mpv_shim/osc_bridge.py
 #, python-brace-format
 msgid "Ends at {0}"
 msgstr ""
 
+#. Tooltip of the volume button on the playback controls. An imperative
+#. verb.
 #: jellyfin_mpv_shim/mpvtk_browser/hud.py
 msgid "Mute"
 msgstr ""
 
+#. The application's settings screen. Used as the page title, the
+#. navigation-bar button, and the tooltip of the gear button on the
+#. playback controls, which opens the menu of playback options.
 #: jellyfin_mpv_shim/mpvtk_browser/hud.py
 #: jellyfin_mpv_shim/mpvtk_browser/settings/__init__.py
 #: jellyfin_mpv_shim/mpvtk_browser/window_chrome.py
 msgid "Settings"
 msgstr ""
 
+#. Tooltip of the button on the playback controls that fills the screen
+#. with the video.
 #: jellyfin_mpv_shim/mpvtk_browser/hud.py
 msgid "Fullscreen"
 msgstr ""
 
+#. Status message when adding items to the play queue failed.
 #: jellyfin_mpv_shim/mpvtk_browser/item_actions.py
 #: jellyfin_mpv_shim/mpvtk_browser/tiles.py
 msgid "Those items could not be added to the queue."
 msgstr ""
 
+#. Status message confirming every episode of a show is now set to record.
 #: jellyfin_mpv_shim/mpvtk_browser/item_actions.py
 msgid "Series recording scheduled."
 msgstr ""
 
+#. Status message confirming one programme is now set to record.
 #: jellyfin_mpv_shim/mpvtk_browser/item_actions.py
 msgid "Recording scheduled."
 msgstr ""
 
+#. Status message when the server refused to set up a recording.
 #: jellyfin_mpv_shim/mpvtk_browser/item_actions.py
 msgid "The recording could not be scheduled."
 msgstr ""
 
+#. Question in the dialog confirming a scheduled recording is to be called
+#. off.
 #: jellyfin_mpv_shim/mpvtk_browser/item_actions.py
 msgid "Cancel recording?"
 msgstr ""
 
+#. Status message confirming a scheduled recording was called off.
 #: jellyfin_mpv_shim/mpvtk_browser/item_actions.py
 msgid "Recording cancelled."
 msgstr ""
 
+#. Button in the recording dialog that calls off this single recording. An
+#. imperative verb.
 #: jellyfin_mpv_shim/mpvtk_browser/item_actions.py
 #: jellyfin_mpv_shim/mpvtk_browser/livetv_dialogs.py
 msgid "Cancel Recording"
 msgstr ""
 
+#. Question in the dialog confirming the rule that records every episode is
+#. to be dropped.
 #: jellyfin_mpv_shim/mpvtk_browser/item_actions.py
 msgid "Stop recording this series?"
 msgstr ""
 
+#. Status message confirming the rule that records every episode was
+#. dropped.
 #: jellyfin_mpv_shim/mpvtk_browser/item_actions.py
 msgid "Series recording cancelled."
 msgstr ""
 
+#. Button that stops the rule recording every episode of a show, and the
+#. title of the dialog confirming it. An imperative verb.
 #: jellyfin_mpv_shim/mpvtk_browser/item_actions.py
 #: jellyfin_mpv_shim/mpvtk_browser/livetv_dialogs.py
 #: jellyfin_mpv_shim/mpvtk_browser/pages/livetv.py
@@ -3040,51 +4416,69 @@ msgstr ""
 msgid "Cancel Series"
 msgstr ""
 
+#. Status message when the server refused to call off a recording.
 #: jellyfin_mpv_shim/mpvtk_browser/item_actions.py
 msgid "The recording could not be cancelled."
 msgstr ""
 
+#. Status message confirming the recording dialog's changes reached the
+#. server.
 #: jellyfin_mpv_shim/mpvtk_browser/item_actions.py
 msgid "Recording settings saved."
 msgstr ""
 
+#. Status message when the server refused the recording dialog's changes.
 #: jellyfin_mpv_shim/mpvtk_browser/item_actions.py
 msgid "The recording settings could not be saved."
 msgstr ""
 
+#. Deletes the media file from the server itself, not just the entry. Used
+#. as the action on an item's menu and as the title and confirming button
+#. of the dialog it opens. An imperative verb phrase.
 #: jellyfin_mpv_shim/mpvtk_browser/item_actions.py
 #: jellyfin_mpv_shim/mpvtk_browser/pages/detail.py
 #: jellyfin_mpv_shim/mpvtk_browser/tiles.py
 msgid "Delete from Disk"
 msgstr ""
 
+#. Warning in the dialog that deletes media from the server. This removes
+#. the actual file, not just the library entry.
 #: jellyfin_mpv_shim/mpvtk_browser/item_actions.py
 msgid ""
 "Deleting this item will delete it from both the file system and your media "
 "library. Are you sure you wish to continue?"
 msgstr ""
 
+#. Status message confirming an item was deleted from the server. %s is its
+#. name.
 #: jellyfin_mpv_shim/mpvtk_browser/item_actions.py
 #, python-format
 msgid "%s was deleted."
 msgstr ""
 
+#. Status message when the server refused to delete an item. %s is its
+#. name.
 #: jellyfin_mpv_shim/mpvtk_browser/item_actions.py
 #, python-format
 msgid "%s could not be deleted."
 msgstr ""
 
+#. Question in the dialog that removes a download from this device. The
+#. item stays on the server. %s is its name.
 #: jellyfin_mpv_shim/mpvtk_browser/item_actions.py
 #: jellyfin_mpv_shim/mpvtk_browser/settings/downloads.py
 #, python-format
 msgid "Delete the downloaded copy of %s?"
 msgstr ""
 
+#. Title of the dialog that removes a downloaded copy from this device.
 #: jellyfin_mpv_shim/mpvtk_browser/item_actions.py
 #: jellyfin_mpv_shim/mpvtk_browser/settings/downloads.py
 msgid "Delete Download"
 msgstr ""
 
+#. Confirming button of a dialog that removes something for good: a
+#. downloaded copy, a playlist, a local profile. An imperative verb.
 #: jellyfin_mpv_shim/mpvtk_browser/item_actions.py
 #: jellyfin_mpv_shim/mpvtk_browser/pages/queue_edit.py
 #: jellyfin_mpv_shim/mpvtk_browser/settings/downloads.py
@@ -3092,265 +4486,381 @@ msgstr ""
 msgid "Delete"
 msgstr ""
 
+#. Status message when deleting a downloaded copy from this device failed.
 #: jellyfin_mpv_shim/mpvtk_browser/item_actions.py
 #: jellyfin_mpv_shim/mpvtk_browser/settings/downloads.py
 msgid "The download could not be removed."
 msgstr ""
 
+#. Status message while a file is being handed to whatever application the
+#. system opens it with. %s is the item's name.
 #: jellyfin_mpv_shim/mpvtk_browser/item_actions.py
 #, python-format
 msgid "Opening %s…"
 msgstr ""
 
+#. Status message when the operating system has no application registered
+#. for that file type. %s is the item's name.
 #: jellyfin_mpv_shim/mpvtk_browser/item_actions.py
 #, python-format
 msgid "Nothing on this system could open %s."
 msgstr ""
 
+#. Status message when the item asked for is already on this device. %s is
+#. its name.
 #: jellyfin_mpv_shim/mpvtk_browser/item_actions.py
 #, python-format
 msgid "%s is already downloaded."
 msgstr ""
 
+#. Status message when opening a book fails because the Jellyfin account
+#. lacks the permission that allows downloading.
 #: jellyfin_mpv_shim/mpvtk_browser/item_actions.py
 msgid ""
 "Your account is not allowed to download from this server, and a book can "
 "only be read by downloading it."
 msgstr ""
 
+#. Status message when something was asked of a download that is not on
+#. this device. %s is the item's name.
 #: jellyfin_mpv_shim/mpvtk_browser/item_actions.py
 #, python-format
 msgid "%s has not been downloaded."
 msgstr ""
 
+#. Status message when fetching an item to this device failed. %s is its
+#. name.
 #: jellyfin_mpv_shim/mpvtk_browser/item_actions.py
 #, python-format
 msgid "%s could not be downloaded."
 msgstr ""
 
+#. Status message while an item is being fetched to this device. %s is its
+#. name.
 #: jellyfin_mpv_shim/mpvtk_browser/item_actions.py
 #, python-format
 msgid "Downloading %s…"
 msgstr ""
 
+#. Error in the recording options dialog when the server would not return
+#. the recording rule.
 #: jellyfin_mpv_shim/mpvtk_browser/livetv_dialogs.py
 msgid "The recording could not be read."
 msgstr ""
 
+#. Button on a programme page, and the title of the dialog it opens,
+#. holding the rule that records every episode of this show.
 #: jellyfin_mpv_shim/mpvtk_browser/livetv_dialogs.py
 #: jellyfin_mpv_shim/mpvtk_browser/pages/livetv.py
 msgid "Series Options"
 msgstr ""
 
+#. Title of the dialog holding one programme's recording settings. A noun
+#. naming the thing being set up.
 #: jellyfin_mpv_shim/mpvtk_browser/livetv_dialogs.py
 msgid "Recording"
 msgstr ""
 
+#. Label of the dropdown in the series recording dialog choosing which
+#. episodes are recorded. A noun-like form label here, not the button of
+#. the same English word that starts a recording.
 #: jellyfin_mpv_shim/mpvtk_browser/livetv_dialogs.py
 msgctxt "series recording rule setting"
 msgid "Record"
 msgstr ""
 
+#. Choice in the "Record" dropdown of the series recording dialog: record
+#. first-run episodes and skip repeats.
 #: jellyfin_mpv_shim/mpvtk_browser/livetv_dialogs.py
 msgid "New episodes only"
 msgstr ""
 
+#. Choice in the "Record" dropdown of the series recording dialog: record
+#. every showing, repeats included.
 #: jellyfin_mpv_shim/mpvtk_browser/livetv_dialogs.py
 msgid "All episodes"
 msgstr ""
 
+#. Checkbox in the series recording dialog. "My library" is the viewer's
+#. own Jellyfin collection.
 #: jellyfin_mpv_shim/mpvtk_browser/livetv_dialogs.py
 msgid "Don't record episodes that are already in my library"
 msgstr ""
 
+#. Choice in the "Channels" dropdown of the series recording dialog,
+#. restricting it to one channel. %s is that channel's name.
 #: jellyfin_mpv_shim/mpvtk_browser/livetv_dialogs.py
 #, python-format
 msgid "Only %s"
 msgstr ""
 
+#. Choice in the "Channels" dropdown of the series recording dialog, used
+#. when the channel's name is not known.
 #: jellyfin_mpv_shim/mpvtk_browser/livetv_dialogs.py
 msgid "One channel"
 msgstr ""
 
+#. Label of the dropdown in the series recording dialog choosing which
+#. channels count. A form label, not the Live TV tab of the same English
+#. word.
 #: jellyfin_mpv_shim/mpvtk_browser/livetv_dialogs.py
 msgctxt "series recording rule setting"
 msgid "Channels"
 msgstr ""
 
+#. Choice in the "Channels" dropdown of the series recording dialog: record
+#. the show wherever it airs.
 #: jellyfin_mpv_shim/mpvtk_browser/livetv_dialogs.py
 msgid "All channels"
 msgstr ""
 
+#. Label of the dropdown in the series recording dialog deciding whether
+#. only showings at the usual time count. The time of day a programme is
+#. broadcast.
 #: jellyfin_mpv_shim/mpvtk_browser/livetv_dialogs.py
 msgid "Air time"
 msgstr ""
 
+#. Choice in the "Air time" dropdown of the series recording dialog: only
+#. showings near this time of day. %s is a clock time, already formatted.
 #: jellyfin_mpv_shim/mpvtk_browser/livetv_dialogs.py
 #, python-format
 msgid "Around %s"
 msgstr ""
 
+#. Choice in the "Air time" dropdown of the series recording dialog: only
+#. showings at the time the series normally airs.
 #: jellyfin_mpv_shim/mpvtk_browser/livetv_dialogs.py
 msgid "Original air time"
 msgstr ""
 
+#. Choice in the "Air time" dropdown of the series recording dialog: record
+#. the show whenever it airs.
 #: jellyfin_mpv_shim/mpvtk_browser/livetv_dialogs.py
 msgid "Anytime"
 msgstr ""
 
+#. Label of the dropdown in the series recording dialog limiting how many
+#. recorded episodes are kept before old ones are deleted. Followed by a
+#. count such as "5 episodes".
 #: jellyfin_mpv_shim/mpvtk_browser/livetv_dialogs.py
 msgid "Keep up to"
 msgstr ""
 
+#. Label of the number field in the recording dialog: begin recording this
+#. many minutes before the programme starts.
 #: jellyfin_mpv_shim/mpvtk_browser/livetv_dialogs.py
 msgid "Start early (minutes)"
 msgstr ""
 
+#. Label of the number field in the recording dialog: keep recording this
+#. many minutes after the programme ends.
 #: jellyfin_mpv_shim/mpvtk_browser/livetv_dialogs.py
 msgid "Stop late (minutes)"
 msgstr ""
 
+#. Choice in the "Keep up to" dropdown of the series recording dialog:
+#. never delete old episodes to make room.
 #: jellyfin_mpv_shim/mpvtk_browser/livetv_dialogs.py
 msgid "As many as possible"
 msgstr ""
 
+#. Choice in the "Keep up to" dropdown of the series recording dialog. The
+#. singular of "%d episodes".
 #: jellyfin_mpv_shim/mpvtk_browser/livetv_dialogs.py
 msgid "1 episode"
 msgstr ""
 
+#. Choice in the "Keep up to" dropdown of the series recording dialog, for
+#. counts of two or more. The singular case is a separate string.
 #: jellyfin_mpv_shim/mpvtk_browser/livetv_dialogs.py
 #, python-format
 msgid "%d episodes"
 msgstr ""
 
+#. Label of the dropdown in Guide Settings choosing the order of channels.
+#. Followed by "Channel number" or "Recently watched".
 #: jellyfin_mpv_shim/mpvtk_browser/livetv_dialogs.py
 msgid "Sort channels by"
 msgstr ""
 
+#. Choice in the "Sort channels by" dropdown of Guide Settings: order
+#. channels by the number the provider gives them.
 #: jellyfin_mpv_shim/mpvtk_browser/livetv_dialogs.py
 msgid "Channel number"
 msgstr ""
 
+#. Choice in the "Sort channels by" dropdown of Guide Settings: put the
+#. channels watched most recently first.
 #: jellyfin_mpv_shim/mpvtk_browser/livetv_dialogs.py
 msgid "Recently watched"
 msgstr ""
 
+#. Checkbox in Guide Settings, moving channels marked as favourites to the
+#. top of the guide.
 #: jellyfin_mpv_shim/mpvtk_browser/livetv_dialogs.py
 msgid "Place favorite channels at the beginning"
 msgstr ""
 
+#. Checkbox in Guide Settings, tinting each guide cell by the kind of
+#. programme it holds.
 #: jellyfin_mpv_shim/mpvtk_browser/livetv_dialogs.py
 msgid "Color coded backgrounds"
 msgstr ""
 
+#. Heading in Guide Settings, above checkboxes choosing which badges guide
+#. cells may show.
 #: jellyfin_mpv_shim/mpvtk_browser/livetv_dialogs.py
 msgid "Show indicators for"
 msgstr ""
 
+#. Heading in Guide Settings, above checkboxes choosing which kinds of
+#. programme are colour coded.
 #: jellyfin_mpv_shim/mpvtk_browser/livetv_dialogs.py
 msgid "Categories"
 msgstr ""
 
+#. Button on the Live TV guide, and the title of the dialog it opens,
+#. holding how channels are sorted and which badges are shown.
 #: jellyfin_mpv_shim/mpvtk_browser/livetv_dialogs.py
 #: jellyfin_mpv_shim/mpvtk_browser/pages/livetv.py
 msgid "Guide Settings"
 msgstr ""
 
+#. Error shown when Guide Settings could not be written to the server.
 #: jellyfin_mpv_shim/mpvtk_browser/livetv_dialogs.py
 msgid "Guide settings could not be saved."
 msgstr ""
 
+#. Checkbox in Guide Settings: badge programmes broadcast in high
+#. definition. American spelling of "programmes".
 #: jellyfin_mpv_shim/mpvtk_browser/live_tv.py
 msgid "HD programs"
 msgstr ""
 
+#. Checkbox in Guide Settings: badge programmes going out as they happen.
 #: jellyfin_mpv_shim/mpvtk_browser/live_tv.py
 msgid "Live broadcasts"
 msgstr ""
 
+#. Checkbox in Guide Settings: badge first-run episodes.
 #: jellyfin_mpv_shim/mpvtk_browser/live_tv.py
 msgid "New episodes"
 msgstr ""
 
+#. Checkbox in Guide Settings: badge first showings.
 #: jellyfin_mpv_shim/mpvtk_browser/live_tv.py
 msgid "Premieres"
 msgstr ""
 
+#. Checkbox in Guide Settings: badge episodes shown before.
 #: jellyfin_mpv_shim/mpvtk_browser/live_tv.py
 msgid "Repeat episodes"
 msgstr ""
 
+#. Checkbox in Guide Settings, colour coding film programmes. Also a
+#. Jellyfin library kind.
 #: jellyfin_mpv_shim/mpvtk_browser/live_tv.py
 #: jellyfin_mpv_shim/mpvtk_browser/pages/search.py
 #: jellyfin_mpv_shim/mpvtk_browser/repository.py
 msgid "Movies"
 msgstr ""
 
+#. Checkbox in Guide Settings, colour coding sports programmes.
 #: jellyfin_mpv_shim/mpvtk_browser/live_tv.py
 msgid "Sports"
 msgstr ""
 
+#. Checkbox in Guide Settings, colour coding children's programmes.
 #: jellyfin_mpv_shim/mpvtk_browser/live_tv.py
 msgid "Kids"
 msgstr ""
 
+#. Checkbox in Guide Settings, colour coding news programmes.
 #: jellyfin_mpv_shim/mpvtk_browser/live_tv.py
 msgid "News"
 msgstr ""
 
+#. Badge on a Live TV guide cell: the programme is going out as it happens
+#. rather than from a recording. Kept short; the cell is narrow.
 #: jellyfin_mpv_shim/mpvtk_browser/live_tv.py
 #: jellyfin_mpv_shim/mpvtk_browser/pages/livetv.py
 msgid "Live"
 msgstr ""
 
+#. Badge on a Live TV guide cell: the first showing of this programme. Kept
+#. short; the cell is narrow.
 #: jellyfin_mpv_shim/mpvtk_browser/live_tv.py
 #: jellyfin_mpv_shim/mpvtk_browser/pages/livetv.py
 msgid "Premiere"
 msgstr ""
 
+#. Badge on a Live TV guide cell: a first-run episode rather than a repeat.
+#. Kept short; the cell is narrow.
 #: jellyfin_mpv_shim/mpvtk_browser/live_tv.py
 msgid "New"
 msgstr ""
 
+#. One English word, two senses. A badge on a Live TV guide cell marking an
+#. episode shown before, where it is an adjective; and the tooltip of the
+#. loop button on the now-playing bar, where it is a verb. Both must stay
+#. short.
 #: jellyfin_mpv_shim/mpvtk_browser/live_tv.py
 #: jellyfin_mpv_shim/mpvtk_browser/music.py
 #: jellyfin_mpv_shim/mpvtk_browser/pages/livetv.py
 msgid "Repeat"
 msgstr ""
 
+#. Heading over recordings whose air date is unknown, in a list otherwise
+#. grouped by day.
 #: jellyfin_mpv_shim/mpvtk_browser/live_tv.py
 msgid "Scheduled"
 msgstr ""
 
+#. Error shown when an item took too long to start playing.
 #: jellyfin_mpv_shim/mpvtk_browser/load_feedback.py
 msgid "Timed out loading this item"
 msgstr ""
 
+#. Error shown when an item would not start playing.
 #: jellyfin_mpv_shim/mpvtk_browser/load_feedback.py
 msgid "Could not play this item"
 msgstr ""
 
+#. Button on the playback error screen that tries again while asking the
+#. server to re-encode the video. An imperative verb phrase.
 #: jellyfin_mpv_shim/mpvtk_browser/load_feedback.py
 msgid "Retry with Transcode"
 msgstr ""
 
+#. State of the repeat button on the now-playing bar: play the whole queue
+#. again when it ends.
 #: jellyfin_mpv_shim/mpvtk_browser/music.py
 msgid "Repeat all"
 msgstr ""
 
+#. State of the repeat button on the now-playing bar: play the current
+#. track over and over.
 #: jellyfin_mpv_shim/mpvtk_browser/music.py
 msgid "Repeat one"
 msgstr ""
 
+#. State of the repeat button on the now-playing bar: stop when the queue
+#. ends.
 #: jellyfin_mpv_shim/mpvtk_browser/music.py
 msgid "Repeat off"
 msgstr ""
 
+#. Tooltip of the rewind button on the now-playing bar. %d is how many
+#. seconds it jumps.
 #: jellyfin_mpv_shim/mpvtk_browser/music.py
 #, python-format
 msgid "Back %d seconds"
 msgstr ""
 
+#. Action on an item's menu that starts it. An imperative verb, and it must
+#. not read the same as "Played": in one language it did, and a filter row
+#. came out saying "Not played / Play".
 #: jellyfin_mpv_shim/mpvtk_browser/music.py
 #: jellyfin_mpv_shim/mpvtk_browser/pages/books.py
 #: jellyfin_mpv_shim/mpvtk_browser/pages/detail.py
@@ -3359,243 +4869,342 @@ msgstr ""
 msgid "Play"
 msgstr ""
 
+#. Tooltip of the button on the now-playing bar that halts playback. An
+#. imperative verb.
 #: jellyfin_mpv_shim/mpvtk_browser/music.py
 msgid "Pause"
 msgstr ""
 
+#. Tooltip of the fast-forward button on the now-playing bar. %d is how
+#. many seconds it jumps.
 #: jellyfin_mpv_shim/mpvtk_browser/music.py
 #, python-format
 msgid "Forward %d seconds"
 msgstr ""
 
+#. Tooltip of the button on the now-playing bar that ends playback. An
+#. imperative verb.
 #: jellyfin_mpv_shim/mpvtk_browser/music.py
 msgid "Stop"
 msgstr ""
 
+#. Button that unmarks an item, channel or track as a favourite. An
+#. imperative verb phrase.
 #: jellyfin_mpv_shim/mpvtk_browser/music.py
 #: jellyfin_mpv_shim/mpvtk_browser/pages/livetv.py
 #: jellyfin_mpv_shim/mpvtk_browser/tiles.py
 msgid "Remove from favorites"
 msgstr ""
 
+#. Button that marks an item, channel or track as a favourite. An
+#. imperative verb phrase.
 #: jellyfin_mpv_shim/mpvtk_browser/music.py
 #: jellyfin_mpv_shim/mpvtk_browser/pages/livetv.py
 #: jellyfin_mpv_shim/mpvtk_browser/tiles.py
 msgid "Add to favorites"
 msgstr ""
 
+#. Tooltip of the loudness slider on the now-playing bar.
 #: jellyfin_mpv_shim/mpvtk_browser/music.py
 msgid "Volume"
 msgstr ""
 
+#. Status message when a web address could not be handed to the system's
+#. browser.
 #: jellyfin_mpv_shim/mpvtk_browser/pages/base.py
 msgid "Could not open that link."
 msgstr ""
 
+#. Caption under an audiobook's title, counting its chapters.
 #: jellyfin_mpv_shim/mpvtk_browser/pages/books.py
 #, python-format
 msgid "%d chapters"
 msgstr ""
 
+#. Action on an item's menu that carries on from where watching stopped. An
+#. imperative verb.
 #: jellyfin_mpv_shim/mpvtk_browser/pages/books.py
 #: jellyfin_mpv_shim/mpvtk_browser/pages/detail.py
 #: jellyfin_mpv_shim/mpvtk_browser/tiles.py
 msgid "Resume"
 msgstr ""
 
+#. Button on a book or audiobook's page that starts it from the beginning
+#. rather than resuming. An imperative verb; it restarts the book, not the
+#. application.
 #: jellyfin_mpv_shim/mpvtk_browser/pages/books.py
 msgid "Restart"
 msgstr ""
 
+#. Action on an item's menu that puts it at the end of the list of things
+#. queued to play. An imperative verb phrase.
 #: jellyfin_mpv_shim/mpvtk_browser/pages/books.py
 #: jellyfin_mpv_shim/mpvtk_browser/pages/music.py
 #: jellyfin_mpv_shim/mpvtk_browser/tiles.py
 msgid "Add to play queue"
 msgstr ""
 
+#. Button on a book or audiobook's page that marks it as read or listened
+#. to, drawn ticked when it already is. It replaces "Watched", which is
+#. wrong for something you read or listen to.
 #: jellyfin_mpv_shim/mpvtk_browser/pages/books.py
 msgid "Finished"
 msgstr ""
 
+#. Shown in place of a page's content when the item could not be fetched
+#. from the server.
 #: jellyfin_mpv_shim/mpvtk_browser/pages/books.py
 #: jellyfin_mpv_shim/mpvtk_browser/pages/detail.py
 msgid "Item not available."
 msgstr ""
 
+#. Caption on an audiobook's page saying how far in the listener has got,
+#. as in "1h 12m in". %s is an already-formatted duration.
 #: jellyfin_mpv_shim/mpvtk_browser/pages/books.py
 #, python-format
 msgid "%s in"
 msgstr ""
 
+#. Column heading in an audiobook's chapter table: the time each chapter
+#. begins at.
 #: jellyfin_mpv_shim/mpvtk_browser/pages/books.py
 msgid "Start"
 msgstr ""
 
+#. Caption under a book's title, counting its pages.
 #: jellyfin_mpv_shim/mpvtk_browser/pages/books.py
 #, python-format
 msgid "%d pages"
 msgstr ""
 
+#. Action on a book's menu that opens it in the reader. An imperative verb.
+#. It carries a context because the English word is also the past tense
+#. used for a book already finished.
 #: jellyfin_mpv_shim/mpvtk_browser/pages/books.py
 #: jellyfin_mpv_shim/mpvtk_browser/tiles.py
 msgctxt "open a book"
 msgid "Read"
 msgstr ""
 
+#. Button on a book's page that hands the file to whatever application the
+#. system opens it with. An imperative verb phrase.
 #: jellyfin_mpv_shim/mpvtk_browser/pages/books.py
 msgid "Open Externally"
 msgstr ""
 
+#. Shown on a book's page while the file is being fetched to this device.
 #: jellyfin_mpv_shim/mpvtk_browser/pages/books.py
 msgid "Downloading…"
 msgstr ""
 
+#. Shown on a book's page while the stored reading position is being
+#. fetched from the server.
 #: jellyfin_mpv_shim/mpvtk_browser/pages/books.py
 msgid "Progress…"
 msgstr ""
 
+#. Shown in place of a grid or list that has no items in it.
 #: jellyfin_mpv_shim/mpvtk_browser/pages/byname.py
 #: jellyfin_mpv_shim/mpvtk_browser/tile_renderer.py
 msgid "Nothing here."
 msgstr ""
 
+#. Error shown when a comic file would not open.
 #: jellyfin_mpv_shim/mpvtk_browser/pages/comic.py
 msgid "This comic could not be opened."
 msgstr ""
 
+#. Error shown when one page of a comic could not be decoded.
 #: jellyfin_mpv_shim/mpvtk_browser/pages/comic.py
 msgid "This page could not be read."
 msgstr ""
 
+#. Error shown when fetching a book or comic to this device did not finish.
 #: jellyfin_mpv_shim/mpvtk_browser/pages/comic.py
 #: jellyfin_mpv_shim/mpvtk_browser/pages/reader.py
 msgid "The download failed."
 msgstr ""
 
+#. Shown while a comic file is being fetched to this device.
 #: jellyfin_mpv_shim/mpvtk_browser/pages/comic.py
 msgid "Getting the comic…"
 msgstr ""
 
+#. Tooltip of the comic reader's button that makes the page smaller. An
+#. imperative verb phrase.
 #: jellyfin_mpv_shim/mpvtk_browser/pages/comic.py
 msgid "Zoom out"
 msgstr ""
 
+#. Tooltip of the comic reader's button that makes the page larger. An
+#. imperative verb phrase.
 #: jellyfin_mpv_shim/mpvtk_browser/pages/comic.py
 msgid "Zoom in"
 msgstr ""
 
+#. Heading of the row of items similar to the one being viewed. Jellyfin
+#. Web uses the same phrase.
 #: jellyfin_mpv_shim/mpvtk_browser/pages/detail.py
 #: jellyfin_mpv_shim/mpvtk_browser/pages/series.py
 msgid "More Like This"
 msgstr ""
 
+#. Action on an episode's menu that opens the page of the series it belongs
+#. to. An imperative verb phrase.
 #: jellyfin_mpv_shim/mpvtk_browser/pages/detail.py
 #: jellyfin_mpv_shim/mpvtk_browser/tiles.py
 msgid "Go to Series"
 msgstr ""
 
+#. Button on an item's page that plays its trailer.
 #: jellyfin_mpv_shim/mpvtk_browser/pages/detail.py
 #: jellyfin_mpv_shim/mpvtk_browser/pages/series.py
 msgid "Trailer"
 msgstr ""
 
+#. Heading over an item's chapter thumbnails on its page. Jellyfin Web uses
+#. the same word.
 #: jellyfin_mpv_shim/mpvtk_browser/pages/detail.py
 msgid "Scenes"
 msgstr ""
 
+#. Stands in for the name of a media version the server did not name. A
+#. version is one of several files for the same item, such as a 4K and a
+#. 1080p copy.
 #: jellyfin_mpv_shim/mpvtk_browser/pages/detail.py
 #, python-format
 msgid "Version %d"
 msgstr ""
 
+#. Label of the dropdown on an item's page choosing between several files
+#. of the same item, such as a 4K and a 1080p copy.
 #: jellyfin_mpv_shim/mpvtk_browser/pages/detail.py
 msgid "Version"
 msgstr ""
 
+#. Prefix on an unnamed subtitle track in the subtitle dropdown on an
+#. item's page. Deliberately clipped, because it sits inside a narrow list.
 #: jellyfin_mpv_shim/mpvtk_browser/pages/detail.py
 msgid "Sub"
 msgstr ""
 
+#. Caption on an item's page: the clock time it would finish at if started
+#. now. %s is a time of day, already formatted.
 #: jellyfin_mpv_shim/mpvtk_browser/pages/detail.py
 #, python-format
 msgid "Ends at %s"
 msgstr ""
 
+#. Shown on the Favorites page when nothing has been marked.
 #: jellyfin_mpv_shim/mpvtk_browser/pages/favorites.py
 msgid "Nothing is marked as a favourite yet."
 msgstr ""
 
+#. Shown on the Genres page when the server listed none.
 #: jellyfin_mpv_shim/mpvtk_browser/pages/genres.py
 msgid "No genres to show for this library."
 msgstr ""
 
+#. Two uses. A choice in a library's Sort dropdown, ordering items
+#. alphabetically by title; and the first column heading in a library shown
+#. as a list.
 #: jellyfin_mpv_shim/mpvtk_browser/pages/grid.py
 #: jellyfin_mpv_shim/mpvtk_browser/tile_renderer.py
 msgid "Name"
 msgstr ""
 
+#. Choice in a library's Sort dropdown: order items by when they arrived on
+#. the server.
 #: jellyfin_mpv_shim/mpvtk_browser/pages/grid.py
 msgid "Date Added"
 msgstr ""
 
+#. Choice in a library's Sort dropdown: order items by when they were
+#. originally released.
 #: jellyfin_mpv_shim/mpvtk_browser/pages/grid.py
 msgid "Release Date"
 msgstr ""
 
+#. Choice in a library's Sort dropdown: order items by the score viewers at
+#. large have given them.
 #: jellyfin_mpv_shim/mpvtk_browser/pages/grid.py
 msgid "Community Rating"
 msgstr ""
 
+#. Choice in a library's Sort dropdown: order items by when they were last
+#. watched.
 #: jellyfin_mpv_shim/mpvtk_browser/pages/grid.py
 msgid "Date Played"
 msgstr ""
 
+#. Choice in a library's Sort dropdown: order items by how many times they
+#. have been watched.
 #: jellyfin_mpv_shim/mpvtk_browser/pages/grid.py
 msgid "Play Count"
 msgstr ""
 
+#. Choice in a library's Sort dropdown: order items by how long they run.
 #: jellyfin_mpv_shim/mpvtk_browser/pages/grid.py
 msgid "Runtime"
 msgstr ""
 
+#. Choice in a library's Sort dropdown: order items by the score
+#. professional reviewers have given them.
 #: jellyfin_mpv_shim/mpvtk_browser/pages/grid.py
 msgid "Critics Rating"
 msgstr ""
 
+#. Choice in a library's Sort dropdown: order items unpredictably.
 #: jellyfin_mpv_shim/mpvtk_browser/pages/grid.py
 msgid "Random"
 msgstr ""
 
+#. Choice in a television library's Sort dropdown: order series by when
+#. their newest episode arrived.
 #: jellyfin_mpv_shim/mpvtk_browser/pages/grid.py
 msgid "Date Episode Added"
 msgstr ""
 
+#. Button above a library grid that opens the View settings modal. A noun:
+#. how this library is displayed.
 #: jellyfin_mpv_shim/mpvtk_browser/pages/grid.py
 msgid "View"
 msgstr ""
 
+#. Button above a library grid, and the title of the page it opens, listing
+#. the broadcasters that made the items.
 #: jellyfin_mpv_shim/mpvtk_browser/pages/grid.py
 msgid "Networks"
 msgstr ""
 
+#. Button above a library grid, and the title of the page it opens, listing
+#. groups of related items.
 #: jellyfin_mpv_shim/mpvtk_browser/pages/grid.py
 msgid "Collections"
 msgstr ""
 
+#. Button above a library grid that opens the filter panel, when filters
+#. are set. %d is how many are set.
 #: jellyfin_mpv_shim/mpvtk_browser/pages/grid.py
 #, python-format
 msgid "Filter (%d)"
 msgstr ""
 
+#. Button above a library grid that opens the filter panel, when no filters
+#. are set. A verb.
 #: jellyfin_mpv_shim/mpvtk_browser/pages/grid.py
 msgid "Filter"
 msgstr ""
 
+#. Button above a library grid that queues every item and starts playing.
+#. An imperative verb phrase.
 #: jellyfin_mpv_shim/mpvtk_browser/pages/grid.py
 #: jellyfin_mpv_shim/mpvtk_browser/pages/playlist.py
 msgid "Play All"
 msgstr ""
 
+#. Button above a library grid that queues every item in a random order and
+#. starts playing. An imperative verb.
 #: jellyfin_mpv_shim/mpvtk_browser/pages/grid.py
 #: jellyfin_mpv_shim/mpvtk_browser/pages/music.py
 #: jellyfin_mpv_shim/mpvtk_browser/pages/playlist.py
@@ -3603,179 +5212,252 @@ msgstr ""
 msgid "Shuffle"
 msgstr ""
 
+#. Label beside the dropdown that orders a library grid. A verb.
 #: jellyfin_mpv_shim/mpvtk_browser/pages/grid.py
 msgid "Sort"
 msgstr ""
 
+#. Status message when a change made in the View settings modal did not
+#. reach the server.
 #: jellyfin_mpv_shim/mpvtk_browser/pages/grid.py
 msgid "That view setting could not be saved."
 msgstr ""
 
+#. Status message when Play was chosen on something the app found no
+#. playable item inside.
 #: jellyfin_mpv_shim/mpvtk_browser/pages/grid.py
 #: jellyfin_mpv_shim/mpvtk_browser/tiles.py
 msgid "There is nothing here to play."
 msgstr ""
 
+#. Heading of the home-screen row holding the viewer's libraries.
 #: jellyfin_mpv_shim/mpvtk_browser/pages/home.py
 msgid "Libraries"
 msgstr ""
 
+#. Shown on the home screen when the server returned nothing to list.
 #: jellyfin_mpv_shim/mpvtk_browser/pages/home.py
 msgid "Nothing to show yet."
 msgstr ""
 
+#. Name of a tab on the Live TV page, listing what is on now and coming up.
+#. American spelling of "programmes"; these are television shows, not
+#. computer programs.
 #: jellyfin_mpv_shim/mpvtk_browser/pages/livetv.py
 msgid "Programs"
 msgstr ""
 
+#. Name of a tab on the Live TV page, showing the grid of channels against
+#. time. A television listings grid.
 #: jellyfin_mpv_shim/mpvtk_browser/pages/livetv.py
 msgid "Guide"
 msgstr ""
 
+#. Name of a tab on the Live TV page, listing the channels available. A
+#. plural noun. Two other uses of this English word carry contexts: a form
+#. label in the recording dialog, and the audio channel count.
 #: jellyfin_mpv_shim/mpvtk_browser/pages/livetv.py
 #: jellyfin_mpv_shim/mpvtk_browser/pages/search.py
 msgid "Channels"
 msgstr ""
 
+#. Name of a tab on the Live TV page, listing what has already been
+#. recorded.
 #: jellyfin_mpv_shim/mpvtk_browser/pages/livetv.py
 msgid "Recordings"
 msgstr ""
 
+#. Name of a tab on the Live TV page, listing what is set to record in
+#. future. A noun.
 #: jellyfin_mpv_shim/mpvtk_browser/pages/livetv.py
 msgid "Schedule"
 msgstr ""
 
+#. Name of a tab on the Live TV page, listing the shows set to record every
+#. episode of. A television series.
 #: jellyfin_mpv_shim/mpvtk_browser/pages/livetv.py
 #: jellyfin_mpv_shim/mpvtk_browser/repository.py
 msgid "Series"
 msgstr ""
 
+#. Shown on the Live TV Programs tab when the server returned no listings.
 #: jellyfin_mpv_shim/mpvtk_browser/pages/livetv.py
 msgid "No programs are listed right now."
 msgstr ""
 
+#. Tooltip of the button that moves the Live TV guide back one day.
 #: jellyfin_mpv_shim/mpvtk_browser/pages/livetv.py
 msgid "Previous Day"
 msgstr ""
 
+#. Tooltip of the button that scrolls the Live TV guide back a few hours.
 #: jellyfin_mpv_shim/mpvtk_browser/pages/livetv.py
 msgid "Earlier"
 msgstr ""
 
+#. One English word, two senses. A button on the Live TV guide that scrolls
+#. forward a few hours; and a button on the update banner that puts the
+#. notice off for now. A third use, on the restart banner, carries a
+#. context of its own.
 #: jellyfin_mpv_shim/mpvtk_browser/pages/livetv.py
 #: jellyfin_mpv_shim/mpvtk_browser/window_chrome.py
 msgid "Later"
 msgstr ""
 
+#. Tooltip of the button that moves the Live TV guide forward one day.
 #: jellyfin_mpv_shim/mpvtk_browser/pages/livetv.py
 msgid "Next Day"
 msgstr ""
 
+#. Button that jumps the Live TV guide back to the current time. An adverb.
 #: jellyfin_mpv_shim/mpvtk_browser/pages/livetv.py
 msgid "Now"
 msgstr ""
 
+#. Caption above the Live TV guide, saying which slice of the channel list
+#. is on screen, as in "Channels 1-12 of 240".
 #: jellyfin_mpv_shim/mpvtk_browser/pages/livetv.py
 #, python-format
 msgid "Channels %(from)d-%(to)d of %(total)d"
 msgstr ""
 
+#. Tooltip of the button that shows the previous group of channels in the
+#. Live TV guide.
 #: jellyfin_mpv_shim/mpvtk_browser/pages/livetv.py
 msgid "Previous Channels"
 msgstr ""
 
+#. Tooltip of the button that shows the next group of channels in the Live
+#. TV guide.
 #: jellyfin_mpv_shim/mpvtk_browser/pages/livetv.py
 msgid "More Channels"
 msgstr ""
 
+#. Shown on the Live TV Channels tab when it is filtered to favourites and
+#. none are marked.
 #: jellyfin_mpv_shim/mpvtk_browser/pages/livetv.py
 msgid "No favorite channels yet."
 msgstr ""
 
+#. Caption on the Live TV Channels tab, counting how many channels there
+#. are.
 #: jellyfin_mpv_shim/mpvtk_browser/pages/livetv.py
 #, python-format
 msgid "%d channels"
 msgstr ""
 
+#. Heading over the most recent recordings on the Live TV Recordings tab.
 #: jellyfin_mpv_shim/mpvtk_browser/pages/livetv.py
 msgid "Latest Recordings"
 msgstr ""
 
+#. Heading over the folders the server files recordings into, on the Live
+#. TV Recordings tab. A noun phrase: folders holding recordings.
 #: jellyfin_mpv_shim/mpvtk_browser/pages/livetv.py
 msgid "Recording Folders"
 msgstr ""
 
+#. Shown on the Live TV Recordings tab when there are no recordings.
 #: jellyfin_mpv_shim/mpvtk_browser/pages/livetv.py
 msgid "Nothing has been recorded yet."
 msgstr ""
 
+#. Shown on the Live TV Schedule tab when nothing is set to record.
 #: jellyfin_mpv_shim/mpvtk_browser/pages/livetv.py
 msgid "Nothing is scheduled to record."
 msgstr ""
 
+#. Shown on the Live TV Series tab when no show is set to record every
+#. episode.
 #: jellyfin_mpv_shim/mpvtk_browser/pages/livetv.py
 msgid "No series are set to record."
 msgstr ""
 
+#. State of a Live TV programme: it will be recorded when it airs.
 #: jellyfin_mpv_shim/mpvtk_browser/pages/livetv.py
 msgid "Scheduled to record"
 msgstr ""
 
+#. State of a Live TV programme: it is being recorded at this moment.
 #: jellyfin_mpv_shim/mpvtk_browser/pages/livetv.py
 msgid "Recording now"
 msgstr ""
 
+#. State of a Live TV programme: a rule is recording every episode of this
+#. show.
 #: jellyfin_mpv_shim/mpvtk_browser/pages/livetv.py
 msgid "Recording this series"
 msgstr ""
 
+#. State of a Live TV programme: a rule records the show, but this
+#. particular airing falls outside it, for instance because it is a repeat.
 #: jellyfin_mpv_shim/mpvtk_browser/pages/livetv.py
 msgid "This series is set to record, but this showing is not scheduled"
 msgstr ""
 
+#. Button that starts playing a Live TV channel that is on air now. An
+#. imperative verb, and it must not read the same as "Watched": in one
+#. language it did, and the button came out saying "Seen".
 #: jellyfin_mpv_shim/mpvtk_browser/pages/livetv.py
 #: jellyfin_mpv_shim/mpvtk_browser/tiles.py
 msgid "Watch"
 msgstr ""
 
+#. Button that starts playing the channel a programme is on, when that
+#. programme is not airing now. An imperative verb.
 #: jellyfin_mpv_shim/mpvtk_browser/pages/livetv.py
 #: jellyfin_mpv_shim/mpvtk_browser/tiles.py
 msgid "Watch Channel"
 msgstr ""
 
+#. Button that ends the recording currently running for this programme. An
+#. imperative verb.
 #: jellyfin_mpv_shim/mpvtk_browser/pages/livetv.py
 #: jellyfin_mpv_shim/mpvtk_browser/tiles.py
 msgid "Stop Recording"
 msgstr ""
 
+#. Button that cancels the scheduled recording of this programme. An
+#. imperative verb phrase.
 #: jellyfin_mpv_shim/mpvtk_browser/pages/livetv.py
 #: jellyfin_mpv_shim/mpvtk_browser/tiles.py
 msgid "Do not record"
 msgstr ""
 
+#. Button on a Live TV programme page that sets it to record. An imperative
+#. verb. The series dialog's form label uses the same English word and
+#. carries a context to keep the two apart.
 #: jellyfin_mpv_shim/mpvtk_browser/pages/livetv.py
 #: jellyfin_mpv_shim/mpvtk_browser/tiles.py
 msgid "Record"
 msgstr ""
 
+#. Button that starts recording every episode of this show. An imperative
+#. verb.
 #: jellyfin_mpv_shim/mpvtk_browser/pages/livetv.py
 #: jellyfin_mpv_shim/mpvtk_browser/tiles.py
 msgid "Record series"
 msgstr ""
 
+#. Shown on a channel's page when the server has no listings for it.
 #: jellyfin_mpv_shim/mpvtk_browser/pages/livetv.py
 msgid "No guide data is available for this channel."
 msgstr ""
 
+#. Caption on a channel's page, saying how many upcoming programmes are
+#. listed. American spelling of "programmes".
 #: jellyfin_mpv_shim/mpvtk_browser/pages/livetv.py
 #, python-format
 msgid "Showing the next %d programs."
 msgstr ""
 
+#. Stands in for the name of a Live TV channel the server did not name.
 #: jellyfin_mpv_shim/mpvtk_browser/pages/livetv.py
 msgid "Channel"
 msgstr ""
 
+#. Name of a tab on the music page, and of a search-results and library
+#. group, holding music albums.
 #: jellyfin_mpv_shim/mpvtk_browser/pages/music_detail.py
 #: jellyfin_mpv_shim/mpvtk_browser/pages/music.py
 #: jellyfin_mpv_shim/mpvtk_browser/pages/search.py
@@ -3783,81 +5465,115 @@ msgstr ""
 msgid "Albums"
 msgstr ""
 
+#. Heading of the row of musicians similar to the one being viewed.
 #: jellyfin_mpv_shim/mpvtk_browser/pages/music_detail.py
 msgid "Similar Artists"
 msgstr ""
 
+#. Button that starts a queue of tracks like the one chosen. Jellyfin Web
+#. uses the same phrase; follow its wording in this language.
 #: jellyfin_mpv_shim/mpvtk_browser/pages/music.py
 msgid "Instant mix"
 msgstr ""
 
+#. Caption under an album or playlist, counting its songs.
 #: jellyfin_mpv_shim/mpvtk_browser/pages/music.py
 #, python-format
 msgid "%d tracks"
 msgstr ""
 
+#. Name of a tab on the music page, listing the artists credited on whole
+#. albums as opposed to individual tracks.
 #: jellyfin_mpv_shim/mpvtk_browser/pages/music.py
 msgid "Album artists"
 msgstr ""
 
+#. Name of a tab on the music page, and of a search-results group, holding
+#. musicians and bands.
 #: jellyfin_mpv_shim/mpvtk_browser/pages/music.py
 #: jellyfin_mpv_shim/mpvtk_browser/pages/search.py
 #: jellyfin_mpv_shim/mpvtk_browser/repository.py
 msgid "Artists"
 msgstr ""
 
+#. Name of a tab on the music page, and of a search-results and library
+#. group, holding individual music tracks.
 #: jellyfin_mpv_shim/mpvtk_browser/pages/music.py
 #: jellyfin_mpv_shim/mpvtk_browser/pages/search.py
 #: jellyfin_mpv_shim/mpvtk_browser/repository.py
 msgid "Songs"
 msgstr ""
 
+#. Status message when music would not start playing.
 #: jellyfin_mpv_shim/mpvtk_browser/pages/music.py
 msgid "Could not start playback."
 msgstr ""
 
+#. Appended to a playlist's name in the page title, marking that the
+#. playlist is open for editing. A verb.
 #: jellyfin_mpv_shim/mpvtk_browser/pages/playlist.py
 #: jellyfin_mpv_shim/mpvtk_browser/pages/queue_edit.py
 msgid "Edit"
 msgstr ""
 
+#. Shown on a playlist's page when it has no items.
 #: jellyfin_mpv_shim/mpvtk_browser/pages/playlist.py
 msgid "This playlist is empty."
 msgstr ""
 
+#. Shown on a playlist's page when everything in it is of a kind this
+#. application cannot play.
 #: jellyfin_mpv_shim/mpvtk_browser/pages/playlist.py
 msgid "This playlist has no supported media types."
 msgstr ""
 
+#. Title of the page listing what is queued to play, and the name given to
+#. that queue when it is saved as a playlist.
 #: jellyfin_mpv_shim/mpvtk_browser/pages/queue_edit.py
 msgid "Play Queue"
 msgstr ""
 
+#. Button on the queue and playlist editors that moves the selected rows
+#. one place earlier. A direction.
 #: jellyfin_mpv_shim/mpvtk_browser/pages/queue_edit.py
 msgid "Up"
 msgstr ""
 
+#. Button on the queue and playlist editors that moves the selected rows
+#. one place later. A direction.
 #: jellyfin_mpv_shim/mpvtk_browser/pages/queue_edit.py
 msgid "Down"
 msgstr ""
 
+#. Caption on the queue and playlist editors, counting how many rows are
+#. ticked.
 #: jellyfin_mpv_shim/mpvtk_browser/pages/queue_edit.py
 #, python-format
 msgid "%d selected"
 msgstr ""
 
+#. Button on the queue and playlist editors that ticks every row. An
+#. imperative verb phrase.
 #: jellyfin_mpv_shim/mpvtk_browser/pages/queue_edit.py
 msgid "Select All"
 msgstr ""
 
+#. Button on the queue and playlist editors that unticks every row. An
+#. imperative verb; it deselects rather than deletes.
 #: jellyfin_mpv_shim/mpvtk_browser/pages/queue_edit.py
 msgid "Clear"
 msgstr ""
 
+#. Button on the queue editor that saves the queue as a playlist on the
+#. server.
 #: jellyfin_mpv_shim/mpvtk_browser/pages/queue_edit.py
 msgid "To Playlist"
 msgstr ""
 
+#. Button that takes something out of a list without deleting the thing
+#. itself: rows out of the queue or a playlist, an item out of a
+#. collection, a server out of the saved list, a download off this device.
+#. An imperative verb.
 #: jellyfin_mpv_shim/mpvtk_browser/pages/queue_edit.py
 #: jellyfin_mpv_shim/mpvtk_browser/settings/downloads.py
 #: jellyfin_mpv_shim/mpvtk_browser/settings/servers.py
@@ -3865,284 +5581,391 @@ msgstr ""
 msgid "Remove"
 msgstr ""
 
+#. Shown on the queue editor when nothing is queued.
 #: jellyfin_mpv_shim/mpvtk_browser/pages/queue_edit.py
 msgid "The queue is empty."
 msgstr ""
 
+#. Status message when taking rows out of the queue or a playlist failed.
 #: jellyfin_mpv_shim/mpvtk_browser/pages/queue_edit.py
 msgid "Those items could not be removed."
 msgstr ""
 
+#. Status message when moving rows in the queue failed.
 #: jellyfin_mpv_shim/mpvtk_browser/pages/queue_edit.py
 msgid "The queue could not be reordered."
 msgstr ""
 
+#. Button that changes a name: a local profile in Settings, or a playlist
+#. on its edit page. An imperative verb.
 #: jellyfin_mpv_shim/mpvtk_browser/pages/queue_edit.py
 #: jellyfin_mpv_shim/mpvtk_browser/settings/servers.py
 msgid "Rename"
 msgstr ""
 
+#. Checkbox on the playlist editor. When on, other users of the server can
+#. see this playlist.
 #: jellyfin_mpv_shim/mpvtk_browser/pages/queue_edit.py
 msgid "Public"
 msgstr ""
 
+#. Button on the playlist editor, and the title of the dialog it opens,
+#. removing the playlist from the server.
 #: jellyfin_mpv_shim/mpvtk_browser/pages/queue_edit.py
 msgid "Delete Playlist"
 msgstr ""
 
+#. Question in the dialog that removes a playlist from the server. %s is
+#. the playlist's name.
 #: jellyfin_mpv_shim/mpvtk_browser/pages/queue_edit.py
 #, python-format
 msgid "Delete the playlist %s?"
 msgstr ""
 
+#. Column heading on the queue and playlist editors: what kind of item the
+#. row is, such as Episode or Song.
 #: jellyfin_mpv_shim/mpvtk_browser/pages/queue_edit.py
 msgid "Type"
 msgstr ""
 
+#. Column heading giving how long an item runs: in the queue and playlist
+#. editors, and in a music track table.
 #: jellyfin_mpv_shim/mpvtk_browser/pages/queue_edit.py
 #: jellyfin_mpv_shim/mpvtk_browser/tile_renderer.py
 msgid "Time"
 msgstr ""
 
+#. Status message when moving rows in a playlist failed.
 #: jellyfin_mpv_shim/mpvtk_browser/pages/queue_edit.py
 msgid "The playlist could not be reordered."
 msgstr ""
 
+#. Status message when removing a playlist from the server failed.
 #: jellyfin_mpv_shim/mpvtk_browser/pages/queue_edit.py
 msgid "The playlist could not be deleted."
 msgstr ""
 
+#. Message shown when the Public checkbox is used before the server has
+#. said whether the playlist is public.
 #: jellyfin_mpv_shim/mpvtk_browser/pages/queue_edit.py
 msgid ""
 "Still reading this playlist's visibility from the server. Try again in a "
 "moment."
 msgstr ""
 
+#. Error shown when a book file would not open.
 #: jellyfin_mpv_shim/mpvtk_browser/pages/reader.py
 msgid "This book could not be opened."
 msgstr ""
 
+#. Entry on the book reader's context menu that puts the paragraph under
+#. the pointer on the clipboard. An imperative verb phrase.
 #: jellyfin_mpv_shim/mpvtk_browser/pages/reader.py
 msgid "Copy Paragraph"
 msgstr ""
 
+#. Entry on the book reader's context menu that puts the whole page on the
+#. clipboard. An imperative verb phrase.
 #: jellyfin_mpv_shim/mpvtk_browser/pages/reader.py
 msgid "Copy Page"
 msgstr ""
 
+#. Status message confirming a paragraph reached the clipboard.
 #: jellyfin_mpv_shim/mpvtk_browser/pages/reader.py
 msgid "Copied the paragraph."
 msgstr ""
 
+#. Status message confirming a page reached the clipboard.
 #: jellyfin_mpv_shim/mpvtk_browser/pages/reader.py
 msgid "Copied the page."
 msgstr ""
 
+#. Status message when Copy was pressed with no text under the cursor.
 #: jellyfin_mpv_shim/mpvtk_browser/pages/reader.py
 msgid "There is nothing to copy."
 msgstr ""
 
+#. Status message when this build of MPV cannot reach the system clipboard.
 #: jellyfin_mpv_shim/mpvtk_browser/pages/reader.py
 msgid "Copying is not available."
 msgstr ""
 
+#. Status message when text could not be put on the clipboard.
 #: jellyfin_mpv_shim/mpvtk_browser/pages/reader.py
 #: jellyfin_mpv_shim/mpvtk_browser/settings/logs.py
 msgid "Could not copy"
 msgstr ""
 
+#. Status message when the clipboard could not be reached, so the text was
+#. written to a file instead. %s is that file's path.
 #: jellyfin_mpv_shim/mpvtk_browser/pages/reader.py
 #: jellyfin_mpv_shim/mpvtk_browser/settings/logs.py
 #, python-format
 msgid "No clipboard available — saved to %s"
 msgstr ""
 
+#. Tooltip of the book reader's dropdown listing the chapters. A noun: the
+#. table of contents.
 #: jellyfin_mpv_shim/mpvtk_browser/pages/reader.py
 msgid "Contents"
 msgstr ""
 
+#. Shown while a book file is being fetched to this device.
 #: jellyfin_mpv_shim/mpvtk_browser/pages/reader.py
 msgid "Getting the book…"
 msgstr ""
 
+#. Error shown when a book was fetched but its pages could not be laid out.
 #: jellyfin_mpv_shim/mpvtk_browser/pages/reader.py
 msgid "This book could not be drawn."
 msgstr ""
 
+#. Tooltip of the book reader's button that shrinks the type.
 #: jellyfin_mpv_shim/mpvtk_browser/pages/reader.py
 msgid "Smaller text"
 msgstr ""
 
+#. Tooltip of the book reader's button that enlarges the type.
 #: jellyfin_mpv_shim/mpvtk_browser/pages/reader.py
 msgid "Larger text"
 msgstr ""
 
+#. Tooltip of the book reader's button that switches between the dark,
+#. sepia and light page backgrounds. British spelling here; the settings
+#. row of the same meaning is spelled the same way.
 #: jellyfin_mpv_shim/mpvtk_browser/pages/reader.py
 msgid "Page colour"
 msgstr ""
 
+#. Shown on the search page before anything has been typed.
 #: jellyfin_mpv_shim/mpvtk_browser/pages/search.py
 msgid "Type in the search box above."
 msgstr ""
 
+#. Heading of the search page. %s is what was typed.
 #: jellyfin_mpv_shim/mpvtk_browser/pages/search.py
 #, python-format
 msgid "Results for \"%s\""
 msgstr ""
 
+#. Name of a search-results and library group holding television series.
+#. Plural noun.
 #: jellyfin_mpv_shim/mpvtk_browser/pages/search.py
 #: jellyfin_mpv_shim/mpvtk_browser/repository.py
 msgid "Shows"
 msgstr ""
 
+#. Name of a search-results and library group holding standalone videos
+#. that are not films or episodes.
 #: jellyfin_mpv_shim/mpvtk_browser/pages/search.py
 #: jellyfin_mpv_shim/mpvtk_browser/repository.py
 msgid "Videos"
 msgstr ""
 
+#. Heading of the search-results row holding actors and film-makers.
 #: jellyfin_mpv_shim/mpvtk_browser/pages/search.py
 msgid "People"
 msgstr ""
 
+#. Heading of the search-results row holding Live TV programmes. Short,
+#. because it labels a row of narrow tiles.
 #: jellyfin_mpv_shim/mpvtk_browser/pages/search.py
 msgid "On TV"
 msgstr ""
 
+#. Heading of the search-results row holding matches that fit none of the
+#. rows above it.
 #: jellyfin_mpv_shim/mpvtk_browser/pages/search.py
 msgid "Other"
 msgstr ""
 
+#. Shown on the search page when nothing matched.
 #: jellyfin_mpv_shim/mpvtk_browser/pages/search.py
 msgid "No results found."
 msgstr ""
 
+#. Button on a season's page that opens the page of the series it belongs
+#. to.
 #: jellyfin_mpv_shim/mpvtk_browser/pages/season.py
 msgid "To Series"
 msgstr ""
 
+#. Heading over a series' seasons on its page. Do not confuse with
+#. "Reasons": an earlier translation sweep put a translation of this word
+#. there.
 #: jellyfin_mpv_shim/mpvtk_browser/pages/series.py
 msgid "Seasons"
 msgstr ""
 
+#. Status message when fetching the next batch of a long list failed.
 #: jellyfin_mpv_shim/mpvtk_browser/pagination.py
 msgid "Could not load more items."
 msgstr ""
 
+#. Status message when fetching one page of a paged grid failed.
 #: jellyfin_mpv_shim/mpvtk_browser/pagination.py
 msgid "Could not load this page."
 msgstr ""
 
+#. Heading of the home-screen row holding Live TV programmes airing at this
+#. moment.
 #: jellyfin_mpv_shim/mpvtk_browser/repository.py
 msgid "On Now"
 msgstr ""
 
+#. Heading of a home-screen row of newly added items. {0} is a library's
+#. name, such as "Movies" or "Anime".
 #: jellyfin_mpv_shim/mpvtk_browser/repository.py
 #, python-brace-format
 msgid "Recently Added in {0}"
 msgstr ""
 
+#. Heading of a Live TV row listing episodes airing soon.
 #: jellyfin_mpv_shim/mpvtk_browser/repository.py
 msgid "Upcoming Episodes"
 msgstr ""
 
+#. Heading of a Live TV row listing films airing soon.
 #: jellyfin_mpv_shim/mpvtk_browser/repository.py
 msgid "Upcoming Movies"
 msgstr ""
 
+#. Heading of a Live TV row listing sports airing soon.
 #: jellyfin_mpv_shim/mpvtk_browser/repository.py
 msgid "Upcoming Sports"
 msgstr ""
 
+#. Heading of a Live TV row listing children's programmes airing soon.
 #: jellyfin_mpv_shim/mpvtk_browser/repository.py
 msgid "Upcoming Kids"
 msgstr ""
 
+#. Heading of a Live TV row listing news programmes airing soon.
 #: jellyfin_mpv_shim/mpvtk_browser/repository.py
 msgid "Upcoming News"
 msgstr ""
 
+#. Name of a search-results group holding film trailers.
 #: jellyfin_mpv_shim/mpvtk_browser/repository.py
 msgid "Trailers"
 msgstr ""
 
+#. Name given to the stand-in server that holds what is on this device,
+#. shown in the server picker when browsing offline.
 #: jellyfin_mpv_shim/mpvtk_browser/repository.py
 msgid "Downloaded"
 msgstr ""
 
+#. Name of the offline library holding downloaded television series.
 #: jellyfin_mpv_shim/mpvtk_browser/repository.py
 msgid "TV Shows"
 msgstr ""
 
+#. Name of the offline library holding downloaded playlists.
 #: jellyfin_mpv_shim/mpvtk_browser/repository.py
 msgid "Playlists"
 msgstr ""
 
+#. Heading of the offline home-screen row listing films on this device.
 #: jellyfin_mpv_shim/mpvtk_browser/repository.py
 msgid "Downloaded Movies"
 msgstr ""
 
+#. Heading of the offline home-screen row listing standalone videos on this
+#. device.
 #: jellyfin_mpv_shim/mpvtk_browser/repository.py
 msgid "Downloaded Videos"
 msgstr ""
 
+#. Heading of the offline home-screen row listing television series on this
+#. device.
 #: jellyfin_mpv_shim/mpvtk_browser/repository.py
 msgid "Downloaded Shows"
 msgstr ""
 
+#. Heading of the offline home-screen row listing books on this device.
 #: jellyfin_mpv_shim/mpvtk_browser/repository.py
 msgid "Downloaded Books"
 msgstr ""
 
+#. Stands in for the name of a season the server did not name. %d is its
+#. number.
 #: jellyfin_mpv_shim/mpvtk_browser/repository.py
 #, python-format
 msgid "Season %d"
 msgstr ""
 
+#. Status message confirming a setting was written. %s is that setting's
+#. name.
 #: jellyfin_mpv_shim/mpvtk_browser/settings/base.py
 #, python-format
 msgid "Saved: %s"
 msgstr ""
 
+#. Status message when what was typed into a settings field was not
+#. accepted. %s is that setting's name.
 #: jellyfin_mpv_shim/mpvtk_browser/settings/base.py
 #, python-format
 msgid "Invalid value: %s"
 msgstr ""
 
+#. Status message when saving one setting forced another off. Both
+#. placeholders are settings' names.
 #: jellyfin_mpv_shim/mpvtk_browser/settings/base.py
 #, python-format
 msgid "Saved: %(key)s (also turned off \"%(other)s\")"
 msgstr ""
 
+#. Shown on the Downloads page when nothing is on this device.
 #: jellyfin_mpv_shim/mpvtk_browser/settings/downloads.py
 msgid "Nothing downloaded yet."
 msgstr ""
 
+#. Button beside a downloads group that deletes the items in it already
+#. watched. An imperative verb phrase.
 #: jellyfin_mpv_shim/mpvtk_browser/settings/downloads.py
 msgid "Remove Watched"
 msgstr ""
 
+#. Marker beside a download that has been watched, in a row of small
+#. captions. Lower case, because it sits among other fragments rather than
+#. starting a sentence.
 #: jellyfin_mpv_shim/mpvtk_browser/settings/downloads.py
 msgid "watched"
 msgstr ""
 
+#. Question in the dialog that removes watched downloads. %s is the group
+#. they are in, such as a series name.
 #: jellyfin_mpv_shim/mpvtk_browser/settings/downloads.py
 #, python-format
 msgid "Delete the watched downloads in %s?"
 msgstr ""
 
+#. First entry of the interface language dropdown: follow whatever language
+#. the desktop is set to. Every other entry is a language's own name in
+#. that language and is not translated.
 #: jellyfin_mpv_shim/mpvtk_browser/settings/general.py
 msgid "Use the system language"
 msgstr ""
 
+#. Checkbox at the top of Settings that reveals the rows not sorted into a
+#. group.
 #: jellyfin_mpv_shim/mpvtk_browser/settings/general.py
 msgid "Show advanced settings"
 msgstr ""
 
+#. Button that opens the folder holding this application's configuration
+#. files, in the system's file manager. On the Settings screen, the Logs
+#. tab and the system tray menu. An imperative verb phrase.
 #: jellyfin_mpv_shim/mpvtk_browser/settings/general.py
 #: jellyfin_mpv_shim/mpvtk_browser/settings/logs.py jellyfin_mpv_shim/tray.py
 msgid "Open Config Folder"
 msgstr ""
 
+#. Explanation under the Open Config Folder button in Settings. "mpv.conf"
+#. is a filename and "hwdec" an MPV option name; leave both as they are.
+#. "Hardware Decoding" is a setting on this screen, so keep it matching
+#. that translation.
 #: jellyfin_mpv_shim/mpvtk_browser/settings/general.py
 msgid ""
 "Advanced MPV options go in mpv.conf, in this folder. MPV reads it at startup "
@@ -4151,626 +5974,888 @@ msgid ""
 "alone."
 msgstr ""
 
+#. Caption under a settings row whose change does nothing until the
+#. application is started again.
 #: jellyfin_mpv_shim/mpvtk_browser/settings/general.py
 msgid "Requires restart"
 msgstr ""
 
+#. Shown when a settings search found nothing. %s is what was typed.
 #: jellyfin_mpv_shim/mpvtk_browser/settings/general.py
 #, python-format
 msgid "No settings match \"%s\"."
 msgstr ""
 
+#. Explanation shown when a settings search found nothing. General, Browse
+#. and Playback are tab names on this screen; keep them matching those
+#. translations.
 #: jellyfin_mpv_shim/mpvtk_browser/settings/general.py
 msgid ""
 "Only the General, Browse and Playback tabs are searched. Some settings are "
 "hidden until the setting they depend on is turned on."
 msgstr ""
 
+#. Caption under settings search results. %d is how many were found.
+#. Phrased with a count after a colon on purpose, because this application
+#. has no plural handling.
 #: jellyfin_mpv_shim/mpvtk_browser/settings/general.py
 #, python-format
 msgid "Matches: %d. Pick a tab above to stop searching."
 msgstr ""
 
+#. Button beside the download folder in Settings that relocates what is
+#. already downloaded to a new folder. An imperative verb.
 #: jellyfin_mpv_shim/mpvtk_browser/settings/general.py
 msgid "Move"
 msgstr ""
 
+#. Explanation shown under "Keep Running in Background" once it is on. The
+#. backticked text is a shell command; leave it as it is.
 #: jellyfin_mpv_shim/mpvtk_browser/settings/general.py
 msgid ""
 "To stop the application, re-launch and uncheck this option or run `jellyfin-"
 "mpv-shim stop`."
 msgstr ""
 
+#. Explanation under a settings row that is switched on but cannot work.
+#. "pypresence" is a software package name; "Logs" is a tab on this
+#. Settings screen.
 #: jellyfin_mpv_shim/mpvtk_browser/settings/general.py
 msgid ""
 "Not active: the \"pypresence\" package is missing or failed to load. Install "
 "it and restart. (Details in the Logs tab.)"
 msgstr ""
 
+#. Explanation under the Hardware Decoding setting when the user's own MPV
+#. configuration decides it instead. "mpv.conf" is a filename and "hwdec"
+#. an MPV option; leave both and the %s value as they are.
 #: jellyfin_mpv_shim/mpvtk_browser/settings/general.py
 #, python-format
 msgid "Pinned by config: your mpv.conf sets hwdec=%s, which overrides this."
 msgstr ""
 
+#. Explanation under a per-server setting. %s is the server it applies to;
+#. "servers tab" is the Servers & Users tab of this Settings screen.
 #: jellyfin_mpv_shim/mpvtk_browser/settings/general.py
 #, python-format
 msgid "Applies to %s, enable other servers in servers tab."
 msgstr ""
 
+#. Question in the dialog that returns downloads to the folder this
+#. application chooses itself.
 #: jellyfin_mpv_shim/mpvtk_browser/settings/general.py
 msgid "Move the downloads back to the default folder?"
 msgstr ""
 
+#. Confirming button of the dialog that returns downloads to the folder
+#. this application chooses itself.
 #: jellyfin_mpv_shim/mpvtk_browser/settings/general.py
 msgid "Use the default folder"
 msgstr ""
 
+#. Status message while downloaded files are being relocated. %d is the
+#. percentage done; the doubled percent sign prints one.
 #: jellyfin_mpv_shim/mpvtk_browser/settings/general.py
 #, python-format
 msgid "Moving downloads… %d%%"
 msgstr ""
 
+#. Status message when relocating the download folder did not finish.
 #: jellyfin_mpv_shim/mpvtk_browser/settings/general.py
 msgid "Moving the downloads failed."
 msgstr ""
 
+#. Status message after the download folder was relocated, saying the
+#. application must be started again.
 #: jellyfin_mpv_shim/mpvtk_browser/settings/general.py
 msgid "Download folder moved. Restart to finish switching."
 msgstr ""
 
+#. Status message while downloaded files are being relocated, before any
+#. progress figure is known.
 #: jellyfin_mpv_shim/mpvtk_browser/settings/general.py
 msgid "Moving downloads…"
 msgstr ""
 
+#. Status message when a second download-folder move was asked for while
+#. one is running.
 #: jellyfin_mpv_shim/mpvtk_browser/settings/general.py
 msgid "A move is already in progress."
 msgstr ""
 
+#. Status message when offline browsing was chosen but nothing is on this
+#. device.
 #: jellyfin_mpv_shim/mpvtk_browser/settings/general.py
 msgid "Nothing downloaded to browse offline."
 msgstr ""
 
+#. Status message when no Jellyfin server answered.
 #: jellyfin_mpv_shim/mpvtk_browser/settings/general.py
 msgid "Could not reach a server."
 msgstr ""
 
+#. Name of the Settings section that chooses which rows the home screen
+#. shows.
 #: jellyfin_mpv_shim/mpvtk_browser/settings/home.py
 #: jellyfin_mpv_shim/mpvtk_browser/settings/__init__.py
 msgid "Home Screen"
 msgstr ""
 
+#. Shown in the Home Screen settings while offline, because these are
+#. stored on the server.
 #: jellyfin_mpv_shim/mpvtk_browser/settings/home.py
 msgid "Connect to a server to change the home screen sections."
 msgstr ""
 
+#. Shown in the Home Screen settings when the server would not return them.
 #: jellyfin_mpv_shim/mpvtk_browser/settings/home.py
 msgid "These settings could not be loaded from your server."
 msgstr ""
 
+#. Button that retries fetching the home screen settings from the server.
+#. An imperative verb phrase.
 #: jellyfin_mpv_shim/mpvtk_browser/settings/home.py
 msgid "Try Again"
 msgstr ""
 
+#. Explanation in the Home Screen settings. "Jellyfin Web" is the browser
+#. client's product name; leave it as-is.
 #: jellyfin_mpv_shim/mpvtk_browser/settings/home.py
 msgid "These settings are stored on your server and shared with Jellyfin Web."
 msgstr ""
 
+#. Heading in the Home Screen settings, above the list of rows the home
+#. screen shows.
 #: jellyfin_mpv_shim/mpvtk_browser/settings/home.py
 msgid "Sections"
 msgstr ""
 
+#. Explanation under the Sections heading in the Home Screen settings.
 #: jellyfin_mpv_shim/mpvtk_browser/settings/home.py
 msgid ""
 "The rows the home screen shows, in order. Sections this app cannot draw are "
 "left as your web client set them."
 msgstr ""
 
+#. Shown for a home-screen row set to something this application cannot
+#. draw. %s is that section's name as Jellyfin Web calls it.
 #: jellyfin_mpv_shim/mpvtk_browser/settings/home.py
 #, python-format
 msgid "Set to “%s” in Jellyfin Web, which this app does not display."
 msgstr ""
 
+#. Label of one home-screen row in the settings list. %d is its position,
+#. counting from one.
 #: jellyfin_mpv_shim/mpvtk_browser/settings/home.py
 #, python-format
 msgid "Section %d"
 msgstr ""
 
+#. Checkbox in the Home Screen settings. The quoted names are home-screen
+#. rows; keep them matching those translations.
 #: jellyfin_mpv_shim/mpvtk_browser/settings/home.py
 msgid "Use episode images in 'Next Up' and 'Continue Watching' sections"
 msgstr ""
 
+#. Explanation under the episode-images checkbox in the Home Screen
+#. settings.
 #: jellyfin_mpv_shim/mpvtk_browser/settings/home.py
 msgid ""
 "Off by default: the show's artwork is used instead, because an episode image "
 "can spoil the episode you have not watched yet."
 msgstr ""
 
+#. Status message when the home screen settings would not come back from
+#. the server.
 #: jellyfin_mpv_shim/mpvtk_browser/settings/home.py
 msgid "Could not load the home screen settings."
 msgstr ""
 
+#. Status message confirming the home screen settings reached the server.
 #: jellyfin_mpv_shim/mpvtk_browser/settings/home.py
 msgid "Home screen settings saved."
 msgstr ""
 
+#. Status message when the home screen settings could not be written to the
+#. server.
 #: jellyfin_mpv_shim/mpvtk_browser/settings/home.py
 msgid "Could not save the home screen settings."
 msgstr ""
 
+#. Status message confirming the order of the home screen rows reached the
+#. server.
 #: jellyfin_mpv_shim/mpvtk_browser/settings/home.py
 msgid "Home screen layout saved."
 msgstr ""
 
+#. Status message when the order of the home screen rows could not be
+#. written to the server.
 #: jellyfin_mpv_shim/mpvtk_browser/settings/home.py
 msgid "Could not save the home screen layout."
 msgstr ""
 
+#. Name of the first tab of Settings, holding what belongs to this
+#. installation rather than to browsing or watching.
 #: jellyfin_mpv_shim/mpvtk_browser/settings/__init__.py
 msgid "General"
 msgstr ""
 
+#. Name of a Settings tab, holding what governs the library browser: the
+#. theme, the grid and downloads. A verb used as a tab name.
 #: jellyfin_mpv_shim/mpvtk_browser/settings/__init__.py
 msgid "Browse"
 msgstr ""
 
+#. Name of a Settings tab, holding the Jellyfin servers and this
+#. application's local profiles.
 #: jellyfin_mpv_shim/mpvtk_browser/settings/__init__.py
 msgid "Servers & Users"
 msgstr ""
 
+#. Name of a Settings tab showing this application's diagnostic output.
 #: jellyfin_mpv_shim/mpvtk_browser/settings/__init__.py
 #: jellyfin_mpv_shim/mpvtk_browser/settings/logs.py
 msgid "Logs"
 msgstr ""
 
+#. Placeholder in the empty field that searches the settings.
 #: jellyfin_mpv_shim/mpvtk_browser/settings/__init__.py
 msgid "Search settings…"
 msgstr ""
 
+#. Button on the Logs tab that puts the log on the clipboard. An imperative
+#. verb.
 #: jellyfin_mpv_shim/mpvtk_browser/settings/logs.py
 msgid "Copy"
 msgstr ""
 
+#. Shown on the Logs tab when nothing has been logged.
 #: jellyfin_mpv_shim/mpvtk_browser/settings/logs.py
 msgid "No log output captured yet."
 msgstr ""
 
+#. Status message when Copy was pressed on an empty log.
 #: jellyfin_mpv_shim/mpvtk_browser/settings/logs.py
 msgid "There is nothing to copy yet."
 msgstr ""
 
+#. Status message confirming the log reached the clipboard. %d is how many
+#. lines.
 #: jellyfin_mpv_shim/mpvtk_browser/settings/logs.py
 #, python-format
 msgid "Copied %d log lines."
 msgstr ""
 
+#. Placeholder in the empty field where the name of a new local profile is
+#. typed, in the Users settings. These are this application's own profiles,
+#. each with its own servers, not Jellyfin accounts.
 #: jellyfin_mpv_shim/mpvtk_browser/settings/servers.py
 msgid "New user name…"
 msgstr ""
 
+#. Button in the Users settings that creates a new local profile. An
+#. imperative verb phrase.
 #: jellyfin_mpv_shim/mpvtk_browser/settings/servers.py
 msgid "Add User"
 msgstr ""
 
+#. Shown in the Servers settings when this profile has signed in to
+#. nothing.
 #: jellyfin_mpv_shim/mpvtk_browser/settings/servers.py
 msgid "No servers configured yet."
 msgstr ""
 
+#. Heading of the Users section of Settings, listing this application's
+#. local profiles.
 #: jellyfin_mpv_shim/mpvtk_browser/settings/servers.py
 msgid "Users"
 msgstr ""
 
+#. Subtitle under the Users heading in Settings. These are this
+#. application's own local profiles, not Jellyfin accounts, and a locked
+#. one asks for its numeric passcode before it will open.
 #: jellyfin_mpv_shim/mpvtk_browser/settings/servers.py
 msgid ""
 "Each user has its own servers and device identity; a locked user needs a PIN "
 "to switch to."
 msgstr ""
 
+#. Heading of the Servers section of Settings. %s is the name of the local
+#. profile whose servers are listed.
 #: jellyfin_mpv_shim/mpvtk_browser/settings/servers.py
 #, python-format
 msgid "Servers for %s"
 msgstr ""
 
+#. Heading of the Servers section of Settings, used when no profile is
+#. named.
 #: jellyfin_mpv_shim/mpvtk_browser/settings/servers.py
 msgid "Servers"
 msgstr ""
 
+#. Button beside a local profile in Settings that alters its numeric
+#. passcode. An imperative verb phrase.
 #: jellyfin_mpv_shim/mpvtk_browser/settings/servers.py
 msgid "Change PIN"
 msgstr ""
 
+#. Button beside a local profile in Settings that gives it a numeric
+#. passcode. An imperative verb phrase.
 #: jellyfin_mpv_shim/mpvtk_browser/settings/servers.py
 msgid "Set PIN"
 msgstr ""
 
+#. Question in the dialog that removes a local profile. %s is the profile's
+#. name; "saved logins" are the servers it is signed in to.
 #: jellyfin_mpv_shim/mpvtk_browser/settings/servers.py
 #, python-format
 msgid "Delete user %s and its saved logins?"
 msgstr ""
 
+#. Title of the dialog that removes a local profile.
 #: jellyfin_mpv_shim/mpvtk_browser/settings/servers.py
 msgid "Delete User"
 msgstr ""
 
+#. Marker beside the local profile currently in use, in the Users settings.
+#. Lower case, a small caption rather than a sentence.
 #: jellyfin_mpv_shim/mpvtk_browser/settings/servers.py
 msgid "active"
 msgstr ""
 
+#. State beside a server in Settings: the application can reach it.
 #: jellyfin_mpv_shim/mpvtk_browser/settings/servers.py
 msgid "Connected"
 msgstr ""
 
+#. State beside a server in Settings: the application cannot reach it.
 #: jellyfin_mpv_shim/mpvtk_browser/settings/servers.py
 msgid "Offline"
 msgstr ""
 
+#. Checkbox beside a server in Settings, letting that server's new episodes
+#. be fetched automatically.
 #: jellyfin_mpv_shim/mpvtk_browser/settings/servers.py
 msgid "Auto-download"
 msgstr ""
 
+#. Question in the dialog that forgets a server. %s is the server's name.
 #: jellyfin_mpv_shim/mpvtk_browser/settings/servers.py
 #, python-format
 msgid "Remove %s and its saved login?"
 msgstr ""
 
+#. Title of the dialog that forgets a server.
 #: jellyfin_mpv_shim/mpvtk_browser/settings/servers.py
 msgid "Remove Server"
 msgstr ""
 
+#. Status message when forgetting a server failed.
 #: jellyfin_mpv_shim/mpvtk_browser/settings/servers.py
 msgid "The server could not be removed."
 msgstr ""
 
+#. Status message when creating a local profile failed.
 #: jellyfin_mpv_shim/mpvtk_browser/settings/servers.py
 msgid "That user could not be added."
 msgstr ""
 
+#. Title of the dialog that changes a local profile's name.
 #: jellyfin_mpv_shim/mpvtk_browser/settings/servers.py
 msgid "Rename User"
 msgstr ""
 
+#. Status message when changing a local profile's name failed.
 #: jellyfin_mpv_shim/mpvtk_browser/settings/servers.py
 msgid "That user could not be renamed."
 msgstr ""
 
+#. Column heading in a library shown as a list: the item's release year.
 #: jellyfin_mpv_shim/mpvtk_browser/tile_renderer.py
 msgid "Year"
 msgstr ""
 
+#. Column heading in a library shown as a list: how long the item runs.
 #: jellyfin_mpv_shim/mpvtk_browser/tile_renderer.py
 msgid "Length"
 msgstr ""
 
+#. Column heading in a music track table: who performs the track.
 #: jellyfin_mpv_shim/mpvtk_browser/tile_renderer.py
 msgid "Artist"
 msgstr ""
 
+#. Column heading in a music track table: which album the track is from.
 #: jellyfin_mpv_shim/mpvtk_browser/tile_renderer.py
 msgid "Album"
 msgstr ""
 
+#. Action on an item's menu that starts the item over rather than resuming.
+#. An imperative verb phrase.
 #: jellyfin_mpv_shim/mpvtk_browser/tiles.py
 msgid "Play from beginning"
 msgstr ""
 
+#. Action on an item's menu that puts it directly after what is playing
+#. now. An imperative verb phrase.
 #: jellyfin_mpv_shim/mpvtk_browser/tiles.py
 msgid "Play next"
 msgstr ""
 
+#. Action on an item's menu that tells the server it has not been watched.
+#. An imperative verb phrase.
 #: jellyfin_mpv_shim/mpvtk_browser/tiles.py
 msgid "Mark unplayed"
 msgstr ""
 
+#. Action on an item's menu that tells the server it has been watched. An
+#. imperative verb phrase.
 #: jellyfin_mpv_shim/mpvtk_browser/tiles.py
 msgid "Mark played"
 msgstr ""
 
+#. Action on an item's menu that opens the playlist chooser. An imperative
+#. verb phrase.
 #: jellyfin_mpv_shim/mpvtk_browser/tiles.py
 msgid "Add to playlist"
 msgstr ""
 
+#. Action on an item's menu, and the title of the dialog it opens, taking
+#. the item out of the playlist being viewed. An imperative verb phrase.
 #: jellyfin_mpv_shim/mpvtk_browser/tiles.py
 msgid "Remove from playlist"
 msgstr ""
 
+#. Action on an item's menu, and the title of the dialog it opens, taking
+#. the item out of the collection being viewed. An imperative verb phrase.
 #: jellyfin_mpv_shim/mpvtk_browser/tiles.py
 msgid "Remove from collection"
 msgstr ""
 
+#. Question in the confirmation dialog. %s is the item's name.
 #: jellyfin_mpv_shim/mpvtk_browser/tiles.py
 #, python-format
 msgid "Remove %s from this playlist?"
 msgstr ""
 
+#. Question in the confirmation dialog. %s is the item's name.
 #: jellyfin_mpv_shim/mpvtk_browser/tiles.py
 #, python-format
 msgid "Remove %s from this collection?"
 msgstr ""
 
+#. Status message when Add to play queue was chosen on something the app
+#. found no playable item inside.
 #: jellyfin_mpv_shim/mpvtk_browser/tiles.py
 msgid "There is nothing here to queue."
 msgstr ""
 
+#. How a clock time is assembled on a twelve-hour clock. {time} is like
+#. "8:30" and {period} is the translation of AM or PM. Reorder them, or
+#. drop the space, if that is how the language writes a time.
 #: jellyfin_mpv_shim/mpvtk_browser/timefmt.py
 #, python-brace-format
 msgctxt "12-hour clock"
 msgid "{time} {period}"
 msgstr ""
 
+#. The morning half of a twelve-hour clock, as in "8:30 AM". Many languages
+#. have their own marker; some drop it and use a 24-hour clock instead.
 #: jellyfin_mpv_shim/mpvtk_browser/timefmt.py
 msgctxt "12-hour clock"
 msgid "AM"
 msgstr ""
 
+#. The afternoon half of a twelve-hour clock, as in "8:30 PM". Many
+#. languages have their own marker; some drop it and use a 24-hour clock
+#. instead.
 #: jellyfin_mpv_shim/mpvtk_browser/timefmt.py
 msgctxt "12-hour clock"
 msgid "PM"
 msgstr ""
 
+#. Tooltip of the navigation bar's search button. A verb.
 #: jellyfin_mpv_shim/mpvtk_browser/views.py
 #: jellyfin_mpv_shim/mpvtk_browser/window_chrome.py
 msgid "Search"
 msgstr ""
 
+#. Tooltip of the window button that hides the window to the taskbar.
 #: jellyfin_mpv_shim/mpvtk_browser/window_chrome.py
 msgid "Minimize"
 msgstr ""
 
+#. Tooltip of the window button that returns a maximized window to its
+#. former size.
 #: jellyfin_mpv_shim/mpvtk_browser/window_chrome.py
 msgid "Restore"
 msgstr ""
 
+#. Tooltip of the window button that fills the screen with the window.
 #: jellyfin_mpv_shim/mpvtk_browser/window_chrome.py
 msgid "Maximize"
 msgstr ""
 
+#. Tooltip of the grip in the window's bottom corner that drags the window
+#. larger or smaller. A verb.
 #: jellyfin_mpv_shim/mpvtk_browser/window_chrome.py
 msgid "Resize"
 msgstr ""
 
+#. Name of the home screen, on the navigation bar's Home button and as the
+#. window title when nothing else names the page.
 #: jellyfin_mpv_shim/mpvtk_browser/window_chrome.py
 msgid "Home"
 msgstr ""
 
+#. Tooltip of the navigation bar's dropdown that switches between Jellyfin
+#. servers.
 #: jellyfin_mpv_shim/mpvtk_browser/window_chrome.py
 msgid "Server"
 msgstr ""
 
+#. Tooltip of the navigation bar's dropdown that switches between accounts
+#. on this server.
 #: jellyfin_mpv_shim/mpvtk_browser/window_chrome.py
 msgid "User"
 msgstr ""
 
+#. Placeholder in the empty search field on the navigation bar.
 #: jellyfin_mpv_shim/mpvtk_browser/window_chrome.py
 msgid "Search…"
 msgstr ""
 
+#. Banner shown when settings were changed that only take effect after the
+#. application is started again. %s is a comma-separated list of those
+#. settings' names.
 #: jellyfin_mpv_shim/mpvtk_browser/window_chrome.py
 #, python-format
 msgid "Restart to apply: %s"
 msgstr ""
 
+#. Button on the restart banner that closes and reopens the application
+#. immediately. An imperative verb.
 #: jellyfin_mpv_shim/mpvtk_browser/window_chrome.py
 msgid "Restart Now"
 msgstr ""
 
+#. Button on the banner asking for a restart, putting it off for now. It
+#. carries a context because the update banner has a button of the same
+#. English word that dismisses a different thing.
 #: jellyfin_mpv_shim/mpvtk_browser/window_chrome.py
 msgctxt "Restart banner"
 msgid "Later"
 msgstr ""
 
+#. Banner announcing a newer release, shown inside a Flatpak where the
+#. desktop's own updater installs it. %s is the version number; the quoted
+#. command is a shell command and stays as it is.
 #: jellyfin_mpv_shim/mpvtk_browser/window_chrome.py
 #, python-format
 msgid "Update available: %s — run “flatpak update”"
 msgstr ""
 
+#. Banner announcing a newer release of this application. %s is the version
+#. number.
 #: jellyfin_mpv_shim/mpvtk_browser/window_chrome.py
 #, python-format
 msgid "Update available: %s"
 msgstr ""
 
+#. Button on the update banner that opens the release notes. The ellipsis
+#. means it opens something else.
 #: jellyfin_mpv_shim/mpvtk_browser/window_chrome.py
 msgid "Details…"
 msgstr ""
 
+#. Button on the update banner that hides it for this version for good. An
+#. imperative verb.
 #: jellyfin_mpv_shim/mpvtk_browser/window_chrome.py
 msgid "Ignore"
 msgstr ""
 
+#. Tooltip of the update banner's Ignore button.
 #: jellyfin_mpv_shim/mpvtk_browser/window_chrome.py
 msgid "Do not mention this version again"
 msgstr ""
 
+#. Banner shown when no server could be reached and only downloaded items
+#. are listed.
 #: jellyfin_mpv_shim/mpvtk_browser/window_chrome.py
 msgid "Offline — showing what's available."
 msgstr ""
 
+#. Button on the offline banner that opens the server settings. An
+#. imperative verb phrase.
 #: jellyfin_mpv_shim/mpvtk_browser/window_chrome.py jellyfin_mpv_shim/tray.py
 msgid "Configure Servers"
 msgstr ""
 
+#. Bar along the bottom while items are being fetched. %(name)s is what is
+#. downloading now and %(n)d how many are still queued.
 #: jellyfin_mpv_shim/mpvtk_browser/window_chrome.py
 #, python-format
 msgid "Downloading %(name)s — %(n)d remaining"
 msgstr ""
 
+#. Bar along the bottom while items are being fetched and the current one
+#. has no name. %(n)d is how many are still queued.
 #: jellyfin_mpv_shim/mpvtk_browser/window_chrome.py
 #, python-format
 msgid "Downloading — %(n)d remaining"
 msgstr ""
 
+#. Button on the downloading bar that opens the downloads page. An
+#. imperative verb phrase.
 #: jellyfin_mpv_shim/mpvtk_browser/window_chrome.py
 msgid "View Downloads"
 msgstr ""
 
+#. Stands in for a value the player could not report, on the playback
+#. controls. Lower case, because it appears inside a line rather than
+#. starting one.
 #: jellyfin_mpv_shim/osc_bridge.py
 msgid "unknown"
 msgstr ""
 
+#. Entry on the settings menu of the classic on-screen controls, opening
+#. MPV's own statistics overlay.
 #: jellyfin_mpv_shim/osc_bridge.py
 msgid "Playback Data"
 msgstr ""
 
+#. Marker beside a quality option on the playback controls, meaning the
+#. server would re-encode the video to reach it. A noun here.
 #: jellyfin_mpv_shim/osc_bridge.py
 msgid "Transcode"
 msgstr ""
 
+#. First entry of a video profile list for a narrower scope, meaning "stop
+#. overriding and follow the wider setting".
 #: jellyfin_mpv_shim/osc_bridge.py jellyfin_mpv_shim/video_profile.py
 msgid "Use the default"
 msgstr ""
 
+#. Value shown beside the SyncPlay row on the playback controls when this
+#. device is watching in sync with a group.
 #: jellyfin_mpv_shim/osc_bridge.py
 msgid "SyncPlay enabled"
 msgstr ""
 
+#. Shown over the video while the next item is being opened.
 #: jellyfin_mpv_shim/player.py
 msgid "Please wait, loading..."
 msgstr ""
 
+#. Warning drawn over the video when the server is re-encoding it. "c" is a
+#. keyboard key; leave the letter as it is. Keep the line break.
 #: jellyfin_mpv_shim/player.py
 msgid ""
 "Your remote video is transcoding!\n"
 "Press c to adjust bandwidth settings if this is not needed."
 msgstr ""
 
+#. Shown over the video when playback reaches the end of a downloaded
+#. episode and the one after it is not on this device.
 #: jellyfin_mpv_shim/player.py
 msgid "Next episode is not downloaded."
 msgstr ""
 
+#. How an episode is named in what this application reports to the server
+#. and to Discord. {0} and {1} are numbers.
 #: jellyfin_mpv_shim/player_reporting.py
 #, python-brace-format
 msgid "Season {0} - Episode {1}"
 msgstr ""
 
+#. State of the SmoothVideo Project integration on the in-player menu: it
+#. is switched off.
 #: jellyfin_mpv_shim/svp_integration.py
 msgid "Disabled"
 msgstr ""
 
+#. Title of the in-player submenu listing SmoothVideo Project profiles. SVP
+#. is a third-party frame interpolation product; leave the abbreviation as-
+#. is.
 #: jellyfin_mpv_shim/svp_integration.py
 msgid "Select SVP Profile"
 msgstr ""
 
+#. Shown on the in-player menu when SmoothVideo Project is installed but
+#. not running.
 #: jellyfin_mpv_shim/svp_integration.py
 msgid "SVP is Not Active"
 msgstr ""
 
+#. Entry on the in-player SVP menu that switches the integration off. An
+#. imperative verb.
 #: jellyfin_mpv_shim/svp_integration.py
 msgid "Disable"
 msgstr ""
 
+#. Shown on the in-player menu when the SmoothVideo Project integration is
+#. switched off.
 #: jellyfin_mpv_shim/svp_integration.py
 msgid "SVP is Disabled"
 msgstr ""
 
+#. Entry on the in-player menu that switches the SmoothVideo Project
+#. integration on. An imperative verb phrase.
 #: jellyfin_mpv_shim/svp_integration.py
 msgid "Enable SVP"
 msgstr ""
 
+#. Error when the folder chosen for downloads is the one already in use.
 #: jellyfin_mpv_shim/sync/manager.py
 msgid "The downloads are already in that folder."
 msgstr ""
 
+#. Error when the download folder was changed while something is being
+#. fetched.
 #: jellyfin_mpv_shim/sync/manager.py
 msgid ""
 "Can't change the download folder while a download is in progress. Wait for "
 "it to finish, then try again."
 msgstr ""
 
+#. Error when the folder chosen for downloads sits within the present one,
+#. which the move cannot handle.
 #: jellyfin_mpv_shim/sync/manager.py
 msgid ""
 "That folder is inside the current download folder. Choose one outside it."
 msgstr ""
 
+#. Error when the folder chosen for downloads could not be opened.
 #: jellyfin_mpv_shim/sync/manager.py
 msgid "Can't read that folder. Check the path and its permissions."
 msgstr ""
 
+#. Error when the folder chosen for downloads already holds this
+#. application's files.
 #: jellyfin_mpv_shim/sync/manager.py
 msgid "That folder already contains downloads. Choose an empty folder."
 msgstr ""
 
+#. Error when the folder chosen for downloads holds other files, which this
+#. application would take charge of.
 #: jellyfin_mpv_shim/sync/manager.py
 msgid ""
 "That folder isn't empty. Choose an empty folder — the download folder is "
 "managed by this app and anything else in it can be moved or removed."
 msgstr ""
 
+#. Error when the folder chosen for downloads could not be made.
 #: jellyfin_mpv_shim/sync/manager.py
 msgid "Can't create that folder. Check the path and its permissions."
 msgstr ""
 
+#. Error when the download folder was changed while a transfer is still
+#. ending.
 #: jellyfin_mpv_shim/sync/manager.py
 msgid "A download is still finishing. Wait for it to stop, then try again."
 msgstr ""
 
+#. Error when the disk holding the chosen folder is too small for what is
+#. already downloaded.
 #: jellyfin_mpv_shim/sync/manager.py
 msgid ""
 "There isn't enough space on that drive to move the downloads. Free some "
 "space and try again — nothing was moved."
 msgstr ""
 
+#. Error when relocating the downloads did not finish, saying nothing was
+#. lost.
 #: jellyfin_mpv_shim/sync/manager.py
 msgid ""
 "Moving the downloads failed. They were left in place; the download folder "
 "was not changed."
 msgstr ""
 
+#. Error when the watch-together group asked for is gone.
 #: jellyfin_mpv_shim/syncplay.py
 msgid "The specified SyncPlay group does not exist."
 msgstr ""
 
+#. Error when the Jellyfin account may not start a watch-together group.
 #: jellyfin_mpv_shim/syncplay.py
 msgid "Creating SyncPlay groups is not allowed."
 msgstr ""
 
+#. Error when the Jellyfin account may not join this watch-together group.
 #: jellyfin_mpv_shim/syncplay.py
 msgid "SyncPlay group access was denied."
 msgstr ""
 
+#. Error when the Jellyfin account may not see what the watch-together
+#. group is playing.
 #: jellyfin_mpv_shim/syncplay.py
 msgid "Access to the SyncPlay library was denied."
 msgstr ""
 
+#. Default name of a watch-together group. {0} is the name of whoever
+#. started it; the possessive ending is English and should be rendered
+#. however the language marks possession.
 #: jellyfin_mpv_shim/syncplay.py
 #, python-brace-format
 msgid "{0}'s group"
 msgstr ""
 
+#. Shown over the video while SyncPlay speeds playback slightly to catch up
+#. with the group. {0} is the speed multiplier. The name is SyncPlay's own
+#. term for the technique.
 #: jellyfin_mpv_shim/syncplay.py
 #, python-brace-format
 msgid "SpeedToSync (x{0})"
 msgstr ""
 
+#. Shown over the video when SyncPlay gave up trying to keep this device in
+#. step with the group.
 #: jellyfin_mpv_shim/syncplay.py
 msgid "Sync Disabled (Too Many Attempts)"
 msgstr ""
 
+#. Shown over the video while SyncPlay jumps the playback position to catch
+#. up with the group. The name is SyncPlay's own term for the technique.
 #: jellyfin_mpv_shim/syncplay.py
 #, python-brace-format
 msgid "SkipToSync (x{0})"
 msgstr ""
 
+#. Shown over the video when this device joins a watch-together group.
 #: jellyfin_mpv_shim/syncplay.py
 msgid "SyncPlay enabled."
 msgstr ""
 
+#. Shown over the video when this device leaves a watch-together group.
 #: jellyfin_mpv_shim/syncplay.py
 msgid "SyncPlay disabled."
 msgstr ""
 
+#. Shown over the video when somebody enters the watch-together group. {0}
+#. is their name.
 #: jellyfin_mpv_shim/syncplay.py
 #, python-brace-format
 msgid "{0} has joined."
 msgstr ""
 
+#. Shown over the video when somebody leaves the watch-together group. {0}
+#. is their name.
 #: jellyfin_mpv_shim/syncplay.py
 #, python-brace-format
 msgid "{0} has left."
 msgstr ""
 
+#. Shown over the video while somebody in the watch-together group is still
+#. loading, so everyone waits. {0} is their name.
 #: jellyfin_mpv_shim/syncplay.py
 #, python-brace-format
 msgid "{0} is buffering…"
 msgstr ""
 
+#. Warning shown when no tray icon could be created on GNOME. The quoted
+#. extension name is how it appears in the GNOME extensions site; leave it
+#. as it is. "Allow Background" is a setting on this application's Settings
+#. screen.
 #: jellyfin_mpv_shim/tray.py
 msgid ""
 "GNOME does not draw a system tray on its own. Install the \"AppIndicator and "
@@ -4778,24 +6863,36 @@ msgid ""
 "Background\" in Settings to run without a window anyway."
 msgstr ""
 
+#. Warning shown when no tray icon could be created. "Allow Background" is
+#. a setting on this application's Settings screen; keep it matching that
+#. translation.
 #: jellyfin_mpv_shim/tray.py
 msgid ""
 "No system tray is running on this desktop. Turn on \"Allow Background\" in "
 "Settings to run without a window anyway."
 msgstr ""
 
+#. Entry on this application's system tray menu that brings the window up.
+#. An imperative verb phrase.
 #: jellyfin_mpv_shim/tray.py
 msgid "Show Library Browser"
 msgstr ""
 
+#. Entry on this application's system tray menu, on Windows, that reveals
+#. the terminal window. An imperative verb phrase.
 #: jellyfin_mpv_shim/tray.py
 msgid "Show Console"
 msgstr ""
 
+#. Entry on this application's system tray menu that closes it. An
+#. imperative verb.
 #: jellyfin_mpv_shim/tray.py
 msgid "Quit"
 msgstr ""
 
+#. Notice drawn over the video when a newer release exists. {0} is the
+#. version number, "c" a keyboard key, and "MPV Shim" this application's
+#. short name. Keep the line break.
 #: jellyfin_mpv_shim/update_check.py
 #, python-brace-format
 msgid ""
@@ -4803,6 +6900,9 @@ msgid ""
 "Open menu (press c) for details."
 msgstr ""
 
+#. Notice drawn over the video inside a Flatpak when a newer release
+#. exists. {0} is the version number and the quoted text a shell command.
+#. Keep the line break.
 #: jellyfin_mpv_shim/update_check.py
 #, python-brace-format
 msgid ""
@@ -4810,99 +6910,149 @@ msgid ""
 "Run \"flatpak update\" to install it."
 msgstr ""
 
+#. Marker beside the local profile used when none is chosen, in the
+#. terminal's user list. Lower case and bracketed, appended after a name.
 #: jellyfin_mpv_shim/users.py
 msgid "(default)"
 msgstr ""
 
+#. Terminal menu entry that creates a local profile of this application.
 #: jellyfin_mpv_shim/users.py
 msgid "New User"
 msgstr ""
 
+#. Printed in the terminal when the profile asked to be deleted is the one
+#. in use.
 #: jellyfin_mpv_shim/users.py
 msgid "Switch to another user before deleting this one."
 msgstr ""
 
+#. Printed in the terminal when deleting the last remaining local profile
+#. was refused.
 #: jellyfin_mpv_shim/users.py
 msgid "At least one user is required."
 msgstr ""
 
+#. Printed in the terminal when the named local profile does not exist.
 #: jellyfin_mpv_shim/users.py
 msgid "User not found."
 msgstr ""
 
+#. Stands in for a track's language when the file does not say.
+#. Deliberately clipped to four characters, because it sits inside a track
+#. name in a narrow list.
 #: jellyfin_mpv_shim/utils.py
 msgid "Unkn"
 msgstr ""
 
+#. Appended to a subtitle track's name when it is meant to be shown even
+#. with subtitles off, such as for on-screen signs. The leading space
+#. separates it from the language before it; keep it.
 #: jellyfin_mpv_shim/utils.py
 msgid " Forced"
 msgstr ""
 
+#. Name of a video shader profile in the in-player profile list. The
+#. bracketed word is the upscaling algorithm's own name; leave it as it is.
 #: jellyfin_mpv_shim/video_profile.py
 msgid "Generic (FSRCNNX)"
 msgstr ""
 
+#. Name of a video shader profile in the in-player profile list. The
+#. bracketed text names the upscaling algorithm; leave it as it is.
 #: jellyfin_mpv_shim/video_profile.py
 msgid "Generic High (FSRCNNX x16)"
 msgstr ""
 
+#. Name of a video shader profile for animation. "Anime4K" and "Faithful"
+#. are the algorithm's own names and SD means standard definition; leave
+#. the whole technical part as it is.
 #: jellyfin_mpv_shim/video_profile.py
 msgid "Anime4K x4 Faithful (For SD)"
 msgstr ""
 
+#. Name of a video shader profile for animation. "Anime4K" and "Perceptual"
+#. are the algorithm's own names; leave the technical part as it is.
 #: jellyfin_mpv_shim/video_profile.py
 msgid "Anime4K x4 Perceptual (For SD)"
 msgstr ""
 
+#. Name of a video shader profile for animation. The technical names are
+#. the algorithm's own; leave them as they are.
 #: jellyfin_mpv_shim/video_profile.py
 msgid "Anime4K x4 Perceptual + Deblur (For SD)"
 msgstr ""
 
+#. Name of a video shader profile for animation. HD means high definition;
+#. leave the technical part as it is.
 #: jellyfin_mpv_shim/video_profile.py
 msgid "Anime4K x2 Faithful (For HD)"
 msgstr ""
 
+#. Name of a video shader profile for animation. Leave the technical part
+#. as it is.
 #: jellyfin_mpv_shim/video_profile.py
 msgid "Anime4K x2 Perceptual (For HD)"
 msgstr ""
 
+#. Name of a video shader profile for animation. Leave the technical part
+#. as it is.
 #: jellyfin_mpv_shim/video_profile.py
 msgid "Anime4K x2 Perceptual + Deblur (For HD)"
 msgstr ""
 
+#. Name of a video shader profile. "ArtCNN" is the algorithm's own name;
+#. the bracketed words say what it does.
 #: jellyfin_mpv_shim/video_profile.py
 msgid "ArtCNN (Denoise + Sharpen)"
 msgstr ""
 
+#. Name of a video shader profile. The bracketed code is the model's own
+#. name; leave it as it is.
 #: jellyfin_mpv_shim/video_profile.py
 msgid "ArtCNN High (C4F32)"
 msgstr ""
 
+#. Name of the widest video-profile scope: the profile used when nothing
+#. narrower is set.
 #: jellyfin_mpv_shim/video_profile.py
 msgid "Default (all media)"
 msgstr ""
 
+#. Name of a video-profile scope: the profile applies to everything in the
+#. library being viewed.
 #: jellyfin_mpv_shim/video_profile.py
 msgid "This Library"
 msgstr ""
 
+#. Name of a video-profile scope: the profile applies to every episode of
+#. this series.
 #: jellyfin_mpv_shim/video_profile.py
 msgid "This Series"
 msgstr ""
 
+#. Shown for a video-profile scope that has no profile of its own, so it
+#. follows a wider one.
 #: jellyfin_mpv_shim/video_profile.py
 msgid "Not set"
 msgstr ""
 
+#. Marks which video-profile scope is actually deciding right now. {0} is
+#. that scope's name; the arrow is drawn from plain characters and should
+#. be kept.
 #: jellyfin_mpv_shim/video_profile.py
 #, python-brace-format
 msgid "{0}  <-- in effect"
 msgstr ""
 
+#. Title of the in-player screen that chooses a video profile per scope. A
+#. video profile is a saved set of MPV shader and rendering options.
 #: jellyfin_mpv_shim/video_profile.py
 msgid "Video Playback Profile"
 msgstr ""
 
+#. Title of the in-player submenu listing the shader profiles that can be
+#. applied.
 #: jellyfin_mpv_shim/video_profile.py
 msgid "Select Shader Profile"
 msgstr ""

--- a/jellyfin_mpv_shim/messages/be/LC_MESSAGES/base.po
+++ b/jellyfin_mpv_shim/messages/be/LC_MESSAGES/base.po
@@ -5190,6 +5190,24 @@ msgstr "Профілі прайгравання відэа"
 msgid "Select Shader Profile"
 msgstr "Выберыце профіль шэйдара"
 
+msgctxt "subtitle position"
+msgid "Top"
+msgstr "Зверху"
+
+#, fuzzy
+msgctxt "list position"
+msgid "Top"
+msgstr "Зверху"
+
+msgctxt "subtitle position"
+msgid "Bottom"
+msgstr "Знізу"
+
+#, fuzzy
+msgctxt "list position"
+msgid "Bottom"
+msgstr "Знізу"
+
 #, fuzzy
 #~| msgid "SyncPlay enabled."
 #~ msgid "SyncPlay Enabled"

--- a/jellyfin_mpv_shim/messages/bg/LC_MESSAGES/base.po
+++ b/jellyfin_mpv_shim/messages/bg/LC_MESSAGES/base.po
@@ -5307,6 +5307,24 @@ msgstr "Профили за възпроизвеждане на видеото"
 msgid "Select Shader Profile"
 msgstr "Избери профил за шейдъри"
 
+msgctxt "subtitle position"
+msgid "Top"
+msgstr "Горе"
+
+#, fuzzy
+msgctxt "list position"
+msgid "Top"
+msgstr "Горе"
+
+msgctxt "subtitle position"
+msgid "Bottom"
+msgstr "Отдолу"
+
+#, fuzzy
+msgctxt "list position"
+msgid "Bottom"
+msgstr "Отдолу"
+
 #, fuzzy
 #~| msgid ""
 #~| "Could not add server.\n"

--- a/jellyfin_mpv_shim/messages/bn/LC_MESSAGES/base.po
+++ b/jellyfin_mpv_shim/messages/bn/LC_MESSAGES/base.po
@@ -5339,6 +5339,32 @@ msgstr "ভিডিও প্লেব্যাক প্রোফাইলস�
 msgid "Select Shader Profile"
 msgstr "শেডার প্রোফাইল নির্বাচন করুন"
 
+msgctxt "setting value"
+msgid "Default"
+msgstr "ডিফল্ট"
+
+msgctxt "media stream flag"
+msgid "Default"
+msgstr "ডিফল্ট"
+
+msgctxt "subtitle position"
+msgid "Top"
+msgstr "উপরে"
+
+#, fuzzy
+msgctxt "list position"
+msgid "Top"
+msgstr "উপরে"
+
+msgctxt "subtitle position"
+msgid "Bottom"
+msgstr "নিচে"
+
+#, fuzzy
+msgctxt "list position"
+msgid "Bottom"
+msgstr "নিচে"
+
 #, fuzzy
 #~| msgid ""
 #~| "Could not add server.\n"

--- a/jellyfin_mpv_shim/messages/br/LC_MESSAGES/base.po
+++ b/jellyfin_mpv_shim/messages/br/LC_MESSAGES/base.po
@@ -5378,6 +5378,22 @@ msgstr ""
 msgid "Select Shader Profile"
 msgstr ""
 
+msgctxt "setting value"
+msgid "Default"
+msgstr "Dre ziouer"
+
+msgctxt "media stream flag"
+msgid "Default"
+msgstr "Dre ziouer"
+
+msgctxt "playback control"
+msgid "Repeat"
+msgstr "Adlenn"
+
+msgctxt "guide badge"
+msgid "Repeat"
+msgstr "Adlenn"
+
 #, fuzzy
 #~| msgid ""
 #~| "Could not add server.\n"

--- a/jellyfin_mpv_shim/messages/bs/LC_MESSAGES/base.po
+++ b/jellyfin_mpv_shim/messages/bs/LC_MESSAGES/base.po
@@ -5604,6 +5604,40 @@ msgstr "Profili za reprodukciju videa"
 msgid "Select Shader Profile"
 msgstr "Odaberite profil shadera"
 
+msgctxt "setting value"
+msgid "Default"
+msgstr "Zadano"
+
+msgctxt "media stream flag"
+msgid "Default"
+msgstr "Zadano"
+
+msgctxt "playback control"
+msgid "Repeat"
+msgstr "Ponovi"
+
+msgctxt "guide badge"
+msgid "Repeat"
+msgstr "Ponovi"
+
+msgctxt "subtitle position"
+msgid "Top"
+msgstr "Izdvajamo"
+
+#, fuzzy
+msgctxt "list position"
+msgid "Top"
+msgstr "Izdvajamo"
+
+msgctxt "subtitle position"
+msgid "Bottom"
+msgstr "Dole"
+
+#, fuzzy
+msgctxt "list position"
+msgid "Bottom"
+msgstr "Dole"
+
 #, fuzzy
 #~| msgid ""
 #~| "Could not add server.\n"

--- a/jellyfin_mpv_shim/messages/ca/LC_MESSAGES/base.po
+++ b/jellyfin_mpv_shim/messages/ca/LC_MESSAGES/base.po
@@ -5319,6 +5319,59 @@ msgstr "Perfil de reproducció de vídeo"
 msgid "Select Shader Profile"
 msgstr "Seleccioneu el perfil d'ombres"
 
+msgctxt "setting value"
+msgid "Default"
+msgstr "Per defecte"
+
+msgctxt "media stream flag"
+msgid "Default"
+msgstr "Per defecte"
+
+msgctxt "guide navigation"
+msgid "Later"
+msgstr "Més tard"
+
+#, fuzzy
+msgctxt "update banner"
+msgid "Later"
+msgstr "Més tard"
+
+msgctxt "playback control"
+msgid "Repeat"
+msgstr "Repeteix"
+
+msgctxt "guide badge"
+msgid "Repeat"
+msgstr "Repeteix"
+
+#, fuzzy
+msgctxt "form label"
+msgid "Confirm"
+msgstr "Confirma"
+
+#, fuzzy
+msgctxt "dialog heading"
+msgid "Confirm"
+msgstr "Confirma"
+
+msgctxt "subtitle position"
+msgid "Top"
+msgstr "Superior"
+
+#, fuzzy
+msgctxt "list position"
+msgid "Top"
+msgstr "Superior"
+
+msgctxt "subtitle position"
+msgid "Bottom"
+msgstr "Inferior"
+
+#, fuzzy
+msgctxt "list position"
+msgid "Bottom"
+msgstr "Inferior"
+
 #~ msgid "MPV UI with thumbnails"
 #~ msgstr "Interfície MPV amb miniatures"
 

--- a/jellyfin_mpv_shim/messages/ckb/LC_MESSAGES/base.po
+++ b/jellyfin_mpv_shim/messages/ckb/LC_MESSAGES/base.po
@@ -5230,6 +5230,32 @@ msgstr "لاڕووی خستنەوەسەری ڤیدیۆ"
 msgid "Select Shader Profile"
 msgstr ""
 
+msgctxt "setting value"
+msgid "Default"
+msgstr "بنەڕەتی"
+
+msgctxt "media stream flag"
+msgid "Default"
+msgstr "بنەڕەتی"
+
+msgctxt "subtitle position"
+msgid "Top"
+msgstr "سەرەوە"
+
+#, fuzzy
+msgctxt "list position"
+msgid "Top"
+msgstr "سەرەوە"
+
+msgctxt "subtitle position"
+msgid "Bottom"
+msgstr "ژێرەوە"
+
+#, fuzzy
+msgctxt "list position"
+msgid "Bottom"
+msgstr "ژێرەوە"
+
 #, fuzzy
 #~| msgid "Could not copy the log."
 #~ msgid "Could not copy the text."

--- a/jellyfin_mpv_shim/messages/cs/LC_MESSAGES/base.po
+++ b/jellyfin_mpv_shim/messages/cs/LC_MESSAGES/base.po
@@ -5500,6 +5500,50 @@ msgstr "Profily přehrávání videa"
 msgid "Select Shader Profile"
 msgstr "Vybrat shader"
 
+msgctxt "setting value"
+msgid "Default"
+msgstr "Výchozí"
+
+msgctxt "media stream flag"
+msgid "Default"
+msgstr "Výchozí"
+
+msgctxt "playback control"
+msgid "Repeat"
+msgstr "Opakovat"
+
+msgctxt "guide badge"
+msgid "Repeat"
+msgstr "Opakovat"
+
+#, fuzzy
+msgctxt "form label"
+msgid "Confirm"
+msgstr "Potvrdit"
+
+#, fuzzy
+msgctxt "dialog heading"
+msgid "Confirm"
+msgstr "Potvrdit"
+
+msgctxt "subtitle position"
+msgid "Top"
+msgstr "Nahoře"
+
+#, fuzzy
+msgctxt "list position"
+msgid "Top"
+msgstr "Nahoře"
+
+msgctxt "subtitle position"
+msgid "Bottom"
+msgstr "Dole"
+
+#, fuzzy
+msgctxt "list position"
+msgid "Bottom"
+msgstr "Dole"
+
 #, fuzzy
 #~| msgid ""
 #~| "Could not add server.\n"

--- a/jellyfin_mpv_shim/messages/cy/LC_MESSAGES/base.po
+++ b/jellyfin_mpv_shim/messages/cy/LC_MESSAGES/base.po
@@ -5521,6 +5521,40 @@ msgstr "Proffiliau Chwarae"
 msgid "Select Shader Profile"
 msgstr "Dewis Proffil Cysgodydd"
 
+msgctxt "setting value"
+msgid "Default"
+msgstr "Diofyn"
+
+msgctxt "media stream flag"
+msgid "Default"
+msgstr "Diofyn"
+
+msgctxt "playback control"
+msgid "Repeat"
+msgstr "Ailadrodd"
+
+msgctxt "guide badge"
+msgid "Repeat"
+msgstr "Ailadrodd"
+
+msgctxt "subtitle position"
+msgid "Top"
+msgstr "Top"
+
+#, fuzzy
+msgctxt "list position"
+msgid "Top"
+msgstr "Top"
+
+msgctxt "subtitle position"
+msgid "Bottom"
+msgstr "Gwaelod"
+
+#, fuzzy
+msgctxt "list position"
+msgid "Bottom"
+msgstr "Gwaelod"
+
 #, fuzzy
 #~| msgid ""
 #~| "Could not add server.\n"

--- a/jellyfin_mpv_shim/messages/da/LC_MESSAGES/base.po
+++ b/jellyfin_mpv_shim/messages/da/LC_MESSAGES/base.po
@@ -5322,6 +5322,50 @@ msgstr "Videoafspilningsprofil"
 msgid "Select Shader Profile"
 msgstr "Vælg shaderprofil"
 
+msgctxt "setting value"
+msgid "Default"
+msgstr "Standard"
+
+msgctxt "media stream flag"
+msgid "Default"
+msgstr "Standard"
+
+msgctxt "playback control"
+msgid "Repeat"
+msgstr "Gentag"
+
+msgctxt "guide badge"
+msgid "Repeat"
+msgstr "Gentag"
+
+#, fuzzy
+msgctxt "form label"
+msgid "Confirm"
+msgstr "Bekræft"
+
+#, fuzzy
+msgctxt "dialog heading"
+msgid "Confirm"
+msgstr "Bekræft"
+
+msgctxt "subtitle position"
+msgid "Top"
+msgstr "Top"
+
+#, fuzzy
+msgctxt "list position"
+msgid "Top"
+msgstr "Top"
+
+msgctxt "subtitle position"
+msgid "Bottom"
+msgstr "Bund"
+
+#, fuzzy
+msgctxt "list position"
+msgid "Bottom"
+msgstr "Bund"
+
 #~ msgid "MPV UI with thumbnails"
 #~ msgstr "MPV brugerflade med miniaturebilleder"
 

--- a/jellyfin_mpv_shim/messages/de/LC_MESSAGES/base.po
+++ b/jellyfin_mpv_shim/messages/de/LC_MESSAGES/base.po
@@ -5527,6 +5527,50 @@ msgstr "Videowiedergabeprofil"
 msgid "Select Shader Profile"
 msgstr "Shaderprofil wählen"
 
+msgctxt "setting value"
+msgid "Default"
+msgstr "Standard"
+
+msgctxt "media stream flag"
+msgid "Default"
+msgstr "Standard"
+
+msgctxt "playback control"
+msgid "Repeat"
+msgstr "Wiederholen"
+
+msgctxt "guide badge"
+msgid "Repeat"
+msgstr "Wiederholen"
+
+#, fuzzy
+msgctxt "form label"
+msgid "Confirm"
+msgstr "Bestätigen"
+
+#, fuzzy
+msgctxt "dialog heading"
+msgid "Confirm"
+msgstr "Bestätigen"
+
+msgctxt "subtitle position"
+msgid "Top"
+msgstr "Oben"
+
+#, fuzzy
+msgctxt "list position"
+msgid "Top"
+msgstr "Oben"
+
+msgctxt "subtitle position"
+msgid "Bottom"
+msgstr "Unten"
+
+#, fuzzy
+msgctxt "list position"
+msgid "Bottom"
+msgstr "Unten"
+
 #~ msgid "MPV UI with thumbnails"
 #~ msgstr "MPV UI mit Vorschaubildern"
 

--- a/jellyfin_mpv_shim/messages/dv/LC_MESSAGES/base.po
+++ b/jellyfin_mpv_shim/messages/dv/LC_MESSAGES/base.po
@@ -4966,5 +4966,13 @@ msgstr ""
 msgid "Select Shader Profile"
 msgstr ""
 
+msgctxt "setting value"
+msgid "Default"
+msgstr "ޑީފޯލްޓް"
+
+msgctxt "media stream flag"
+msgid "Default"
+msgstr "ޑީފޯލްޓް"
+
 #~ msgid "Password:"
 #~ msgstr "ފާސްބަސް"

--- a/jellyfin_mpv_shim/messages/el/LC_MESSAGES/base.po
+++ b/jellyfin_mpv_shim/messages/el/LC_MESSAGES/base.po
@@ -5602,6 +5602,40 @@ msgstr "Προφίλ Αναπαραγωγής Βίντεο"
 msgid "Select Shader Profile"
 msgstr "Επιλέξτε προφίλ Shader"
 
+msgctxt "setting value"
+msgid "Default"
+msgstr "Προεπιλογή"
+
+msgctxt "media stream flag"
+msgid "Default"
+msgstr "Προεπιλογή"
+
+msgctxt "playback control"
+msgid "Repeat"
+msgstr "Επανάληψη"
+
+msgctxt "guide badge"
+msgid "Repeat"
+msgstr "Επανάληψη"
+
+msgctxt "subtitle position"
+msgid "Top"
+msgstr "Πάνω"
+
+#, fuzzy
+msgctxt "list position"
+msgid "Top"
+msgstr "Πάνω"
+
+msgctxt "subtitle position"
+msgid "Bottom"
+msgstr "Κάτω"
+
+#, fuzzy
+msgctxt "list position"
+msgid "Bottom"
+msgstr "Κάτω"
+
 #, fuzzy
 #~| msgid ""
 #~| "Could not add server.\n"

--- a/jellyfin_mpv_shim/messages/en_GB/LC_MESSAGES/base.po
+++ b/jellyfin_mpv_shim/messages/en_GB/LC_MESSAGES/base.po
@@ -5571,6 +5571,50 @@ msgstr "Video Playback Profiles"
 msgid "Select Shader Profile"
 msgstr "Select Shader Profile"
 
+msgctxt "setting value"
+msgid "Default"
+msgstr "Default"
+
+msgctxt "media stream flag"
+msgid "Default"
+msgstr "Default"
+
+msgctxt "playback control"
+msgid "Repeat"
+msgstr "Repeat"
+
+msgctxt "guide badge"
+msgid "Repeat"
+msgstr "Repeat"
+
+#, fuzzy
+msgctxt "form label"
+msgid "Confirm"
+msgstr "Confirm"
+
+#, fuzzy
+msgctxt "dialog heading"
+msgid "Confirm"
+msgstr "Confirm"
+
+msgctxt "subtitle position"
+msgid "Top"
+msgstr "Top"
+
+#, fuzzy
+msgctxt "list position"
+msgid "Top"
+msgstr "Top"
+
+msgctxt "subtitle position"
+msgid "Bottom"
+msgstr "Bottom"
+
+#, fuzzy
+msgctxt "list position"
+msgid "Bottom"
+msgstr "Bottom"
+
 #~ msgid "MPV UI with thumbnails"
 #~ msgstr "MPV UI with thumbnails"
 

--- a/jellyfin_mpv_shim/messages/eo/LC_MESSAGES/base.po
+++ b/jellyfin_mpv_shim/messages/eo/LC_MESSAGES/base.po
@@ -5558,6 +5558,40 @@ msgstr "Profiloj pri ludado de videoj"
 msgid "Select Shader Profile"
 msgstr "Elekti Ombrigilan Profilon"
 
+msgctxt "setting value"
+msgid "Default"
+msgstr "Defaŭlte"
+
+msgctxt "media stream flag"
+msgid "Default"
+msgstr "Defaŭlte"
+
+msgctxt "playback control"
+msgid "Repeat"
+msgstr "Ripeto"
+
+msgctxt "guide badge"
+msgid "Repeat"
+msgstr "Ripeto"
+
+msgctxt "subtitle position"
+msgid "Top"
+msgstr "Supro"
+
+#, fuzzy
+msgctxt "list position"
+msgid "Top"
+msgstr "Supro"
+
+msgctxt "subtitle position"
+msgid "Bottom"
+msgstr "Malsupro"
+
+#, fuzzy
+msgctxt "list position"
+msgid "Bottom"
+msgstr "Malsupro"
+
 #, fuzzy
 #~| msgid ""
 #~| "Could not add server.\n"

--- a/jellyfin_mpv_shim/messages/es/LC_MESSAGES/base.po
+++ b/jellyfin_mpv_shim/messages/es/LC_MESSAGES/base.po
@@ -5437,6 +5437,54 @@ msgstr "Perfil de Reproducción de Video"
 msgid "Select Shader Profile"
 msgstr "Seleccionar Perfil de Sombras"
 
+# seeded from jellyfin-web: Default
+msgctxt "setting value"
+msgid "Default"
+msgstr "Predeterminado"
+
+# seeded from jellyfin-web: MediaInfoDefault
+msgctxt "media stream flag"
+msgid "Default"
+msgstr "Por defecto"
+
+#, fuzzy
+msgctxt "playback control"
+msgid "Repeat"
+msgstr "Repetir"
+
+#, fuzzy
+msgctxt "guide badge"
+msgid "Repeat"
+msgstr "Repetir"
+
+#, fuzzy
+msgctxt "form label"
+msgid "Confirm"
+msgstr "Confirmar"
+
+#, fuzzy
+msgctxt "dialog heading"
+msgid "Confirm"
+msgstr "Confirmar"
+
+msgctxt "subtitle position"
+msgid "Top"
+msgstr "Superior"
+
+#, fuzzy
+msgctxt "list position"
+msgid "Top"
+msgstr "Superior"
+
+msgctxt "subtitle position"
+msgid "Bottom"
+msgstr "Inferior"
+
+#, fuzzy
+msgctxt "list position"
+msgid "Bottom"
+msgstr "Inferior"
+
 #~ msgid "MPV UI with thumbnails"
 #~ msgstr "Interfaz MPV con miniaturas"
 

--- a/jellyfin_mpv_shim/messages/es_419/LC_MESSAGES/base.po
+++ b/jellyfin_mpv_shim/messages/es_419/LC_MESSAGES/base.po
@@ -5518,6 +5518,50 @@ msgstr "Perfiles de Reproducción de Video"
 msgid "Select Shader Profile"
 msgstr "Seleccionar el Perfil de Sombreado"
 
+msgctxt "setting value"
+msgid "Default"
+msgstr "Por defecto"
+
+msgctxt "media stream flag"
+msgid "Default"
+msgstr "Por defecto"
+
+msgctxt "playback control"
+msgid "Repeat"
+msgstr "Repetir"
+
+msgctxt "guide badge"
+msgid "Repeat"
+msgstr "Repetir"
+
+#, fuzzy
+msgctxt "form label"
+msgid "Confirm"
+msgstr "Confirmar"
+
+#, fuzzy
+msgctxt "dialog heading"
+msgid "Confirm"
+msgstr "Confirmar"
+
+msgctxt "subtitle position"
+msgid "Top"
+msgstr "Arriba"
+
+#, fuzzy
+msgctxt "list position"
+msgid "Top"
+msgstr "Arriba"
+
+msgctxt "subtitle position"
+msgid "Bottom"
+msgstr "Abajo"
+
+#, fuzzy
+msgctxt "list position"
+msgid "Bottom"
+msgstr "Abajo"
+
 #, fuzzy
 #~| msgid ""
 #~| "Could not add server.\n"

--- a/jellyfin_mpv_shim/messages/es_AR/LC_MESSAGES/base.po
+++ b/jellyfin_mpv_shim/messages/es_AR/LC_MESSAGES/base.po
@@ -5602,6 +5602,40 @@ msgstr "Perfiles de reproducción de video"
 msgid "Select Shader Profile"
 msgstr "Seleccionar perfil de sombreador"
 
+msgctxt "setting value"
+msgid "Default"
+msgstr "Predeterminado"
+
+msgctxt "media stream flag"
+msgid "Default"
+msgstr "Predeterminado"
+
+msgctxt "playback control"
+msgid "Repeat"
+msgstr "Repetir"
+
+msgctxt "guide badge"
+msgid "Repeat"
+msgstr "Repetir"
+
+msgctxt "subtitle position"
+msgid "Top"
+msgstr "Superior"
+
+#, fuzzy
+msgctxt "list position"
+msgid "Top"
+msgstr "Superior"
+
+msgctxt "subtitle position"
+msgid "Bottom"
+msgstr "Fondo"
+
+#, fuzzy
+msgctxt "list position"
+msgid "Bottom"
+msgstr "Fondo"
+
 #, fuzzy
 #~| msgid ""
 #~| "Could not add server.\n"

--- a/jellyfin_mpv_shim/messages/es_MX/LC_MESSAGES/base.po
+++ b/jellyfin_mpv_shim/messages/es_MX/LC_MESSAGES/base.po
@@ -5466,6 +5466,14 @@ msgstr ""
 msgid "Select Shader Profile"
 msgstr ""
 
+msgctxt "playback control"
+msgid "Repeat"
+msgstr "Repetir"
+
+msgctxt "guide badge"
+msgid "Repeat"
+msgstr "Repetir"
+
 #, fuzzy
 #~| msgid ""
 #~| "Could not add server.\n"

--- a/jellyfin_mpv_shim/messages/et/LC_MESSAGES/base.po
+++ b/jellyfin_mpv_shim/messages/et/LC_MESSAGES/base.po
@@ -5576,6 +5576,40 @@ msgstr "Video taasesituse profiilid"
 msgid "Select Shader Profile"
 msgstr "Vali Varjutaja Profiil"
 
+msgctxt "setting value"
+msgid "Default"
+msgstr "Vaikimisi"
+
+msgctxt "media stream flag"
+msgid "Default"
+msgstr "Vaikimisi"
+
+msgctxt "playback control"
+msgid "Repeat"
+msgstr "Korda"
+
+msgctxt "guide badge"
+msgid "Repeat"
+msgstr "Korda"
+
+msgctxt "subtitle position"
+msgid "Top"
+msgstr "Üleval"
+
+#, fuzzy
+msgctxt "list position"
+msgid "Top"
+msgstr "Üleval"
+
+msgctxt "subtitle position"
+msgid "Bottom"
+msgstr "All"
+
+#, fuzzy
+msgctxt "list position"
+msgid "Bottom"
+msgstr "All"
+
 #, fuzzy
 #~| msgid ""
 #~| "Could not add server.\n"

--- a/jellyfin_mpv_shim/messages/eu/LC_MESSAGES/base.po
+++ b/jellyfin_mpv_shim/messages/eu/LC_MESSAGES/base.po
@@ -5579,6 +5579,32 @@ msgstr "Bideo Erreprodukzio Profilak"
 msgid "Select Shader Profile"
 msgstr "Itzal-Profilak Aukeratu"
 
+msgctxt "playback control"
+msgid "Repeat"
+msgstr "Errepikatu"
+
+msgctxt "guide badge"
+msgid "Repeat"
+msgstr "Errepikatu"
+
+msgctxt "subtitle position"
+msgid "Top"
+msgstr "Goian"
+
+#, fuzzy
+msgctxt "list position"
+msgid "Top"
+msgstr "Goian"
+
+msgctxt "subtitle position"
+msgid "Bottom"
+msgstr "Azpian"
+
+#, fuzzy
+msgctxt "list position"
+msgid "Bottom"
+msgstr "Azpian"
+
 #, fuzzy
 #~| msgid ""
 #~| "Could not add server.\n"

--- a/jellyfin_mpv_shim/messages/fa/LC_MESSAGES/base.po
+++ b/jellyfin_mpv_shim/messages/fa/LC_MESSAGES/base.po
@@ -5553,6 +5553,32 @@ msgstr "پروفایل های پخش ویدئو"
 msgid "Select Shader Profile"
 msgstr "نمایه سایه بان را انتخاب کنید"
 
+msgctxt "playback control"
+msgid "Repeat"
+msgstr "تکرار"
+
+msgctxt "guide badge"
+msgid "Repeat"
+msgstr "تکرار"
+
+msgctxt "subtitle position"
+msgid "Top"
+msgstr "بالا"
+
+#, fuzzy
+msgctxt "list position"
+msgid "Top"
+msgstr "بالا"
+
+msgctxt "subtitle position"
+msgid "Bottom"
+msgstr "پایین"
+
+#, fuzzy
+msgctxt "list position"
+msgid "Bottom"
+msgstr "پایین"
+
 #, fuzzy
 #~| msgid ""
 #~| "Could not add server.\n"

--- a/jellyfin_mpv_shim/messages/fi/LC_MESSAGES/base.po
+++ b/jellyfin_mpv_shim/messages/fi/LC_MESSAGES/base.po
@@ -5575,6 +5575,40 @@ msgstr "Video toistoprofiilit"
 msgid "Select Shader Profile"
 msgstr "Valitse varjostimen profiili"
 
+msgctxt "setting value"
+msgid "Default"
+msgstr "Oletus"
+
+msgctxt "media stream flag"
+msgid "Default"
+msgstr "Oletus"
+
+msgctxt "playback control"
+msgid "Repeat"
+msgstr "Toista uudelleen"
+
+msgctxt "guide badge"
+msgid "Repeat"
+msgstr "Toista uudelleen"
+
+msgctxt "subtitle position"
+msgid "Top"
+msgstr "Ylin"
+
+#, fuzzy
+msgctxt "list position"
+msgid "Top"
+msgstr "Ylin"
+
+msgctxt "subtitle position"
+msgid "Bottom"
+msgstr "Pohja"
+
+#, fuzzy
+msgctxt "list position"
+msgid "Bottom"
+msgstr "Pohja"
+
 #, fuzzy
 #~| msgid ""
 #~| "Could not add server.\n"

--- a/jellyfin_mpv_shim/messages/fil/LC_MESSAGES/base.po
+++ b/jellyfin_mpv_shim/messages/fil/LC_MESSAGES/base.po
@@ -5586,6 +5586,40 @@ msgstr "Mga Profile sa Pag-playback ng Video"
 msgid "Select Shader Profile"
 msgstr "Piliin ang Shader Profile"
 
+msgctxt "setting value"
+msgid "Default"
+msgstr "Default"
+
+msgctxt "media stream flag"
+msgid "Default"
+msgstr "Default"
+
+msgctxt "playback control"
+msgid "Repeat"
+msgstr "Ulitin"
+
+msgctxt "guide badge"
+msgid "Repeat"
+msgstr "Ulitin"
+
+msgctxt "subtitle position"
+msgid "Top"
+msgstr "Itaas"
+
+#, fuzzy
+msgctxt "list position"
+msgid "Top"
+msgstr "Itaas"
+
+msgctxt "subtitle position"
+msgid "Bottom"
+msgstr "Ibaba"
+
+#, fuzzy
+msgctxt "list position"
+msgid "Bottom"
+msgstr "Ibaba"
+
 #, fuzzy
 #~| msgid ""
 #~| "Could not add server.\n"

--- a/jellyfin_mpv_shim/messages/fr/LC_MESSAGES/base.po
+++ b/jellyfin_mpv_shim/messages/fr/LC_MESSAGES/base.po
@@ -5494,6 +5494,50 @@ msgstr "Profils de lecture vidéo"
 msgid "Select Shader Profile"
 msgstr "Sélectionner le profil du nuanceur"
 
+msgctxt "setting value"
+msgid "Default"
+msgstr "Par défaut"
+
+msgctxt "media stream flag"
+msgid "Default"
+msgstr "Par défaut"
+
+msgctxt "playback control"
+msgid "Repeat"
+msgstr "Répéter"
+
+msgctxt "guide badge"
+msgid "Repeat"
+msgstr "Répéter"
+
+#, fuzzy
+msgctxt "form label"
+msgid "Confirm"
+msgstr "Confirmer"
+
+#, fuzzy
+msgctxt "dialog heading"
+msgid "Confirm"
+msgstr "Confirmer"
+
+msgctxt "subtitle position"
+msgid "Top"
+msgstr "Haut"
+
+#, fuzzy
+msgctxt "list position"
+msgid "Top"
+msgstr "Haut"
+
+msgctxt "subtitle position"
+msgid "Bottom"
+msgstr "Bas"
+
+#, fuzzy
+msgctxt "list position"
+msgid "Bottom"
+msgstr "Bas"
+
 #, fuzzy
 #~| msgid "Quit and Mark Unwatched"
 #~ msgid "Mark Unwatched"

--- a/jellyfin_mpv_shim/messages/ga/LC_MESSAGES/base.po
+++ b/jellyfin_mpv_shim/messages/ga/LC_MESSAGES/base.po
@@ -5605,6 +5605,40 @@ msgstr "Próifílí Athsheinm Físe"
 msgid "Select Shader Profile"
 msgstr "Roghnaigh Próifíl an Scáthóra"
 
+msgctxt "setting value"
+msgid "Default"
+msgstr "Réamhshocrú"
+
+msgctxt "media stream flag"
+msgid "Default"
+msgstr "Réamhshocrú"
+
+msgctxt "playback control"
+msgid "Repeat"
+msgstr "Athdhéan"
+
+msgctxt "guide badge"
+msgid "Repeat"
+msgstr "Athdhéan"
+
+msgctxt "subtitle position"
+msgid "Top"
+msgstr "Barr"
+
+#, fuzzy
+msgctxt "list position"
+msgid "Top"
+msgstr "Barr"
+
+msgctxt "subtitle position"
+msgid "Bottom"
+msgstr "Bun"
+
+#, fuzzy
+msgctxt "list position"
+msgid "Bottom"
+msgstr "Bun"
+
 #, fuzzy
 #~| msgid ""
 #~| "Could not add server.\n"

--- a/jellyfin_mpv_shim/messages/gl/LC_MESSAGES/base.po
+++ b/jellyfin_mpv_shim/messages/gl/LC_MESSAGES/base.po
@@ -5525,6 +5525,41 @@ msgstr "Perfís de Reprodución de Vídeo"
 msgid "Select Shader Profile"
 msgstr "Seleccionar Perfil de Sombras"
 
+msgctxt "setting value"
+msgid "Default"
+msgstr "Por defecto"
+
+msgctxt "media stream flag"
+msgid "Default"
+msgstr "Por defecto"
+
+msgctxt "playback control"
+msgid "Repeat"
+msgstr "Repetir"
+
+msgctxt "guide badge"
+msgid "Repeat"
+msgstr "Repetir"
+
+#, fuzzy
+msgctxt "form label"
+msgid "Confirm"
+msgstr "Confirmar"
+
+#, fuzzy
+msgctxt "dialog heading"
+msgid "Confirm"
+msgstr "Confirmar"
+
+msgctxt "subtitle position"
+msgid "Top"
+msgstr "Superior"
+
+#, fuzzy
+msgctxt "list position"
+msgid "Top"
+msgstr "Superior"
+
 #, fuzzy
 #~| msgid ""
 #~| "Could not add server.\n"

--- a/jellyfin_mpv_shim/messages/gsw/LC_MESSAGES/base.po
+++ b/jellyfin_mpv_shim/messages/gsw/LC_MESSAGES/base.po
@@ -5225,6 +5225,14 @@ msgstr ""
 msgid "Select Shader Profile"
 msgstr ""
 
+msgctxt "setting value"
+msgid "Default"
+msgstr "Standard"
+
+msgctxt "media stream flag"
+msgid "Default"
+msgstr "Standard"
+
 #, fuzzy
 #~| msgid ""
 #~| "Could not add server.\n"

--- a/jellyfin_mpv_shim/messages/he/LC_MESSAGES/base.po
+++ b/jellyfin_mpv_shim/messages/he/LC_MESSAGES/base.po
@@ -5453,6 +5453,40 @@ msgstr "פרופילים לניגון וידאו"
 msgid "Select Shader Profile"
 msgstr "בחר פרופיל Shader"
 
+msgctxt "setting value"
+msgid "Default"
+msgstr "ברירת מחדל"
+
+msgctxt "media stream flag"
+msgid "Default"
+msgstr "ברירת מחדל"
+
+msgctxt "playback control"
+msgid "Repeat"
+msgstr "חזרה"
+
+msgctxt "guide badge"
+msgid "Repeat"
+msgstr "חזרה"
+
+msgctxt "subtitle position"
+msgid "Top"
+msgstr "ראש"
+
+#, fuzzy
+msgctxt "list position"
+msgid "Top"
+msgstr "ראש"
+
+msgctxt "subtitle position"
+msgid "Bottom"
+msgstr "תחתית"
+
+#, fuzzy
+msgctxt "list position"
+msgid "Bottom"
+msgstr "תחתית"
+
 #~ msgid "Could not copy the text."
 #~ msgstr "לא ניתן היה להעתיק את הטקסט."
 

--- a/jellyfin_mpv_shim/messages/hr/LC_MESSAGES/base.po
+++ b/jellyfin_mpv_shim/messages/hr/LC_MESSAGES/base.po
@@ -5604,6 +5604,40 @@ msgstr "Profili reprodukcije video zapisa"
 msgid "Select Shader Profile"
 msgstr "Odaberite Shader Profil"
 
+msgctxt "setting value"
+msgid "Default"
+msgstr "Zadano"
+
+msgctxt "media stream flag"
+msgid "Default"
+msgstr "Zadano"
+
+msgctxt "playback control"
+msgid "Repeat"
+msgstr "Ponovi"
+
+msgctxt "guide badge"
+msgid "Repeat"
+msgstr "Ponovi"
+
+msgctxt "subtitle position"
+msgid "Top"
+msgstr "Gornji rub"
+
+#, fuzzy
+msgctxt "list position"
+msgid "Top"
+msgstr "Gornji rub"
+
+msgctxt "subtitle position"
+msgid "Bottom"
+msgstr "Donji rub"
+
+#, fuzzy
+msgctxt "list position"
+msgid "Bottom"
+msgstr "Donji rub"
+
 #, fuzzy
 #~| msgid ""
 #~| "Could not add server.\n"

--- a/jellyfin_mpv_shim/messages/hu/LC_MESSAGES/base.po
+++ b/jellyfin_mpv_shim/messages/hu/LC_MESSAGES/base.po
@@ -5620,6 +5620,50 @@ msgstr "Videólejátszási profilok"
 msgid "Select Shader Profile"
 msgstr "Árnyalóprofil kiválasztása"
 
+msgctxt "setting value"
+msgid "Default"
+msgstr "Alapértelmezett"
+
+msgctxt "media stream flag"
+msgid "Default"
+msgstr "Alapértelmezett"
+
+msgctxt "playback control"
+msgid "Repeat"
+msgstr "Ismétlés"
+
+msgctxt "guide badge"
+msgid "Repeat"
+msgstr "Ismétlés"
+
+#, fuzzy
+msgctxt "form label"
+msgid "Confirm"
+msgstr "Megerősítés"
+
+#, fuzzy
+msgctxt "dialog heading"
+msgid "Confirm"
+msgstr "Megerősítés"
+
+msgctxt "subtitle position"
+msgid "Top"
+msgstr "Felül"
+
+#, fuzzy
+msgctxt "list position"
+msgid "Top"
+msgstr "Felül"
+
+msgctxt "subtitle position"
+msgid "Bottom"
+msgstr "Alul"
+
+#, fuzzy
+msgctxt "list position"
+msgid "Bottom"
+msgstr "Alul"
+
 #~ msgid "MPV UI with thumbnails"
 #~ msgstr "MPV felület bélyegképekkel"
 

--- a/jellyfin_mpv_shim/messages/id/LC_MESSAGES/base.po
+++ b/jellyfin_mpv_shim/messages/id/LC_MESSAGES/base.po
@@ -5584,6 +5584,32 @@ msgstr "Profil Pemutaran Video"
 msgid "Select Shader Profile"
 msgstr "Pilih Profil Shader"
 
+msgctxt "playback control"
+msgid "Repeat"
+msgstr "Ulangi"
+
+msgctxt "guide badge"
+msgid "Repeat"
+msgstr "Ulangi"
+
+msgctxt "subtitle position"
+msgid "Top"
+msgstr "Atas"
+
+#, fuzzy
+msgctxt "list position"
+msgid "Top"
+msgstr "Atas"
+
+msgctxt "subtitle position"
+msgid "Bottom"
+msgstr "Bawah"
+
+#, fuzzy
+msgctxt "list position"
+msgid "Bottom"
+msgstr "Bawah"
+
 #, fuzzy
 #~| msgid ""
 #~| "Could not add server.\n"

--- a/jellyfin_mpv_shim/messages/it/LC_MESSAGES/base.po
+++ b/jellyfin_mpv_shim/messages/it/LC_MESSAGES/base.po
@@ -5302,6 +5302,60 @@ msgstr "Profili riproduzione video"
 msgid "Select Shader Profile"
 msgstr "Seleziona profilo shader"
 
+msgctxt "setting value"
+msgid "Default"
+msgstr "Predefinito"
+
+msgctxt "media stream flag"
+msgid "Default"
+msgstr "Predefinito"
+
+msgctxt "guide navigation"
+msgid "Later"
+msgstr "Dopo"
+
+#, fuzzy
+msgctxt "update banner"
+msgid "Later"
+msgstr "Dopo"
+
+msgctxt "playback control"
+msgid "Repeat"
+msgstr "Ripeti"
+
+#, fuzzy
+msgctxt "guide badge"
+msgid "Repeat"
+msgstr "Ripeti"
+
+#, fuzzy
+msgctxt "form label"
+msgid "Confirm"
+msgstr "Conferma"
+
+#, fuzzy
+msgctxt "dialog heading"
+msgid "Confirm"
+msgstr "Conferma"
+
+msgctxt "subtitle position"
+msgid "Top"
+msgstr "In alto"
+
+#, fuzzy
+msgctxt "list position"
+msgid "Top"
+msgstr "In alto"
+
+msgctxt "subtitle position"
+msgid "Bottom"
+msgstr "In basso"
+
+#, fuzzy
+msgctxt "list position"
+msgid "Bottom"
+msgstr "In basso"
+
 #~ msgid "MPV UI with thumbnails"
 #~ msgstr "Interfaccia MPV con miniature"
 

--- a/jellyfin_mpv_shim/messages/ja/LC_MESSAGES/base.po
+++ b/jellyfin_mpv_shim/messages/ja/LC_MESSAGES/base.po
@@ -5595,6 +5595,40 @@ msgstr "動画再生プロファイル"
 msgid "Select Shader Profile"
 msgstr "シェーダープロファイルを選択"
 
+msgctxt "setting value"
+msgid "Default"
+msgstr "デフォルト"
+
+msgctxt "media stream flag"
+msgid "Default"
+msgstr "デフォルト"
+
+msgctxt "playback control"
+msgid "Repeat"
+msgstr "リピート"
+
+msgctxt "guide badge"
+msgid "Repeat"
+msgstr "リピート"
+
+msgctxt "subtitle position"
+msgid "Top"
+msgstr "上"
+
+#, fuzzy
+msgctxt "list position"
+msgid "Top"
+msgstr "上"
+
+msgctxt "subtitle position"
+msgid "Bottom"
+msgstr "下"
+
+#, fuzzy
+msgctxt "list position"
+msgid "Bottom"
+msgstr "下"
+
 #, fuzzy
 #~| msgid ""
 #~| "Could not add server.\n"

--- a/jellyfin_mpv_shim/messages/jbo/LC_MESSAGES/base.po
+++ b/jellyfin_mpv_shim/messages/jbo/LC_MESSAGES/base.po
@@ -4965,6 +4965,24 @@ msgstr ""
 msgid "Select Shader Profile"
 msgstr ""
 
+msgctxt "subtitle position"
+msgid "Top"
+msgstr "galraipau"
+
+#, fuzzy
+msgctxt "list position"
+msgid "Top"
+msgstr "galraipau"
+
+msgctxt "subtitle position"
+msgid "Bottom"
+msgstr "dziraipau"
+
+#, fuzzy
+msgctxt "list position"
+msgid "Bottom"
+msgstr "dziraipau"
+
 #~ msgid "Application Log"
 #~ msgstr "te plivei lo proga"
 

--- a/jellyfin_mpv_shim/messages/ka/LC_MESSAGES/base.po
+++ b/jellyfin_mpv_shim/messages/ka/LC_MESSAGES/base.po
@@ -5577,6 +5577,40 @@ msgstr "ვიდეოს დაკვრის პროფილები"
 msgid "Select Shader Profile"
 msgstr "შეიდერის პროფილის არჩევა"
 
+msgctxt "setting value"
+msgid "Default"
+msgstr "ნაგულისხმევი"
+
+msgctxt "media stream flag"
+msgid "Default"
+msgstr "ნაგულისხმევი"
+
+msgctxt "playback control"
+msgid "Repeat"
+msgstr "გამეორება"
+
+msgctxt "guide badge"
+msgid "Repeat"
+msgstr "გამეორება"
+
+msgctxt "subtitle position"
+msgid "Top"
+msgstr "ზედა"
+
+#, fuzzy
+msgctxt "list position"
+msgid "Top"
+msgstr "ზედა"
+
+msgctxt "subtitle position"
+msgid "Bottom"
+msgstr "ქვედა"
+
+#, fuzzy
+msgctxt "list position"
+msgid "Bottom"
+msgstr "ქვედა"
+
 #, fuzzy
 #~| msgid ""
 #~| "Could not add server.\n"

--- a/jellyfin_mpv_shim/messages/kk/LC_MESSAGES/base.po
+++ b/jellyfin_mpv_shim/messages/kk/LC_MESSAGES/base.po
@@ -5556,6 +5556,40 @@ msgstr "Beine oinatu profaily"
 msgid "Select Shader Profile"
 msgstr "Şeider profailyn tañdau"
 
+msgctxt "setting value"
+msgid "Default"
+msgstr "Ädepkı"
+
+msgctxt "media stream flag"
+msgid "Default"
+msgstr "Ädepkı"
+
+msgctxt "playback control"
+msgid "Repeat"
+msgstr "Qaitalau"
+
+msgctxt "guide badge"
+msgid "Repeat"
+msgstr "Qaitalau"
+
+msgctxt "subtitle position"
+msgid "Top"
+msgstr "Joğaryda"
+
+#, fuzzy
+msgctxt "list position"
+msgid "Top"
+msgstr "Joğaryda"
+
+msgctxt "subtitle position"
+msgid "Bottom"
+msgstr "Tömende"
+
+#, fuzzy
+msgctxt "list position"
+msgid "Bottom"
+msgstr "Tömende"
+
 #, fuzzy
 #~| msgid ""
 #~| "Could not add server.\n"

--- a/jellyfin_mpv_shim/messages/km/LC_MESSAGES/base.po
+++ b/jellyfin_mpv_shim/messages/km/LC_MESSAGES/base.po
@@ -5240,6 +5240,24 @@ msgstr "កម្រងព័ត៌មានការចាក់វីដេអ
 msgid "Select Shader Profile"
 msgstr ""
 
+msgctxt "subtitle position"
+msgid "Top"
+msgstr "កំពូល"
+
+#, fuzzy
+msgctxt "list position"
+msgid "Top"
+msgstr "កំពូល"
+
+msgctxt "subtitle position"
+msgid "Bottom"
+msgstr "បាត"
+
+#, fuzzy
+msgctxt "list position"
+msgid "Bottom"
+msgstr "បាត"
+
 #, fuzzy
 #~| msgid ""
 #~| "Could not add server.\n"

--- a/jellyfin_mpv_shim/messages/kn/LC_MESSAGES/base.po
+++ b/jellyfin_mpv_shim/messages/kn/LC_MESSAGES/base.po
@@ -4897,3 +4897,11 @@ msgstr ""
 #: jellyfin_mpv_shim/video_profile.py
 msgid "Select Shader Profile"
 msgstr ""
+
+msgctxt "setting value"
+msgid "Default"
+msgstr "ಪೂರ್ವನಿಯೋಜಿತ"
+
+msgctxt "media stream flag"
+msgid "Default"
+msgstr "ಪೂರ್ವನಿಯೋಜಿತ"

--- a/jellyfin_mpv_shim/messages/ko/LC_MESSAGES/base.po
+++ b/jellyfin_mpv_shim/messages/ko/LC_MESSAGES/base.po
@@ -5568,6 +5568,32 @@ msgstr "비디오 재생 프로필"
 msgid "Select Shader Profile"
 msgstr "셰이더 프로필 선택"
 
+msgctxt "playback control"
+msgid "Repeat"
+msgstr "반복"
+
+msgctxt "guide badge"
+msgid "Repeat"
+msgstr "반복"
+
+msgctxt "subtitle position"
+msgid "Top"
+msgstr "위"
+
+#, fuzzy
+msgctxt "list position"
+msgid "Top"
+msgstr "위"
+
+msgctxt "subtitle position"
+msgid "Bottom"
+msgstr "밑"
+
+#, fuzzy
+msgctxt "list position"
+msgid "Bottom"
+msgstr "밑"
+
 #, fuzzy
 #~| msgid ""
 #~| "Could not add server.\n"

--- a/jellyfin_mpv_shim/messages/kw/LC_MESSAGES/base.po
+++ b/jellyfin_mpv_shim/messages/kw/LC_MESSAGES/base.po
@@ -4915,3 +4915,11 @@ msgstr ""
 #: jellyfin_mpv_shim/video_profile.py
 msgid "Select Shader Profile"
 msgstr ""
+
+msgctxt "setting value"
+msgid "Default"
+msgstr "Defowt"
+
+msgctxt "media stream flag"
+msgid "Default"
+msgstr "Defowt"

--- a/jellyfin_mpv_shim/messages/lb/LC_MESSAGES/base.po
+++ b/jellyfin_mpv_shim/messages/lb/LC_MESSAGES/base.po
@@ -5300,6 +5300,42 @@ msgstr "Videowiedergabeprofiler"
 msgid "Select Shader Profile"
 msgstr ""
 
+msgctxt "setting value"
+msgid "Default"
+msgstr "Standard"
+
+msgctxt "media stream flag"
+msgid "Default"
+msgstr "Standard"
+
+msgctxt "playback control"
+msgid "Repeat"
+msgstr "Wiederhuelen"
+
+msgctxt "guide badge"
+msgid "Repeat"
+msgstr "Wiederhuelen"
+
+#, fuzzy
+msgctxt "subtitle position"
+msgid "Top"
+msgstr "Uewen"
+
+#, fuzzy
+msgctxt "list position"
+msgid "Top"
+msgstr "Uewen"
+
+#, fuzzy
+msgctxt "subtitle position"
+msgid "Bottom"
+msgstr "Ënnen"
+
+#, fuzzy
+msgctxt "list position"
+msgid "Bottom"
+msgstr "Ënnen"
+
 # seeded from jellyfin-web: Display
 #, fuzzy
 #~ msgid "Display"

--- a/jellyfin_mpv_shim/messages/lt/LC_MESSAGES/base.po
+++ b/jellyfin_mpv_shim/messages/lt/LC_MESSAGES/base.po
@@ -4874,6 +4874,64 @@ msgstr "Vaizdo atkūrimo profilis"
 msgid "Select Shader Profile"
 msgstr "Pasirinkite Shader profilį"
 
+#, fuzzy
+msgctxt "setting value"
+msgid "Default"
+msgstr "Numatytasis"
+
+#, fuzzy
+msgctxt "media stream flag"
+msgid "Default"
+msgstr "Numatytasis"
+
+#, fuzzy
+msgctxt "guide navigation"
+msgid "Later"
+msgstr "Vėliau"
+
+#, fuzzy
+msgctxt "update banner"
+msgid "Later"
+msgstr "Vėliau"
+
+#, fuzzy
+msgctxt "playback control"
+msgid "Repeat"
+msgstr "Kartoti"
+
+#, fuzzy
+msgctxt "guide badge"
+msgid "Repeat"
+msgstr "Kartoti"
+
+#, fuzzy
+msgctxt "form label"
+msgid "Confirm"
+msgstr "Patvirtinti"
+
+#, fuzzy
+msgctxt "dialog heading"
+msgid "Confirm"
+msgstr "Patvirtinti"
+
+msgctxt "subtitle position"
+msgid "Top"
+msgstr "Viršuje"
+
+#, fuzzy
+msgctxt "list position"
+msgid "Top"
+msgstr "Viršuje"
+
+msgctxt "subtitle position"
+msgid "Bottom"
+msgstr "Apačioje"
+
+#, fuzzy
+msgctxt "list position"
+msgid "Bottom"
+msgstr "Apačioje"
+
 #~ msgid "MPV UI with thumbnails"
 #~ msgstr "MPV vartotojo sąsaja su miniatiūromis"
 

--- a/jellyfin_mpv_shim/messages/lv/LC_MESSAGES/base.po
+++ b/jellyfin_mpv_shim/messages/lv/LC_MESSAGES/base.po
@@ -5519,6 +5519,42 @@ msgstr "Video atskaņošanas profils"
 msgid "Select Shader Profile"
 msgstr "Izvēlieties ēnotāja profilu"
 
+msgctxt "playback control"
+msgid "Repeat"
+msgstr "Atkārtot"
+
+msgctxt "guide badge"
+msgid "Repeat"
+msgstr "Atkārtot"
+
+#, fuzzy
+msgctxt "form label"
+msgid "Confirm"
+msgstr "Apstiprināt"
+
+#, fuzzy
+msgctxt "dialog heading"
+msgid "Confirm"
+msgstr "Apstiprināt"
+
+msgctxt "subtitle position"
+msgid "Top"
+msgstr "Augšā"
+
+#, fuzzy
+msgctxt "list position"
+msgid "Top"
+msgstr "Augšā"
+
+msgctxt "subtitle position"
+msgid "Bottom"
+msgstr "Apakšā"
+
+#, fuzzy
+msgctxt "list position"
+msgid "Bottom"
+msgstr "Apakšā"
+
 #~ msgid "Could not copy the text."
 #~ msgstr "Nevarēja kopēt tekstu."
 

--- a/jellyfin_mpv_shim/messages/mi/LC_MESSAGES/base.po
+++ b/jellyfin_mpv_shim/messages/mi/LC_MESSAGES/base.po
@@ -4895,3 +4895,11 @@ msgstr ""
 #: jellyfin_mpv_shim/video_profile.py
 msgid "Select Shader Profile"
 msgstr ""
+
+msgctxt "setting value"
+msgid "Default"
+msgstr "Taunoa"
+
+msgctxt "media stream flag"
+msgid "Default"
+msgstr "Taunoa"

--- a/jellyfin_mpv_shim/messages/ml/LC_MESSAGES/base.po
+++ b/jellyfin_mpv_shim/messages/ml/LC_MESSAGES/base.po
@@ -5450,6 +5450,22 @@ msgstr ""
 msgid "Select Shader Profile"
 msgstr ""
 
+msgctxt "setting value"
+msgid "Default"
+msgstr "സ്ഥിരസ്ഥിതി"
+
+msgctxt "media stream flag"
+msgid "Default"
+msgstr "സ്ഥിരസ്ഥിതി"
+
+msgctxt "playback control"
+msgid "Repeat"
+msgstr "ആവർത്തിച്ച്"
+
+msgctxt "guide badge"
+msgid "Repeat"
+msgstr "ആവർത്തിച്ച്"
+
 #, fuzzy
 #~| msgid ""
 #~| "Could not add server.\n"

--- a/jellyfin_mpv_shim/messages/mn/LC_MESSAGES/base.po
+++ b/jellyfin_mpv_shim/messages/mn/LC_MESSAGES/base.po
@@ -5587,6 +5587,40 @@ msgstr "Видео тоглуулах профайл"
 msgid "Select Shader Profile"
 msgstr "Shader Profile-г сонгоно уу"
 
+msgctxt "setting value"
+msgid "Default"
+msgstr "Анхдагч"
+
+msgctxt "media stream flag"
+msgid "Default"
+msgstr "Анхдагч"
+
+msgctxt "playback control"
+msgid "Repeat"
+msgstr "Давтах"
+
+msgctxt "guide badge"
+msgid "Repeat"
+msgstr "Давтах"
+
+msgctxt "subtitle position"
+msgid "Top"
+msgstr "Дээд"
+
+#, fuzzy
+msgctxt "list position"
+msgid "Top"
+msgstr "Дээд"
+
+msgctxt "subtitle position"
+msgid "Bottom"
+msgstr "Доод"
+
+#, fuzzy
+msgctxt "list position"
+msgid "Bottom"
+msgstr "Доод"
+
 #, fuzzy
 #~| msgid ""
 #~| "Could not add server.\n"

--- a/jellyfin_mpv_shim/messages/mr/LC_MESSAGES/base.po
+++ b/jellyfin_mpv_shim/messages/mr/LC_MESSAGES/base.po
@@ -5303,6 +5303,24 @@ msgstr ""
 msgid "Select Shader Profile"
 msgstr "शेडर प्रोफाइल निवडा"
 
+msgctxt "subtitle position"
+msgid "Top"
+msgstr "वर"
+
+#, fuzzy
+msgctxt "list position"
+msgid "Top"
+msgstr "वर"
+
+msgctxt "subtitle position"
+msgid "Bottom"
+msgstr "खाली"
+
+#, fuzzy
+msgctxt "list position"
+msgid "Bottom"
+msgstr "खाली"
+
 #~ msgid "Fail"
 #~ msgstr "अपयशी"
 

--- a/jellyfin_mpv_shim/messages/ms/LC_MESSAGES/base.po
+++ b/jellyfin_mpv_shim/messages/ms/LC_MESSAGES/base.po
@@ -5288,6 +5288,34 @@ msgstr ""
 msgid "Select Shader Profile"
 msgstr ""
 
+msgctxt "setting value"
+msgid "Default"
+msgstr "Default"
+
+msgctxt "media stream flag"
+msgid "Default"
+msgstr "Default"
+
+#, fuzzy
+msgctxt "subtitle position"
+msgid "Top"
+msgstr "Atas"
+
+#, fuzzy
+msgctxt "list position"
+msgid "Top"
+msgstr "Atas"
+
+#, fuzzy
+msgctxt "subtitle position"
+msgid "Bottom"
+msgstr "Bawah"
+
+#, fuzzy
+msgctxt "list position"
+msgid "Bottom"
+msgstr "Bawah"
+
 #, fuzzy
 #~| msgid ""
 #~| "Could not add server.\n"

--- a/jellyfin_mpv_shim/messages/nb_NO/LC_MESSAGES/base.po
+++ b/jellyfin_mpv_shim/messages/nb_NO/LC_MESSAGES/base.po
@@ -5598,6 +5598,40 @@ msgstr "Videoavspillingsprofiler"
 msgid "Select Shader Profile"
 msgstr "Velg shaderprofil"
 
+msgctxt "setting value"
+msgid "Default"
+msgstr "Standard"
+
+msgctxt "media stream flag"
+msgid "Default"
+msgstr "Standard"
+
+msgctxt "playback control"
+msgid "Repeat"
+msgstr "Gjenta"
+
+msgctxt "guide badge"
+msgid "Repeat"
+msgstr "Gjenta"
+
+msgctxt "subtitle position"
+msgid "Top"
+msgstr "Øverst"
+
+#, fuzzy
+msgctxt "list position"
+msgid "Top"
+msgstr "Øverst"
+
+msgctxt "subtitle position"
+msgid "Bottom"
+msgstr "Nederst"
+
+#, fuzzy
+msgctxt "list position"
+msgid "Bottom"
+msgstr "Nederst"
+
 #, fuzzy
 #~| msgid ""
 #~| "Could not add server.\n"

--- a/jellyfin_mpv_shim/messages/nds/LC_MESSAGES/base.po
+++ b/jellyfin_mpv_shim/messages/nds/LC_MESSAGES/base.po
@@ -5215,6 +5215,24 @@ msgstr "Videowiedergabeprofile"
 msgid "Select Shader Profile"
 msgstr "Shader-Profil auswählen"
 
+msgctxt "subtitle position"
+msgid "Top"
+msgstr "Oben"
+
+#, fuzzy
+msgctxt "list position"
+msgid "Top"
+msgstr "Oben"
+
+msgctxt "subtitle position"
+msgid "Bottom"
+msgstr "Unten"
+
+#, fuzzy
+msgctxt "list position"
+msgid "Bottom"
+msgstr "Unten"
+
 #, fuzzy
 #~ msgid "Could not copy the text."
 #~ msgstr ""

--- a/jellyfin_mpv_shim/messages/ne/LC_MESSAGES/base.po
+++ b/jellyfin_mpv_shim/messages/ne/LC_MESSAGES/base.po
@@ -5362,6 +5362,32 @@ msgstr "भिडियो प्लेब्याक प्रोफाइल�
 msgid "Select Shader Profile"
 msgstr "शेडर प्रोफाइल चयन गर्नुहोस्"
 
+msgctxt "setting value"
+msgid "Default"
+msgstr "पूर्वनिर्धारित"
+
+msgctxt "media stream flag"
+msgid "Default"
+msgstr "पूर्वनिर्धारित"
+
+msgctxt "subtitle position"
+msgid "Top"
+msgstr "माथि"
+
+#, fuzzy
+msgctxt "list position"
+msgid "Top"
+msgstr "माथि"
+
+msgctxt "subtitle position"
+msgid "Bottom"
+msgstr "तल"
+
+#, fuzzy
+msgctxt "list position"
+msgid "Bottom"
+msgstr "तल"
+
 #, fuzzy
 #~| msgid ""
 #~| "Could not add server.\n"

--- a/jellyfin_mpv_shim/messages/nl/LC_MESSAGES/base.po
+++ b/jellyfin_mpv_shim/messages/nl/LC_MESSAGES/base.po
@@ -5546,6 +5546,42 @@ msgstr "Video-afspeelprofielen"
 msgid "Select Shader Profile"
 msgstr "Selecteer Shader profiel"
 
+msgctxt "playback control"
+msgid "Repeat"
+msgstr "Herhaling"
+
+msgctxt "guide badge"
+msgid "Repeat"
+msgstr "Herhaling"
+
+#, fuzzy
+msgctxt "form label"
+msgid "Confirm"
+msgstr "Bevestigen"
+
+#, fuzzy
+msgctxt "dialog heading"
+msgid "Confirm"
+msgstr "Bevestigen"
+
+msgctxt "subtitle position"
+msgid "Top"
+msgstr "Boven"
+
+#, fuzzy
+msgctxt "list position"
+msgid "Top"
+msgstr "Boven"
+
+msgctxt "subtitle position"
+msgid "Bottom"
+msgstr "Onder"
+
+#, fuzzy
+msgctxt "list position"
+msgid "Bottom"
+msgstr "Onder"
+
 #~ msgid "MPV UI with thumbnails"
 #~ msgstr "MPV-interface met miniaturen"
 

--- a/jellyfin_mpv_shim/messages/nn/LC_MESSAGES/base.po
+++ b/jellyfin_mpv_shim/messages/nn/LC_MESSAGES/base.po
@@ -5293,6 +5293,22 @@ msgstr ""
 msgid "Select Shader Profile"
 msgstr ""
 
+msgctxt "setting value"
+msgid "Default"
+msgstr "Standard"
+
+msgctxt "media stream flag"
+msgid "Default"
+msgstr "Standard"
+
+msgctxt "playback control"
+msgid "Repeat"
+msgstr "Gjenta"
+
+msgctxt "guide badge"
+msgid "Repeat"
+msgstr "Gjenta"
+
 # seeded from jellyfin-web: Display
 #, fuzzy
 #~ msgid "Display"

--- a/jellyfin_mpv_shim/messages/oc/LC_MESSAGES/base.po
+++ b/jellyfin_mpv_shim/messages/oc/LC_MESSAGES/base.po
@@ -4881,3 +4881,11 @@ msgstr ""
 #: jellyfin_mpv_shim/video_profile.py
 msgid "Select Shader Profile"
 msgstr ""
+
+msgctxt "setting value"
+msgid "Default"
+msgstr "Defaut"
+
+msgctxt "media stream flag"
+msgid "Default"
+msgstr "Defaut"

--- a/jellyfin_mpv_shim/messages/pl/LC_MESSAGES/base.po
+++ b/jellyfin_mpv_shim/messages/pl/LC_MESSAGES/base.po
@@ -5489,6 +5489,50 @@ msgstr "Profile odtwarzania wideo"
 msgid "Select Shader Profile"
 msgstr "Wybierz profil shadera"
 
+msgctxt "setting value"
+msgid "Default"
+msgstr "Domyślnie"
+
+msgctxt "media stream flag"
+msgid "Default"
+msgstr "Domyślnie"
+
+msgctxt "playback control"
+msgid "Repeat"
+msgstr "Powtórz"
+
+msgctxt "guide badge"
+msgid "Repeat"
+msgstr "Powtórz"
+
+#, fuzzy
+msgctxt "form label"
+msgid "Confirm"
+msgstr "Potwierdź"
+
+#, fuzzy
+msgctxt "dialog heading"
+msgid "Confirm"
+msgstr "Potwierdź"
+
+msgctxt "subtitle position"
+msgid "Top"
+msgstr "Na górze"
+
+#, fuzzy
+msgctxt "list position"
+msgid "Top"
+msgstr "Na górze"
+
+msgctxt "subtitle position"
+msgid "Bottom"
+msgstr "Na dole"
+
+#, fuzzy
+msgctxt "list position"
+msgid "Bottom"
+msgstr "Na dole"
+
 #~ msgid "MPV UI with thumbnails"
 #~ msgstr "Interfejs MPV z miniaturami"
 

--- a/jellyfin_mpv_shim/messages/pt/LC_MESSAGES/base.po
+++ b/jellyfin_mpv_shim/messages/pt/LC_MESSAGES/base.po
@@ -5475,6 +5475,61 @@ msgstr "Perfil de reprodução de vídeo"
 msgid "Select Shader Profile"
 msgstr "Selecionar perfil de shader"
 
+# seeded from jellyfin-web: Default
+msgctxt "setting value"
+msgid "Default"
+msgstr "Predefinição"
+
+# seeded from jellyfin-web: MediaInfoDefault
+msgctxt "media stream flag"
+msgid "Default"
+msgstr "Predefinido"
+
+msgctxt "guide navigation"
+msgid "Later"
+msgstr "Mais tarde"
+
+#, fuzzy
+msgctxt "update banner"
+msgid "Later"
+msgstr "Mais tarde"
+
+msgctxt "playback control"
+msgid "Repeat"
+msgstr "Repetir"
+
+msgctxt "guide badge"
+msgid "Repeat"
+msgstr "Repetir"
+
+#, fuzzy
+msgctxt "form label"
+msgid "Confirm"
+msgstr "Confirmar"
+
+#, fuzzy
+msgctxt "dialog heading"
+msgid "Confirm"
+msgstr "Confirmar"
+
+msgctxt "subtitle position"
+msgid "Top"
+msgstr "Topo"
+
+#, fuzzy
+msgctxt "list position"
+msgid "Top"
+msgstr "Topo"
+
+msgctxt "subtitle position"
+msgid "Bottom"
+msgstr "Fundo"
+
+#, fuzzy
+msgctxt "list position"
+msgid "Bottom"
+msgstr "Fundo"
+
 #~ msgid "MPV UI with thumbnails"
 #~ msgstr "Interface do MPV com miniaturas"
 

--- a/jellyfin_mpv_shim/messages/pt_BR/LC_MESSAGES/base.po
+++ b/jellyfin_mpv_shim/messages/pt_BR/LC_MESSAGES/base.po
@@ -5529,6 +5529,40 @@ msgstr "Perfis de reprodução de vídeo"
 msgid "Select Shader Profile"
 msgstr "Selecione o perfil do shader"
 
+msgctxt "setting value"
+msgid "Default"
+msgstr "Padrão"
+
+msgctxt "media stream flag"
+msgid "Default"
+msgstr "Padrão"
+
+msgctxt "playback control"
+msgid "Repeat"
+msgstr "Repetir"
+
+msgctxt "guide badge"
+msgid "Repeat"
+msgstr "Repetir"
+
+msgctxt "subtitle position"
+msgid "Top"
+msgstr "Topo"
+
+#, fuzzy
+msgctxt "list position"
+msgid "Top"
+msgstr "Topo"
+
+msgctxt "subtitle position"
+msgid "Bottom"
+msgstr "Fundo"
+
+#, fuzzy
+msgctxt "list position"
+msgid "Bottom"
+msgstr "Fundo"
+
 #, fuzzy
 #~| msgid ""
 #~| "Could not add server.\n"

--- a/jellyfin_mpv_shim/messages/pt_PT/LC_MESSAGES/base.po
+++ b/jellyfin_mpv_shim/messages/pt_PT/LC_MESSAGES/base.po
@@ -5465,6 +5465,61 @@ msgstr "Perfil de reprodução de vídeo"
 msgid "Select Shader Profile"
 msgstr "Selecionar perfil de shader"
 
+# seeded from jellyfin-web: Default
+msgctxt "setting value"
+msgid "Default"
+msgstr "Predefinição"
+
+# seeded from jellyfin-web: MediaInfoDefault
+msgctxt "media stream flag"
+msgid "Default"
+msgstr "Predefinido"
+
+msgctxt "guide navigation"
+msgid "Later"
+msgstr "Mais tarde"
+
+#, fuzzy
+msgctxt "update banner"
+msgid "Later"
+msgstr "Mais tarde"
+
+msgctxt "playback control"
+msgid "Repeat"
+msgstr "Repetir"
+
+msgctxt "guide badge"
+msgid "Repeat"
+msgstr "Repetir"
+
+#, fuzzy
+msgctxt "form label"
+msgid "Confirm"
+msgstr "Confirmar"
+
+#, fuzzy
+msgctxt "dialog heading"
+msgid "Confirm"
+msgstr "Confirmar"
+
+msgctxt "subtitle position"
+msgid "Top"
+msgstr "Topo"
+
+#, fuzzy
+msgctxt "list position"
+msgid "Top"
+msgstr "Topo"
+
+msgctxt "subtitle position"
+msgid "Bottom"
+msgstr "Fundo"
+
+#, fuzzy
+msgctxt "list position"
+msgid "Bottom"
+msgstr "Fundo"
+
 #~ msgid "MPV UI with thumbnails"
 #~ msgstr "Interface do MPV com miniaturas"
 

--- a/jellyfin_mpv_shim/messages/ro/LC_MESSAGES/base.po
+++ b/jellyfin_mpv_shim/messages/ro/LC_MESSAGES/base.po
@@ -5598,6 +5598,40 @@ msgstr "Profiluri de Redare Video"
 msgid "Select Shader Profile"
 msgstr "Selectați Profilul Shader"
 
+msgctxt "setting value"
+msgid "Default"
+msgstr "Implicit"
+
+msgctxt "media stream flag"
+msgid "Default"
+msgstr "Implicit"
+
+msgctxt "playback control"
+msgid "Repeat"
+msgstr "Repetă"
+
+msgctxt "guide badge"
+msgid "Repeat"
+msgstr "Repetă"
+
+msgctxt "subtitle position"
+msgid "Top"
+msgstr "De-asupra"
+
+#, fuzzy
+msgctxt "list position"
+msgid "Top"
+msgstr "De-asupra"
+
+msgctxt "subtitle position"
+msgid "Bottom"
+msgstr "Dedesubt"
+
+#, fuzzy
+msgctxt "list position"
+msgid "Bottom"
+msgstr "Dedesubt"
+
 #, fuzzy
 #~| msgid ""
 #~| "Could not add server.\n"

--- a/jellyfin_mpv_shim/messages/ru/LC_MESSAGES/base.po
+++ b/jellyfin_mpv_shim/messages/ru/LC_MESSAGES/base.po
@@ -5563,6 +5563,50 @@ msgstr "Профили воспроизведения видео"
 msgid "Select Shader Profile"
 msgstr "Выбрать профиль шейдера"
 
+msgctxt "setting value"
+msgid "Default"
+msgstr "По умолчанию"
+
+msgctxt "media stream flag"
+msgid "Default"
+msgstr "По умолчанию"
+
+msgctxt "playback control"
+msgid "Repeat"
+msgstr "Повтор"
+
+msgctxt "guide badge"
+msgid "Repeat"
+msgstr "Повтор"
+
+#, fuzzy
+msgctxt "form label"
+msgid "Confirm"
+msgstr "Подтвердить"
+
+#, fuzzy
+msgctxt "dialog heading"
+msgid "Confirm"
+msgstr "Подтвердить"
+
+msgctxt "subtitle position"
+msgid "Top"
+msgstr "Вверху"
+
+#, fuzzy
+msgctxt "list position"
+msgid "Top"
+msgstr "Вверху"
+
+msgctxt "subtitle position"
+msgid "Bottom"
+msgstr "Внизу"
+
+#, fuzzy
+msgctxt "list position"
+msgid "Bottom"
+msgstr "Внизу"
+
 #, fuzzy
 #~| msgid ""
 #~| "Could not add server.\n"

--- a/jellyfin_mpv_shim/messages/sk/LC_MESSAGES/base.po
+++ b/jellyfin_mpv_shim/messages/sk/LC_MESSAGES/base.po
@@ -5528,6 +5528,32 @@ msgstr "Profily prehrávania videa"
 msgid "Select Shader Profile"
 msgstr "Vyberte profil shadera"
 
+msgctxt "playback control"
+msgid "Repeat"
+msgstr "Opakovať"
+
+msgctxt "guide badge"
+msgid "Repeat"
+msgstr "Opakovať"
+
+msgctxt "subtitle position"
+msgid "Top"
+msgstr "Hore"
+
+#, fuzzy
+msgctxt "list position"
+msgid "Top"
+msgstr "Hore"
+
+msgctxt "subtitle position"
+msgid "Bottom"
+msgstr "Dole"
+
+#, fuzzy
+msgctxt "list position"
+msgid "Bottom"
+msgstr "Dole"
+
 #, fuzzy
 #~| msgid ""
 #~| "Could not add server.\n"

--- a/jellyfin_mpv_shim/messages/sl/LC_MESSAGES/base.po
+++ b/jellyfin_mpv_shim/messages/sl/LC_MESSAGES/base.po
@@ -5270,6 +5270,24 @@ msgstr "Profili predvajanja videa"
 msgid "Select Shader Profile"
 msgstr "Izberi profil senčenja"
 
+msgctxt "subtitle position"
+msgid "Top"
+msgstr "Na vrhu"
+
+#, fuzzy
+msgctxt "list position"
+msgid "Top"
+msgstr "Na vrhu"
+
+msgctxt "subtitle position"
+msgid "Bottom"
+msgstr "Na dnu"
+
+#, fuzzy
+msgctxt "list position"
+msgid "Bottom"
+msgstr "Na dnu"
+
 #, fuzzy
 #~| msgid ""
 #~| "Could not add server.\n"

--- a/jellyfin_mpv_shim/messages/sq/LC_MESSAGES/base.po
+++ b/jellyfin_mpv_shim/messages/sq/LC_MESSAGES/base.po
@@ -5400,6 +5400,32 @@ msgstr "Profilet e luajtjes së videos"
 msgid "Select Shader Profile"
 msgstr "Zgjidh profilin e hijëzuesit"
 
+msgctxt "setting value"
+msgid "Default"
+msgstr "Parazgjedhur"
+
+msgctxt "media stream flag"
+msgid "Default"
+msgstr "Parazgjedhur"
+
+msgctxt "subtitle position"
+msgid "Top"
+msgstr "Lartë"
+
+#, fuzzy
+msgctxt "list position"
+msgid "Top"
+msgstr "Lartë"
+
+msgctxt "subtitle position"
+msgid "Bottom"
+msgstr "Poshtë"
+
+#, fuzzy
+msgctxt "list position"
+msgid "Bottom"
+msgstr "Poshtë"
+
 #, fuzzy
 #~| msgid ""
 #~| "Could not add server.\n"

--- a/jellyfin_mpv_shim/messages/sr/LC_MESSAGES/base.po
+++ b/jellyfin_mpv_shim/messages/sr/LC_MESSAGES/base.po
@@ -5656,6 +5656,50 @@ msgstr "Профил репродукције снимка"
 msgid "Select Shader Profile"
 msgstr "Изабери шедера (Shader) профил"
 
+msgctxt "setting value"
+msgid "Default"
+msgstr "Подразумевано"
+
+msgctxt "media stream flag"
+msgid "Default"
+msgstr "Подразумевано"
+
+msgctxt "playback control"
+msgid "Repeat"
+msgstr "Понови"
+
+msgctxt "guide badge"
+msgid "Repeat"
+msgstr "Понови"
+
+#, fuzzy
+msgctxt "form label"
+msgid "Confirm"
+msgstr "Потврди"
+
+#, fuzzy
+msgctxt "dialog heading"
+msgid "Confirm"
+msgstr "Потврди"
+
+msgctxt "subtitle position"
+msgid "Top"
+msgstr "Горе"
+
+#, fuzzy
+msgctxt "list position"
+msgid "Top"
+msgstr "Горе"
+
+msgctxt "subtitle position"
+msgid "Bottom"
+msgstr "Доле"
+
+#, fuzzy
+msgctxt "list position"
+msgid "Bottom"
+msgstr "Доле"
+
 #, fuzzy
 #~| msgid ""
 #~| "Could not add server.\n"

--- a/jellyfin_mpv_shim/messages/sv/LC_MESSAGES/base.po
+++ b/jellyfin_mpv_shim/messages/sv/LC_MESSAGES/base.po
@@ -5551,6 +5551,32 @@ msgstr "Uppspelningsprofiler"
 msgid "Select Shader Profile"
 msgstr "Välj shaderprofil"
 
+msgctxt "playback control"
+msgid "Repeat"
+msgstr "Upprepa"
+
+msgctxt "guide badge"
+msgid "Repeat"
+msgstr "Upprepa"
+
+msgctxt "subtitle position"
+msgid "Top"
+msgstr "Längst upp"
+
+#, fuzzy
+msgctxt "list position"
+msgid "Top"
+msgstr "Längst upp"
+
+msgctxt "subtitle position"
+msgid "Bottom"
+msgstr "Längst ner"
+
+#, fuzzy
+msgctxt "list position"
+msgid "Bottom"
+msgstr "Längst ner"
+
 #, fuzzy
 #~| msgid ""
 #~| "Could not add server.\n"

--- a/jellyfin_mpv_shim/messages/ta/LC_MESSAGES/base.po
+++ b/jellyfin_mpv_shim/messages/ta/LC_MESSAGES/base.po
@@ -5595,6 +5595,40 @@ msgstr "வீடியோ பின்னணி சுயவிவரங்க�
 msgid "Select Shader Profile"
 msgstr "ஷேடர் சுயவிவரத்தைத் தேர்ந்தெடுக்கவும்"
 
+msgctxt "setting value"
+msgid "Default"
+msgstr "இயல்புநிலை"
+
+msgctxt "media stream flag"
+msgid "Default"
+msgstr "இயல்புநிலை"
+
+msgctxt "playback control"
+msgid "Repeat"
+msgstr "மீண்டும்"
+
+msgctxt "guide badge"
+msgid "Repeat"
+msgstr "மீண்டும்"
+
+msgctxt "subtitle position"
+msgid "Top"
+msgstr "மேலே"
+
+#, fuzzy
+msgctxt "list position"
+msgid "Top"
+msgstr "மேலே"
+
+msgctxt "subtitle position"
+msgid "Bottom"
+msgstr "கீழே"
+
+#, fuzzy
+msgctxt "list position"
+msgid "Bottom"
+msgstr "கீழே"
+
 #, fuzzy
 #~| msgid ""
 #~| "Could not add server.\n"

--- a/jellyfin_mpv_shim/messages/th/LC_MESSAGES/base.po
+++ b/jellyfin_mpv_shim/messages/th/LC_MESSAGES/base.po
@@ -5236,6 +5236,32 @@ msgstr "โปรไฟล์การเล่นวิดีโอ"
 msgid "Select Shader Profile"
 msgstr "เลือกโปรไฟล์ Shader"
 
+msgctxt "setting value"
+msgid "Default"
+msgstr "ค่าเริ่มต้น"
+
+msgctxt "media stream flag"
+msgid "Default"
+msgstr "ค่าเริ่มต้น"
+
+msgctxt "subtitle position"
+msgid "Top"
+msgstr "ด้านบน"
+
+#, fuzzy
+msgctxt "list position"
+msgid "Top"
+msgstr "ด้านบน"
+
+msgctxt "subtitle position"
+msgid "Bottom"
+msgstr "ด้านล่าง"
+
+#, fuzzy
+msgctxt "list position"
+msgid "Bottom"
+msgstr "ด้านล่าง"
+
 #, fuzzy
 #~| msgid ""
 #~| "Could not add server.\n"

--- a/jellyfin_mpv_shim/messages/tr/LC_MESSAGES/base.po
+++ b/jellyfin_mpv_shim/messages/tr/LC_MESSAGES/base.po
@@ -5595,6 +5595,52 @@ msgstr "Video Oynatma Profilleri"
 msgid "Select Shader Profile"
 msgstr "Gölgelendirici Profili Seçin"
 
+# seeded from jellyfin-web: Default
+msgctxt "setting value"
+msgid "Default"
+msgstr "Varsayılan"
+
+# seeded from jellyfin-web: MediaInfoDefault
+msgctxt "media stream flag"
+msgid "Default"
+msgstr "Öntanımlı"
+
+msgctxt "playback control"
+msgid "Repeat"
+msgstr "Tekrarla"
+
+msgctxt "guide badge"
+msgid "Repeat"
+msgstr "Tekrarla"
+
+#, fuzzy
+msgctxt "form label"
+msgid "Confirm"
+msgstr "Onayla"
+
+#, fuzzy
+msgctxt "dialog heading"
+msgid "Confirm"
+msgstr "Onayla"
+
+msgctxt "subtitle position"
+msgid "Top"
+msgstr "Üst"
+
+#, fuzzy
+msgctxt "list position"
+msgid "Top"
+msgstr "Üst"
+
+msgctxt "subtitle position"
+msgid "Bottom"
+msgstr "Alt kısım"
+
+#, fuzzy
+msgctxt "list position"
+msgid "Bottom"
+msgstr "Alt kısım"
+
 #~ msgid "MPV UI with thumbnails"
 #~ msgstr "Küçük resimli MPV arayüzü"
 

--- a/jellyfin_mpv_shim/messages/ug/LC_MESSAGES/base.po
+++ b/jellyfin_mpv_shim/messages/ug/LC_MESSAGES/base.po
@@ -4954,3 +4954,11 @@ msgstr ""
 #: jellyfin_mpv_shim/video_profile.py
 msgid "Select Shader Profile"
 msgstr ""
+
+msgctxt "setting value"
+msgid "Default"
+msgstr "سۈكۈتتىكى"
+
+msgctxt "media stream flag"
+msgid "Default"
+msgstr "سۈكۈتتىكى"

--- a/jellyfin_mpv_shim/messages/uk/LC_MESSAGES/base.po
+++ b/jellyfin_mpv_shim/messages/uk/LC_MESSAGES/base.po
@@ -5573,6 +5573,40 @@ msgstr "Профілі відтворення відео"
 msgid "Select Shader Profile"
 msgstr "Виберіть профіль шейдера"
 
+msgctxt "setting value"
+msgid "Default"
+msgstr "За замовчуванням"
+
+msgctxt "media stream flag"
+msgid "Default"
+msgstr "За замовчуванням"
+
+msgctxt "playback control"
+msgid "Repeat"
+msgstr "Повторювати"
+
+msgctxt "guide badge"
+msgid "Repeat"
+msgstr "Повторювати"
+
+msgctxt "subtitle position"
+msgid "Top"
+msgstr "Зверху"
+
+#, fuzzy
+msgctxt "list position"
+msgid "Top"
+msgstr "Зверху"
+
+msgctxt "subtitle position"
+msgid "Bottom"
+msgstr "Знизу"
+
+#, fuzzy
+msgctxt "list position"
+msgid "Bottom"
+msgstr "Знизу"
+
 #, fuzzy
 #~| msgid ""
 #~| "Could not add server.\n"

--- a/jellyfin_mpv_shim/messages/uz/LC_MESSAGES/base.po
+++ b/jellyfin_mpv_shim/messages/uz/LC_MESSAGES/base.po
@@ -5120,6 +5120,14 @@ msgstr ""
 msgid "Select Shader Profile"
 msgstr ""
 
+msgctxt "setting value"
+msgid "Default"
+msgstr "Joriy"
+
+msgctxt "media stream flag"
+msgid "Default"
+msgstr "Joriy"
+
 # seeded from jellyfin-web: Display
 #, fuzzy
 #~ msgid "Display"

--- a/jellyfin_mpv_shim/messages/vi/LC_MESSAGES/base.po
+++ b/jellyfin_mpv_shim/messages/vi/LC_MESSAGES/base.po
@@ -5586,6 +5586,32 @@ msgstr "Cấu hình phát lại video"
 msgid "Select Shader Profile"
 msgstr "Chọn hồ sơ Shader"
 
+msgctxt "playback control"
+msgid "Repeat"
+msgstr "Lặp lại"
+
+msgctxt "guide badge"
+msgid "Repeat"
+msgstr "Lặp lại"
+
+msgctxt "subtitle position"
+msgid "Top"
+msgstr "Ở Trên"
+
+#, fuzzy
+msgctxt "list position"
+msgid "Top"
+msgstr "Ở Trên"
+
+msgctxt "subtitle position"
+msgid "Bottom"
+msgstr "Ở Dưới"
+
+#, fuzzy
+msgctxt "list position"
+msgid "Bottom"
+msgstr "Ở Dưới"
+
 #, fuzzy
 #~| msgid ""
 #~| "Could not add server.\n"

--- a/jellyfin_mpv_shim/messages/zh_Hans/LC_MESSAGES/base.po
+++ b/jellyfin_mpv_shim/messages/zh_Hans/LC_MESSAGES/base.po
@@ -5157,6 +5157,60 @@ msgstr "视频播放预设"
 msgid "Select Shader Profile"
 msgstr "选择着色器配置预设"
 
+msgctxt "setting value"
+msgid "Default"
+msgstr "默认"
+
+msgctxt "media stream flag"
+msgid "Default"
+msgstr "默认"
+
+msgctxt "guide navigation"
+msgid "Later"
+msgstr "之后"
+
+#, fuzzy
+msgctxt "update banner"
+msgid "Later"
+msgstr "之后"
+
+msgctxt "playback control"
+msgid "Repeat"
+msgstr "循环播放"
+
+#, fuzzy
+msgctxt "guide badge"
+msgid "Repeat"
+msgstr "循环播放"
+
+#, fuzzy
+msgctxt "form label"
+msgid "Confirm"
+msgstr "确认"
+
+#, fuzzy
+msgctxt "dialog heading"
+msgid "Confirm"
+msgstr "确认"
+
+msgctxt "subtitle position"
+msgid "Top"
+msgstr "顶部"
+
+#, fuzzy
+msgctxt "list position"
+msgid "Top"
+msgstr "顶部"
+
+msgctxt "subtitle position"
+msgid "Bottom"
+msgstr "底部"
+
+#, fuzzy
+msgctxt "list position"
+msgid "Bottom"
+msgstr "底部"
+
 #~ msgid "MPV UI with thumbnails"
 #~ msgstr "带缩略图的 MPV UI"
 

--- a/jellyfin_mpv_shim/messages/zh_Hant/LC_MESSAGES/base.po
+++ b/jellyfin_mpv_shim/messages/zh_Hant/LC_MESSAGES/base.po
@@ -5581,6 +5581,40 @@ msgstr "影片播放設定檔"
 msgid "Select Shader Profile"
 msgstr "選擇陰影設定檔"
 
+msgctxt "setting value"
+msgid "Default"
+msgstr "預設"
+
+msgctxt "media stream flag"
+msgid "Default"
+msgstr "預設"
+
+msgctxt "playback control"
+msgid "Repeat"
+msgstr "重複"
+
+msgctxt "guide badge"
+msgid "Repeat"
+msgstr "重複"
+
+msgctxt "subtitle position"
+msgid "Top"
+msgstr "頂部"
+
+#, fuzzy
+msgctxt "list position"
+msgid "Top"
+msgstr "頂部"
+
+msgctxt "subtitle position"
+msgid "Bottom"
+msgstr "底部"
+
+#, fuzzy
+msgctxt "list position"
+msgid "Bottom"
+msgstr "底部"
+
 #, fuzzy
 #~| msgid ""
 #~| "Could not add server.\n"

--- a/jellyfin_mpv_shim/messages/zh_Hant_HK/LC_MESSAGES/base.po
+++ b/jellyfin_mpv_shim/messages/zh_Hant_HK/LC_MESSAGES/base.po
@@ -5459,6 +5459,42 @@ msgstr "影片播放設定檔"
 msgid "Select Shader Profile"
 msgstr "揀著色器 (Shader) 設定檔"
 
+msgctxt "playback control"
+msgid "Repeat"
+msgstr "重複播放"
+
+msgctxt "guide badge"
+msgid "Repeat"
+msgstr "重複播放"
+
+#, fuzzy
+msgctxt "form label"
+msgid "Confirm"
+msgstr "確認"
+
+#, fuzzy
+msgctxt "dialog heading"
+msgid "Confirm"
+msgstr "確認"
+
+msgctxt "subtitle position"
+msgid "Top"
+msgstr "頂部"
+
+#, fuzzy
+msgctxt "list position"
+msgid "Top"
+msgstr "頂部"
+
+msgctxt "subtitle position"
+msgid "Bottom"
+msgstr "底部"
+
+#, fuzzy
+msgctxt "list position"
+msgid "Bottom"
+msgstr "底部"
+
 #~ msgid "MPV UI with thumbnails"
 #~ msgstr "附預覽圖嘅 MPV 介面"
 

--- a/jellyfin_mpv_shim/mpvtk_browser/auth.py
+++ b/jellyfin_mpv_shim/mpvtk_browser/auth.py
@@ -12,7 +12,7 @@ core's ``navigate`` / ``nav_stack``.
 
 import logging
 
-from ..i18n import _
+from ..i18n import _, _p
 from ..mpvtk.widgets import (
     Box,
     Busy,
@@ -139,7 +139,8 @@ class AuthMixin:
             rows += [
                 self._pin_field(_("New PIN"), "ps-new", state, "new",
                                 on_submit=save),
-                self._pin_field(_("Confirm"), "ps-confirm", state, "confirm",
+                self._pin_field(_p("form label", "Confirm"), "ps-confirm",
+                                state, "confirm",
                                 on_submit=save),
                 Checkbox(_("Require this PIN at startup"), state["startup"],
                          id="ps-startup",

--- a/jellyfin_mpv_shim/mpvtk_browser/components/media_info.py
+++ b/jellyfin_mpv_shim/mpvtk_browser/components/media_info.py
@@ -184,7 +184,7 @@ def stream_attributes(stream, source=None):
     add("NAL", stream.get("NalLengthSize"))
     if kind in ("Subtitle", "Audio"):
         # Only the true ones; see the docstring.
-        for flag, label in (("IsDefault", _("Default")),
+        for flag, label in (("IsDefault", _p("media stream flag", "Default")),
                             ("IsForced", _("Forced")),
                             ("IsExternal", _("External"))):
             if stream.get(flag):

--- a/jellyfin_mpv_shim/mpvtk_browser/config.py
+++ b/jellyfin_mpv_shim/mpvtk_browser/config.py
@@ -573,7 +573,7 @@ LABELED_ENUMS = {
         (_("Fit Page"), "page"),
     ],
     "hud_scrim": [
-        (_("Default"), "default"),
+        (_p("setting value", "Default"), "default"),
         (_("Panel behind the controls"), "panel"),
         (_("None (shadowed text)"), "none"),
     ],

--- a/jellyfin_mpv_shim/mpvtk_browser/dialogs.py
+++ b/jellyfin_mpv_shim/mpvtk_browser/dialogs.py
@@ -1097,7 +1097,7 @@ class DialogsMixin:
         truncated. `_message` had worked this out and used
         `chrome.paragraph`; this one had not.
         """
-        title = title or _("Confirm")
+        title = title or _p("dialog heading", "Confirm")
         yes = yes or _("OK")
 
         def build():

--- a/jellyfin_mpv_shim/mpvtk_browser/live_tv.py
+++ b/jellyfin_mpv_shim/mpvtk_browser/live_tv.py
@@ -19,7 +19,7 @@ DisplayPreferences document as "true"/"false" *strings* — why that matters is
 import datetime
 import re
 
-from ..i18n import _
+from ..i18n import _, _p
 
 # -- preferences -----------------------------------------------------------
 
@@ -522,7 +522,7 @@ def program_indicators(item, indicators):
     # statement about an episode, and a film shown twice is not one.
     if (item.get("IsSeries") and item.get("IsRepeat")
             and indicators.get("repeat")):
-        return _("Repeat")
+        return _p("guide badge", "Repeat")
     return ""
 
 

--- a/jellyfin_mpv_shim/mpvtk_browser/music.py
+++ b/jellyfin_mpv_shim/mpvtk_browser/music.py
@@ -9,7 +9,7 @@ from a foreign thread by core's ``on_playstate``) and ``_np_thread`` (the
 state lives in the route dict.
 """
 
-from ..i18n import _
+from ..i18n import _, _p
 from ..mpvtk.widgets import (Box, Column, Dropdown, Icon, Row, Slider,
                              Text)
 from . import components, theme
@@ -444,7 +444,9 @@ class MusicMixin:
             right.append(self._np_btn(
                 "repeat_one" if repeat == "one" else "repeat", "np-repeat",
                 lambda: self._cycle_repeat(),
-                self._REPEAT_TIPS.get(repeat, _("Repeat")),
+                self._REPEAT_TIPS.get(repeat,
+                                              _p("playback control",
+                                                 "Repeat")),
                 color=(theme.ACCENT if repeat != "none"
                        else theme.SUBTLE_FG)))
         if tiers["volbar"]:

--- a/jellyfin_mpv_shim/mpvtk_browser/pages/livetv.py
+++ b/jellyfin_mpv_shim/mpvtk_browser/pages/livetv.py
@@ -14,7 +14,7 @@ why the settings dialog saves through the repository and not into
 
 import datetime
 
-from ...i18n import _
+from ...i18n import _, _p
 from ...mpvtk.widgets import (
     Button, Column, Icon, Row, Spacer, Text, VScroll)
 from .. import components, guide_view, live_tv, theme
@@ -398,7 +398,8 @@ class LiveTvPage(Page):
             nav("chevron_left", "lt-prevwin", -step, _("Earlier")),
             Text("%s   %s" % (live_tv.fmt_day(start), live_tv.fmt_time(start)),
                  size="normal", bold=True),
-            nav("chevron_right", "lt-nextwin", step, _("Later")),
+            nav("chevron_right", "lt-nextwin", step,
+                _p("guide navigation", "Later")),
             nav("keyboard_double_arrow_right", "lt-nextday", DAY,
                 _("Next Day")),
             controls.action_btn("schedule", _("Now"), "lt-now",
@@ -827,7 +828,7 @@ class ProgramPage(Page):
         if start is not None:
             parts.insert(0, live_tv.fmt_day(start))
         for field, label in (("IsLive", _("Live")), ("IsPremiere", _("Premiere")),
-                             ("IsRepeat", _("Repeat"))):
+                             ("IsRepeat", _p("guide badge", "Repeat"))):
             if item.get(field):
                 parts.append(label)
         if item.get("OfficialRating"):

--- a/jellyfin_mpv_shim/mpvtk_browser/pages/queue_edit.py
+++ b/jellyfin_mpv_shim/mpvtk_browser/pages/queue_edit.py
@@ -12,7 +12,7 @@ drops ``on_error`` when the epoch has moved, so navigating away mid-flight can
 leave a rejected edit in the route dict.
 """
 
-from ...i18n import _
+from ...i18n import _, _p
 from ...mpvtk.widgets import (
     Button,
     Checkbox,
@@ -202,13 +202,15 @@ class QueuePage(SelectionPage):
         n = len(entries)
         toolbar = chrome.wrap_row([
             Text(_("Play Queue"), size="page", bold=True), Spacer(),
-            Button(_("Top"), id="q-top", icon="vertical_align_top",
+            Button(_p("list position", "Top"), id="q-top",
+                   icon="vertical_align_top",
                    on_click=lambda: self._move("top")),
             Button(_("Up"), id="q-up", icon="keyboard_arrow_up",
                    on_click=lambda: self._move("up")),
             Button(_("Down"), id="q-down", icon="keyboard_arrow_down",
                    on_click=lambda: self._move("down")),
-            Button(_("Bottom"), id="q-bottom", icon="vertical_align_bottom",
+            Button(_p("list position", "Bottom"), id="q-bottom",
+                   icon="vertical_align_bottom",
                    on_click=lambda: self._move("bottom")),
             Text(_("%d selected") % len(sel) if sel else "", size="small",
                  color=theme.SUBTLE_FG),
@@ -344,13 +346,15 @@ class PlaylistEditPage(SelectionPage):
         sel = self.selection()
         n = len(items)
         toolbar = chrome.wrap_row([
-            Button(_("Top"), id="pe-top", icon="vertical_align_top",
+            Button(_p("list position", "Top"), id="pe-top",
+                   icon="vertical_align_top",
                    on_click=lambda: self._move("top")),
             Button(_("Up"), id="pe-up", icon="keyboard_arrow_up",
                    on_click=lambda: self._move("up")),
             Button(_("Down"), id="pe-down", icon="keyboard_arrow_down",
                    on_click=lambda: self._move("down")),
-            Button(_("Bottom"), id="pe-bottom", icon="vertical_align_bottom",
+            Button(_p("list position", "Bottom"), id="pe-bottom",
+                   icon="vertical_align_bottom",
                    on_click=lambda: self._move("bottom")),
             Spacer(),
             Text(_("%d selected") % len(sel) if sel else "", size="small",

--- a/jellyfin_mpv_shim/mpvtk_browser/window_chrome.py
+++ b/jellyfin_mpv_shim/mpvtk_browser/window_chrome.py
@@ -470,7 +470,7 @@ def banner(b):
             # entirely -- a much bigger switch, and one nobody revisits.
             Button(_("Details\u2026"), id="banner-open",
                    on_click=lambda: b._open_url(b._update["url"])),
-            Button(_("Later"), id="banner-dismiss",
+            Button(_p("update banner", "Later"), id="banner-dismiss",
                    on_click=b._dismiss_update),
             Button(_("Ignore"), id="banner-ignore",
                    tip=_("Do not mention this version again"),

--- a/jellyfin_mpv_shim/osc_bridge.py
+++ b/jellyfin_mpv_shim/osc_bridge.py
@@ -11,7 +11,7 @@ exactly like the ``c`` menu would.
 import logging
 
 from .conf import settings
-from .i18n import _
+from .i18n import _, _p
 from .menu import COLOR_LIST, SIZE_LIST, TRANSCODE_LEVELS, lang_filter
 from .utils import get_sub_display_title
 
@@ -201,7 +201,9 @@ class OscBridge:
         size = self._options(SIZE_LIST, settings.subtitle_size)
         color = self._options(COLOR_LIST, settings.subtitle_color)
         position = self._options(
-            [(_("Bottom"), "bottom"), (_("Top"), "top"), (_("Middle"), "middle")],
+            [(_p("subtitle position", "Bottom"), "bottom"),
+             (_p("subtitle position", "Top"), "top"),
+             (_("Middle"), "middle")],
             settings.subtitle_position,
         )
 

--- a/regen_pot.sh
+++ b/regen_pot.sh
@@ -116,7 +116,21 @@ xgettext \
     --add-location=file \
     --foreign-user \
     --package-name=jellyfin-mpv-shim \
-    -o "$POT" "${SOURCES[@]}"
+    -o "$POT.new" "${SOURCES[@]}"
+
+# Carry the hand-written translator context across the regeneration.
+#
+# The `#.` comments in base.pot are the only context a Weblate translator
+# gets -- the string and a filename is everything else they see -- and
+# xgettext regenerates the template wholesale, so without this step every
+# one of them dies on each run. They are keyed on (msgctxt, msgid), so a
+# reworded string DROPS its note and the drop is reported; carrying it
+# across a reword is the failure docs/i18n.md section 5 already records.
+# Via a third file, so a failure anywhere in here leaves the committed
+# template alone rather than truncating it.
+python3 tools/pot_context.py "$POT.new" --restore "$POT" -o "$POT.ctx"
+mv "$POT.ctx" "$POT"
+rm -f "$POT.new"
 
 # Flag the translations that RAISE when the app formats them.
 #

--- a/seed_from_jellyfin_web.py
+++ b/seed_from_jellyfin_web.py
@@ -101,7 +101,27 @@ CONTEXT_KEYS = {
     ("series recording rule setting", "Channels"): "LabelChannels",
     ("dialog heading", "Download"): "Download",
     ("home screen section type", "None"): "None",
+    # jellyfin-web splits this pair too, and 15 of its languages translate
+    # the two differently. tools/po_recontext.py already seeded the locales
+    # that had a translation when the split happened; this is what keeps a
+    # later sweep sending each sense to the right key.
+    ("setting value", "Default"): "Default",
+    ("media stream flag", "Default"): "MediaInfoDefault",
 }
+
+#: Contexts with no jellyfin-web key at all, listed so a reader does not go
+#: looking. `Later`, `Confirm`, `Top` and `Bottom` are ours: jellyfin-web has
+#: one key or none for each English word, so it can neither seed them nor
+#: have detected that they carry two senses. They were found by reading the
+#: call sites while writing the .pot's translator comments, and they are the
+#: half of the ambiguity problem the canary cannot reach.
+UNSEEDABLE_CONTEXTS = (
+    ("guide navigation", "Later"), ("update banner", "Later"),
+    ("form label", "Confirm"), ("dialog heading", "Confirm"),
+    ("subtitle position", "Top"), ("list position", "Top"),
+    ("subtitle position", "Bottom"), ("list position", "Bottom"),
+    ("playback control", "Repeat"), ("guide badge", "Repeat"),
+)
 
 BRACE = re.compile(r"\{([^{}]*)\}")
 PRINTF = re.compile(r"%(?:\(([^)]*)\))?[-#0 +]*[\d*]*(?:\.[\d*]+)?[hlL]?([a-zA-Z%])")

--- a/tests/test_msgfmt.py
+++ b/tests/test_msgfmt.py
@@ -127,6 +127,20 @@ class TestParsing(unittest.TestCase):
         source = '#~ msgid "Gone"\n#~ msgstr "Parti"\n\nmsgid "Play"\nmsgstr "Jouer"\n'
         self.assertEqual(parse(source), {"Play": "Jouer"})
 
+    def test_a_fuzzy_obsolete_entry_does_not_swallow_the_next_one(self):
+        """msgmerge puts the "#, fuzzy" of an obsolete entry above the "#~".
+
+        Nothing flushes during the "#~" run, because there is no msgstr the
+        parser can see, so that flag used to survive to the next LIVE entry
+        and drop it from the .mo in silence. Latent for as long as obsolete
+        entries were the last thing in every catalog; tools/po_recontext.py
+        writing a new entry after them is what surfaced it, and Weblate or a
+        hand edit could do the same.
+        """
+        source = ('#, fuzzy\n#~| msgid "was"\n#~ msgid "Gone"\n'
+                  '#~ msgstr "Parti"\n\nmsgid "Play"\nmsgstr "Jouer"\n')
+        self.assertEqual(parse(source), {"Play": "Jouer"})
+
     def test_context_is_part_of_the_key(self):
         source = (
             'msgctxt "button"\nmsgid "Record"\nmsgstr "Enregistrer"\n'

--- a/tests/test_pot_context.py
+++ b/tests/test_pot_context.py
@@ -1,0 +1,88 @@
+"""Every string in the template must carry translator context.
+
+A Weblate translator for this project sees the English string and a
+filename. Nothing else: `--add-location=file` removed line numbers on
+purpose (docs/i18n.md section 2), only eleven entries carry a `msgctxt`, and
+there are no screenshots attached. So "Off" arrives as three letters that
+have to serve five different settings dropdowns, and `%s` arrives holding
+nothing in particular.
+
+The `#.` comments in `base.pot` are the only channel that reaches them, and
+this is what keeps the channel from going quiet one string at a time. A new
+`_()` call fails here until someone writes down what it means -- which is
+the only moment anyone is thinking about that string.
+
+`tools/pot_context.py` is what preserves those comments across
+`regen_pot.sh`; this is the other half, because preservation alone cannot
+tell a comment that was never written from one that was lost.
+"""
+
+# Run as a script, this is what puts the repo root on sys.path -- without
+# it `jellyfin_mpv_shim` resolves to whatever is pip-installed. A no-op
+# under `discover`; tests/test_module_paths.py is the guard.
+if __name__ == "__main__":
+    import os
+    import sys
+
+    sys.path.insert(0, os.path.dirname(
+        os.path.dirname(os.path.abspath(__file__))))
+
+import os
+import sys
+import unittest
+
+REPO = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+sys.path.insert(0, REPO)
+
+from tools.pot_context import parse, uncommented    # noqa: E402
+
+POT = os.path.join(REPO, "jellyfin_mpv_shim", "messages", "base.pot")
+
+#: Long enough to say what the string labels and where it sits. Anything
+#: shorter is a restatement of the msgid, which is what the translator
+#: already has.
+MIN_CONTEXT = 20
+
+
+class PotContextTest(unittest.TestCase):
+    def test_every_entry_has_context(self):
+        missing = uncommented(POT)
+        # assertFalse on the count, not assertEqual on the list: an empty
+        # template would otherwise dump all 1,083 strings into the failure.
+        self.assertFalse(
+            missing,
+            "%d string(s) in base.pot have no '#.' translator context. "
+            "Add one above the entry in base.pot saying what the string "
+            "labels and which screen it is on; regen_pot.sh preserves it. "
+            "First few: %r" % (len(missing), missing[:5]))
+
+    def test_context_says_something(self):
+        """A comment that only echoes the msgid is not context."""
+        thin = []
+        for block in parse(POT):
+            if block.is_header or not block.comments:
+                continue
+            text = " ".join(block.comments).strip()
+            if len(text) < MIN_CONTEXT or text.lower() == block.msgid.lower():
+                thin.append((block.msgid, text))
+        self.assertEqual(thin, [],
+                         "translator context that restates the string or "
+                         "says too little: %r" % (thin[:5],))
+
+    def test_no_translators_prefix(self):
+        """The `TRANSLATORS:` marker belongs in source, and there is none.
+
+        xgettext writes that prefix when it lifts a comment out of Python
+        with `--add-comments`. This project does not pass that flag (see
+        tools/pot_context.py for why), so the prefix here would mean
+        somebody wrote the context in a place the next regeneration reads
+        from -- two authorities for one comment, and the .pot one loses.
+        """
+        offenders = [block.msgid for block in parse(POT)
+                     if any(c.startswith("TRANSLATORS:")
+                            for c in block.comments)]
+        self.assertEqual(offenders, [])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tools/msgfmt.py
+++ b/tools/msgfmt.py
@@ -196,9 +196,18 @@ def parse(text: str) -> Dict[str, str]:
             continue
 
         if line.startswith("#"):
-            # An obsolete entry is commented out wholesale. Its lines never
-            # reach the parser below, so skipping them here is enough.
+            # An obsolete entry is commented out wholesale, so its lines
+            # never reach the parser below. Skipping them is not quite
+            # enough: msgmerge writes the "#, fuzzy" of a fuzzy obsolete
+            # entry on the line ABOVE the "#~" run, and that flag was
+            # already on the entry being built. Nothing flushes during the
+            # run -- there is no msgstr to flush -- so the flag survived to
+            # the next LIVE entry and dropped it from the .mo without a
+            # word. Latent only because obsolete entries sit at the end of
+            # a catalogue and normally have nothing after them.
             if line.startswith("#~"):
+                entry = _Entry()
+                section = None
                 continue
             if line.startswith("#,"):
                 flags = [f.strip() for f in line[2:].split(",")]

--- a/tools/po_recontext.py
+++ b/tools/po_recontext.py
@@ -1,0 +1,317 @@
+"""Carry a catalogue's translations across the addition of a `msgctxt`.
+
+    python3 tools/po_recontext.py --plan tools/recontext_plans/<name>.json \
+        --web-src ~/src/jellyfin-web [--dry-run]
+
+**A context is part of gettext's key**, so giving one to a string that never
+had one discards every existing translation of it -- 60 locales for `Default`,
+66 for `Top`. That cost is what has kept two-sense msgids in this catalogue
+unsplit (docs/i18n.md section 6), and this is what removes it: the volunteer's
+words are moved onto the new keys instead of being dropped on the floor.
+
+**It writes to the per-locale `.po` files**, which CLAUDE.md otherwise
+forbids. Same standing as `tools/po_lint.py --fuzzy`: a bounded, deliberate
+exception, run once per split, touching only the entries the plan names.
+Weblate cannot do this itself -- it sees a new msgid and an obsolete one, with
+nothing connecting them.
+
+The plan says, per msgid, what each new context should inherit. Every entry it
+writes lands in exactly one of four states, and which one is a claim about
+evidence rather than a default:
+
+``as-is``
+    We know the existing translation carries this sense, so it moves over
+    unmarked and the locale keeps working. The evidence is one of two things:
+    jellyfin-web agrees with itself in this language (a `# seeded from
+    jellyfin-web:` marker means the seeder found every key for that English
+    saying the same thing, so both senses are that word); or the translation
+    already existed at the commit named by ``since``, which is when the second
+    sense first reached the source -- so it cannot have been written for it.
+
+``seeded``
+    jellyfin-web has its own key for *this* sense and this language
+    translates it, so we take that rather than guess. Only `Default` has
+    this, and it is the case worth having: 15 of jellyfin-web's languages
+    translate `Default` and `MediaInfoDefault` differently, and ours were
+    seeded from whichever won.
+
+``fuzzy``
+    The words are carried over but flagged. Both compilers drop fuzzy
+    entries, so the string falls back to English until a human looks, and
+    Weblate lists it as "Needs editing" with the old wording in front of
+    them. This is where an honest "we do not know" goes.
+
+There is deliberately no "drop it, we know it is wrong" state. Knowing that
+a language distinguishes the senses means holding jellyfin-web's translation
+of both keys -- and holding them means there is a right word to seed, so the
+drop never has a case of its own. What looked like one was jellyfin-web
+having translated only the sibling key, which is silence and not evidence.
+
+Untranslated and obsolete entries are ignored, and an entry that already
+carries the context is left exactly as it is, so a re-run cannot overwrite a
+volunteer's later work.
+"""
+
+import argparse
+import json
+import os
+import pathlib
+import subprocess
+import sys
+
+HERE = os.path.dirname(os.path.abspath(__file__))
+REPO = os.path.dirname(HERE)
+sys.path.insert(0, REPO)
+
+from tools.msgfmt import unescape, _quoted, PoError          # noqa: E402
+
+MESSAGES = os.path.join(REPO, "jellyfin_mpv_shim", "messages")
+MARKER = "# seeded from jellyfin-web: "
+
+
+def _escape(text):
+    return (text.replace("\\", "\\\\").replace('"', '\\"')
+                .replace("\n", "\\n").replace("\t", "\\t"))
+
+
+class Entry:
+    """One `.po` stanza, kept as its own lines so it can be rewritten."""
+
+    def __init__(self, lines):
+        self.lines = lines
+        self.ctx = None
+        self.msgid = ""
+        self.msgstr = ""
+        self.flags = []
+        self.obsolete = False
+        self.seeded_key = None
+        self._parse()
+
+    def _parse(self):
+        field = None
+        for index, raw in enumerate(self.lines):
+            line = raw.strip()
+            if line.startswith("#~"):
+                self.obsolete = True
+                continue
+            if line.startswith("#,"):
+                self.flags += [f.strip() for f in line[2:].split(",")]
+                continue
+            if raw.startswith(MARKER):
+                self.seeded_key = raw[len(MARKER):].strip()
+                continue
+            if line.startswith("#"):
+                continue
+            if line.startswith("msgctxt"):
+                field = "ctx"
+                self.ctx = unescape(_quoted(line[7:].strip(), index + 1),
+                                    index + 1)
+                continue
+            if line.startswith("msgid_plural"):
+                field = None
+                continue
+            if line.startswith("msgid"):
+                field = "msgid"
+                self.msgid = unescape(_quoted(line[5:].strip(), index + 1),
+                                      index + 1)
+                continue
+            if line.startswith("msgstr"):
+                field = "str"
+                rest = line[6:].strip()
+                if rest.startswith("["):
+                    rest = rest.split("]", 1)[1].strip()
+                self.msgstr = unescape(_quoted(rest, index + 1), index + 1)
+                continue
+            if line.startswith('"') and field is not None:
+                text = unescape(_quoted(line, index + 1), index + 1)
+                if field == "ctx":
+                    self.ctx += text
+                elif field == "msgid":
+                    self.msgid += text
+                elif field == "str":
+                    self.msgstr += text
+
+    @property
+    def fuzzy(self):
+        return "fuzzy" in self.flags
+
+
+def parse_po(path):
+    with open(path, "r", encoding="utf-8") as handle:
+        lines = handle.read().splitlines()
+    entries, current = [], []
+    for line in lines:
+        if line.strip():
+            current.append(line)
+        elif current:
+            entries.append(Entry(current))
+            current = []
+    if current:
+        entries.append(Entry(current))
+    return entries
+
+
+def render(entries):
+    out = []
+    for entry in entries:
+        out.extend(entry.lines)
+        out.append("")
+    return "\n".join(out)
+
+
+def new_entry(ctx, msgid, msgstr, fuzzy=False, seeded_key=None):
+    lines = []
+    if seeded_key:
+        lines.append(MARKER + seeded_key)
+    if fuzzy:
+        lines.append("#, fuzzy")
+    lines.append('msgctxt "%s"' % _escape(ctx))
+    lines.append('msgid "%s"' % _escape(msgid))
+    lines.append('msgstr "%s"' % _escape(msgstr))
+    return Entry(lines)
+
+
+def existed_at(commit, path, ctx, msgid):
+    """Whether `path` already translated (ctx, msgid) at `commit`.
+
+    The dating evidence behind an ``as-is``: if the words were in the
+    catalogue before the second sense reached the source, they were not
+    written for it.
+    """
+    rel = os.path.relpath(path, REPO)
+    try:
+        blob = subprocess.run(
+            ["git", "-C", REPO, "show", "%s:%s" % (commit, rel)],
+            capture_output=True, check=True).stdout.decode("utf-8")
+    except (subprocess.CalledProcessError, UnicodeDecodeError):
+        return False        # the locale did not exist yet, so neither did it
+    for entry in [Entry(b.splitlines()) for b in blob.split("\n\n") if b.strip()]:
+        if (entry.ctx, entry.msgid) == (ctx, msgid):
+            return bool(entry.msgstr) and not entry.fuzzy and not entry.obsolete
+    return False
+
+
+def web_strings(web_src, locale):
+    """jellyfin-web's strings for a locale directory name, or None."""
+    from importlib.util import spec_from_file_location, module_from_spec
+
+    spec = spec_from_file_location(
+        "_seed", os.path.join(REPO, "seed_from_jellyfin_web.py"))
+    seed = module_from_spec(spec)
+    spec.loader.exec_module(seed)
+    path = seed.web_file(pathlib.Path(web_src) / "src" / "strings", locale)
+    if path is None:
+        return None
+    return json.loads(path.read_text(encoding="utf-8"))
+
+
+def decide(rule, entry, web, since_ok):
+    """``(msgstr, fuzzy, seeded_key, state)`` for one context of one locale."""
+    key = rule.get("web_key")
+    sibling = rule.get("web_sibling")
+    if web is not None and key:
+        mine = web.get(key)
+        theirs = web.get(sibling) if sibling else None
+        if theirs and mine == theirs:
+            # Every jellyfin-web key for this English says the same thing
+            # here, so the word we already have serves both senses.
+            return entry.msgstr, False, None, "as-is"
+        if theirs and mine:
+            # jellyfin-web splits the senses in this language, so its own
+            # word for THIS sense is the answer -- whichever of the two ours
+            # happened to carry. Taking it is not overwriting a volunteer:
+            # the key it is going onto did not exist until now.
+            return mine, False, key, "seeded"
+        # Only ONE of the two keys is translated here, which says nothing
+        # about whether this language distinguishes the senses -- and an
+        # untranslated sibling must not be read as one. Dropping on that
+        # cost af/bn/ckb/dv/gsw/kn/mi/ms/ne/oc/sq/th/ug/uz a working
+        # translation apiece before this fell through instead.
+    if entry.seeded_key:
+        # The seeder only writes a marker where every jellyfin-web key for
+        # that English agreed in this language, so both senses are that word.
+        return entry.msgstr, False, None, "as-is"
+    if since_ok:
+        return entry.msgstr, False, None, "as-is"
+    return entry.msgstr, True, None, "fuzzy"
+
+
+def apply_plan(path, plan, web_src, dry_run):
+    locale = pathlib.Path(path).parts[-3]
+    entries = parse_po(path)
+    have = {(e.ctx, e.msgid) for e in entries if not e.obsolete}
+    web = web_strings(web_src, locale) if web_src else None
+
+    counts = {"as-is": 0, "seeded": 0, "fuzzy": 0}
+    added = []
+    for rule in plan:
+        msgid = rule["msgid"]
+        source = next((e for e in entries
+                       if not e.obsolete and e.ctx is None
+                       and e.msgid == msgid and e.msgstr and not e.fuzzy),
+                      None)
+        if source is None:
+            continue
+        for ctx_rule in rule["contexts"]:
+            ctx = ctx_rule["ctx"]
+            if (ctx, msgid) in have:
+                continue        # already split, or a volunteer got there first
+            since = ctx_rule.get("since")
+            since_ok = bool(since) and existed_at(since, path, None, msgid)
+            merged = dict(rule)
+            merged.update(ctx_rule)
+            text, fuzzy, seeded, state = decide(merged, source, web, since_ok)
+            counts[state] += 1
+            added.append(new_entry(ctx, msgid, text, fuzzy, seeded))
+    if added and not dry_run:
+        # Before the obsolete tail, where msgmerge would have put them. Not
+        # cosmetic: a live entry after a fuzzy "#~" run was silently dropped
+        # by tools/msgfmt.py until that was fixed, and GNU msgfmt and Weblate
+        # both write obsolete entries last, so nothing else has to think
+        # about the other order.
+        at = next((i for i, e in enumerate(entries) if e.obsolete), len(entries))
+        entries[at:at] = added
+        with open(path, "w", encoding="utf-8") as handle:
+            handle.write(render(entries))
+    return locale, counts, len(added)
+
+
+def main(argv=None):
+    ap = argparse.ArgumentParser(description=__doc__.split("\n")[0])
+    ap.add_argument("--plan", required=True,
+                    help="JSON describing the splits (see the module docstring)")
+    ap.add_argument("--web-src",
+                    help="path to a jellyfin-web checkout, for the senses it "
+                         "has a key of its own for")
+    ap.add_argument("--dry-run", action="store_true")
+    args = ap.parse_args(argv)
+
+    with open(args.plan, encoding="utf-8") as handle:
+        plan = json.load(handle)
+
+    totals = {"as-is": 0, "seeded": 0, "fuzzy": 0}
+    written = 0
+    for entry in sorted(os.listdir(MESSAGES)):
+        path = os.path.join(MESSAGES, entry, "LC_MESSAGES", "base.po")
+        if not os.path.isfile(path):
+            continue
+        try:
+            locale, counts, n = apply_plan(path, plan, args.web_src,
+                                           args.dry_run)
+        except PoError as exc:
+            print("%s: could not read: %s" % (entry, exc), file=sys.stderr)
+            return 1
+        for k, v in counts.items():
+            totals[k] += v
+        written += n
+        if any(counts.values()):
+            print("%-12s %s" % (locale, " ".join(
+                "%s=%d" % (k, v) for k, v in counts.items() if v)))
+    print("\n%s %d entr(ies): %s"
+          % ("would write" if args.dry_run else "wrote", written,
+             ", ".join("%s=%d" % kv for kv in totals.items())))
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tools/pot_context.py
+++ b/tools/pot_context.py
@@ -1,0 +1,279 @@
+"""Carry the translator context in `base.pot` across a regeneration.
+
+    python3 tools/pot_context.py --restore new.pot --from base.pot -o base.pot
+    python3 tools/pot_context.py --check base.pot
+
+**A Weblate translator sees the English string and a filename.** No line
+number (`--add-location=file`, docs/i18n.md section 2), no enclosing function,
+no screenshot -- so "Off" arrives as three letters that must serve five
+different settings dropdowns, and `%s` arrives holding nothing. The `#.`
+comments in `base.pot` are the only channel that reaches them, and this is
+what keeps those comments alive.
+
+**Why the comments live in the `.pot` and not in the source.** xgettext can
+lift `# TRANSLATORS:` comments out of Python with `--add-comments`, which is
+the idiomatic answer and was not taken, for two reasons:
+
+- 158 of the msgids are extracted from more than one file. Identical comments
+  at every site collapse to one `#.` line and differing ones stack, so the
+  source form is only correct while every site is edited together -- and the
+  one that drifts reads as a second sense the translator must reconcile.
+- It is ~1,100 comments across 65 files, dwarfing the code comments in the
+  ones that hold a lot of strings (config.py alone has 234 strings).
+
+So the `.pot` is edited by hand and regeneration preserves what is there.
+That makes it a generated file with hand-written content in it, which is the
+cost; `--check` and `tests/test_pot_context.py` are what make the cost safe,
+because the failure mode -- a comment silently lost -- is then loud.
+
+**Entries are keyed on `(msgctxt, msgid)`, which is gettext's own key.** A
+reworded string therefore *loses* its comment rather than keeping a stale one,
+and `--restore` names every comment it had to drop. That direction is
+deliberate: docs/i18n.md section 5 records the opposite failure, where
+msgmerge carried a note across a reword and left `Blend Frames` credited to
+the key for `Dropped frames`. A dropped note is a line in the report; a
+retained one is wrong in a file nobody rereads.
+"""
+
+import argparse
+import os
+import re
+import sys
+
+
+class PotError(Exception):
+    pass
+
+
+_ESCAPES = {"n": "\n", "t": "\t", "r": "\r", '"': '"', "\\": "\\"}
+
+
+def unescape(text):
+    out = []
+    index = 0
+    while index < len(text):
+        char = text[index]
+        if char == "\\":
+            index += 1
+            if index >= len(text):
+                raise PotError("trailing backslash in %r" % text)
+            out.append(_ESCAPES.get(text[index], text[index]))
+        else:
+            out.append(char)
+        index += 1
+    return "".join(out)
+
+
+_QUOTED = re.compile(r'^\s*"((?:[^"\\]|\\.)*)"\s*$')
+
+
+def _quoted(line):
+    match = _QUOTED.match(line)
+    if match is None:
+        raise PotError("expected a quoted string, got %r" % line.strip())
+    return unescape(match.group(1))
+
+
+class Block:
+    """One `.pot` stanza: its lines, its key, and where a `#.` would go."""
+
+    def __init__(self, lines):
+        self.lines = lines
+        self.msgctxt = None
+        self.msgid = ""
+        self.comments = []          # the `#.` text, without the marker
+        self._parse()
+
+    def _parse(self):
+        field = None
+        for line in self.lines:
+            stripped = line.strip()
+            if stripped.startswith("#."):
+                self.comments.append(stripped[2:].strip())
+                continue
+            if stripped.startswith("#"):
+                continue
+            if stripped.startswith("msgctxt"):
+                field = "msgctxt"
+                self.msgctxt = _quoted(stripped[7:])
+                continue
+            if stripped.startswith("msgid_plural"):
+                field = None
+                continue
+            if stripped.startswith("msgid"):
+                field = "msgid"
+                self.msgid = _quoted(stripped[5:])
+                continue
+            if stripped.startswith("msgstr"):
+                field = None
+                continue
+            if stripped.startswith('"') and field is not None:
+                text = _quoted(stripped)
+                if field == "msgctxt":
+                    self.msgctxt += text
+                else:
+                    self.msgid += text
+
+    @property
+    def key(self):
+        return (self.msgctxt, self.msgid)
+
+    @property
+    def is_header(self):
+        return self.msgid == "" and self.msgctxt is None
+
+    def with_comments(self, comments):
+        """These lines with `comments` as the entry's only `#.` block.
+
+        PO order is `#` translator, `#.` extracted, `#:` reference, `#,`
+        flag, and every tool that reads one expects that. The index is
+        computed on the list with the old `#.` lines already dropped: taking
+        it from `self.lines` instead worked on the first pass and slid the
+        block one `#:` line further down on every pass after, because the
+        lines it counted were no longer the lines it indexed into.
+        """
+        kept = [line for line in self.lines
+                if not line.strip().startswith("#.")]
+        at = 0
+        while at < len(kept):
+            stripped = kept[at].strip()
+            if stripped.startswith("#") and not stripped.startswith(
+                    ("#:", "#,", "#~")):
+                at += 1                 # a plain translator comment
+                continue
+            break
+        return kept[:at] + ["#. " + text if text else "#."
+                            for text in comments] + kept[at:]
+
+
+def parse(path):
+    """Every stanza of a `.pot`, in file order, blank lines dropped."""
+    with open(path, "r", encoding="utf-8") as handle:
+        lines = handle.read().splitlines()
+    blocks = []
+    current = []
+    for line in lines:
+        if line.strip():
+            current.append(line)
+        elif current:
+            blocks.append(Block(current))
+            current = []
+    if current:
+        blocks.append(Block(current))
+    return blocks
+
+
+def render(blocks):
+    out = []
+    for block in blocks:
+        out.extend(block.lines)
+        out.append("")
+    return "\n".join(out)
+
+
+def restore(new_path, old_path, out_path):
+    """Put the old template's `#.` comments back onto the new one.
+
+    Returns ``(restored, orphans, missing)`` -- counts of comments carried
+    over, comments whose string no longer exists, and entries that end up
+    with no comment at all.
+    """
+    new_blocks = parse(new_path)
+    try:
+        old_blocks = parse(old_path)
+    except OSError:
+        old_blocks = []
+
+    old = {}
+    for block in old_blocks:
+        if block.is_header or not block.comments:
+            continue
+        old[block.key] = block.comments
+
+    seen = set()
+    restored = 0
+    for block in new_blocks:
+        if block.is_header:
+            continue
+        comments = old.get(block.key)
+        if comments and not block.comments:
+            block.lines = block.with_comments(comments)
+            block.comments = list(comments)
+            restored += 1
+        if block.key in old:
+            seen.add(block.key)
+
+    orphans = [key for key in old if key not in seen]
+    missing = [block.key for block in new_blocks
+               if not block.is_header and not block.comments]
+
+    with open(out_path, "w", encoding="utf-8") as handle:
+        handle.write(render(new_blocks))
+    return restored, orphans, missing
+
+
+def uncommented(path):
+    """``[(msgctxt, msgid), ...]`` for every entry with no `#.` comment."""
+    return [block.key for block in parse(path)
+            if not block.is_header and not block.comments]
+
+
+def _show(keys, limit=20):
+    for msgctxt, msgid in keys[:limit]:
+        label = "%r" % msgid[:70]
+        if msgctxt is not None:
+            label = "[%s] %s" % (msgctxt, label)
+        print("    " + label)
+    if len(keys) > limit:
+        print("    ... and %d more" % (len(keys) - limit))
+
+
+def main(argv=None):
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("pot")
+    parser.add_argument("--restore", metavar="OLD",
+                        help="carry OLD's #. comments onto the given template")
+    parser.add_argument("-o", "--out",
+                        help="where to write --restore's result "
+                             "(default: overwrite the given template)")
+    parser.add_argument("--check", action="store_true",
+                        help="exit 1 if any entry has no #. comment")
+    args = parser.parse_args(argv)
+
+    if args.restore:
+        out = args.out or args.pot
+        restored, orphans, missing = restore(args.pot, args.restore, out)
+        print("  kept %d translator comment(s)" % restored)
+        if orphans:
+            # Loud, and by string: this is a reworded msgid, and the note
+            # that described the old wording is now gone for good.
+            print("  DROPPED %d comment(s) whose string no longer exists:"
+                  % len(orphans))
+            _show(sorted(orphans, key=lambda k: (k[0] or "", k[1])))
+        if missing:
+            print("  %d entr(ies) still have no context" % len(missing))
+        return 0
+
+    if args.check:
+        missing = uncommented(args.pot)
+        if missing:
+            print("%s: %d entr(ies) have no translator context:"
+                  % (os.path.relpath(args.pot), len(missing)), file=sys.stderr)
+            for msgctxt, msgid in missing[:40]:
+                label = "%r" % msgid[:70]
+                if msgctxt is not None:
+                    label = "[%s] %s" % (msgctxt, label)
+                print("    " + label, file=sys.stderr)
+            if len(missing) > 40:
+                print("    ... and %d more" % (len(missing) - 40),
+                      file=sys.stderr)
+            return 1
+        print("%s: every entry has translator context."
+              % os.path.relpath(args.pot))
+        return 0
+
+    parser.error("give --restore or --check")
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tools/recontext_plans/2026-09-two-sense.json
+++ b/tools/recontext_plans/2026-09-two-sense.json
@@ -1,0 +1,83 @@
+[
+  {
+    "msgid": "Default",
+    "why": "A choice in the scrim dropdown ('change nothing, let MPV decide') and a Media Info flag marking the stream a player picks. jellyfin-web needs Default and MediaInfoDefault, and 15 of its languages translate them differently. The settings sense is the older one: it entered the catalogue on 2026-08-01, the flag on 2026-08-08 (3eea6e47).",
+    "contexts": [
+      {
+        "ctx": "setting value",
+        "web_key": "Default",
+        "web_sibling": "MediaInfoDefault",
+        "since": "3eea6e47^"
+      },
+      {
+        "ctx": "media stream flag",
+        "web_key": "MediaInfoDefault",
+        "web_sibling": "Default"
+      }
+    ]
+  },
+  {
+    "msgid": "Later",
+    "why": "The guide's 'forward a few hours' and the update banner's 'put it off'. The guide sense reached the catalogue on 2026-07-28; the banner one on 2026-08-22 (04a6ae5f), so anything translated before that commit is the guide.",
+    "contexts": [
+      {
+        "ctx": "guide navigation",
+        "since": "04a6ae5f^"
+      },
+      {
+        "ctx": "update banner"
+      }
+    ]
+  },
+  {
+    "msgid": "Repeat",
+    "why": "A Live TV guide badge (an adjective: this episode has been shown before) and the loop button on the now-playing bar (a verb). jellyfin-web's single Repeat key sits with RepeatAll/RepeatOne/RepeatMode, so every seeded value is the playback sense; the badge arrived on 2026-07-28 (07ad2c26).",
+    "contexts": [
+      {
+        "ctx": "playback control",
+        "since": "07ad2c26^"
+      },
+      {
+        "ctx": "guide badge"
+      }
+    ]
+  },
+  {
+    "msgid": "Confirm",
+    "why": "The Set PIN dialog's 'type it again' field label (a verb) and the default title of the yes/no dialog (a noun). Both senses arrived in the same commit, so there is no earlier one to inherit and nothing to date against: every locale is fuzzy on both.",
+    "contexts": [
+      {
+        "ctx": "form label"
+      },
+      {
+        "ctx": "dialog heading"
+      }
+    ]
+  },
+  {
+    "msgid": "Top",
+    "why": "Where subtitles are drawn on screen, and the queue and playlist editors' button that moves rows to the start of the list. The subtitle sense has been in the catalogue since 2020-08-10; the list one arrived on 2026-07-24 (ad0a141b).",
+    "contexts": [
+      {
+        "ctx": "subtitle position",
+        "since": "ad0a141b^"
+      },
+      {
+        "ctx": "list position"
+      }
+    ]
+  },
+  {
+    "msgid": "Bottom",
+    "why": "Where subtitles are drawn on screen, and the queue and playlist editors' button that moves rows to the end of the list. Same dates as Top.",
+    "contexts": [
+      {
+        "ctx": "subtitle position",
+        "since": "ad0a141b^"
+      },
+      {
+        "ctx": "list position"
+      }
+    ]
+  }
+]


### PR DESCRIPTION
This PR does three things:
1. Adds description text to translation keys
2. Moves a few translation keys that genuinely have multiple meanings
3. Adds a linter for translation keys lacking a description