### PR TITLE
Add additional tests for defect classes found post 3.0.0

### DIFF
--- a/docs/POSTMORTEM_3.0.0.md
+++ b/docs/POSTMORTEM_3.0.0.md
@@ -799,16 +799,41 @@ declaration is where the next reader learns the resolver exists.
 Guard: `tests/test_no_frozen_key_literals.py`. Precedent that it works: R10 was
 found by writing this predicate down, not by reading the file.
 
-### 5.2 Four lines in `tools/audit_owned_state.py:51` — cheapest possible
+### 5.2 Four lines in `tools/audit_owned_state.py` — DONE, and not four lines
 
 Add `_sync_path`, `ThumbnailStore._gone`, `mpv.TIMEOUT` and `_login["pass"]` to
 `OWNED`. `docs/RISK_MAP_2026-09.md` §7 already specifies them, already argues
 they are the cheapest Tier-1 coverage in the tree, and the tool is already wired
-into the suite. This is bookkeeping, not engineering.
+into the suite. ~~This is bookkeeping, not engineering.~~
+
+**It was not bookkeeping, and the reason is the finding.** Only
+`ThumbnailStore._gone` fitted the tool as written; the other three did not, and
+each in a different way:
+
+- **`_sync_path` and `_login` are not confined to one file.** The tool took one
+  module per entry, and the browser is one `self` spread across a dozen mixin
+  modules — so scoping either of them to the file that touches it today would
+  have been *this document's own defect shape*, the right rule at one of
+  several sites, installed by the tool meant to catch it. `scope` now takes a
+  directory, and owners are spelled `path:function`.
+- **`mpv.TIMEOUT` does not hang off `self` at all.** It is a module global of
+  the backend library. The walker only matched `self.<attr>`, so the entry
+  would have found nothing and reported a clean tree forever — the failure
+  `test_no_second_owner.py`'s second test exists to catch. `obj` now names what
+  the state hangs off.
+- **`_login["pass"]` is a dict key, and the entry is deliberately weaker than
+  the risk it records.** The tool matches attributes, not subscripts, so the
+  scope is the whole `_login` dict with six owners. Six is a weak check and it
+  is the honest one; the *repair* — clearing `pass` after a successful login,
+  the way `_pin` already clears — is a behaviour change and is not this.
+
+Each of the three was mutation-tested: a second owner in the same file, one in
+a sibling mixin module, and a second writer of the global from another module
+are all reported.
 
 Note the tool's own rule while doing it: *"`owners` records the sites that exist,
-never the ones that may"* (`audit_owned_state.py:30-35`) — a speculative name
-pre-authorises the very second owner the audit exists to catch.
+never the ones that may"* — a speculative name pre-authorises the very second
+owner the audit exists to catch.
 
 ### 5.3 `tools/audit_act_targets.py` — specified, never built
 

--- a/docs/POSTMORTEM_3.0.0.md
+++ b/docs/POSTMORTEM_3.0.0.md
@@ -879,6 +879,13 @@ write must route through a `PlayerManager` owner method. It covers C6 above and
 R7 (`player_window.py:621` `set_picture_view` lacking the `_video is None and
 not _loading` guard that `reset_picture_view` grew at `:597`).
 
+**One correction to this section's own R7 example**, found while writing the
+lint: `reset_picture_view`'s `_video is None and not _loading` guard covers only
+its `keepaspect` write, and `set_picture_view` does not write `keepaspect` at
+all — the two are symmetric on zoom and pan. `docs/do-not-fix.md` F15 already
+records R7 as **unverified** and asks for the interleaving to be constructed
+first. The lint does not rest on it; C6/R8 is the confirmed example.
+
 **The site count, taken before any patch: ten, in two of the seventeen gateway
 modules.** Four writes (`speed`, `video_aspect_override`, `mute`, `fullscreen`,
 all in `hud.py`) and six reads, of which two are read-only by construction —

--- a/docs/POSTMORTEM_3.0.0.md
+++ b/docs/POSTMORTEM_3.0.0.md
@@ -879,6 +879,28 @@ unreachable while reporting a pass"* — applies exactly: a fake or fixture whos
 `grep -rn phud tests/_*.py` finds nothing modelling it.
 `tools/audit_fake_contracts.py` is the existing home for this.
 
+**DONE, and not there — that pointer was wrong.** `audit_fake_contracts.py`
+extracts what production *Python* reaches on a collaborator; `phud.mode` is
+renderer state and never crosses into Python except as the `phud_mode` field of
+the `debug_state` reply, which `tests/integration/test_mpvtk_hud.py` already
+reads. There was nothing for it to audit.
+
+The gap the section names is real, and it was a missing *case* rather than a
+missing field: nothing had ever clicked bare video with HUD mode **off** and
+`mpvtk_mouse` still enabled — the state a lua OSC leaves the renderer in, where
+all three fall-throughs are dead and the buttons go nowhere. That case is now in
+`tests/lua/test_renderer.lua`, next to the HUD-up block it is the negative of,
+and it opens by asserting `phud_mode` is actually false, because a fixture that
+quietly had the mode on would pass every one of its assertions for the wrong
+reason.
+
+Mutation-checked one gate at a time: ungating the click, the double click and
+the right click each fails exactly its own assertion, and publishing
+`phud_mode = true` fails the setup guard. The first draft shared one command log
+across the three presses, so a left click that wrongly paused also answered the
+right click's assertion — three assertions, one of them measuring the others.
+They get a log each.
+
 ### 5.6 A binding-lifetime lint — the one instrument that fits `renderer.lua`
 
 Every `mp.add_forced_key_binding(<key>, '<name>', …)` in `renderer.lua` should

--- a/docs/POSTMORTEM_3.0.0.md
+++ b/docs/POSTMORTEM_3.0.0.md
@@ -785,7 +785,7 @@ tree — CLAUDE.md's own finding is that *advisory prose does not change the rat
 and this repo has twice ended a loop with an enumerating instrument (C4, C5) and
 zero times with a careful re-read.
 
-### 5.1 `tools/audit_frozen_key_literals.py` (new, ~150 lines) — highest value
+### 5.1 `tools/audit_frozen_key_literals.py` — BUILT, and it found three more
 
 Covers C1 / R1, R2, R3, R10 — the cluster with the worst live record and no
 instrument at all. Structure copied verbatim from
@@ -798,6 +798,41 @@ declaration is where the next reader learns the resolver exists.
 
 Guard: `tests/test_no_frozen_key_literals.py`. Precedent that it works: R10 was
 found by writing this predicate down, not by reading the file.
+
+**Built, with two departures from the spec above and one result.**
+
+The spec said *"scan for string literals equal to any of their defaults"*. That
+matches 85 sites, most of them noise — `'left'` is an alignment far more often
+than it is a key, and the first run flagged a debug overlay's `'F'` glyph on
+`kb_fullscreen`. So the vocabulary is the **multi-character** defaults only, and
+matching is case-sensitive on mpv's uppercase spelling, which is exactly what
+separates a key from a direction here. Both limits are stated in the file: a
+frozen key written lowercase in binding code is invisible to it.
+
+The second departure is the grain. Declaring 49 individual literals would have
+been exempted into uselessness, so a declaration covers a *scope* — 20 of them.
+That needed real scope tracking in Lua rather than "the last `function` line
+seen": without it a file-scope constant is charged to whatever function is
+above, which put **R3 inside `phud_wake_key`** — the resolver that is R3's own
+counter-example.
+
+**Three more findings, from the first clean run:**
+
+- **R2 has a second site.** `_shell_claimed_keys` claims the literal `SPACE`
+  and `_shell_key` dispatches on `key == "SPACE"`. Two independent freezes of
+  `kb_pause`; the risk map records the claim only.
+- **`phud_bind_summon`** compares the loop's key against a literal `ENTER` to
+  choose its handler, so resolving R3's table would not by itself repair it.
+- **`phud_bind_wake`** compares the *resolved* wake key against `ENTER` to
+  decide whether waking the HUD also toggles pause — so moving `hud_wake_key`
+  silently drops the pause half. That is a product question rather than a
+  freeze, and it is declared as one.
+
+Seven declared-open rows in all, none repaired here: every one needs a
+config-file edit to reach, which is §7's reason for deferring them, and the
+status is a field on the declaration rather than a word in its prose. The first
+draft read `"OPEN" in why` and disagreed with itself about two rows — the
+tool's own defect shape, in the tool.
 
 ### 5.2 Four lines in `tools/audit_owned_state.py` — DONE, and not four lines
 

--- a/docs/POSTMORTEM_3.0.0.md
+++ b/docs/POSTMORTEM_3.0.0.md
@@ -835,14 +835,38 @@ Note the tool's own rule while doing it: *"`owners` records the sites that exist
 never the ones that may"* — a speculative name pre-authorises the very second
 owner the audit exists to catch.
 
-### 5.3 `tools/audit_act_targets.py` — specified, never built
+### 5.3 `tools/audit_act_targets.py` — ~~specified, never built~~ BUILT
 
 `docs/RISK_MAP_2026-09.md` §7 says *"stays first among the lints: it covers R7
-and R8 (Tier 1 and Tier 2)"*. It does not exist — `ls tools/audit_*.py` returns
-four files and this is not one of them. Its rule: every gateway `_act` property
+and R8 (Tier 1 and Tier 2)"*. ~~It does not exist~~ — it does now, with
+`tests/test_no_act_reachthrough.py`. Its rule: every gateway `_act` property
 write must route through a `PlayerManager` owner method. It covers C6 above and
 R7 (`player_window.py:621` `set_picture_view` lacking the `_video is None and
 not _loading` guard that `reset_picture_view` grew at `:597`).
+
+**The site count, taken before any patch: ten, in two of the seventeen gateway
+modules.** Four writes (`speed`, `video_aspect_override`, `mute`, `fullscreen`,
+all in `hud.py`) and six reads, of which two are read-only by construction —
+the Playback Data panel's seven counters, and the diagnostics screen handing the
+handle to `clipboard.copy_or_save` as an argument.
+
+**Three of the four writes have a `PlayerManager` method sitting there
+unused** — `set_speed`, `set_mute` and `set_fullscreen` all exist. The fourth,
+`set_aspect`, exists only on `enrich-e2e-tests`, whose one production change is
+exactly this repair. So the lint's first run says the fix for most of this is
+*calling what is already written*, and none of it is made here: routing a write
+through `set_fullscreen` changes who takes the player lock, which is a behaviour
+change and `set_speed` carries no `@synchronous` either, so the honest repair is
+both halves at once and belongs in its own commit.
+
+Two things the first run found that hand-reading did not. A reach spelled
+`getattr(playerManager, "_player", None)` carries the handle as a **string**, so
+no `Attribute` node holds it and an AST walk goes straight past — the package
+has one. And writing the declaration list by hand produced **six** keys naming
+functions that do not exist, because the enclosing `def` of a `_act` lambda is
+often a nested one (`toggle_fullscreen.flip`, not `toggle_fullscreen`). The
+stale-key check caught all six on the first run, which is the case it was
+written for.
 
 ### 5.4 Make `_load` check coverage instead of reordering the list
 

--- a/docs/POSTMORTEM_3.0.0.md
+++ b/docs/POSTMORTEM_3.0.0.md
@@ -977,6 +977,18 @@ for all three, so none of it shipped.
 menus. They do **not** cover A4, which needs right-click **over bare video, with
 `mouse_click_pauses` off, after the HUD auto-hides**. The coverage that would
 have caught #724/#737 is a fourth state in the same file, not one of these three.
+
+**That fourth state exists now**, as two tests rather than one, because the
+cluster turned out to be two properties: the right button reaching the picture
+(A4), and the left button still reaching a tile after a skip segment has come
+and gone (#737). Both mutation-controlled, both green on both backends.
+
+The second one is worth more than a test. Putting the leak back — deleting the
+one `remove_key_binding` line — fails it on the click, which means the
+preemption is now *shown* rather than argued from how mpv ranks bindings. That
+was one of the two things §3.3 could not establish. The other, whether the
+reporter's freeze is this leak, is unchanged: this predicts the freeze on the
+first skip segment and the report says "after a video or two".
 Ship the branch anyway — it is real coverage — but do not let it be mistaken for
 this cluster's guard.
 

--- a/docs/POSTMORTEM_3.0.0.md
+++ b/docs/POSTMORTEM_3.0.0.md
@@ -899,6 +899,27 @@ property mpv's builtin scripts set should have an observer or a declared
 and not `context-menu/open` — one rule, one of two sites, and §3.3 names it as a
 live #737 candidate.
 
+**DONE as the lint; the fix is deliberately not in it, and the measurement
+changed what the fix would have to be.** `PUBLISHED` in the same tool now
+enumerates all four `user-data/mpv/*` properties mpv's scripts set, each either
+observed, declared irrelevant, or recorded as a gap that the test pins so a
+*new* one has to be argued for.
+
+`tools/probe_key_precedence.py` asks the question of a real mpv by pressing the
+key, and it refutes the premise this section was written on. A standing forced
+binding of ours does **not** outrank an overlay that opens after it — the
+overlay wins. The exposure is the third case: we re-bind while it is up, which
+the HUD does on pointer movement, and then the menu is drawn and dead. Same
+answer for the console, so `renderer.lua`'s own comment about why its console
+handler exists was wrong for a release and is corrected. Full table:
+`docs/mpv-backends.md` §5.
+
+The repair is one handler mirroring the console's, and it is not made here: it
+lands on the input arbiter — `docs/do-not-fix.md` F37, the worst regression
+surface in the tree — and #737's fix is still ahead of its own evidence one
+branch below. What is measured is mpv's mechanism. What is **not** measured is
+that a real session reaches the third case, and that is a real-mpv e2e leg.
+
 ### 5.7 Ship the branch's mouse e2e coverage — but know what it does and does not cover
 
 `tests/e2e/test_mouse_routing.py` — real `MBTN_RIGHT` presses at `:358` and

--- a/docs/POSTMORTEM_3.0.0.md
+++ b/docs/POSTMORTEM_3.0.0.md
@@ -1027,7 +1027,7 @@ first skip segment and the report says "after a video or two".
 Ship the branch anyway — it is real coverage — but do not let it be mistaken for
 this cluster's guard.
 
-### 5.8 The process rule that actually fires
+### 5.8 The process rule that actually fires — BUILT as `tools/selffix_rate.py`
 
 The daily table in §1 is computable in one command. **A release should not tag
 while the trailing-3-day self-fix rate is above the window's opening rate.** On
@@ -1036,6 +1036,30 @@ later. This is CLAUDE.md's stated trigger — *"when a round's findings land mos
 in code that earlier rounds fixed, stop applying them one at a time and run
 `/breakfix-review`"* — with a number attached so it can fire without anyone
 noticing it should.
+
+**`tools/selffix_rate.py --since <ref> --daily` is that command**, and it exits
+non-zero when the gate is failing. Run against this release it says **DO NOT
+TAG**: opening 24.4%, trailing 47.7%.
+
+It reproduces §1's numerators exactly — 56 self-fixes by instrument A, 40 by B —
+and the daily table with them, 20.0% on 2026-09-01 and 78.6% on 2026-09-02. The
+denominators differ on purpose: §1 kept the prose commits in them and excluded
+them only from the numerator, and this drops them from both, so 44.1%/29.9%
+reads here as 46.3%/30.9%. The excluded count is printed on every run so the two
+can be reconciled.
+
+Two corrections came out of building it. **There are six prose-compression
+commits, not four** — `f1127df4` and `775d8d79` are the same batch on the same
+day and the hand count missed them, which is the argument for the filter being
+code. And the AST comparison §1 describes needs **docstrings stripped before
+comparing**: a docstring is an AST node, so a plain `ast.dump` calls a
+prose-only commit a behaviour change. The first version of the tool did that and
+disagreed with §1 by exactly the commits §1 had proved prose-only.
+
+The 0.0% trap has an assertion rather than a warning:
+`tests/test_selffix_rate.py` fails the tool if blame produces no lines at all
+across a non-empty window, because an instrument that reports "no rot" when it
+has measured nothing is worse than no instrument.
 
 ---
 

--- a/docs/RELEASE_SHAPE_POST_3.0.0.md
+++ b/docs/RELEASE_SHAPE_POST_3.0.0.md
@@ -898,11 +898,29 @@ zero-risk substitute is a release-notes line:
    currently suspended."* So the Lua test is necessary and not sufficient.
 2. **A real-mpv leg for the same property:** `click_pauses = false` → a skip
    segment arms → the button hides → return to the browser → left-click a tile.
-   That is the cross-product no existing suite covers.
+   That is the cross-product no existing suite covers. **DONE** —
+   `test_a_real_click_still_activates_after_a_skip_segment`.
 3. **A4 through real `MBTN_RIGHT` down/up over bare video with the HUD
    auto-hidden.** `tests/e2e/test_mouse_routing.py`'s two `MBTN_RIGHT` calls are
-   at `:358` and `:456` and are both on nodes — CONFIRMED, and it is the honest
-   limit the postmortem records at §5.7.
+   at `:358` and `:456` and are both on nodes — CONFIRMED, and it was the honest
+   limit the postmortem records at §5.7. **DONE** —
+   `test_the_right_button_pauses_over_a_hidden_hud`.
+
+**Both are mutation-controlled, and criterion 2's control settles the half of
+#737 that was inferred.** Deleting `mp.remove_key_binding('mpvtk_skip_click')`
+from `phud_skip_unbind` — i.e. putting the defect back — makes the click test
+fail on the tile, naming the leak, while every other test in the file stays
+green; reverting A4's `mpvtk_phud_rclick` binding fails only the right-button
+test. Green on both backends, 8 of 8.
+
+So *"a leaked forced `mbtn_left` eats browser clicks"* is no longer inferred
+from how mpv ranks bindings — it is demonstrated, through mpv's own section
+stack, which is precisely what `tests/lua/fake_mp.lua` says it cannot model.
+**What that does NOT settle is whether this is #737's cause.** The mechanism
+predicts the freeze on the *first* skip segment and the report says "after a
+video or two"; those agree only if not every episode offered a Skip button, and
+that question still belongs to the reporter or to a hand repro. Do not write
+"fixes #737" on the strength of this.
 4. **The pairing lint green with zero exemptions.**
 5. **A CI build to each reporter (§5.4) — Izzie's to send, per the policy
    above — which is the strongest evidence available here and the only kind for

--- a/docs/RISK_MAP_2026-09.md
+++ b/docs/RISK_MAP_2026-09.md
@@ -316,6 +316,11 @@ them needs a config-file edit to reach*. By this rule it is post-3.0.0 work. It
 should still be built, because R10 proves the class is live and growing; it
 should not be built first.
 
+**BUILT (last, per that rule), and the class was indeed growing: seven open
+rows, not four.** R2 turned out to have a second site, and two more are in the
+HUD's summon bindings. None repaired — the reachability argument above is
+unchanged. `docs/POSTMORTEM_3.0.0.md` §5.1.
+
 **One platform exception.** `conf.py:413` is
 `mpv_ext: bool = sys.platform.startswith("darwin")` — **the external backend is
 the default on macOS.** So `mpv.TIMEOUT` (jsonipc-only, lowered 120s→5s and

--- a/docs/RISK_MAP_2026-09.md
+++ b/docs/RISK_MAP_2026-09.md
@@ -330,8 +330,10 @@ without the platform qualifier gets this backwards for every Mac user.
   which no setting gates.
 - The four declared entries on `tools/audit_owned_state.py` (`_sync_path`,
   `ThumbnailStore._gone`, `mpv.TIMEOUT`, `_login["pass"]`) are the cheapest
-  Tier-1 coverage available — a bookkeeping extension to a tool that exists,
-  not new machinery.
+  Tier-1 coverage available — ~~a bookkeeping extension to a tool that exists,
+  not new machinery.~~ **DONE, and three of the four needed the tool to grow
+  first: a directory scope for the browser's mixins, and a way to name state
+  that does not hang off `self`.** `docs/POSTMORTEM_3.0.0.md` §5.2.
 - `test_config_cells.py` drops: its verified cell is `headless`-gated, i.e.
   Tier 3.
 - The `_MpvHandle` capsule is unaffected — mpv re-creation is reached by

--- a/docs/RISK_MAP_2026-09.md
+++ b/docs/RISK_MAP_2026-09.md
@@ -327,7 +327,9 @@ without the platform qualifier gets this backwards for every Mac user.
 
 - `tools/audit_act_targets.py` stays first among the lints: it covers R7 and R8
   (Tier 1 and Tier 2) and its Rule B reach-throughs are in `gateway/hud.py`,
-  which no setting gates.
+  which no setting gates. **BUILT.** Ten sites, all declared; three of the four
+  writes have an unused `PlayerManager` method waiting, and the fourth is the
+  aspect-override commit on `enrich-e2e-tests`. `docs/POSTMORTEM_3.0.0.md` §5.3.
 - The four declared entries on `tools/audit_owned_state.py` (`_sync_path`,
   `ThumbnailStore._gone`, `mpv.TIMEOUT`, `_login["pass"]`) are the cheapest
   Tier-1 coverage available — ~~a bookkeeping extension to a tool that exists,

--- a/docs/mpv-backends.md
+++ b/docs/mpv-backends.md
@@ -307,12 +307,20 @@ re-installs its nav keys on pointer movement and on every lifecycle event, so an
 overlay that came up first can lose its keyboard a moment later and remain on
 screen with nothing to activate. That is what the `user-data/mpv/console/open`
 handler exists for — it drops our claims for as long as the console is up.
-`any_unicode` is the exception to the ordering rule: it outranks an exact key
-whichever went in first, so the block claim has to be released regardless.
+`any_unicode` does **not** escape the ordering rule, and it is worth being
+precise because the renderer depends on it not escaping: it outranks an exact
+key installed *before* it, and loses to one installed after. That is exactly why
+`ui_resume` binds the browse block **first** and says so at `renderer.lua:5771` —
+installed last it swallowed a printable `ui_select_key` (#717). The console
+handler still has to release it, because the console's own keys go in after
+ours.
 
 **The comment on that handler said the opposite for a release** — that our
 bindings outranked the console — and the handler was right for a reason its own
-comment did not give. `tools/audit_key_bindings.py:PUBLISHED` now enumerates
+comment did not give. The rule was in the file the whole time: `:5771` states it
+correctly, 1,200 lines away, because getting it wrong there had cost #717. One
+rule, right at one site and wrong at another, which is the shape
+`docs/RISK_MAP_2026-09.md` §2 is a table of. `tools/audit_key_bindings.py:PUBLISHED` now enumerates
 every `user-data/mpv/*` property mpv's builtin scripts set, with what the
 renderer owes each; `context-menu/open` is recorded there as watched by nothing.
 

--- a/docs/mpv-backends.md
+++ b/docs/mpv-backends.md
@@ -285,6 +285,37 @@ purpose — while the library or the HUD is up the pointer really is over a UI �
 and enables them only for as long as it is. The player's sections are enabled for
 the life of the process.
 
+### Forced does not mean first — the later section wins
+
+Two forced sections holding the same key is the normal case, not a corner one:
+`renderer.lua` forces ENTER, ESC, the arrows and `any_unicode`, and so do mpv's
+own `console.lua` and `context_menu.lua`. Which one gets the key is decided by
+**order**, not by the word "forced".
+
+Measured with `tools/probe_key_precedence.py`, which presses the key and reports
+the handler that ran rather than reading `priority` off `input-bindings`. Same
+answer for the console and the context menu, on two master builds:
+
+| when | who receives ENTER |
+|---|---|
+| nothing open | ours |
+| the overlay opens *after* our binding | the overlay's |
+| we re-bind while the overlay is up | **ours, and the overlay stays drawn** |
+
+Only the third row is an exposure, and it is not hypothetical: the HUD
+re-installs its nav keys on pointer movement and on every lifecycle event, so an
+overlay that came up first can lose its keyboard a moment later and remain on
+screen with nothing to activate. That is what the `user-data/mpv/console/open`
+handler exists for — it drops our claims for as long as the console is up.
+`any_unicode` is the exception to the ordering rule: it outranks an exact key
+whichever went in first, so the block claim has to be released regardless.
+
+**The comment on that handler said the opposite for a release** — that our
+bindings outranked the console — and the handler was right for a reason its own
+comment did not give. `tools/audit_key_bindings.py:PUBLISHED` now enumerates
+every `user-data/mpv/*` property mpv's builtin scripts set, with what the
+renderer owes each; `context-menu/open` is recorded there as watched by nothing.
+
 ### Which keys the shim binds, and why so few (#16)
 
 The governing rule is *stop intercepting keys whose meaning we did not change*.

--- a/jellyfin_mpv_shim/mpvtk/renderer.lua
+++ b/jellyfin_mpv_shim/mpvtk/renderer.lua
@@ -6903,11 +6903,18 @@ mp.register_script_message('mpvtk-debug', function(json)
     end
 end)
 
--- mpv's console (`) wants the keyboard, but our ENTER and arrow bindings
--- are FORCED and outrank it: typing a command and pressing ENTER summoned
--- the HUD (and toggled pause) instead of running the command, with no way
--- back but ESC. Hand the keys over for as long as the console is up, and
--- take them again when it closes.
+-- mpv's console (`) wants the keyboard, and typing a command and pressing
+-- ENTER summoned the HUD (and toggled pause) instead of running it, with no
+-- way back but ESC. Hand the keys over for as long as the console is up,
+-- and take them again when it closes.
+--
+-- NOT because our bindings "outrank" it, which this said until it was
+-- measured: between two forced sections the LATER one wins, so a console
+-- opened after our ENTER is bound receives the key. What takes it back is a
+-- RE-bind while the console is up -- the HUD re-installs its nav keys on
+-- pointer movement and on every lifecycle event -- and the any_unicode
+-- block claim, which outranks an exact key in either order. Same exposure,
+-- same measurement, at mpv's context menu: tools/audit_key_bindings.py.
 --
 -- Restored from what was actually bound rather than re-derived: which of
 -- the three groups is live depends on browse-vs-HUD, hud_grab_keys and
@@ -6920,9 +6927,10 @@ end)
 -- this chunk is at 192 of LuaJIT's 200 top-level locals, and going over
 -- does not fail at the call, it fails to load the renderer at all.
 --
--- The property is mpv >= 0.38 and reads nil both before the console is
--- first opened and on builds without it. nil is falsy, which is the right
--- answer for "the console is not up" in either case.
+-- The property is mpv >= 0.40 (8669205d92), not 0.38 as this said, and
+-- reads nil both before the console is first opened and on builds without
+-- it. nil is falsy, which is the right answer for "the console is not up"
+-- in either case.
 mp.observe_property('user-data/mpv/console/open', 'bool', function(_, open)
     if open then
         if state.kb_saved then return end

--- a/jellyfin_mpv_shim/mpvtk/renderer.lua
+++ b/jellyfin_mpv_shim/mpvtk/renderer.lua
@@ -6913,8 +6913,9 @@ end)
 -- opened after our ENTER is bound receives the key. What takes it back is a
 -- RE-bind while the console is up -- the HUD re-installs its nav keys on
 -- pointer movement and on every lifecycle event -- and the any_unicode
--- block claim, which outranks an exact key in either order. Same exposure,
--- same measurement, at mpv's context menu: tools/audit_key_bindings.py.
+-- block claim, which outranks an exact key installed BEFORE it (which is
+-- why ui_resume binds it first; see the note there). Same exposure, same
+-- measurement, at mpv's context menu: tools/audit_key_bindings.py.
 --
 -- Restored from what was actually bound rather than re-derived: which of
 -- the three groups is live depends on browse-vs-HUD, hud_grab_keys and

--- a/tests/e2e/test_mouse_routing.py
+++ b/tests/e2e/test_mouse_routing.py
@@ -449,9 +449,13 @@ class MouseRoutingTest(unittest.TestCase):
         """
         self._hud_idle(click_pauses=False)
         self.app.set_hud_skip("Skip Intro")
+        # Well inside `PHUD_SKIP_S` (10s), which is the button's own
+        # auto-hide: a wait that outlasts it would watch the segment arm
+        # and disarm, and then report that it never armed.
         self._wait(lambda: self._state().get("phud_skip") is True,
-                   "no skip segment ever armed, so `mpvtk_skip_click` was "
-                   "never bound and there is nothing to leak")
+                   "no skip segment ever armed within 5s, so "
+                   "`mpvtk_skip_click` was never bound and there is nothing "
+                   "to leak", timeout=5.0)
         self.app.set_hud_skip("")
         self._wait(lambda: not self._state().get("phud_skip"),
                    "the skip button never went away")

--- a/tests/e2e/test_mouse_routing.py
+++ b/tests/e2e/test_mouse_routing.py
@@ -405,6 +405,102 @@ class MouseRoutingTest(unittest.TestCase):
             "no node table and pointer input cannot recover it")
 
 
+    # -- the skip button, and what it leaves behind (#737 / A4) ------------
+
+    def _hud_idle(self, click_pauses):
+        """HUD mode with the bar auto-hidden -- most of playback.
+
+        Not summoned: `phud_skip_bind` returns early while the bar is
+        `shown`, and the standalone Skip button only exists when it is not.
+        `hide` is short so nothing here waits on a real auto-hide.
+        """
+        self.app.set_active(False)
+        time.sleep(0.3)
+        self.app.set_hud(True, {"hide": 2, "mode": "hover",
+                                "click": click_pauses})
+        self._wait(lambda: self._state().get("phud_mode") is True,
+                   "the renderer never entered HUD mode, so neither the "
+                   "skip button nor the summon bindings exist")
+        self._wait(lambda: not self._state().get("phud_shown"),
+                   "the HUD came up shown; the bindings under test are the "
+                   "hidden bar's")
+
+    def test_a_real_click_still_activates_after_a_skip_segment(self):
+        """#737, through mpv rather than through the renderer's handlers.
+
+        With `mouse_click_pauses` off, `phud_skip_bind` forces `mbtn_left`
+        as `mpvtk_skip_click` for the few seconds the standalone Skip button
+        is up -- and a forced binding outranks the browser's own
+        `mpvtk_mouse` section, so if the segment ends without releasing it,
+        every later click runs its else-branch (`begin-vo-dragging`) instead
+        of reaching a tile. The reporter's words: "the UI becomes
+        unresponsive after a few videos ... switching back to left click to
+        pause this behavior never occurs".
+
+        **This is the leg the Lua suite cannot be.** `tests/lua/fake_mp.lua`
+        dispatches by binding NAME, so it can show the binding is gone and
+        not that a leaked one would have preempted anything -- the fake says
+        so itself. The preemption is mpv's section stack, and that needs
+        mpv.
+
+        Control: deleting `mp.remove_key_binding('mpvtk_skip_click')` from
+        `phud_skip_unbind` turns this red on the click, and leaves every
+        other test in this file green.
+        """
+        self._hud_idle(click_pauses=False)
+        self.app.set_hud_skip("Skip Intro")
+        self._wait(lambda: self._state().get("phud_skip") is True,
+                   "no skip segment ever armed, so `mpvtk_skip_click` was "
+                   "never bound and there is nothing to leak")
+        self.app.set_hud_skip("")
+        self._wait(lambda: not self._state().get("phud_skip"),
+                   "the skip button never went away")
+
+        self.app.set_hud(False)
+        time.sleep(0.3)
+        self.app.set_active(True)
+        time.sleep(0.4)
+        self._repaint()
+        self._assert_a_click_activates(
+            "a real left click is dead in the library after one skip "
+            "segment -- a forced mbtn_left outlived the button and is "
+            "dragging the window instead of reaching the tile")
+
+    def test_the_right_button_pauses_over_a_hidden_hud(self):
+        """A4, through a real MBTN_RIGHT rather than on a node.
+
+        In mpv's modality (`mouse_click_pauses` off) the left button drags
+        the window and the right one pauses. `on_rclick` does that only
+        while the bar is `shown`; the bar is hidden for most of playback,
+        and what used to cover the gap was mpv's own default. Our pin move
+        took it away -- v0.41.0 binds MBTN_RIGHT to `cycle pause`, master to
+        `script-binding select/context-menu` -- so right click over a hidden
+        HUD did nothing at all.
+
+        The two existing MBTN_RIGHT presses in this file are both on library
+        tiles, which is a different question with the same button.
+
+        Control: removing the `mpvtk_phud_rclick` binding from
+        `phud_bind_summon` turns this red.
+        """
+        self._hud_idle(click_pauses=False)
+        st = self._state()
+        # Mid-window, where a hidden HUD is nothing but picture. The skip
+        # button is down, so `hit_skip` cannot claim this press.
+        self.handle.command("mouse", int((st.get("w") or 2) / 2),
+                            int((st.get("h") or 2) / 2))
+        time.sleep(0.3)
+        before = bool(self.handle.pause)
+        self.handle.command("keydown", "MBTN_RIGHT")
+        time.sleep(0.1)
+        self.handle.command("keyup", "MBTN_RIGHT")
+        self._wait(
+            lambda: bool(self.handle.pause) != before,
+            "a real right click over a hidden HUD did not toggle pause "
+            "(pause is still %r) -- nothing of ours holds MBTN_RIGHT and "
+            "mpv's own default on this pin is the context menu" % before,
+            timeout=5.0)
+
     def _navigate(self, label, route):
         """Go to a screen by route, then wait for the renderer to hold it.
 

--- a/tests/lua/test_renderer.lua
+++ b/tests/lua/test_renderer.lua
@@ -3205,6 +3205,49 @@ ok(not did("cycle", "fullscreen"),
    "double-clicking empty library background toggled full screen")
 fake.send("mpvtk-active", "no")
 
+-- ------------- and the state NONE of the three fall-throughs can answer
+--
+-- All three of them -- click, double click and right click on bare video --
+-- open with `state.phud.mode and state.phud.shown`, and `phud.mode` is only
+-- ever true under `osc_style` mpvtk. Give the window to a lua OSC and the
+-- mode never comes on, so with `mpvtk_mouse` still enabled every button
+-- reaches a handler that has no branch for it and stops there: the picture
+-- is unreachable by mouse and mpv's own bindings never see the key.
+--
+-- That is #724 / #726, and the repair is one level up -- the app sends
+-- `mpvtk-active no` so the sections drop to priority -1 and mpv wins the
+-- mouse (asserted above, and `tests/test_classic_osc_mouse.py` pins that the
+-- app actually sends it on the transitions a video goes through). What THIS
+-- pins is why that is load-bearing rather than tidy, and it is the case a
+-- fixture cannot reach if `phud.mode` is set for it: with the mode off, the
+-- fall-throughs are dead code and their absence is silent.
+fake.send("mpvtk-hud", "no")
+fake.send("mpvtk-active", "yes")
+scene({})                               -- bare video, no node anywhere
+repaint()
+fake.mouse(640, 360)
+fake.reset_events()
+fake.send("mpvtk-debug", fake.token({ cmd = "state" }))
+ok((last_event("debug_state") or {}).phud_mode ~= true,
+   "the no-HUD case was set up with HUD mode ON, so it proves nothing")
+-- One button per log. `did` scans everything recorded since the last
+-- reset, so sharing a log lets a left click that wrongly paused answer the
+-- RIGHT click's assertion too -- three assertions, one of them measuring
+-- the others. Measured: it happens.
+fake.log.commands = {}
+fake.key("mbtn_left")
+ok(not did("cycle", "pause"),
+   "with no HUD mode a bare-video click reached the pause fall-through")
+fake.log.commands = {}
+fake.key("mbtn_right")
+ok(not did("cycle", "pause"),
+   "with no HUD mode a bare-video right click reached the fall-through")
+fake.log.commands = {}
+fake.key("mbtn_left_dbl")
+ok(not did("cycle", "fullscreen"),
+   "with no HUD mode a bare-video double click reached the fall-through")
+fake.send("mpvtk-active", "no")
+
 -- ================================================ HUD nav + seek bar
 
 -- Leave HUD mode with a known syncplay answer: `pause_now` hands the

--- a/tests/test_no_act_reachthrough.py
+++ b/tests/test_no_act_reachthrough.py
@@ -1,0 +1,133 @@
+"""The browser reaches the player through `PlayerManager`, or says why not.
+
+`_act` defers whenever the player lock is busy, and the lock is held for the
+whole of a playback start -- so a `_act` body runs at an unknown time with
+no lock held. `PlayerManager`'s methods are where the rules about that live.
+A body that writes `pm._player.<prop>` instead skips every one of them, and
+both live examples cost a user something no setting explains: R7 made every
+film in a session play stretched, R8 made every film start windowed.
+
+Runs `tools/audit_act_targets.py`. A finding here is not automatically a
+bug: route it through the manager method, or add the site to `DECLARED`
+with the reason it is the right shape.
+"""
+
+# Run as a script, this is what puts the repo root on sys.path -- without
+# it `jellyfin_mpv_shim` resolves to whatever is pip-installed. A no-op
+# under `discover`; tests/test_module_paths.py is the guard.
+if __name__ == "__main__":
+    import os
+    import sys
+
+    sys.path.insert(0, os.path.dirname(
+        os.path.dirname(os.path.abspath(__file__))))
+
+import ast
+import os
+import sys
+import unittest
+
+sys.argv = [sys.argv[0]]      # importing the shim reaches args.get_args()
+
+ROOT = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+sys.path.insert(0, os.path.join(ROOT, "tools"))
+
+import audit_act_targets as audit    # noqa: E402
+
+
+class ActTargetsTest(unittest.TestCase):
+    def test_nothing_reaches_the_handle_undeclared(self):
+        findings = audit.audit()
+        if findings:
+            self.fail(
+                "\n".join(
+                    "%s:%d rule %s -- %s reaches `_player.%s`"
+                    % (s.module, s.line, s.rule, s.func, s.prop)
+                    for s in findings)
+                + "\n\nSee tools/audit_act_targets.py — route it through "
+                  "the PlayerManager method, or add the site to DECLARED "
+                  "with the reason.")
+
+    def test_no_declaration_outlives_its_site(self):
+        """The guard on the guard. A key for a site that moved or went away
+        is not harmless bookkeeping: it pre-authorises the next reach with
+        the same name, and the audit stays quiet because the key is already
+        there. Writing this list by hand produced six such keys on the
+        first run, which is why it is a test and not a habit."""
+        self.assertEqual([], audit.stale())
+
+    def test_every_declaration_says_why(self):
+        for key, why in audit.DECLARED.items():
+            with self.subTest(key):
+                self.assertGreater(
+                    len(why), 60,
+                    "%s is declared without saying what makes it the right "
+                    "shape" % key)
+
+    def test_a_write_is_found_in_both_spellings(self):
+        """`x._player.p = v` and `setattr(x._player, "p", v)` are the same
+        reach, and the gateway uses both. A rule that saw one of them would
+        pass this package today and miss the next line somebody writes."""
+        for src, prop in (
+            ("def f(pm):\n    pm._player.volume = 5\n", "volume"),
+            ("def f(pm):\n    setattr(pm._player, 'volume', 5)\n", "volume"),
+        ):
+            with self.subTest(src.strip()):
+                found = self._sites_in(src)
+                writes = [s for s in found if s.rule == "A"]
+                self.assertEqual(1, len(writes), found)
+                self.assertEqual(prop, writes[0].prop)
+
+    def test_a_computed_property_name_is_still_a_write(self):
+        """`setattr(pm._player, name, v)` cannot be attributed to a
+        property, which makes it the worst version of this reach rather
+        than an exempt one."""
+        found = self._sites_in(
+            "def f(pm, name):\n    setattr(pm._player, name, 5)\n")
+        writes = [s for s in found if s.rule == "A"]
+        self.assertEqual(["<computed>"], [s.prop for s in writes])
+
+    def test_the_handle_taken_by_getattr_is_a_read(self):
+        """It is the same reach with the name as a string, so no Attribute
+        node carries it. The package had one when this file was written."""
+        found = self._sites_in(
+            "def f(pm):\n    p = getattr(pm, '_player', None)\n    return p\n")
+        self.assertEqual([("f", "B")], [(s.func, s.rule) for s in found])
+
+    def test_a_write_is_not_also_counted_as_a_read(self):
+        """One reach, one finding. Reporting both halves of `setattr` would
+        make every repair look like two and every count wrong."""
+        found = self._sites_in(
+            "def f(pm):\n    setattr(pm._player, 'volume', 5)\n")
+        self.assertEqual(["A"], [s.rule for s in found])
+
+    def test_a_nested_def_is_named_by_its_chain(self):
+        """`flip` says nothing on its own and there can be two of them in a
+        file; the declaration has to name a site, not a common word."""
+        found = self._sites_in(
+            "def outer(self):\n"
+            "    def flip(pm):\n"
+            "        pm._player.fullscreen = True\n"
+            "    self._act(flip)\n")
+        self.assertEqual(["outer.flip"], [s.func for s in found])
+
+    @staticmethod
+    def _sites_in(src):
+        """Run the module scanner over a snippet, via a temp file -- the
+        scanner reads source rather than importing, which is what lets it
+        run against a package whose import has side effects."""
+        import tempfile
+
+        with tempfile.NamedTemporaryFile("w", suffix=".py",
+                                         delete=False) as fh:
+            fh.write(src)
+            path = fh.name
+        try:
+            ast.parse(src)          # a broken snippet is a broken test
+            return audit._scan(path)
+        finally:
+            os.unlink(path)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_no_frozen_key_literals.py
+++ b/tests/test_no_frozen_key_literals.py
@@ -1,0 +1,169 @@
+"""A literal mpv key name that a setting can move has to be declared.
+
+The recurring shape, four times over: a function resolves a `kb_*` /
+`ui_select_key` / `hud_wake_key` setting on one line and writes the default
+spelling as a literal on the next. R10 sits one screen from R3, inside a
+function that resolves the very setting it then hardcodes, and four surveys
+plus a session of hand work walked past it -- so this is a predicate rather
+than a fifth careful reading.
+
+Runs `tools/audit_frozen_key_literals.py`. A finding is not automatically a
+bug: resolve the setting, or declare the site with the reason the literal is
+right. What the declaration buys is that the next person to add one has to
+answer the question, and finds out from it that a resolver exists.
+"""
+
+# Run as a script, this is what puts the repo root on sys.path -- without
+# it `jellyfin_mpv_shim` resolves to whatever is pip-installed. A no-op
+# under `discover`; tests/test_module_paths.py is the guard.
+if __name__ == "__main__":
+    import os
+    import sys
+
+    sys.path.insert(0, os.path.dirname(
+        os.path.dirname(os.path.abspath(__file__))))
+
+import os
+import re
+import sys
+import unittest
+
+sys.argv = [sys.argv[0]]      # importing the shim reaches args.get_args()
+
+ROOT = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+sys.path.insert(0, os.path.join(ROOT, "tools"))
+
+import audit_frozen_key_literals as audit    # noqa: E402
+
+RENDERER = os.path.join(ROOT, "jellyfin_mpv_shim", "mpvtk", "renderer.lua")
+
+
+class FrozenKeyLiteralsTest(unittest.TestCase):
+    def test_every_site_is_declared(self):
+        found = audit.undeclared()
+        if found:
+            self.fail(
+                "\n".join("%s:%d %r in %s"
+                          % (os.path.relpath(s.path, ROOT), s.line,
+                             s.literal, s.scope) for s in found)
+                + "\n\nSee tools/audit_frozen_key_literals.py — resolve the "
+                  "setting, or declare the site with the reason.")
+
+    def test_no_declaration_outlives_its_site(self):
+        """A key matching nothing pre-authorises the next literal written in
+        a scope by that name. Writing this table by hand put six entries on
+        functions that hold no key literal at all, and a seventh (R10) on
+        the wrong function entirely, so the check is not theoretical."""
+        self.assertEqual([], audit.stale())
+
+    def test_every_declaration_says_why(self):
+        for key, (status, why) in audit.DECLARED.items():
+            with self.subTest(key):
+                self.assertIn(status, (audit.OPEN, audit.OK))
+                self.assertGreater(
+                    len(why), 60,
+                    "%s is declared without a reason a reader can act on"
+                    % key)
+
+    def test_the_open_findings_are_still_named(self):
+        """These are declared as FINDINGS, not exemptions, and the whole
+        value of that is a reader seeing it. If someone repairs one, the
+        declaration has to stop claiming it is open — and the way that
+        surfaces is this list going stale.
+
+        The status is a field, not a word in the reason. The first draft
+        read `"OPEN" in why` and disagreed with itself over two entries
+        whose prose said "open with it" and "SECOND SITE" — which is the
+        same defect the tool is about, in the tool.
+        """
+        self.assertEqual(
+            ["app.py:MpvtkBrowser._shell_claimed_keys",
+             "app.py:MpvtkBrowser._shell_key",
+             "player.py:PlayerManager",
+             "renderer.lua:PHUD_SUMMON_KEYS",
+             "renderer.lua:phud_bind_summon",
+             "renderer.lua:phud_bind_wake",
+             "renderer.lua:phud_skip_bind"],
+            audit.open_findings())
+
+    def test_the_key_names_come_from_conf(self):
+        """Listing them here instead would stop covering a new `kb_*` the
+        day it is added, silently. Reading `conf.py` means a renamed setting
+        changes the answer loudly."""
+        keys = audit._key_names()
+        self.assertEqual({"ENTER", "ESC", "SPACE", "UP", "DOWN",
+                          "LEFT", "RIGHT"}, keys)
+
+    def test_a_new_frozen_literal_is_reported(self):
+        """Guard on the guard: a literal in a scope nobody declared has to
+        be a finding, or the table is decoration."""
+        import tempfile
+
+        with tempfile.NamedTemporaryFile("w", suffix=".lua",
+                                         delete=False) as fh:
+            fh.write("local function jms_probe()\n"
+                     "    mp.add_forced_key_binding('ENTER', 'x', f)\n"
+                     "end\n")
+            path = fh.name
+        self.addCleanup(os.unlink, path)
+        found = audit._scan_lua(path, audit._key_names())
+        self.assertEqual([("jms_probe", "ENTER")],
+                         [(s.scope, s.literal) for s in found])
+
+    def test_a_key_name_in_a_comment_is_not_a_site(self):
+        """`renderer.lua` explains these keys at length. Charging prose
+        would bury the real sites under its own documentation."""
+        import tempfile
+
+        with tempfile.NamedTemporaryFile("w", suffix=".lua",
+                                         delete=False) as fh:
+            fh.write("-- we force 'ENTER' here for the reason above\n"
+                     "local function jms_probe()\n"
+                     "    return 1\n"
+                     "end\n")
+            path = fh.name
+        self.addCleanup(os.unlink, path)
+        self.assertEqual([], audit._scan_lua(path, audit._key_names()))
+
+    def test_a_file_scope_constant_is_not_charged_to_the_function_above(self):
+        """The scope tracker's own bug, kept as a case. `PHUD_SUMMON_KEYS`
+        is R3 and it follows `phud_wake_key`; charging it there put the R3
+        declaration on the resolver that is the counter-example to it."""
+        import tempfile
+
+        with tempfile.NamedTemporaryFile("w", suffix=".lua",
+                                         delete=False) as fh:
+            fh.write("local function jms_resolver()\n"
+                     "    return state.k or 'ESC'\n"
+                     "end\n"
+                     "\n"
+                     "local JMS_KEYS = { 'ENTER' }\n")
+            path = fh.name
+        self.addCleanup(os.unlink, path)
+        found = audit._scan_lua(path, audit._key_names())
+        self.assertEqual(
+            [("jms_resolver", "ESC"), ("JMS_KEYS", "ENTER")],
+            [(s.scope, s.literal) for s in found])
+
+    def test_the_scan_sees_every_uppercase_literal_in_the_renderer(self):
+        """Scope attribution is a labelling job and must never be a filter.
+        The scope tracker was rewritten once already; this is what says the
+        rewrite moved sites between labels rather than dropping them."""
+        keys = audit._key_names()
+        with open(RENDERER, encoding="utf-8") as fh:
+            lines = fh.read().splitlines()
+        raw = set()
+        for lineno, line in enumerate(lines, 1):
+            if line.lstrip().startswith("--"):
+                continue
+            for match in re.finditer(r"'([^'\n]*)'|\"([^\"\n]*)\"", line):
+                value = match.group(1) or match.group(2)
+                if value in keys:
+                    raw.add((lineno, value))
+        got = {(s.line, s.literal) for s in audit.sites()
+               if s.path.endswith(".lua")}
+        self.assertEqual(raw, got)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_no_second_owner.py
+++ b/tests/test_no_second_owner.py
@@ -37,8 +37,8 @@ class OwnedStateTest(unittest.TestCase):
         if findings:
             lines = []
             for entry, strays in findings:
-                lines.append("%s: self.%s reached in %s"
-                             % (entry.module, entry.attr,
+                lines.append("%s (%s) reached in %s"
+                             % (entry.state, entry.scope,
                                 ", ".join(sorted(strays))))
                 lines.append("    " + entry.why)
             self.fail("\n".join(lines) +
@@ -50,23 +50,23 @@ class OwnedStateTest(unittest.TestCase):
         """The guard on the guard. A renamed attribute finds nothing
         anywhere, reports a clean tree, and checks nothing ever again."""
         for entry in audit.OWNED:
-            with self.subTest("%s.%s" % (entry.module, entry.attr)):
+            with self.subTest("%s in %s" % (entry.state, entry.scope)):
                 sites = audit._sites(entry)
                 self.assertTrue(
                     sites,
-                    "self.%s is not touched anywhere in %s any more — it was "
+                    "%s is not touched anywhere in %s any more — it was "
                     "renamed or removed, and this entry has been checking "
-                    "nothing" % (entry.attr, entry.module))
+                    "nothing" % (entry.state, entry.scope))
                 phantom = sorted(entry.owners - set(sites))
                 self.assertFalse(
                     phantom,
-                    "declared owners of self.%s that do not touch it: %r. An "
+                    "declared owners of %s that do not touch it: %r. An "
                     "owner is a record of a site that exists, not permission "
                     "for one that might: left standing, it pre-authorises "
                     "exactly the second owner this audit is for, and the "
                     "audit stays silent because the name is already listed. "
                     "Real sites: %r"
-                    % (entry.attr, phantom, sorted(sites)))
+                    % (entry.state, phantom, sorted(sites)))
 
 
 if __name__ == "__main__":

--- a/tests/test_no_unpaired_bindings.py
+++ b/tests/test_no_unpaired_bindings.py
@@ -108,5 +108,89 @@ class UnpairedBindingsTest(unittest.TestCase):
                 "%s is exempted without explaining the release" % name)
 
 
+class MpvUserDataTest(unittest.TestCase):
+    """The other direction: keys mpv's own scripts take while we hold ours.
+
+    `tools/audit_key_bindings.PUBLISHED` is the enumeration of the
+    `user-data/mpv/*` properties mpv's builtin scripts set. A property the
+    renderer observes is a keyboard loan it makes; one it does not is a
+    loan it never makes, and the difference has to be a decision somebody
+    wrote down rather than a file nobody re-read.
+    """
+
+    def test_renderer_and_the_declaration_agree(self):
+        mod = _audit()
+        findings = mod.audit_user_data(RENDERER)
+        self.assertEqual(
+            [], findings,
+            "; ".join("user-data/mpv/%s: %s" % f for f in findings))
+
+    def test_the_known_gaps_are_exactly_these(self):
+        """A recorded gap stays visible; a NEW one has to be argued for.
+
+        `context-menu/open` is the one, and it is deliberate: mpv's menu
+        forces ENTER, ESC and the arrows, it is what MBTN_RIGHT opens on
+        the master pin both builds ship, and nothing hands our keys back
+        while it is up. The repair lands on the input arbiter, which is
+        why it is not being made quietly next to a lint.
+        """
+        mod = _audit()
+        self.assertEqual(["context-menu/open"], mod.gaps())
+
+    def test_every_entry_says_which_script_and_which_release(self):
+        """The list cannot be derived -- mpv's source is not in this repo
+        -- so each row has to carry enough for the next reader to re-check
+        it against a tree they do have."""
+        mod = _audit()
+        for prop, entry in mod.PUBLISHED.items():
+            with self.subTest(prop):
+                self.assertIn(entry.state,
+                              ("observed", "not-input", "gap"))
+                self.assertTrue(entry.by.endswith(".lua"), entry.by)
+                self.assertGreater(len(entry.since), 4, entry.since)
+                self.assertGreater(
+                    len(entry.why), 40,
+                    "%s is declared without saying what it is for" % prop)
+
+    def test_a_dropped_observer_is_reported(self):
+        """Guard on the guard, in the direction that matters: if the
+        console handler is deleted or its property renamed, this has to
+        fail rather than report a clean tree."""
+        import tempfile
+
+        mod = _audit()
+        with open(RENDERER, encoding="utf-8") as fh:
+            src = fh.read()
+        src = src.replace("user-data/mpv/console/open",
+                          "user-data/mpv/console/open-RENAMED")
+        with tempfile.NamedTemporaryFile("w", suffix=".lua",
+                                         delete=False) as fh:
+            fh.write(src)
+            path = fh.name
+        self.addCleanup(os.unlink, path)
+        findings = mod.audit_user_data(path)
+        self.assertTrue(
+            any(prop == "console/open" for prop, _why in findings),
+            findings)
+
+    def test_an_undeclared_observer_is_reported(self):
+        """And the other direction: observing something PUBLISHED does not
+        know about is a property nobody has version-checked."""
+        import tempfile
+
+        mod = _audit()
+        src = ("mp.observe_property('user-data/mpv/console/open', 'bool',\n"
+               "    function() end)\n"
+               "mp.observe_property('user-data/mpv/invented/open', 'bool',\n"
+               "    function() end)\n")
+        with tempfile.NamedTemporaryFile("w", suffix=".lua",
+                                         delete=False) as fh:
+            fh.write(src)
+            path = fh.name
+        self.addCleanup(os.unlink, path)
+        findings = mod.audit_user_data(path)
+        self.assertEqual(["invented/open"], [p for p, _w in findings])
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_no_unpaired_bindings.py
+++ b/tests/test_no_unpaired_bindings.py
@@ -163,8 +163,12 @@ class MpvUserDataTest(unittest.TestCase):
             src = fh.read()
         src = src.replace("user-data/mpv/console/open",
                           "user-data/mpv/console/open-RENAMED")
+        # encoding, explicitly: renderer.lua has a set-union sign in a
+        # comment and Windows defaults a text write to cp1252, which
+        # cannot encode it -- so the guard died where it means to PASS.
         with tempfile.NamedTemporaryFile("w", suffix=".lua",
-                                         delete=False) as fh:
+                                         delete=False,
+                                         encoding="utf-8") as fh:
             fh.write(src)
             path = fh.name
         self.addCleanup(os.unlink, path)

--- a/tests/test_selffix_rate.py
+++ b/tests/test_selffix_rate.py
@@ -1,0 +1,138 @@
+"""The release gate's own arithmetic, and the trap it exists to avoid.
+
+`tools/selffix_rate.py` is run by hand before a tag, not by this suite --
+it walks git history and answers with a number to read rather than a
+threshold to assert (docs/testing.md section 7). What is testable is its
+pure half, and one thing that is not optional: the postmortem's first run
+of this measurement reported a clean 0.0% because every `git blame` call
+had errored to empty. An instrument that reports "no rot" when it has
+measured nothing is worse than no instrument.
+"""
+
+# Run as a script, this is what puts the repo root on sys.path -- without
+# it `jellyfin_mpv_shim` resolves to whatever is pip-installed. A no-op
+# under `discover`; tests/test_module_paths.py is the guard.
+if __name__ == "__main__":
+    import os
+    import sys
+
+    sys.path.insert(0, os.path.dirname(
+        os.path.dirname(os.path.abspath(__file__))))
+
+import ast
+import os
+import sys
+import unittest
+
+sys.argv = [sys.argv[0]]      # importing the shim reaches args.get_args()
+
+ROOT = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+sys.path.insert(0, os.path.join(ROOT, "tools"))
+
+import selffix_rate as gate    # noqa: E402
+
+
+class BlameGuardTest(unittest.TestCase):
+    def test_measuring_nothing_is_not_a_clean_release(self):
+        """The 0.0% trap, as an assertion.
+
+        `git blame --no-color` is an ambiguous option; git refuses it and
+        the postmortem's first pass read every empty result as "no line in
+        this hunk was written by this window". 187 commits of that is a
+        very convincing zero.
+        """
+        with self.assertRaises(SystemExit) as caught:
+            gate.classify([("0" * 40, "2026-01-01", "a commit")])
+        self.assertIn("0.0%", str(caught.exception))
+
+    def test_an_empty_window_is_not_measured_at_all(self):
+        """No commits is a different answer from no blame, and it must not
+        take the failure path -- a branch with nothing on it is fine."""
+        self.assertEqual([], gate.classify([]))
+
+
+class ProseFilterTest(unittest.TestCase):
+    def test_a_docstring_is_an_ast_node(self):
+        """Which is the bug the first version of the tool had: a bare
+        `ast.dump` comparison calls a docstring-only change a behaviour
+        change, and the tool then disagreed with the postmortem by exactly
+        the commits the postmortem had proved prose-only."""
+        before = 'def f():\n    """One thing."""\n    return 1\n'
+        after = 'def f():\n    """Another, longer thing entirely."""\n    return 1\n'
+        self.assertNotEqual(ast.dump(ast.parse(before)),
+                            ast.dump(ast.parse(after)))
+        self.assertEqual(
+            ast.dump(gate._strip_docstrings(ast.parse(before))),
+            ast.dump(gate._strip_docstrings(ast.parse(after))))
+
+    def test_a_real_change_survives_the_stripping(self):
+        """The other direction, or the filter excuses real commits."""
+        before = 'def f():\n    """Doc."""\n    return 1\n'
+        after = 'def f():\n    """Doc."""\n    return 2\n'
+        self.assertNotEqual(
+            ast.dump(gate._strip_docstrings(ast.parse(before))),
+            ast.dump(gate._strip_docstrings(ast.parse(after))))
+
+    def test_a_module_docstring_is_stripped_too(self):
+        before = '"""Module."""\nX = 1\n'
+        after = '"""Module, rewritten."""\nX = 1\n'
+        self.assertEqual(
+            ast.dump(gate._strip_docstrings(ast.parse(before))),
+            ast.dump(gate._strip_docstrings(ast.parse(after))))
+
+    def test_a_bare_string_statement_is_not_taken_for_a_docstring(self):
+        """Only the FIRST statement of a module, class or def is one. A
+        string used as a statement elsewhere is code, however odd, and
+        rewriting it is a change the filter must not excuse.
+
+        (The first draft of this asserted that stripping the same source
+        twice gave the same answer, which is true of any function at all.)
+        """
+        before = 'def f():\n    x = 1\n    "a marker"\n    return x\n'
+        after = 'def f():\n    x = 1\n    "a different marker"\n    return x\n'
+        self.assertNotEqual(
+            ast.dump(gate._strip_docstrings(ast.parse(before))),
+            ast.dump(gate._strip_docstrings(ast.parse(after))),
+            "a string statement in the body was stripped as a docstring")
+
+
+class GateArithmeticTest(unittest.TestCase):
+    def test_the_rule_compares_opening_and_trailing(self):
+        rising = [("d%d" % i, n, 10, 0.0) for i, n in
+                  enumerate([1, 1, 1, 8, 8, 8])]
+        ok, opening, trailing = gate.gate(rising)
+        self.assertFalse(ok)
+        self.assertAlmostEqual(10.0, opening)
+        self.assertAlmostEqual(80.0, trailing)
+
+    def test_a_settling_window_passes(self):
+        falling = [("d%d" % i, n, 10, 0.0) for i, n in
+                   enumerate([8, 8, 8, 1, 1, 1])]
+        ok, _opening, _trailing = gate.gate(falling)
+        self.assertTrue(ok)
+
+    def test_it_is_a_rate_over_commits_not_over_days(self):
+        """A day with one commit must not weigh the same as a day with
+        thirty, or a quiet Sunday swings the release decision.
+
+        The trailing window here is one commit that IS a self-fix, thirty
+        that are not, and one more that is not. Averaging the three days'
+        rates gives 33.3% and would fail the gate; weighting by commits
+        gives 3.1% and passes, which is the honest reading of a window
+        where 1 of 32 commits repaired itself.
+        """
+        table = [("a", 1, 10, 10.0), ("b", 1, 10, 10.0), ("c", 1, 10, 10.0),
+                 ("d", 1, 1, 100.0), ("e", 0, 30, 0.0), ("f", 0, 1, 0.0)]
+        ok, opening, trailing = gate.gate(table)
+        self.assertAlmostEqual(10.0, opening)
+        self.assertAlmostEqual(100.0 / 32, trailing)
+        self.assertTrue(ok, "a 30-commit clean day was outvoted by a "
+                            "one-commit day")
+
+    def test_too_short_a_window_answers_none_rather_than_guessing(self):
+        self.assertEqual((None, None, None),
+                         gate.gate([("a", 1, 1, 100.0)]))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tools/audit_act_targets.py
+++ b/tools/audit_act_targets.py
@@ -1,0 +1,304 @@
+#!/usr/bin/env python3
+"""Find the browser reaching past `PlayerManager` into mpv.
+
+The gateway's whole job is to be the one door between the browser's loop
+thread and the player. `_act` runs its lambda through `run_action`, which
+**defers whenever the player lock is busy** -- and the lock is held for the
+whole of a playback start. So a `_act` body is not simply "player code that
+runs later": it runs at an unknown time, with no lock held, against an mpv
+whose handle may have been replaced in the meantime.
+
+`PlayerManager`'s own methods are where the rules about all of that live.
+A `_act` body that writes `pm._player.<prop>` instead of calling one of
+them skips every rule that method carries, and the two live examples both
+cost a user something no setting explains:
+
+* **R7** -- `reset_picture_view` grew a `_video is None and not _loading`
+  guard; `set_picture_view` reaches the player through the same deferring
+  `_act` and has none. The reset landing second is what made every film in
+  a session play stretched.
+* **R8** -- `set_fullscreen` records `fullscreen_disable`, *a user-intent
+  flag*, above its own `if not persist: return`. An app-initiated
+  un-fullscreen latches it, and every film from then on starts windowed.
+
+Both are in `docs/RISK_MAP_2026-09.md` section 2, both verified, both open.
+`docs/POSTMORTEM_3.0.0.md` section 5.3 asked for this file by name and
+`docs/RISK_MAP_2026-09.md` section 7 puts it first among the lints, because
+it is the only one of them covering a Tier-1 and a Tier-2 row.
+
+**Two rules, and neither is a correctness check.**
+
+* **A -- a write.** `setattr(pm._player, "x", ...)` or `pm._player.x = ...`
+  inside the gateway. This is the one that matters: it changes mpv without
+  the manager's lock, its guards or its bookkeeping.
+* **B -- a read.** Any other reach for `._player` from the gateway. Weaker
+  on its own -- a read cannot corrupt anything -- but it is how a write
+  gets written: the reader is already holding the handle, so the write is
+  one line away, and three of the four writes below sit next to a read of
+  the same property.
+
+A finding is answered by routing through the `PlayerManager` method, or by
+adding the site to `DECLARED` with the reason it is the right shape. As in
+`tools/audit_owned_state.py`, `DECLARED` records sites that EXIST: a key
+for a site that is gone is a pre-authorisation for the next one, and
+`tests/test_no_act_reachthrough.py` fails on it.
+
+Usage:  tools/audit_act_targets.py [--verbose]
+Exit 1 if anything is undeclared.
+"""
+
+import argparse
+import ast
+import os
+import sys
+
+ROOT = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+GATEWAY = os.path.join("jellyfin_mpv_shim", "mpvtk_browser", "gateway")
+
+#: The handle every rule here is about.
+HANDLE = "_player"
+
+
+class Site:
+    def __init__(self, module, func, prop, rule, line):
+        self.module = module      # basename, e.g. "hud.py"
+        self.func = func
+        self.prop = prop          # the attribute reached off `_player`
+        self.rule = rule          # "A" (write) or "B" (read)
+        self.line = line
+
+    @property
+    def key(self):
+        return "%s:%s:%s:%s" % (self.module, self.func, self.rule, self.prop)
+
+    def __repr__(self):
+        return "<%s line %d>" % (self.key, self.line)
+
+
+#: Every reach that exists today, with why it has not been routed through a
+#: manager method. Three of these name a method that is already there and
+#: simply not called -- they are findings with an owner waiting, recorded
+#: rather than patched because changing who takes the player lock is a
+#: behaviour change and belongs in a commit of its own.
+DECLARED = {
+    "hud.py:set_speed:A:speed": (
+        "`PlayerManager.set_speed` EXISTS (player.py) and this does not "
+        "call it. It also carries no `@synchronous`, so routing through it "
+        "would not by itself add the lock this skips -- the repair is both "
+        "halves at once, and it is a player change rather than a gateway "
+        "one."
+    ),
+    "hud.py:set_aspect:A:video_aspect_override": (
+        "No `PlayerManager.set_aspect` in this tree to route through. One "
+        "exists on the `enrich-e2e-tests` branch, where giving the aspect "
+        "override an owner is the single production change; that commit is "
+        "the repair for this row and it is not merged."
+    ),
+    "hud.py:toggle_mute:A:mute": (
+        "`PlayerManager.set_mute` EXISTS (player.py) and this does not call "
+        "it. Read-modify-write on the handle, so it also decides the new "
+        "value from a read taken at deferred time rather than at click "
+        "time."
+    ),
+    "hud.py:toggle_fullscreen.flip:A:fullscreen": (
+        "Writes the handle and THEN queues `pm.set_fullscreen` for the "
+        "intent flag, so the window changes by one path and the record of "
+        "why by another. `set_fullscreen` is `@synchronous` and this write "
+        "is not. Risk-map R8 is the flag half of that same method, which is "
+        "why the repair is a parameter rather than a moved line."
+    ),
+    "hud.py:toggle_fullscreen.flip:B:fullscreen": (
+        "The read the write on the next line is derived from; same repair."
+    ),
+    "hud.py:get_speed:B:speed": (
+        "Paired with the `set_speed` write above -- one accessor answers "
+        "both."
+    ),
+    "hud.py:get_aspect:B:video_aspect_override": (
+        "Paired with the `set_aspect` write above -- one accessor answers "
+        "both."
+    ),
+    "hud.py:chapters:B:chapter_list": (
+        "Reads mpv's chapter list to draw the chapter row. Read-only, and "
+        "the ACTING half of the same feature already went the other way: "
+        "`chapter_seek` calls `pm.chapter_seek` rather than working out its "
+        "own target, because that was a second definition of \"previous "
+        "chapter\" and it went round SyncPlay."
+    ),
+    "hud.py:player_stats:B:*": (
+        "`getattr(playerManager, \"_player\", None)` -- a presence test "
+        "followed by seven independent property reads for the Playback "
+        "Data panel, each dropped on failure because no mpv has all of "
+        "them at all times. Read-only, and a manager method per counter "
+        "would be seven methods for one panel."
+    ),
+    "diagnostics.py:copy_text:B:*": (
+        "Passes the handle to `clipboard.copy_or_save`, which offers mpv "
+        "first so a box with no wl-copy/xclip/xsel still copies. The handle "
+        "is an argument to a module that owns the clipboard rule, not a "
+        "property reach, and `None` is a supported value."
+    ),
+}
+
+
+def _writes(node):
+    """(prop, ) for a Rule A write in this statement, else None.
+
+    Both spellings: `x._player.p = v` and `setattr(x._player, "p", v)`.
+    """
+    if isinstance(node, (ast.Assign, ast.AugAssign)):
+        targets = node.targets if isinstance(node, ast.Assign) else [
+            node.target]
+        for tgt in targets:
+            if (isinstance(tgt, ast.Attribute)
+                    and isinstance(tgt.value, ast.Attribute)
+                    and tgt.value.attr == HANDLE):
+                return tgt.attr
+    if (isinstance(node, ast.Call)
+            and isinstance(node.func, ast.Name)
+            and node.func.id == "setattr"
+            and len(node.args) >= 2
+            and isinstance(node.args[0], ast.Attribute)
+            and node.args[0].attr == HANDLE):
+        name = node.args[1]
+        if isinstance(name, ast.Constant) and isinstance(name.value, str):
+            return name.value
+        # A computed property name is still a write, and a worse one --
+        # nothing can tell which property it lands on.
+        return "<computed>"
+    return None
+
+
+def _scan(path):
+    """Every Rule A and Rule B site in one gateway module."""
+    module = os.path.basename(path)
+    with open(path, encoding="utf-8") as fh:
+        src = fh.read()
+    tree = ast.parse(src, filename=path)
+
+    sites = []
+    stack = []
+    # Nodes already charged as a write, so the `_player` inside them is not
+    # also reported as a read. A write is the stronger claim about the same
+    # line, and reporting both would make every fix look like two.
+    written = set()
+
+    class Walk(ast.NodeVisitor):
+        def visit_FunctionDef(self, node):
+            stack.append(node.name)
+            self.generic_visit(node)
+            stack.pop()
+
+        visit_AsyncFunctionDef = visit_FunctionDef
+
+        def generic_visit(self, node):
+            prop = _writes(node)
+            if prop is not None:
+                where = ".".join(stack) if stack else "<module>"
+                sites.append(Site(module, where, prop, "A", node.lineno))
+                for sub in ast.walk(node):
+                    if (isinstance(sub, ast.Attribute)
+                            and sub.attr == HANDLE):
+                        written.add(id(sub))
+            ast.NodeVisitor.generic_visit(self, node)
+
+        def visit_Attribute(self, node):
+            if node.attr == HANDLE and id(node) not in written:
+                where = ".".join(stack) if stack else "<module>"
+                sites.append(Site(module, where, "*", "B", node.lineno))
+            self.generic_visit(node)
+
+        def visit_Call(self, node):
+            # `getattr(playerManager, "_player", None)` is the same reach
+            # with the handle spelled as a string, so no Attribute node
+            # carries it and the walk above goes straight past. It was in
+            # this package the first time this file was run.
+            if (isinstance(node.func, ast.Name)
+                    and node.func.id == "getattr"
+                    and len(node.args) >= 2
+                    and isinstance(node.args[1], ast.Constant)
+                    and node.args[1].value == HANDLE):
+                where = ".".join(stack) if stack else "<module>"
+                sites.append(Site(module, where, "*", "B", node.lineno))
+            self.generic_visit(node)
+
+    Walk().visit(tree)
+
+    # A read reported as `*` is really a read of whatever is taken off it;
+    # name it where the source says so, so the declaration is about a
+    # property rather than about a line.
+    src_lines = src.splitlines()
+    for site in sites:
+        if site.rule != "B":
+            continue
+        line = src_lines[site.line - 1]
+        after = line.split("%s." % HANDLE, 1)
+        if len(after) == 2:
+            name = ""
+            for ch in after[1]:
+                if ch.isalnum() or ch == "_":
+                    name += ch
+                else:
+                    break
+            if name:
+                site.prop = name
+    return sites
+
+
+def modules():
+    """Every gateway module, sorted."""
+    base = os.path.join(ROOT, GATEWAY)
+    return [os.path.join(base, n) for n in sorted(os.listdir(base))
+            if n.endswith(".py")]
+
+
+def sites():
+    out = []
+    for path in modules():
+        out.extend(_scan(path))
+    return out
+
+
+def audit():
+    """Sites with no `DECLARED` entry."""
+    return [s for s in sites() if s.key not in DECLARED]
+
+
+def stale():
+    """Declared keys that match no site -- pre-authorisations."""
+    live = {s.key for s in sites()}
+    return sorted(k for k in DECLARED if k not in live)
+
+
+def main(argv=None):
+    ap = argparse.ArgumentParser(description=__doc__)
+    ap.add_argument("--verbose", action="store_true",
+                    help="list every site, declared or not")
+    args = ap.parse_args(argv)
+
+    if args.verbose:
+        for site in sites():
+            print("%-52s line %-5d %s" % (
+                site.key, site.line,
+                "declared" if site.key in DECLARED else "UNDECLARED"))
+        print()
+
+    bad = 0
+    for site in audit():
+        bad += 1
+        print("%s/%s:%d: rule %s -- %s reaches `_player.%s` past "
+              "PlayerManager" % (GATEWAY, site.module, site.line, site.rule,
+                                 site.func, site.prop))
+    for key in stale():
+        bad += 1
+        print("DECLARED holds %r and nothing matches it. A key for a site "
+              "that is gone pre-authorises the next one." % key)
+    if bad:
+        print("\n%d finding(s). Route it through the PlayerManager method, "
+              "or add the site to DECLARED with the reason it is the right "
+              "shape." % bad)
+    return 1 if bad else 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tools/audit_act_targets.py
+++ b/tools/audit_act_targets.py
@@ -10,18 +10,23 @@ whose handle may have been replaced in the meantime.
 
 `PlayerManager`'s own methods are where the rules about all of that live.
 A `_act` body that writes `pm._player.<prop>` instead of calling one of
-them skips every rule that method carries, and the two live examples both
-cost a user something no setting explains:
+them skips every rule that method carries.
 
-* **R7** -- `reset_picture_view` grew a `_video is None and not _loading`
-  guard; `set_picture_view` reaches the player through the same deferring
-  `_act` and has none. The reset landing second is what made every film in
-  a session play stretched.
-* **R8** -- `set_fullscreen` records `fullscreen_disable`, *a user-intent
-  flag*, above its own `if not persist: return`. An app-initiated
-  un-fullscreen latches it, and every film from then on starts windowed.
+* **R8 -- confirmed end to end.** `set_fullscreen` records
+  `fullscreen_disable`, *a user-intent flag*, above its own
+  `if not persist: return`. An app-initiated un-fullscreen latches it and
+  every film from then on starts windowed, with no setting to explain it
+  (`docs/POSTMORTEM_3.0.0.md` C6).
+* **R7 -- the same shape, and NOT established.** `reset_picture_view` grew
+  a `_video is None and not _loading` guard and `set_picture_view` has
+  none. Read the guard before acting on that: it covers only the
+  `keepaspect` write, which `set_picture_view` does not make, and the two
+  are symmetric on zoom and pan. `docs/do-not-fix.md` F15 says *"construct
+  the interleaving before fixing"*, and that is still owed.
 
-Both are in `docs/RISK_MAP_2026-09.md` section 2, both verified, both open.
+Both are rows in `docs/RISK_MAP_2026-09.md` section 2. This file needs
+neither to be true: what it checks is that a reach past the manager is a
+decision somebody wrote down.
 `docs/POSTMORTEM_3.0.0.md` section 5.3 asked for this file by name and
 `docs/RISK_MAP_2026-09.md` section 7 puts it first among the lints, because
 it is the only one of them covering a Tier-1 and a Tier-2 row.

--- a/tools/audit_frozen_key_literals.py
+++ b/tools/audit_frozen_key_literals.py
@@ -1,0 +1,432 @@
+#!/usr/bin/env python3
+"""Every literal mpv key name that a setting can move has to be declared.
+
+Seven settings name a key the user may change -- `ui_select_key`,
+`hud_wake_key` and the `kb_menu_*` group -- and the code that acts on those
+keys writes the *default* spelling as a literal in a good many places. Some
+of those are correct and some are the bug, and they look identical:
+
+* **R1** `player.py`'s `_NAV_KEYPRESS` resolves `"ok"` per press *"because
+  it is the one the user may remap"* -- and freezes `"back"` as `"ESC"` two
+  lines below, while `kb_menu_esc` is equally remappable.
+* **R2** `_shell_claimed_keys` claims the literal `"SPACE"` rather than
+  deriving from the bound `kb_*` set.
+* **R3** `PHUD_SUMMON_KEYS` holds a literal `'ENTER'`, under a setting whose
+  own comment says *"the renderer stops force-binding ENTER when this moves,
+  which is the point"*.
+* **R10** `phud_skip_bind` calls `phud_wake_key()` to decide whether to drop
+  the wake binding, then hardcodes `'ENTER'` on the next two lines -- so the
+  Skip button binds ENTER even when `ui_select_key` has moved.
+
+All four are in `docs/RISK_MAP_2026-09.md` section 2. **R10 was found by
+writing this predicate down, not by reading the file** -- it sits one screen
+from R3, inside a function that resolves the very setting it then hardcodes,
+and four surveys plus a full session of hand work had walked past it. That
+is the argument for the instrument rather than more attention, and it is
+this file's whole warrant.
+
+**Running it added three more to the four.** R2 has a second site: the
+`SPACE` claim and the `SPACE` dispatch freeze `kb_pause` independently, and
+the risk map records only the claim. `phud_bind_summon` compares the loop's
+key against a literal `ENTER` to pick its handler, so resolving R3's table
+would not by itself fix it. And `phud_bind_wake` compares the RESOLVED wake
+key against `ENTER` to decide whether waking the HUD also toggles pause --
+which is a product question nobody has answered, not a freeze, and it is
+declared as such.
+
+**No correctness judgement, because a checker cannot make one.** A frozen
+literal is right wherever the key is mpv's own and not ours to move. What is
+required is that the site be *declared*, which puts the question in front of
+whoever adds one -- and the declaration is where the next reader finds out a
+resolver exists at all.
+
+## What it does not cover, on purpose
+
+**Single-character and punctuation defaults are excluded** -- `kb_stop`
+(`q`), `kb_watched` (`w`), `kb_menu` (`c`), `kb_fullscreen` (`f`),
+`kb_kill_shader` (`k`), `kb_prev`/`kb_next` (`<`, `>`). A one-letter literal
+collides with everything: the first run matched a debug overlay's `'F'`
+glyph on `kb_fullscreen`. None of the four measured defects is one of these,
+and every one of them is a multi-character name.
+
+**Matching is case-sensitive on the mpv spelling.** `conf.py` writes the
+menu keys lowercase (`kb_menu_esc = "esc"`) and every binding site writes
+them uppercase, which is also what separates a key name from a layout
+direction -- `'left'` in `renderer.lua` is an alignment and `'LEFT'` is a
+key. So a frozen key written lowercase in binding code is invisible here.
+
+Usage:  tools/audit_frozen_key_literals.py [--verbose]
+Exit 1 if any site is undeclared, or any declaration has no site.
+`tests/test_no_frozen_key_literals.py` is the guard.
+"""
+
+import argparse
+import ast
+import os
+import re
+import sys
+
+ROOT = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+
+#: Where the keys are acted on. `conf.py` itself is not here -- it is the
+#: source of the defaults, so every literal in it is the declaration.
+PY_FILES = (
+    "jellyfin_mpv_shim/player.py",
+    "jellyfin_mpv_shim/mpvtk_browser/app.py",
+)
+LUA_FILES = (
+    "jellyfin_mpv_shim/mpvtk/renderer.lua",
+)
+
+#: Settings whose value IS an mpv key name.
+SETTING_PREFIX = "kb_"
+SETTING_NAMES = ("ui_select_key", "hud_wake_key")
+
+
+#: A declaration's first field. `OPEN` means "a finding somebody has looked
+#: at and not repaired"; `OK` means "the literal is right here". A field
+#: rather than a word in the prose: the guard has to list the open ones, and
+#: reading that off how a sentence is phrased is how a repaired row goes on
+#: claiming to be a bug.
+OPEN = "open"
+OK = "ok"
+
+
+class Site:
+    def __init__(self, path, scope, literal, line):
+        self.path = path
+        self.scope = scope
+        self.literal = literal
+        self.line = line
+
+    @property
+    def key(self):
+        return "%s:%s" % (os.path.basename(self.path), self.scope)
+
+    def __repr__(self):
+        return "<%s %r line %d>" % (self.key, self.literal, self.line)
+
+
+#: Declared sites, by `<file>:<scope>`. A scope is the enclosing def (or
+#: class, or `<module>` for a file-scope constant), so one entry covers
+#: every key literal in it -- the question is about the function, not about
+#: each spelling.
+#:
+#: As in `tools/audit_owned_state.py`, a key here records a site that
+#: EXISTS. One that matches nothing pre-authorises the next literal in a
+#: scope by that name, and the guard fails on it.
+DECLARED = {
+    # ---------------------------------------------------------- OPEN BUGS
+    # Declared as findings, not exemptions. All are verified open in
+    # docs/RISK_MAP_2026-09.md section 2, and all need a config-file edit to
+    # reach -- which is why section 7 defers them rather than repairing them
+    # under release pressure.
+    "player.py:PlayerManager": (
+        OPEN,
+        "R1 -- OPEN. `_NAV_KEYPRESS` freezes `back` as `ESC` while "
+        "`kb_menu_esc` can move it, in a table whose own comment explains "
+        "that `ok` is resolved per press precisely because the user may "
+        "remap it. The four arrows beside it are `kb_menu_*` and are the "
+        "same question, which nobody has asked of them."
+    ),
+    "app.py:MpvtkBrowser._shell_claimed_keys": (
+        OPEN,
+        "R2 -- OPEN. Claims the literal `SPACE` alongside the volume keys "
+        "instead of deriving from the bound `kb_*` set, so moving "
+        "`kb_pause` leaves the shell claiming a key the player no longer "
+        "uses."
+    ),
+    "app.py:MpvtkBrowser._shell_key": (
+        OPEN,
+        "R2's SECOND SITE, and the risk map records only the first. The "
+        "dispatch half compares `key == \"SPACE\"`, so claim and answer "
+        "freeze the same setting independently and moving `kb_pause` has "
+        "to be got right in both. Found by this predicate."
+    ),
+    "renderer.lua:PHUD_SUMMON_KEYS": (
+        OPEN,
+        "R3 -- OPEN. A literal `{ 'UP', 'DOWN', 'LEFT', 'RIGHT', 'ENTER' }`, "
+        "under a setting (`ui_select_key`) whose comment says the renderer "
+        "stops force-binding ENTER when it moves. Contrast `NAV_KEYS` "
+        "below, which is the same list WITH a resolver."
+    ),
+    "renderer.lua:phud_skip_bind": (
+        OPEN,
+        "R10 -- OPEN, and the one this predicate found rather than a "
+        "reader. The function asks `phud_wake_key()` on one line to decide "
+        "whether to drop the wake binding, then removes "
+        "`mpvtk_summon_ENTER` and force-binds a literal `ENTER` on the next "
+        "two -- so the Skip button takes ENTER even when `ui_select_key` "
+        "has moved."
+    ),
+    "renderer.lua:phud_bind_summon": (
+        OPEN,
+        "Downstream of R3, and open with it: inside the loop over "
+        "`PHUD_SUMMON_KEYS` it compares the loop's key against a literal "
+        "`ENTER` to choose the pause-toggling handler. Resolving the table "
+        "alone would not fix this line."
+    ),
+    "renderer.lua:phud_bind_wake": (
+        OPEN,
+        "OPEN QUESTION rather than a freeze, and it needs a product answer "
+        "before it needs a patch. `wk` here is the RESOLVED wake key, and "
+        "it is compared against `ENTER` to decide whether waking the HUD "
+        "also toggles pause. So moving `hud_wake_key` silently drops the "
+        "pause half. Whether that is intended is written down nowhere."
+    ),
+
+    # ------------------------------------- resolvers, and their own default
+    "renderer.lua:phud_wake_key": (
+        OK,
+        "This IS the resolver -- `state.phud.wake_key or 'ENTER'`. The "
+        "literal is the fallback for a renderer the Python side has not "
+        "told yet, which is the one place a default belongs."
+    ),
+    "renderer.lua:state": (
+        OK,
+        "`select_key = 'ENTER'` in the renderer's initial state table: the "
+        "value `mpvtk-select-key` overwrites at startup. A default, not a "
+        "freeze."
+    ),
+    "renderer.lua:mpvtk-select-key": (
+        OK,
+        "The handler that overwrites it. The literal is what an empty "
+        "message falls back to."
+    ),
+    "renderer.lua:mpvtk-hud": (
+        OK,
+        "`state.phud.wake_key = (opts and opts.key) or 'ENTER'` -- the "
+        "fallback when the app engages the HUD without naming a key."
+    ),
+    "renderer.lua:NAV_KEYS": (
+        OK,
+        "The same five names as `PHUD_SUMMON_KEYS` and the reason that one "
+        "is a finding: the ENTER row carries a third field, and "
+        "`keyclaim.nav_key` substitutes `state.select_key` for it. The "
+        "literal is the DEFAULT of a resolved lookup."
+    ),
+    "renderer.lua:keyclaim.nav_key": (
+        OK,
+        "The substitution itself: `k[3] and (state.select_key or 'ENTER') "
+        "or k[1]`. The literal is the fallback inside the resolver."
+    ),
+
+    # ------------------------------------------- mpv's own keys, not ours
+    "renderer.lua:phud_summon": (
+        OK,
+        "Force-binds `ESC` to dismiss the summoned bar. mpv's ESC, not "
+        "`kb_menu_esc`: that setting is the OSD MENU's escape, and someone "
+        "who moved it did not ask for the HUD's to move with it."
+    ),
+    "renderer.lua:reconcile": (
+        OK,
+        "Force-binds `ESC` to dismiss a scene menu or modal, and drops it "
+        "again when neither is present. Same reading as `phud_summon`: it "
+        "is the renderer's own overlay, not the OSD menu `kb_menu_esc` "
+        "names."
+    ),
+    "renderer.lua:mp.set_key_bindings": (
+        OK,
+        "The `mpvtk_thumb` section: `mbtn_back` synthesizes `keypress ESC` "
+        "rather than reimplementing the app's back ladder, and the comment "
+        "above it says so -- \"ESC is still ESC\". The literal is the "
+        "thing being deferred TO."
+    ),
+
+    # ------------------------------- action names that happen to look like
+    # keys. These are the text box's vocabulary, on the far side of the
+    # key->op map: `bind` translates once and everything below speaks ops.
+    "renderer.lua:bind": (
+        OK,
+        "`bind_text_keys`'s mpv-key -> op table (`['KP_ENTER'] = 'ENTER'`). "
+        "The left-hand side is what mpv delivers to a focused text box, "
+        "which takes the whole keyboard by design; the right-hand side is "
+        "the op name. Neither is a setting's value."
+    ),
+    "renderer.lua:tb_key": (
+        OK,
+        "The op dispatch on the other side of that table. `name` here is an "
+        "op, and the fact that most ops are spelled like their default key "
+        "is what makes this file's grep unable to tell them apart."
+    ),
+    "renderer.lua:nav_activate": (
+        OK,
+        "Hands the text box the `ENTER` op when spatial nav activates a "
+        "focused box. An op, per `tb_key` above."
+    ),
+    "renderer.lua:nav_move": (
+        OK,
+        "Hands the text box `LEFT`/`RIGHT` ops when spatial nav moves "
+        "inside one. Ops, per `tb_key` above."
+    ),
+}
+
+
+def _key_names():
+    """{"ENTER", "ESC", ...} -- multi-character defaults of key settings.
+
+    Read from `conf.py` rather than listed here, so a new `kb_*` setting is
+    covered the day it is added and a renamed one stops being checked
+    loudly rather than quietly.
+    """
+    path = os.path.join(ROOT, "jellyfin_mpv_shim", "conf.py")
+    with open(path, encoding="utf-8") as fh:
+        tree = ast.parse(fh.read(), filename=path)
+    out = set()
+    for node in ast.walk(tree):
+        if not (isinstance(node, ast.AnnAssign)
+                and isinstance(node.target, ast.Name)):
+            continue
+        name = node.target.id
+        if not (name.startswith(SETTING_PREFIX) or name in SETTING_NAMES):
+            continue
+        value = node.value
+        if not (isinstance(value, ast.Constant)
+                and isinstance(value.value, str)):
+            continue
+        if len(value.value) > 1 and value.value.isalpha():
+            out.add(value.value.upper())
+    return out
+
+
+def _scan_py(path, keys):
+    with open(path, encoding="utf-8") as fh:
+        tree = ast.parse(fh.read(), filename=path)
+    sites, stack = [], []
+
+    class Walk(ast.NodeVisitor):
+        def visit_FunctionDef(self, node):
+            stack.append(node.name)
+            self.generic_visit(node)
+            stack.pop()
+
+        visit_AsyncFunctionDef = visit_FunctionDef
+
+        def visit_ClassDef(self, node):
+            # Kept in the scope, because a class-body constant is exactly
+            # where R1 lives and "<module>" would not say so.
+            stack.append(node.name)
+            self.generic_visit(node)
+            stack.pop()
+
+        def visit_Constant(self, node):
+            if isinstance(node.value, str) and node.value in keys:
+                sites.append(Site(path, ".".join(stack) or "<module>",
+                                  node.value, node.lineno))
+            self.generic_visit(node)
+
+    Walk().visit(tree)
+    return sites
+
+
+#: `function name(`, `local function name(`, `name = function(`.
+_LUA_DEF = re.compile(
+    r"^\s*(?:local\s+)?function\s+([\w.:]+)"
+    r"|^\s*(?:local\s+)?([\w.]+)\s*=\s*function")
+#: File-scope anchors that are not functions. Without these, everything
+#: between two functions collapses into one `<module>` scope -- in this
+#: file that is ten unrelated sites under one declaration, which is a
+#: blanket exemption wearing a reason.
+_LUA_ANCHOR = re.compile(
+    r"^(?:local\s+)?([\w.]+)\s*="              # local NAV_KEYS = {
+    r"|^mp\.register_script_message\('([\w-]+)'"
+    r"|^(mp\.set_key_bindings)\(")
+_LUA_STR = re.compile(r"'([^'\n]*)'|\"([^\"\n]*)\"")
+
+
+def _scan_lua(path, keys):
+    """Lua has no AST here, so scope is tracked by the last definition seen.
+
+    A file-scope `end` in column 0 closes the current function; anything
+    nested is charged to the outermost one, which is the right grain here
+    -- the question is about the function, not about each closure inside
+    it. It over-attributes and never misses a literal.
+    """
+    with open(path, encoding="utf-8") as fh:
+        lines = fh.read().splitlines()
+    sites, scope = [], "<module>"
+    for lineno, line in enumerate(lines, 1):
+        hit = _LUA_DEF.match(line)
+        anchor = None if hit else _LUA_ANCHOR.match(line)
+        if hit:
+            scope = hit.group(1) or hit.group(2)
+        elif anchor:
+            scope = (anchor.group(1) or anchor.group(2)
+                     or anchor.group(3))
+        elif line == "end" or line.startswith("end)"):
+            # A file-scope function closes with `end` in column 0. Without
+            # this the next file-scope constant is charged to whatever
+            # function happened to be above it -- which is how the FIRST
+            # run put `PHUD_SUMMON_KEYS` (R3) inside `phud_wake_key` and
+            # invited a declaration naming the wrong site.
+            scope = "<module>"
+        if line.lstrip().startswith("--"):
+            continue          # a key name in prose is not a binding
+        for match in _LUA_STR.finditer(line):
+            value = match.group(1) or match.group(2)
+            if value in keys:
+                sites.append(Site(path, scope, value, lineno))
+    return sites
+
+
+def sites():
+    keys = _key_names()
+    out = []
+    for rel in PY_FILES:
+        out.extend(_scan_py(os.path.join(ROOT, rel), keys))
+    for rel in LUA_FILES:
+        out.extend(_scan_lua(os.path.join(ROOT, rel), keys))
+    return out
+
+
+def undeclared():
+    return [s for s in sites() if s.key not in DECLARED]
+
+
+def open_findings():
+    """Declared sites that are known bugs rather than settled ones."""
+    return sorted(k for k, (status, _why) in DECLARED.items()
+                  if status == OPEN)
+
+
+def stale():
+    live = {s.key for s in sites()}
+    return sorted(k for k in DECLARED if k not in live)
+
+
+def main(argv=None):
+    ap = argparse.ArgumentParser(description=__doc__)
+    ap.add_argument("--verbose", action="store_true")
+    args = ap.parse_args(argv)
+
+    keys = _key_names()
+    if args.verbose:
+        print("key names from conf.py: %s\n" % ", ".join(sorted(keys)))
+        seen = {}
+        for site in sites():
+            seen.setdefault(site.key, set()).add(site.literal)
+        for key in sorted(seen):
+            print("%-46s %-28s %s"
+                  % (key, ",".join(sorted(seen[key])),
+                     "declared" if key in DECLARED else "UNDECLARED"))
+        print()
+
+    bad = 0
+    for site in undeclared():
+        bad += 1
+        print("%s:%d: %r is a frozen key literal in %s"
+              % (os.path.relpath(site.path, ROOT), site.line, site.literal,
+                 site.scope))
+    for key in stale():
+        bad += 1
+        print("DECLARED holds %r and no site matches it." % key)
+    if bad:
+        print("\n%d finding(s). Resolve the setting, or declare the site "
+              "with the reason the literal is right." % bad)
+    for key in open_findings():
+        print("note: %s is a declared OPEN finding, not an exemption" % key)
+    return 1 if bad else 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tools/audit_frozen_key_literals.py
+++ b/tools/audit_frozen_key_literals.py
@@ -157,7 +157,10 @@ DECLARED = {
         "whether to drop the wake binding, then removes "
         "`mpvtk_summon_ENTER` and force-binds a literal `ENTER` on the next "
         "two -- so the Skip button takes ENTER even when `ui_select_key` "
-        "has moved."
+        "has moved. Also `docs/do-not-fix.md` F35, which records it as "
+        "deliberately left and says what it is waiting on: a decision about "
+        "whether the idle Skip offer follows `hud_wake_key` or "
+        "`ui_select_key`."
     ),
     "renderer.lua:phud_bind_summon": (
         OPEN,
@@ -172,7 +175,9 @@ DECLARED = {
         "before it needs a patch. `wk` here is the RESOLVED wake key, and "
         "it is compared against `ENTER` to decide whether waking the HUD "
         "also toggles pause. So moving `hud_wake_key` silently drops the "
-        "pause half. Whether that is intended is written down nowhere."
+        "pause half. Whether that is intended is written down nowhere, and "
+        "it is the same unanswered question `docs/do-not-fix.md` F35 parks "
+        "one function away."
     ),
 
     # ------------------------------------- resolvers, and their own default

--- a/tools/audit_key_bindings.py
+++ b/tools/audit_key_bindings.py
@@ -27,6 +27,13 @@ enumerated the pairs. This does.
 A finding is not automatically a bug. Either release the binding where its
 owner goes away, or add the name to `ACCEPTED` with the reason it does not
 need releasing -- which is documentation either way.
+
+**Second pass, the other direction: the keys mpv's own scripts take from
+us.** The console and the context menu each force the same keys the
+renderer does, and each publishes a `user-data/mpv/<thing>/open` flag while
+it is up. `PUBLISHED` declares every one of those properties and what the
+renderer owes it. The block above `Published` carries the measurement that
+says why ORDER, and not force, decides who gets the key.
 """
 
 import argparse
@@ -108,6 +115,135 @@ def audit(path):
     return findings
 
 
+# --------------------------------------------------------------------
+# Second pass: the keyboard mpv's own scripts take, and whether we notice.
+#
+# The first pass is about bindings WE install and forget. This one is the
+# other direction, and it is the same rule at the site nobody wrote it at.
+#
+# mpv's builtin console and context menu both install their keys with
+# `mp.add_forced_key_binding`, exactly as the renderer does, and each
+# publishes a `user-data/mpv/<thing>/open` boolean while it is up. The
+# renderer observes the console's and hands its own keys back for the
+# duration. Nothing watches the context menu's.
+#
+# **Measured against mpv 182fa6ca49, not reasoned about** (the probes are
+# in the commit message; each asserts which handler RECEIVED a synthetic
+# `keypress ENTER`, not which one has the larger `priority` number):
+#
+#   A. nothing open .............. our forced ENTER fires
+#   B. the thing opens AFTER us .. ITS binding fires, not ours
+#   C. we re-bind while it is up . OUR binding fires, and it stays open
+#
+# B is why this is not the leak the first pass looks for: a standing
+# binding of ours does not break a menu that opens later. C is the whole
+# exposure -- the HUD re-installs its nav keys on pointer movement and on
+# every lifecycle event, so anything that re-binds while a menu is up
+# takes the key back and leaves the menu on screen with no way to activate
+# an item. That is what the console handler prevents, at one of the two
+# places that need it.
+#
+# It also corrects the console handler's own comment, which says our
+# forced bindings "outrank" the console. They do not; B measures the
+# opposite. What the handler is really for is C, plus the `any_unicode`
+# block claim, which outranks an exact key in either order.
+
+
+class Published:
+    """One `user-data/mpv/*` property, and what the renderer owes it.
+
+    ``state`` is ``observed`` (the renderer watches it and must go on
+    doing so), ``not-input`` (it says nothing about who owns the
+    keyboard, so watching it would be noise), or ``gap`` (it should be
+    watched, it is not, and the reason is recorded rather than fixed
+    quietly).
+    """
+
+    def __init__(self, state, since, by, why):
+        self.state = state
+        self.since = since
+        self.by = by
+        self.why = why
+
+
+#: Everything mpv's builtin scripts publish under `user-data/mpv/`, read
+#: out of mpv's own tree at 182fa6ca49. Not discoverable at lint time --
+#: mpv's source is not in this repo -- so it is a declared list, and the
+#: version each appeared in is part of the declaration because the shim
+#: runs against several.
+PUBLISHED = {
+    "console/open": Published(
+        "observed", "0.40.0 (8669205d92, 2025-01-30)", "console.lua",
+        "The console wants the whole keyboard. The renderer hands back "
+        "nav, summon, skip, wake and the any_unicode block while it is "
+        "up and takes them again on close.",
+    ),
+    "context-menu/open": Published(
+        "gap", "master only (aec426a4d8, 2026-02-19); NOT in v0.41.0",
+        "context_menu.lua",
+        "The menu forces ENTER, ESC, the arrows and any_unicode, and it "
+        "is what MBTN_RIGHT opens on master -- which is the pin both "
+        "shipped builds use. Nothing hands our keys back, so any "
+        "re-bind while it is up (case C above) leaves the menu drawn and "
+        "dead. NOT FIXED HERE ON PURPOSE: the repair lands on the input "
+        "arbiter, which docs/do-not-fix.md F37 records as the worst "
+        "regression surface in the tree, and #737's own fix is still "
+        "ahead of its evidence one branch below. What is measured is the "
+        "mpv mechanism; what is not is that the shim reaches case C in a "
+        "real session, and that is a real-mpv e2e leg, not a lint.",
+    ),
+    "ytdl/path": Published(
+        "not-input", "0.36.0", "ytdl_hook.lua",
+        "Where yt-dlp was found. Says nothing about the keyboard.",
+    ),
+    "ytdl/json-subprocess-result": Published(
+        "not-input", "0.36.0", "ytdl_hook.lua",
+        "The hook's subprocess result, for scripts that want the raw "
+        "answer. Says nothing about the keyboard.",
+    ),
+}
+
+_OBSERVE = re.compile(
+    r"mp\.observe_property\s*\(\s*'user-data/mpv/([^']+)'")
+
+
+def observed(path):
+    """The `user-data/mpv/*` properties the file observes."""
+    with open(path, encoding="utf-8") as fh:
+        return set(_OBSERVE.findall(fh.read()))
+
+
+def audit_user_data(path):
+    """[(prop, problem)] where the renderer and PUBLISHED disagree.
+
+    A declared gap is NOT a finding -- it is printed every run and pinned
+    by the test, so a new one fails and a recorded one stays visible.
+    """
+    seen = observed(path)
+    findings = []
+    for prop, entry in sorted(PUBLISHED.items()):
+        if entry.state == "observed" and prop not in seen:
+            findings.append((prop, "declared observed, and nothing observes "
+                                   "it -- the handler was removed or the "
+                                   "property was renamed"))
+        elif entry.state != "observed" and prop in seen:
+            findings.append((prop, "declared %r, and the renderer observes "
+                                   "it anyway -- move the entry to "
+                                   "'observed' with what the handler does"
+                                   % entry.state))
+    for prop in sorted(seen - set(PUBLISHED)):
+        findings.append((prop, "observed, and not in PUBLISHED -- say which "
+                               "mpv script publishes it and from which "
+                               "release, so the next reader can tell a live "
+                               "property from a dead one"))
+    return findings
+
+
+def gaps():
+    """The properties recorded as watched-by-nothing, on purpose."""
+    return sorted(p for p, e in PUBLISHED.items() if e.state == "gap")
+
+
 def main(argv=None):
     ap = argparse.ArgumentParser(description=__doc__)
     ap.add_argument("files", nargs="*", help="lua files to audit")
@@ -118,13 +254,21 @@ def main(argv=None):
 
     bad = 0
     for path in files:
+        rel = os.path.relpath(path, root)
         for line, name, kind in audit(path):
             bad += 1
             print("%s:%d: %s binding %r is never released"
-                  % (os.path.relpath(path, root), line, kind, name))
+                  % (rel, line, kind, name))
+        for prop, problem in audit_user_data(path):
+            bad += 1
+            print("%s: user-data/mpv/%s: %s" % (rel, prop, problem))
     if bad:
-        print("\n%d unreleased binding(s). Release it where its owner goes "
-              "away, or add it to ACCEPTED with the reason." % bad)
+        print("\n%d finding(s). Release the binding where its owner goes "
+              "away and add it to ACCEPTED with the reason; for a "
+              "user-data property, correct its PUBLISHED entry." % bad)
+    for prop in gaps():
+        print("note: user-data/mpv/%s is watched by nothing, on purpose --"
+              " see PUBLISHED" % prop)
     return 1 if bad else 0
 
 

--- a/tools/audit_key_bindings.py
+++ b/tools/audit_key_bindings.py
@@ -145,8 +145,14 @@ def audit(path):
 #
 # It also corrects the console handler's own comment, which says our
 # forced bindings "outrank" the console. They do not; B measures the
-# opposite. What the handler is really for is C, plus the `any_unicode`
-# block claim, which outranks an exact key in either order.
+# opposite -- and `renderer.lua:5771` had the rule right the whole time,
+# 1,200 lines away: "between two forced bindings of one key the LATER one
+# wins". One rule, written correctly at one site and wrongly at another,
+# which is this repo's signature shape.
+#
+# What the console handler is really for is C, plus the `any_unicode`
+# block claim -- which outranks an exact key installed BEFORE it, and is
+# bound first for that reason.
 
 
 class Published:
@@ -193,11 +199,11 @@ PUBLISHED = {
         "real session, and that is a real-mpv e2e leg, not a lint.",
     ),
     "ytdl/path": Published(
-        "not-input", "0.36.0", "ytdl_hook.lua",
+        "not-input", "0.39.0 (ff47926d6a, 2024-05-09)", "ytdl_hook.lua",
         "Where yt-dlp was found. Says nothing about the keyboard.",
     ),
     "ytdl/json-subprocess-result": Published(
-        "not-input", "0.36.0", "ytdl_hook.lua",
+        "not-input", "0.39.0 (ff47926d6a, 2024-05-09)", "ytdl_hook.lua",
         "The hook's subprocess result, for scripts that want the raw "
         "answer. Says nothing about the keyboard.",
     ),

--- a/tools/audit_owned_state.py
+++ b/tools/audit_owned_state.py
@@ -138,7 +138,9 @@ OWNED = [
             "from -- so a second reader anywhere in the browser is reading a "
             "value the user may have abandoned, and acting on it moves the "
             "download store recursively. Scoped to the whole browser "
-            "because it is one `self` across a dozen mixin modules.",
+            "because it is one `self` across a dozen mixin modules. "
+            "`docs/do-not-fix.md` F42 is this dict, and states why the "
+            "obvious repair is wrong.",
     ),
     Owned(
         scope="mpvtk_browser/",

--- a/tools/audit_owned_state.py
+++ b/tools/audit_owned_state.py
@@ -34,6 +34,21 @@ owner this audit exists to catch: the day that method does reach the state,
 nothing is reported, because the name is already on the list.
 `tests/test_no_second_owner.py` fails on any such name -- `_active_item`
 shipped with two.
+
+**A `scope` is a file or a directory, and it has to be as wide as the object
+is.** `SyncManager` is one class in one file, so the file is the whole of it.
+The browser is not: it is `MpvtkApp` plus a dozen mixin modules sharing one
+`self`, so scoping one of its attributes to the file that happens to touch it
+today is the same one-of-several-sites mistake this tool exists to find --
+the next writer lands in a sibling mixin and nothing reports. Those get
+`mpvtk_browser/`. What a directory costs is that the match is by attribute
+NAME with no class awareness, so a common name scoped wide collects owners
+that are a different object's state. Scope to the file unless the name is
+distinctive.
+
+**`obj` is for state that does not hang off `self`.** `mpv.TIMEOUT` is a
+module global of the backend library, lowered for teardown and never
+restored; it has the same one-writer property and none of the `self.` shape.
 """
 
 import ast
@@ -41,19 +56,41 @@ import os
 
 
 class Owned:
-    def __init__(self, module, attr, owners, why):
-        self.module = module
+    """One piece of state, and the sites allowed to touch it.
+
+    ``scope`` is a repo-relative path: a ``.py`` file, or a directory whose
+    ``.py`` files are all searched. ``obj`` is the name the state hangs off
+    -- ``self`` for an attribute, a module alias for a global. Owners are
+    spelled ``<path>:<function>``, so a finding names the file rather than
+    leaving the reader to guess which module of a mixin stack it came from.
+    """
+
+    def __init__(self, scope, attr, owners, why, obj="self"):
+        self.scope = scope
         self.attr = attr
+        self.obj = obj
         self.owners = frozenset(owners)
         self.why = why
+
+    @property
+    def state(self):
+        """How to spell the state in a message: ``self._cancelled``."""
+        return "%s.%s" % (self.obj, self.attr)
+
+
+#: The path every owner name is written relative to.
+PKG = "jellyfin_mpv_shim"
 
 
 OWNED = [
     Owned(
-        module="jellyfin_mpv_shim/sync/manager.py",
+        scope="sync/manager.py",
         attr="_cancelled",
-        owners=("__init__", "_is_cancelled", "_drop_cancelled", "_uncancel",
-                "_cancel_if_active"),
+        owners=("sync/manager.py:__init__",
+                "sync/manager.py:_is_cancelled",
+                "sync/manager.py:_drop_cancelled",
+                "sync/manager.py:_uncancel",
+                "sync/manager.py:_cancel_if_active"),
         why="`_cancelled` is the record that a user's delete is owed, and "
             "acting on it means removing files and a catalog row. Every "
             "reader goes through `_is_cancelled`; the single actor is "
@@ -61,47 +98,130 @@ OWNED = [
             "the same critical section as the check.",
     ),
     Owned(
-        module="jellyfin_mpv_shim/sync/manager.py",
+        scope="sync/manager.py",
         attr="_active_item",
-        owners=("__init__", "_download", "_cancel_if_active", "relocate"),
+        owners=("sync/manager.py:__init__",
+                "sync/manager.py:_download",
+                "sync/manager.py:_cancel_if_active",
+                "sync/manager.py:relocate"),
         why="Which item the worker owns. A second writer means a delete "
             "either yanks files out from under an open write or misses the "
             "in-flight item entirely. A reader wanting "
             "\"what is downloading\" asks the catalog, as `state` does "
             "(`STATUS_DOWNLOADING`), rather than reaching in here.",
     ),
+    Owned(
+        scope="mpvtk_browser/thumbnails.py",
+        attr="_gone",
+        owners=("mpvtk_browser/thumbnails.py:__init__",
+                "mpvtk_browser/thumbnails.py:is_gone",
+                "mpvtk_browser/thumbnails.py:_work"),
+        why="The set of artwork keys the server answered for with a "
+            "permanent absence, so the browser stops asking. `_work` is the "
+            "only writer and `is_gone` the only reader, and that matters "
+            "because the set is process-lifetime and keyed by image key "
+            "alone -- no server, no user. A second writer, or a reader that "
+            "treats it as a cache rather than as a verdict, turns a "
+            "transient 401 into artwork that stays blank until restart. "
+            "Whether 401/403 belongs in here at all is a live question "
+            "(`docs/RISK_MAP_2026-09.md` section 3.5); this entry pins who "
+            "may answer it.",
+    ),
+    Owned(
+        scope="mpvtk_browser/",
+        attr="_sync_path",
+        owners=("mpvtk_browser/app.py:__init__",
+                "mpvtk_browser/settings/general.py:_setting_row"),
+        why="The download folder the settings form is showing, mirrored off "
+            "the widget so the row can read it back. It is never cleared, "
+            "and it WINS over the saved setting the visible field was drawn "
+            "from -- so a second reader anywhere in the browser is reading a "
+            "value the user may have abandoned, and acting on it moves the "
+            "download store recursively. Scoped to the whole browser "
+            "because it is one `self` across a dozen mixin modules.",
+    ),
+    Owned(
+        scope="mpvtk_browser/",
+        attr="_login",
+        owners=("mpvtk_browser/app.py:__init__",
+                "mpvtk_browser/auth.py:field",
+                "mpvtk_browser/auth.py:_use_known_server",
+                "mpvtk_browser/auth.py:_quick_connect_to",
+                "mpvtk_browser/auth.py:_start_quick_connect",
+                "mpvtk_browser/auth.py:_do_login"),
+        why="The Add Server form's three fields, `pass` among them, held in "
+            "cleartext for as long as the process runs: three sites set it "
+            "and none clears it, so the form re-seeds with the last "
+            "password typed. Contrast `_pin`, whose one dict IS cleared "
+            "(`auth.py` sets `_pin['pin'] = ''`) -- the same rule, written "
+            "at one of two sites, which is this repo's recurring shape. "
+            "Six owners is a weak scope and it is the honest one: the "
+            "check here is that a SEVENTH reader of a cleartext password "
+            "has to say so out loud.",
+    ),
+    Owned(
+        scope=".",
+        attr="TIMEOUT",
+        obj="mpv",
+        owners=("player.py:bound_ipc_replies",),
+        why="The jsonipc backend's reply wait, a module global of the "
+            "library rather than state of ours. `bound_ipc_replies` lowers "
+            "it 120s->5s for teardown and nothing restores it -- and its "
+            "call sites include the MINIMIZE path, which is not a teardown, "
+            "so a long-running session can end up with every IPC reply "
+            "bounded at 5s. Scoped to the package: any module can reach a "
+            "global, so a second writer is not confined to `player.py`.",
+    ),
 ]
 
 ROOT = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
 
 
+def _modules(entry):
+    """The repo-relative `.py` files an entry's scope covers, sorted."""
+    base = os.path.normpath(os.path.join(ROOT, PKG, entry.scope))
+    if base.endswith(".py"):
+        return [os.path.relpath(base, os.path.join(ROOT, PKG))]
+    out = []
+    for dirpath, dirnames, filenames in os.walk(base):
+        dirnames[:] = [d for d in dirnames if d != "__pycache__"]
+        for name in sorted(filenames):
+            if name.endswith(".py"):
+                out.append(os.path.relpath(os.path.join(dirpath, name),
+                                           os.path.join(ROOT, PKG)))
+    return sorted(out)
+
+
 def _sites(entry):
-    """Every function that reaches `self.<attr>`, as {function name: count}."""
-    path = os.path.join(ROOT, entry.module)
-    with open(path, encoding="utf-8") as fh:
-        tree = ast.parse(fh.read(), filename=path)
+    """Every function reaching the state, as {"path:function": count}."""
     found = {}
-    stack = []
 
-    class Walk(ast.NodeVisitor):
-        def visit_FunctionDef(self, node):
-            stack.append(node.name)
-            self.generic_visit(node)
-            stack.pop()
+    for module in _modules(entry):
+        path = os.path.join(ROOT, PKG, module)
+        with open(path, encoding="utf-8") as fh:
+            tree = ast.parse(fh.read(), filename=path)
+        stack = []
 
-        visit_AsyncFunctionDef = visit_FunctionDef
+        class Walk(ast.NodeVisitor):
+            def visit_FunctionDef(self, node):
+                stack.append(node.name)
+                self.generic_visit(node)
+                stack.pop()
 
-        def visit_Attribute(self, node):
-            if (node.attr == entry.attr
-                    and isinstance(node.value, ast.Name)
-                    and node.value.id == "self"):
-                # The nearest enclosing def, so a closure is charged to the
-                # method that defines it rather than to nothing.
-                where = stack[-1] if stack else "<module>"
-                found[where] = found.get(where, 0) + 1
-            self.generic_visit(node)
+            visit_AsyncFunctionDef = visit_FunctionDef
 
-    Walk().visit(tree)
+            def visit_Attribute(self, node):
+                if (node.attr == entry.attr
+                        and isinstance(node.value, ast.Name)
+                        and node.value.id == entry.obj):
+                    # The nearest enclosing def, so a closure is charged to
+                    # the method that defines it rather than to nothing.
+                    where = stack[-1] if stack else "<module>"
+                    key = "%s:%s" % (module, where)
+                    found[key] = found.get(key, 0) + 1
+                self.generic_visit(node)
+
+        Walk().visit(tree)
     return found
 
 
@@ -119,9 +239,8 @@ def audit():
 def main():
     findings = audit()
     for entry, strays in findings:
-        print("%s: self.%s is reached outside its owners: %s"
-              % (entry.module, entry.attr,
-                 ", ".join(sorted(strays))))
+        print("%s (%s) is reached outside its owners: %s"
+              % (entry.state, entry.scope, ", ".join(sorted(strays))))
         print("    %s" % entry.why)
     return 1 if findings else 0
 

--- a/tools/audit_owned_state.py
+++ b/tools/audit_owned_state.py
@@ -179,18 +179,29 @@ OWNED = [
 ROOT = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
 
 
+def _rel(path):
+    """Repo-relative, spelled with `/` on every platform.
+
+    OWNED spells its owners `sync/manager.py:_uncancel`, so the scan has to
+    answer in the same alphabet. `os.path.relpath` hands back backslashes on
+    Windows, every entry then matched nothing, and this audit reports that
+    as a phantom owner: measured, all six entries "failed" there and none
+    here.
+    """
+    return os.path.relpath(path, os.path.join(ROOT, PKG)).replace(os.sep, "/")
+
+
 def _modules(entry):
     """The repo-relative `.py` files an entry's scope covers, sorted."""
     base = os.path.normpath(os.path.join(ROOT, PKG, entry.scope))
     if base.endswith(".py"):
-        return [os.path.relpath(base, os.path.join(ROOT, PKG))]
+        return [_rel(base)]
     out = []
     for dirpath, dirnames, filenames in os.walk(base):
         dirnames[:] = [d for d in dirnames if d != "__pycache__"]
         for name in sorted(filenames):
             if name.endswith(".py"):
-                out.append(os.path.relpath(os.path.join(dirpath, name),
-                                           os.path.join(ROOT, PKG)))
+                out.append(_rel(os.path.join(dirpath, name)))
     return sorted(out)
 
 

--- a/tools/probe_key_precedence.py
+++ b/tools/probe_key_precedence.py
@@ -1,0 +1,175 @@
+#!/usr/bin/env python3
+"""Who receives a key when mpv's own overlays and ours both force it.
+
+The renderer forces ENTER, ESC, the arrows and `any_unicode`. So does mpv's
+console, and so does its context menu. "Forced" is not the tie-break --
+between two forced sections the LATER one wins -- and getting that backwards
+is what a comment in `renderer.lua` did for a release: it said our bindings
+outranked the console, and the handler under it was right for a different
+reason.
+
+So this asks mpv, on the build you actually have, and it asks by pressing
+the key rather than by reading `priority` off `input-bindings`. A number is
+the thing you have to interpret; the handler that fires is the answer.
+
+Three cases, and only the third is an exposure:
+
+  A. nothing open ................ our forced binding fires
+  B. the overlay opens AFTER us .. the overlay's binding fires
+  C. we re-bind while it is up ... ours fires, and the overlay stays drawn
+
+C is what `renderer.lua`'s `user-data/mpv/console/open` handler exists to
+prevent: the HUD re-installs its nav keys on pointer movement and on every
+lifecycle event, so anything that re-binds while an overlay is up leaves it
+on screen with no way to activate an item.
+`tools/audit_key_bindings.py:PUBLISHED` is where each overlay's property is
+declared; this is where its answer is measured.
+
+Run it when the mpv pin moves, or before believing a claim about who wins.
+Read-only: no window, no config, no file in the tree.
+
+Usage:  tools/probe_key_precedence.py [--mpv MPV] [--verbose]
+Exit 1 if any case could not be measured -- an mpv without the overlay, or
+one whose menu never opened. A case that measures cleanly always "passes";
+this is a probe, not a threshold (docs/testing.md section 7).
+"""
+
+import argparse
+import os
+import re
+import shutil
+import subprocess
+import sys
+import tempfile
+
+#: Each overlay: how to open it, and the property that says it is up. The
+#: context menu needs `menu-data` populated -- with an empty menu it returns
+#: before binding anything and before setting its property, which reads as
+#: "no exposure" and is really "the probe did not run".
+OVERLAYS = {
+    "console": {
+        "open": "mp.commandv('script-message-to', 'console', 'enable')",
+        "prop": "user-data/mpv/console/open",
+        "args": [],
+    },
+    "context-menu": {
+        "open": "mp.commandv('script-message-to', 'context_menu', 'open')",
+        "prop": "user-data/mpv/context-menu/open",
+        "args": ["--load-context-menu=yes"],
+    },
+}
+
+_PROBE = """
+-- Stand in for the renderer: a forced ENTER bound at startup.
+local fired = {}
+local function claim()
+    mp.add_forced_key_binding('ENTER', 'jms_probe_enter', function()
+        fired[#fired + 1] = 'OURS'
+    end)
+end
+claim()
+
+mp.set_property_native('menu-data', {
+    { title = 'probe', cmd = 'ignore' },
+})
+
+local function press()
+    fired = {}
+    mp.commandv('keypress', 'ENTER')
+end
+
+local function say(case, note)
+    -- Prefixed so the console, which echoes mpv's own log back into its
+    -- overlay, cannot be mistaken for a result line.
+    print('JMSPROBE ' .. case .. ' ' .. (fired[1] or 'OVERLAY') ..
+          ' open=' .. tostring(mp.get_property_native(%(prop)r)) ..
+          ' ' .. note)
+end
+
+mp.add_timeout(0.5, function()
+    press()
+    mp.add_timeout(0.2, function()
+        say('A', 'nothing-open')
+        %(open)s
+        mp.add_timeout(0.5, function()
+            press()
+            mp.add_timeout(0.2, function()
+                say('B', 'overlay-opened-after-us')
+                %(open)s
+                mp.add_timeout(0.4, function()
+                    claim()          -- what a HUD lifecycle event does
+                    mp.add_timeout(0.2, function()
+                        press()
+                        mp.add_timeout(0.2, function()
+                            say('C', 'we-rebound-while-it-was-up')
+                            mp.commandv('quit')
+                        end)
+                    end)
+                end)
+            end)
+        end)
+    end)
+end)
+"""
+
+_LINE = re.compile(r"JMSPROBE (\w) (OURS|OVERLAY) open=(\S+) (\S+)")
+
+
+def probe(name, mpv="mpv", timeout=40):
+    """[(case, winner, open, note)] for one overlay, in case order."""
+    spec = OVERLAYS[name]
+    tmp = tempfile.mkdtemp(prefix="jms-keyprobe-")
+    try:
+        script = os.path.join(tmp, "probe.lua")
+        with open(script, "w", encoding="utf-8") as fh:
+            fh.write(_PROBE % {"prop": spec["prop"], "open": spec["open"]})
+        cmd = [mpv, "--idle", "--vo=null", "--ao=null", "--no-config",
+               "--script=" + script] + spec["args"]
+        out = subprocess.run(cmd, capture_output=True, text=True,
+                             timeout=timeout).stdout
+    finally:
+        shutil.rmtree(tmp, ignore_errors=True)
+
+    seen, rows = set(), []
+    for case, winner, is_open, note in _LINE.findall(out):
+        if case in seen:      # the console echoes our own lines back
+            continue
+        seen.add(case)
+        rows.append((case, winner, is_open, note))
+    return sorted(rows)
+
+
+def main(argv=None):
+    ap = argparse.ArgumentParser(description=__doc__)
+    ap.add_argument("--mpv", default="mpv", help="mpv binary to ask")
+    ap.add_argument("--verbose", action="store_true")
+    args = ap.parse_args(argv)
+
+    version = subprocess.run([args.mpv, "--version"], capture_output=True,
+                             text=True).stdout.splitlines()[0]
+    print(version)
+
+    bad = 0
+    for name in sorted(OVERLAYS):
+        rows = probe(name, args.mpv)
+        print("\n%s (%s)" % (name, OVERLAYS[name]["prop"]))
+        if len(rows) != 3:
+            bad += 1
+            print("  could not measure: %d of 3 cases reported. This mpv "
+                  "may not have the overlay at all." % len(rows))
+            if args.verbose:
+                print("  got: %r" % (rows,))
+            continue
+        for case, winner, is_open, note in rows:
+            print("  %s  %-8s wins   overlay open=%-5s  (%s)"
+                  % (case, winner, is_open, note))
+        if rows[2][1] != "OURS":
+            print("  NOTE: case C did not reproduce on this build. The "
+                  "re-bind stopped taking the key back, which would make "
+                  "the console handler unnecessary -- check before "
+                  "believing it.")
+    return 1 if bad else 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tools/selffix_rate.py
+++ b/tools/selffix_rate.py
@@ -1,0 +1,333 @@
+#!/usr/bin/env python3
+"""How much of a release window was spent repairing that same window.
+
+`docs/POSTMORTEM_3.0.0.md` §1 measured 3.0.0 at roughly 30-45% by four
+instruments, and §5.8 turned that into the one process rule with a number
+on it:
+
+    A release should not tag while the trailing-3-day self-fix rate is
+    above the window's opening rate.
+
+On 2026-09-02 that rate went 20% -> 79% and never came back down. The tag
+went out five days later. CLAUDE.md states the trigger in words --
+*"when a round's findings land mostly in code that earlier rounds fixed,
+stop"* -- and words did not fire it, which is this file's warrant.
+
+## What it counts
+
+SZZ-lite. For each non-merge commit in the window: take its hunks that
+DELETE or MODIFY a line of a `.py` or `.lua` file outside `docs/`, blame
+those lines at the parent, and call the commit a **self-fix** if any blamed
+commit is itself inside the window.
+
+Four instruments, deliberately, because they answer in different units and
+the postmortem's standing rule is **never quote one figure as "the" rate**:
+
+    A   any in-range blame, over commits that modify existing code
+    A'  the same, over every commit in the window
+    B   majority in-range (more than half the blamed lines)
+    C   shipping code only (`jellyfin_mpv_shim/**`)
+
+## What it cannot see, and why the number is a floor
+
+`git blame` only sees a fix that deletes or edits the line it repairs. The
+normal shape of a correctness fix here is *adding a guard*, and blame is
+blind to that -- 22 of 3.0.0's 187 commits deleted nothing at all, and 16 of
+those added to a file the window had already touched. `--additions` lists
+them so the invisible zone is at least visible.
+
+Prose-only commits are excluded when they can be proved so: a commit whose
+`.py` files are AST-identical, docstrings stripped, cannot carry a defect.
+`--no-prose-filter` turns that off.
+
+**Reconciling with §1's table, because the figures differ and only one
+reason matters.** The numerators are identical -- 56 self-fixes by A, 40 by
+B, over `v3.0.0pre14..v3.0.0` -- and so is the daily table, 20% on
+2026-09-01 and 78.6% on 2026-09-02. The denominators differ because §1 kept
+the prose commits in them and excluded them only from the numerator; this
+drops them from both, which is the answer to "what share of the real
+opportunities were self-fixes". §1 reads 44.1% / 29.9% where this reads
+46.3% / 30.9%, and the count of excluded commits is printed so the two can
+always be reconciled.
+
+That count is **6**, not §1's four: `f1127df4` and `775d8d79` are the same
+prose-compression batch on the same day and were missed by the hand count.
+Which is the argument for the filter being code.
+
+## The 0.0% trap, which is why this is a file and not a shell pipeline
+
+The postmortem's first run reported **0.0%** and looked entirely credible.
+`git blame --no-color` is an *ambiguous option* -- git offers
+`--no-color-lines` and `--no-color-by-age` and refuses to guess -- so every
+blame call errored to empty and the script reported a clean release. This
+one treats "no blame output anywhere" as a failure rather than as an answer,
+and says so. It is the repo's own "gate on the value, not the marker" rule
+applied to the instrument that measures the repo.
+
+Usage:
+    tools/selffix_rate.py --since v3.0.0pre14 --until v3.0.0
+    tools/selffix_rate.py --since origin/master        # an open branch
+    tools/selffix_rate.py --since v3.0.0pre14 --daily  # the gate's table
+
+Exit 1 if the gate is failing (trailing-3-day rate above the opening rate),
+or if the measurement could not be taken. Read the daily table before
+believing either.
+"""
+
+import argparse
+import ast
+import collections
+import os
+import re
+import subprocess
+import sys
+
+ROOT = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+CODE = (".py", ".lua")
+SHIPPING = "jellyfin_mpv_shim/"
+
+#: `@@ -12,3 +12,4 @@` -- the OLD side is what has lines to blame.
+_HUNK = re.compile(r"^@@ -(\d+)(?:,(\d+))? \+\d+(?:,\d+)? @@")
+_FILE = re.compile(r"^\+\+\+ b/(.*)$")
+#: `git blame -l` starts each line with the 40-char sha.
+_BLAME = re.compile(r"^\^?([0-9a-f]{7,40})\s")
+
+
+def git(*args):
+    out = subprocess.run(("git",) + args, cwd=ROOT, capture_output=True,
+                         text=True)
+    return out.stdout
+
+
+def window(since, until):
+    """Non-merge, non-Weblate commits in (since, until], oldest first."""
+    raw = git("log", "--no-merges", "--reverse",
+              "--format=%H\t%ad\t%s", "--date=short",
+              "%s..%s" % (since, until))
+    out = []
+    for line in raw.splitlines():
+        sha, date, subject = line.split("\t", 2)
+        if subject.startswith("Translated using Weblate"):
+            continue
+        out.append((sha, date, subject))
+    return out
+
+
+def _touched(sha):
+    """{path: [(start, count), ...]} for hunks that delete or modify code."""
+    diff = git("diff", "--unified=0", "%s^" % sha, sha, "--", "*.py", "*.lua")
+    hunks, path = collections.defaultdict(list), None
+    for line in diff.splitlines():
+        hit = _FILE.match(line)
+        if hit:
+            path = hit.group(1)
+            continue
+        hit = _HUNK.match(line)
+        if hit and path and not path.startswith("docs/"):
+            start = int(hit.group(1))
+            count = int(hit.group(2) or 1)
+            if count:          # count 0 is a pure insertion: nothing to blame
+                hunks[path].append((start, count))
+    return hunks
+
+
+def _strip_docstrings(tree):
+    """Drop every docstring node.
+
+    **A docstring IS an AST node**, so a bare `ast.dump` comparison calls a
+    docstring-only commit a behaviour change -- which is what the first
+    version of this file did, and it disagreed with the postmortem by
+    exactly the four commits the postmortem had proved prose-only by hand.
+    Comments never reach the AST and need no handling.
+    """
+    for node in ast.walk(tree):
+        if not isinstance(node, (ast.Module, ast.ClassDef, ast.FunctionDef,
+                                 ast.AsyncFunctionDef)):
+            continue
+        body = node.body
+        if (body and isinstance(body[0], ast.Expr)
+                and isinstance(body[0].value, ast.Constant)
+                and isinstance(body[0].value.value, str)):
+            body.pop(0)
+    return tree
+
+
+def _is_prose_only(sha):
+    """True when every changed `.py` is AST-identical bar its docstrings.
+
+    A commit that cannot change behaviour cannot be a defect. The postmortem
+    excluded four of them by hand and this finds six. `.lua` has no AST
+    here, so a commit touching Lua is never called prose-only -- which is
+    conservative in the right direction.
+    """
+    files = [f for f in git("diff", "--name-only", "%s^" % sha, sha,
+                            "--", "*.py", "*.lua").split()]
+    if not files or any(f.endswith(".lua") for f in files):
+        return False
+    for path in files:
+        before = git("show", "%s^:%s" % (sha, path))
+        after = git("show", "%s:%s" % (sha, path))
+        if not before or not after:
+            return False
+        try:
+            a = ast.dump(_strip_docstrings(ast.parse(before)))
+            b = ast.dump(_strip_docstrings(ast.parse(after)))
+        except SyntaxError:
+            return False
+        if a != b:
+            return False
+    return True
+
+
+def classify(commits, verbose=False):
+    """[(sha, date, subject, in_range, total, shipping_only)] per commit."""
+    shas = {c[0] for c in commits}
+    short = {s[:12] for s in shas}
+    rows, blame_lines = [], 0
+    for sha, date, subject in commits:
+        hunks = _touched(sha)
+        hits = total = 0
+        ship_hits = 0
+        for path, spans in hunks.items():
+            for start, count in spans:
+                out = git("blame", "-l", "-L", "%d,+%d" % (start, count),
+                          "%s^" % sha, "--", path)
+                for line in out.splitlines():
+                    hit = _BLAME.match(line)
+                    if not hit:
+                        continue
+                    blame_lines += 1
+                    total += 1
+                    blamed = hit.group(1)
+                    if blamed in shas or blamed[:12] in short:
+                        hits += 1
+                        if path.startswith(SHIPPING):
+                            ship_hits += 1
+        rows.append((sha, date, subject, hits, total, ship_hits,
+                     bool(hunks)))
+        if verbose:
+            print("  %s %s %-3d/%-3d %s"
+                  % (sha[:9], date, hits, total, subject[:56]))
+    if blame_lines == 0 and commits:
+        raise SystemExit(
+            "blame produced no lines at all across %d commits. That is the "
+            "0.0%% trap from docs/POSTMORTEM_3.0.0.md section 1, not a clean "
+            "release -- check the git invocation before believing any "
+            "number here." % len(commits))
+    return rows
+
+
+def rates(rows):
+    modifying = [r for r in rows if r[6]]
+    a_hits = [r for r in modifying if r[3]]
+    b_hits = [r for r in modifying if r[4] and r[3] * 2 > r[4]]
+    c_all = [r for r in modifying if r[5] or r[3]]
+    c_hits = [r for r in modifying if r[5]]
+
+    def pct(n, d):
+        return (100.0 * n / d) if d else 0.0
+    return {
+        "A": (len(a_hits), len(modifying), pct(len(a_hits), len(modifying))),
+        "A'": (len(a_hits), len(rows), pct(len(a_hits), len(rows))),
+        "B": (len(b_hits), len(modifying), pct(len(b_hits), len(modifying))),
+        "C": (len(c_hits), len(c_all), pct(len(c_hits), len(c_all))),
+    }
+
+
+def daily(rows):
+    """[(date, self_fixes, modifying, rate)] oldest first."""
+    per = collections.OrderedDict()
+    for _sha, date, _subj, hits, _total, _ship, modifies in rows:
+        if not modifies:
+            continue
+        got, seen = per.get(date, (0, 0))
+        per[date] = (got + (1 if hits else 0), seen + 1)
+    return [(d, n, m, (100.0 * n / m) if m else 0.0)
+            for d, (n, m) in per.items()]
+
+
+def gate(table, window_days=3):
+    """(ok, opening, trailing) -- section 5.8's rule.
+
+    `opening` is the first `window_days` days of the release window and
+    `trailing` the last. Both are rates over commits, not over days, so a
+    quiet day cannot swing it.
+    """
+    if len(table) < window_days * 2:
+        return None, None, None
+
+    def rate(chunk):
+        n = sum(c[1] for c in chunk)
+        m = sum(c[2] for c in chunk)
+        return (100.0 * n / m) if m else 0.0
+    opening = rate(table[:window_days])
+    trailing = rate(table[-window_days:])
+    return trailing <= opening, opening, trailing
+
+
+def main(argv=None):
+    ap = argparse.ArgumentParser(description=__doc__)
+    ap.add_argument("--since", required=True, help="ref the window opens at")
+    ap.add_argument("--until", default="HEAD")
+    ap.add_argument("--daily", action="store_true", help="per-day table")
+    ap.add_argument("--additions", action="store_true",
+                    help="list the pure-addition commits blame cannot see")
+    ap.add_argument("--no-prose-filter", action="store_true")
+    ap.add_argument("--verbose", action="store_true")
+    args = ap.parse_args(argv)
+
+    commits = window(args.since, args.until)
+    if not commits:
+        raise SystemExit("no commits in %s..%s" % (args.since, args.until))
+    if not args.no_prose_filter:
+        keep = [c for c in commits if not _is_prose_only(c[0])]
+        if len(keep) != len(commits):
+            print("excluded %d prose-only commit(s) -- AST-identical with "
+                  "docstrings stripped.\nThey leave the denominator too, "
+                  "which is where these figures part company with\n"
+                  "docs/POSTMORTEM_3.0.0.md section 1. Same numerators.\n"
+                  % (len(commits) - len(keep)))
+        commits = keep
+
+    print("%s..%s — %d commits\n" % (args.since, args.until, len(commits)))
+    rows = classify(commits, verbose=args.verbose)
+    if args.verbose:
+        print()
+
+    for name, (n, d, pc) in sorted(rates(rows).items()):
+        print("  %-3s %3d / %-3d  %5.1f%%" % (name, n, d, pc))
+    print("\nNever quote one of these as \"the\" rate: they are four "
+          "instruments in\nthree units, and the variance is the finding "
+          "(docs/POSTMORTEM_3.0.0.md section 1).")
+
+    table = daily(rows)
+    if args.daily:
+        print("\n  date        self-fix / modifying   rate")
+        for date, n, m, pc in table:
+            print("  %s  %3d / %-3d            %5.1f%%" % (date, n, m, pc))
+
+    if args.additions:
+        print("\nPure additions — blame cannot see a fix that only adds a "
+              "guard:")
+        for sha, date, subject, _h, _t, _s, modifies in rows:
+            if not modifies:
+                print("  %s %s %s" % (sha[:9], date, subject[:64]))
+
+    ok, opening, trailing = gate(table)
+    print()
+    if ok is None:
+        print("gate: not enough days to compare (need 6, have %d)."
+              % len(table))
+        return 0
+    print("gate: opening 3 days %.1f%%, trailing 3 days %.1f%% — %s"
+          % (opening, trailing, "OK" if ok else "DO NOT TAG"))
+    if not ok:
+        print("      The window is spending more of its commits repairing "
+              "itself than\n      when it opened. docs/POSTMORTEM_3.0.0.md "
+              "section 5.8; CLAUDE.md's\n      'Applying Review Findings' is "
+              "the same rule without the number.")
+    return 0 if ok else 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
This improves the test suite to catch defect classes similar to those found immediately before and following the 3.0.0 release.