### PR TITLE
Aspect override owner

### DIFF
--- a/jellyfin_mpv_shim/mpvtk_browser/gateway/hud.py
+++ b/jellyfin_mpv_shim/mpvtk_browser/gateway/hud.py
@@ -89,7 +89,10 @@ class HudMixin(GatewayCore):
             return 1.0
 
     def set_speed(self, speed):
-        self._act(lambda pm: setattr(pm._player, "speed", float(speed)))
+        # Through the manager's own setter, not a bare attribute write: it is
+        # the one that takes the player lock. Speed itself is per SESSION by
+        # design (tests/e2e/test_type_seams.py), so it is not cleared below.
+        self._act(lambda pm: pm.set_speed(float(speed)))
 
     def get_aspect(self):
         """Current video-aspect-override (-1.0 = auto/unknown)."""
@@ -102,8 +105,7 @@ class HudMixin(GatewayCore):
     def set_aspect(self, value):
         """``value`` is mpv's string form ("-1", "16:9", …) — the
         property parses ratio strings on both backends."""
-        self._act(lambda pm: setattr(
-            pm._player, "video_aspect_override", value))
+        self._act(lambda pm: pm.set_aspect(value))
 
     def toggle_stats(self):
         """Toggle mpv's stats overlay (the gear menu's Playback Data).

--- a/jellyfin_mpv_shim/mpvtk_browser/gateway/hud.py
+++ b/jellyfin_mpv_shim/mpvtk_browser/gateway/hud.py
@@ -89,10 +89,7 @@ class HudMixin(GatewayCore):
             return 1.0
 
     def set_speed(self, speed):
-        # Through the manager's own setter, not a bare attribute write: it is
-        # the one that takes the player lock. Speed itself is per SESSION by
-        # design (tests/e2e/test_type_seams.py), so it is not cleared below.
-        self._act(lambda pm: pm.set_speed(float(speed)))
+        self._act(lambda pm: setattr(pm._player, "speed", float(speed)))
 
     def get_aspect(self):
         """Current video-aspect-override (-1.0 = auto/unknown)."""

--- a/jellyfin_mpv_shim/mpvtk_browser/gateway/playback.py
+++ b/jellyfin_mpv_shim/mpvtk_browser/gateway/playback.py
@@ -32,6 +32,7 @@ class PlaybackMixin(GatewayCore):
         # per episode -- so returning to the library is one of the two
         # places it ends. The other is on_minimize; see there.
         playerManager.clear_deinterlace_override()
+        playerManager.clear_aspect_override()
 
     def apply_browser_fullscreen(self):
         """Push a just-written ``browser_fullscreen`` at the window (#729).
@@ -59,6 +60,7 @@ class PlaybackMixin(GatewayCore):
         # only goes away when the window is closed -- it renders the
         # library -- which makes this the last moment anything is watching.
         playerManager.clear_deinterlace_override()
+        playerManager.clear_aspect_override()
         playerManager.enable_osc(playerManager.osc_enabled)
         playerManager.set_browse_window(False)
 

--- a/jellyfin_mpv_shim/mpvtk_browser/gateway/playback.py
+++ b/jellyfin_mpv_shim/mpvtk_browser/gateway/playback.py
@@ -17,6 +17,12 @@ class PlaybackMixin(GatewayCore):
         from ...player import playerManager
         # mpvtk_active tells the player the in-window UI is on screen — it
         # gates the idle-quit and makes `q` return to the library.
+        # Everything the HUD queued belongs to the session that just ended,
+        # and the drain runs AFTER the clears below -- so say so first. It
+        # covers every gear-menu state at once (aspect, deinterlace, the
+        # stats overlay), which is why it is here rather than beside any one
+        # of them. See PlayerManager.end_hud_session.
+        playerManager.end_hud_session()
         playerManager.mpvtk_active = True
         # Logo-free, free-resizing browse window (not force_window()'s menu
         # splash) — removes the Jellyfin icon and stops aspect-ratio snapping.
@@ -52,6 +58,9 @@ class PlaybackMixin(GatewayCore):
         # eventually drops mpv entirely and gives back its memory and GPU
         # context. It comes back on the next play or when the tray reopens
         # the library (see UserInterface.on_mpv_recreated).
+        # The other end of the same statement; see on_browse_enter. Closing
+        # the window comes through HERE and not through there.
+        playerManager.end_hud_session()
         playerManager.mpvtk_active = False
         # The other end of the per-session deinterlace force, and it is not
         # redundant with on_browse_enter: closing the window comes through

--- a/jellyfin_mpv_shim/player.py
+++ b/jellyfin_mpv_shim/player.py
@@ -576,6 +576,11 @@ def chapter_target(chapters, pos, direction):
     return None
 
 
+#: "we have never written this" -- distinct from every value mpv can hold,
+#: including None, which some properties legitimately are.
+_UNSET = object()
+
+
 class PlayerManager(AudioMixin, ReportingMixin, WindowMixin):
     """
     The underlying player is thread safe, however, locks are used in this
@@ -759,6 +764,21 @@ class PlayerManager(AudioMixin, ReportingMixin, WindowMixin):
         #: states and the same lifetime as the deinterlace one above:
         #: None means "however the file is flagged".
         self._aspect_override = None
+        #: What `video-aspect-override` held before we first wrote it, so
+        #: clearing hands THAT back rather than a -1 we made up. `_UNSET`
+        #: until we write, and that is the load-bearing half: there is no
+        #: aspect setting, so a value at that property came from the user's
+        #: own mpv.conf, and a session that forces nothing must leave it
+        #: alone. Same rule as `_render_written` above, at a property that
+        #: has no preset behind it. Re-read per mpv -- see _init_mpv.
+        self._aspect_pristine = _UNSET
+        #: Bumped when the session the playback HUD belonged to ends.
+        #: `run_action` stamps every DEFERRED ui action with the value it
+        #: saw and the drain drops one whose stamp has moved. A gear-menu
+        #: press that could not run while a playback start held the lock
+        #: otherwise lands on the library, where the control that would undo
+        #: it is not on screen. See `end_hud_session`.
+        self._hud_generation = 0
         # {mpv property: value} for every property any preset-driven setting
         # can write, as the FRESH mpv had them -- so the restore hands back
         # mpv's defaults plus the user's own mpv.conf, and nothing else.
@@ -1082,6 +1102,10 @@ class PlayerManager(AudioMixin, ReportingMixin, WindowMixin):
         # It also means a failure between here and the end of _init_mpv
         # cannot leave the PREVIOUS mpv's values recorded against this one.
         self._render_written = set()
+        # Same reset, same reason: a fresh mpv has the user's mpv.conf
+        # again, and the previous handle's value is not this one's. The
+        # OVERRIDE deliberately survives -- _play_media re-asserts it.
+        self._aspect_pristine = _UNSET
         self._snapshot_render_pristine()
 
         try:
@@ -2157,7 +2181,18 @@ class PlayerManager(AudioMixin, ReportingMixin, WindowMixin):
         # Almost always a playback start in progress. Deferring beats both
         # blocking the caller and dropping the user's input.
         log.debug("Player is busy; deferring UI action to the action thread.")
-        self.put_task(func, self)
+        generation = self._hud_generation
+
+        def unless_the_session_ended(pm):
+            # Read at drain time, so a door that closed while this waited is
+            # what decides. See end_hud_session.
+            if pm._hud_generation != generation:
+                log.debug("Dropping a UI action queued by a session that has "
+                          "since ended.")
+                return None
+            return func(pm)
+
+        self.put_task(unless_the_session_ended, self)
         return None
 
     # Put a task to the event queue.
@@ -2854,18 +2889,22 @@ class PlayerManager(AudioMixin, ReportingMixin, WindowMixin):
         except Exception:
             log.debug("could not apply the deinterlace setting",
                       exc_info=True)
-        # The aspect force, written for every item exactly like the
-        # deinterlace one above -- and, like it, SURVIVING a queue advance:
-        # a badly flagged season is one answer, not one per episode. Without
-        # a per-item write the override is a global nobody owns, and forcing
-        # 4:3 on one film left every later film, photo and comic page at 4:3
-        # with no control reachable to undo it.
-        try:
-            self._player.video_aspect_override = (
-                self._aspect_override if self._aspect_override is not None
-                else -1.0)
-        except Exception:
-            log.debug("could not apply the aspect override", exc_info=True)
+        # The aspect force, re-asserted per item like the deinterlace one
+        # above and SURVIVING a queue advance: a badly flagged season is one
+        # answer, not one per episode. Without it the override is a global
+        # nobody owns, and forcing 4:3 on one film left every later film,
+        # photo and comic page at 4:3 with no control reachable to undo it.
+        #
+        # Only when there IS one. The `else` that wrote -1 here overrode a
+        # `video-aspect-override` in the user's own mpv.conf, at every item,
+        # for a feature they had not touched -- there is no aspect setting,
+        # so this client has no default to assert.
+        if self._aspect_override is not None:
+            try:
+                self._write_aspect(self._aspect_override)
+            except Exception:
+                log.debug("could not apply the aspect override",
+                          exc_info=True)
         self._apply_render_presets()
         # How long mpv holds a still. BEFORE play(), not after the load
         # succeeds: this is what mpv reports as the file's `duration`, so
@@ -3453,21 +3492,57 @@ class PlayerManager(AudioMixin, ReportingMixin, WindowMixin):
         self._deinterlace_override = bool(on)
         self.reapply_deinterlace()
 
+    #: Defaults on the CLASS, not only in `__init__`. Two dozen test modules
+    #: build a PlayerManager with `__new__` and wire the fields they need,
+    #: so a new one that `run_action` or `_play_media` reads unconditionally
+    #: is an AttributeError in every one of them that did not hear about it
+    #: -- and inside a queue drain it is logged and swallowed, which is the
+    #: silent half. The class answering makes the stand-ins right by
+    #: default; `__init__` still sets the instance attribute.
+    _hud_generation = 0
+    _aspect_pristine = _UNSET
+
+    #: The gear menu's Auto row, in mpv's own spelling. It arrives as the
+    #: property VALUE, not as None, and it means "no force" -- storing it
+    #: made `aspect_forced` answer yes to the row that turns forcing off.
+    _ASPECT_AUTO = ("-1", "-1.0", -1, -1.0)
+
+    def _write_aspect(self, value):
+        """Write the property, remembering what it held the first time.
+
+        Nothing else in this client writes `video-aspect-override` and no
+        setting maps to it, so whatever is there before our first write is
+        the user's -- and handing THAT back is what clearing means. Callers
+        hold ``_lock``.
+        """
+        if self._aspect_pristine is _UNSET:
+            try:
+                self._aspect_pristine = self._player.video_aspect_override
+            except Exception:
+                # An mpv too old to have it. -1 is then the honest guess,
+                # and the write below will fail on its own terms anyway.
+                log.debug("could not read the aspect mpv came in with",
+                          exc_info=True)
+                self._aspect_pristine = -1.0
+        self._player.video_aspect_override = value
+
     @synchronous("_lock")
     def set_aspect(self, value):
         """Force an aspect ratio for this session -- the gear menu's Aspect
-        Ratio row. ``value`` is mpv's string form ("16:9"), or None to hand
-        the decision back to the file.
+        Ratio row. ``value`` is mpv's string form ("16:9"); None, or mpv's
+        own spelling of auto, hands the decision back to the file.
 
         ``@synchronous`` and stored, for the same two reasons as
         ``set_deinterlace``: ``run_action``'s deferred path holds no lock, and
         a value written straight at mpv is a global with no owner -- which is
         what this was.
         """
+        if value is None or value in self._ASPECT_AUTO:
+            self.clear_aspect_override()
+            return
         self._aspect_override = value
         try:
-            self._player.video_aspect_override = (
-                value if value is not None else -1.0)
+            self._write_aspect(value)
         except _mpv_errors:
             self._handle_mpv_disconnect()
 
@@ -3482,10 +3557,23 @@ class PlayerManager(AudioMixin, ReportingMixin, WindowMixin):
         override outlives playback onto surfaces `_play_media` never runs
         for: a photo, and a comic page, which `show_picture` loads directly.
         Leaving it set is how a 4:3 force reached a comic.
+
+        It puts back what mpv came in with, not -1: those differ for anyone
+        whose mpv.conf sets one. Never written means never OURS to put back,
+        so that case writes nothing at all.
+
+        No ``@synchronous``, unlike ``set_aspect``: both doors call this
+        inline on the browser's loop thread, and the lock is held for the
+        whole of a playback start -- taking it here would freeze the window
+        for that stretch, which is the freeze ``run_action`` exists to
+        avoid. The ordering this used to lose is settled by
+        ``end_hud_session`` instead, one door up.
         """
         self._aspect_override = None
+        if self._aspect_pristine is _UNSET:
+            return
         try:
-            self._player.video_aspect_override = -1.0
+            self._player.video_aspect_override = self._aspect_pristine
         except _mpv_errors:
             self._handle_mpv_disconnect()
         except Exception:
@@ -3495,6 +3583,33 @@ class PlayerManager(AudioMixin, ReportingMixin, WindowMixin):
         """Whether a session force is in effect, for the gear row's way back
         -- the same question `deinterlace_forced` answers."""
         return self._aspect_override is not None
+
+    def end_hud_session(self):
+        """Declare the playback session over, so nothing it queued lands
+        after it.
+
+        The doors call this BEFORE they clear anything. ``run_action``
+        defers a UI action whenever ``_lock`` is contended, which a playback
+        start holds for up to ``playback_timeout`` -- so a gear-menu press
+        can still be on ``evt_queue`` when the viewer gives up and goes
+        back. Draining it then re-installs a force onto the library, where
+        the gear menu that would undo it is not reachable.
+
+        A generation rather than a drain of the queue: ``evt_queue`` also
+        carries the player's own work (a finished_callback, the shutdown
+        teardown), and discarding THOSE at a door is the bug
+        ``_teardown_player``'s drain has a comment about. This drops only
+        what the ended session asked for, and it covers every gear-menu
+        state at once rather than one guard per control.
+
+        It fires more often than "playback ended": `enter_browse` is called
+        unconditionally when music stops and on a mirror summon, both of
+        which can happen while the library is already up. Dropping a pending
+        HUD action there is still the right answer -- the thing it was aimed
+        at is over -- but do not read a bump as proof that something was
+        playing.
+        """
+        self._hud_generation += 1
 
     def deinterlace_forced(self):
         """Whether a session force is in effect, i.e. whether the setting is

--- a/jellyfin_mpv_shim/player.py
+++ b/jellyfin_mpv_shim/player.py
@@ -755,6 +755,10 @@ class PlayerManager(AudioMixin, ReportingMixin, WindowMixin):
         # outlives a queue advance -- a badly-flagged season is one answer,
         # not one per episode -- and nothing else.
         self._deinterlace_override = None
+        #: The gear menu's Aspect Ratio force, with the same three
+        #: states and the same lifetime as the deinterlace one above:
+        #: None means "however the file is flagged".
+        self._aspect_override = None
         # {mpv property: value} for every property any preset-driven setting
         # can write, as the FRESH mpv had them -- so the restore hands back
         # mpv's defaults plus the user's own mpv.conf, and nothing else.
@@ -2850,6 +2854,18 @@ class PlayerManager(AudioMixin, ReportingMixin, WindowMixin):
         except Exception:
             log.debug("could not apply the deinterlace setting",
                       exc_info=True)
+        # The aspect force, written for every item exactly like the
+        # deinterlace one above -- and, like it, SURVIVING a queue advance:
+        # a badly flagged season is one answer, not one per episode. Without
+        # a per-item write the override is a global nobody owns, and forcing
+        # 4:3 on one film left every later film, photo and comic page at 4:3
+        # with no control reachable to undo it.
+        try:
+            self._player.video_aspect_override = (
+                self._aspect_override if self._aspect_override is not None
+                else -1.0)
+        except Exception:
+            log.debug("could not apply the aspect override", exc_info=True)
         self._apply_render_presets()
         # How long mpv holds a still. BEFORE play(), not after the load
         # succeeds: this is what mpv reports as the file's `duration`, so
@@ -3436,6 +3452,49 @@ class PlayerManager(AudioMixin, ReportingMixin, WindowMixin):
         """
         self._deinterlace_override = bool(on)
         self.reapply_deinterlace()
+
+    @synchronous("_lock")
+    def set_aspect(self, value):
+        """Force an aspect ratio for this session -- the gear menu's Aspect
+        Ratio row. ``value`` is mpv's string form ("16:9"), or None to hand
+        the decision back to the file.
+
+        ``@synchronous`` and stored, for the same two reasons as
+        ``set_deinterlace``: ``run_action``'s deferred path holds no lock, and
+        a value written straight at mpv is a global with no owner -- which is
+        what this was.
+        """
+        self._aspect_override = value
+        try:
+            self._player.video_aspect_override = (
+                value if value is not None else -1.0)
+        except _mpv_errors:
+            self._handle_mpv_disconnect()
+
+    def clear_aspect_override(self):
+        """Drop the aspect force. Called on the way back to the library and
+        on minimize -- the same two doors as
+        :meth:`clear_deinterlace_override`.
+
+        **Unlike that one, this DOES write mpv.** Its sibling can leave the
+        property alone because `_play_media` rewrites it for every item and
+        there is no picture to correct once playback is over. An aspect
+        override outlives playback onto surfaces `_play_media` never runs
+        for: a photo, and a comic page, which `show_picture` loads directly.
+        Leaving it set is how a 4:3 force reached a comic.
+        """
+        self._aspect_override = None
+        try:
+            self._player.video_aspect_override = -1.0
+        except _mpv_errors:
+            self._handle_mpv_disconnect()
+        except Exception:
+            log.debug("could not clear the aspect override", exc_info=True)
+
+    def aspect_forced(self):
+        """Whether a session force is in effect, for the gear row's way back
+        -- the same question `deinterlace_forced` answers."""
+        return self._aspect_override is not None
 
     def deinterlace_forced(self):
         """Whether a session force is in effect, i.e. whether the setting is

--- a/tests/integration/_harness.py
+++ b/tests/integration/_harness.py
@@ -1141,6 +1141,7 @@ def build_player(player_module, video=None):
     # does not skip a write, it raises into `_play_media`'s broad except
     # and leaves the whole feature untested and green.
     pm._deinterlace_override = None
+    pm._aspect_override = None
     pm._no_deinterlace_auto = False
     pm._render_written = set()
     # The real player snapshots this in `_init_mpv`, which build_player

--- a/tests/integration/_harness.py
+++ b/tests/integration/_harness.py
@@ -1142,6 +1142,10 @@ def build_player(player_module, video=None):
     # and leaves the whole feature untested and green.
     pm._deinterlace_override = None
     pm._aspect_override = None
+    # `_aspect_pristine` and `_hud_generation` are deliberately NOT seeded
+    # here: PlayerManager carries them as class attributes precisely so the
+    # two dozen stand-ins that skip `__init__` do not each have to learn
+    # about them. See the note beside them in player.py.
     pm._no_deinterlace_auto = False
     pm._render_written = set()
     # The real player snapshots this in `_init_mpv`, which build_player

--- a/tests/integration/test_mpv_state_restored.py
+++ b/tests/integration/test_mpv_state_restored.py
@@ -15,6 +15,15 @@ point. `ALLOWED` below is the executable form of the "deliberately global"
 list -- every entry is a decision with a reason attached, and adding one is
 how you say a difference is intended rather than accidental.
 
+**What it cannot see.** It compares PROPERTIES, so a feature that leaves a
+*file* loaded rather than a property set is outside its reach -- measured, a
+`clear_picture` that returns without taking the page down passes here,
+because `on_browse_enter` re-asserts the same window properties on the way
+in. `tests/e2e/test_comic_reader.py:_loaded_path` is what covers that half.
+Nor does it see anything written outside a property: an input section, an
+overlay slot, the stats OSD (`_stats_shown` is a Python flag with no mpv
+property behind it -- see `test_picture_options.py`).
+
 Against the FakeMPV rather than a real one: what is under test is what the
 SHIM writes, and the fake records exactly that. A real mpv also changes
 properties on its own (a VO reconfig, a codec's answer), which would make
@@ -59,6 +68,11 @@ ALLOWED = {
     "keep_open": "owned by the queue, not by the window",
     # Bookkeeping the fake exposes that mpv would not.
     "playback_abort": "the fake's idle flag",
+    # A still opened on its own is HELD, deliberately -- "clicking one
+    # picture means show me this" -- and `_play_media` unpauses for the next
+    # item that is not a still. Pinned by
+    # tests/e2e/test_photos.py:test_one_photo_opened_on_its_own_is_held.
+    "pause": "a still is held on purpose; the next item unpauses",
     # Reported BY mpv rather than written by the shim: the fake's
     # `fire_property` answers the duration wait, and nothing clears it.
     "duration": "mpv reports it; the shim never writes it",
@@ -97,10 +111,28 @@ class RestoresMpvStateTest(_Base):
                 and k not in ("init_options",)}
 
     def _return_to_the_library(self):
+        """Everything the browser does on its way back in, and **nothing the
+        scenario does for it**.
+
+        The picture teardown is here rather than in `_show_a_page` on
+        purpose. A scenario that cleaned up after itself would be supplying
+        the very calls whose absence is the bug -- the mistake this file is
+        for. So the two halves are split the way the app splits them: a
+        scenario does the FEATURE, this does the RETURN, and it calls what
+        `pages/comic.py` and `_release_page_grabs` call, through the gateway
+        rather than the player, so a gateway that stopped forwarding is
+        caught too.
+        """
+        from jellyfin_mpv_shim.mpvtk_browser.gateway.picture import (
+            PictureMixin)
         from jellyfin_mpv_shim.mpvtk_browser.gateway.playback import (
             PlaybackMixin)
 
         with mock.patch("jellyfin_mpv_shim.player.playerManager", self.pm):
+            picture = PictureMixin()
+            picture._act = lambda fn: fn(self.pm)
+            picture.clear_picture()
+            picture.reset_picture_view()
             PlaybackMixin().on_browse_enter()
 
     def _assert_restored(self, before, what):
@@ -115,6 +147,54 @@ class RestoresMpvStateTest(_Base):
             "back, or it belongs in ALLOWED with the reason why not." % what)
 
     # -- the scenarios -----------------------------------------------------
+
+    def _play_item(self, media_type="Video", is_photo=False):
+        """`_Base.play()` with the item TYPE varied, because most of what
+        leaks is written on a branch keyed to it -- the photo duration, the
+        audio loop, the audio volume bucket.
+
+        Its own copy of the duration-answering dance rather than a parameter
+        on the shared helper: that helper is used by 37 tests in the module
+        it lives in, and widening it for one caller is how a fixture starts
+        drifting from what those tests think it does.
+        """
+        from test_picture_options import make_video
+
+        video = make_video()
+        video.item = {"MediaType": media_type, "Type": media_type}
+        video.is_photo = is_photo
+        done = threading.Event()
+
+        def answer():
+            while not done.wait(0.02):
+                try:
+                    self.pm._player.fire_property("duration", 100.0)
+                except Exception:
+                    return
+
+        thread = threading.Thread(target=answer, daemon=True)
+        thread.start()
+        self.addCleanup(done.set)
+        try:
+            with mock.patch.object(player_module.settings,
+                                   "playback_timeout", 2):
+                self.pm._play_media(video, "http://example.invalid/s.mkv",
+                                    is_initial_play=True)
+        finally:
+            done.set()
+            thread.join(timeout=1)
+        self.assertIs(self.pm._video, video,
+                      "the start did not complete, so this scenario is "
+                      "measuring a failed load")
+        return video
+
+    def _show_a_page(self, zoom=None):
+        """A comic page: `show_picture` loads it straight into the VO, which
+        is a path `_play_media` never runs, so nothing it writes is undone by
+        the next item."""
+        self.assertTrue(self.pm.show_picture("/tmp/page.png"))
+        if zoom is not None:
+            self.pm.set_picture_view(zoom=zoom, pan_x=0.2, pan_y=-0.3)
 
     def test_playing_an_item_and_coming_back(self):
         """The baseline round trip. If this drifts, every scenario below is
@@ -146,6 +226,68 @@ class RestoresMpvStateTest(_Base):
         self._return_to_the_library()
         self._assert_restored(before, "forcing deinterlace from the gear "
                                       "menu")
+
+    # -- the less-used corners, which is where this pays ------------------
+
+    def test_reading_a_comic_and_coming_back(self):
+        """`show_picture` borrows four properties at once -- `keepaspect`,
+        `image_display_duration`, `keep_open` and the shader profile -- and
+        it is the one load that does not go through `_play_media`, so
+        nothing rewrites them for the next item."""
+        before = self._baseline()
+        self._show_a_page()
+        self._return_to_the_library()
+        self._assert_restored(before, "reading a comic")
+
+    def test_a_comic_zoomed_and_panned(self):
+        """The reading modes write `video-zoom` and `video-pan-*`, which are
+        global. This is the leak that made every film after a comic play
+        zoomed."""
+        before = self._baseline()
+        self._show_a_page(zoom=1.25)
+        self._return_to_the_library()
+        self._assert_restored(before, "zooming and panning a comic page")
+
+    def test_a_comic_opened_while_music_plays(self):
+        """The two features together, now that a page stops the track. Both
+        halves write mpv, and the stop happens between them."""
+        before = self._baseline()
+        self._play_item("Audio")
+        self._show_a_page(zoom=1.25)
+        self._return_to_the_library()
+        self._assert_restored(before, "opening a comic over music")
+
+    def test_music_played_on_repeat_one(self):
+        """`loop-file` is a music feature and a global option."""
+        before = self._baseline()
+        self._play_item("Audio")
+        self.pm.set_repeat("one")
+        self.pm.set_repeat("none")
+        self._return_to_the_library()
+        self._assert_restored(before, "playing a track on repeat-one")
+
+    def test_music_muted_from_the_now_playing_bar(self):
+        before = self._baseline()
+        self._play_item("Audio")
+        self.pm.set_mute(True)
+        self.pm.set_mute(False)
+        self._return_to_the_library()
+        self._assert_restored(before, "muting a track")
+
+    def test_a_photo_viewed_and_left(self):
+        """A still sets `image_display_duration` on a branch of its own."""
+        before = self._baseline()
+        self._play_item("Photo", is_photo=True)
+        self._return_to_the_library()
+        self._assert_restored(before, "viewing a photo")
+
+    def test_fullscreen_toggled_during_playback(self):
+        before = self._baseline()
+        self.play()
+        self.pm.set_fullscreen(True)
+        self.pm.set_fullscreen(False)
+        self._return_to_the_library()
+        self._assert_restored(before, "toggling fullscreen during playback")
 
 
 if __name__ == "__main__":

--- a/tests/integration/test_mpv_state_restored.py
+++ b/tests/integration/test_mpv_state_restored.py
@@ -30,6 +30,7 @@ properties on its own (a VO reconfig, a codec's answer), which would make
 the comparison noisy about things nobody wrote.
 """
 
+import contextlib
 import os
 import sys
 import threading
@@ -188,6 +189,33 @@ class RestoresMpvStateTest(_Base):
                       "measuring a failed load")
         return video
 
+    @contextlib.contextmanager
+    def _player_busy(self):
+        """Hold `_lock` the way a playback start holds it.
+
+        The real thing is `_play_media` waiting on `duration`, which this
+        module already drives elsewhere; what the ordering needs is only
+        that `run_action` finds the lock taken, so this borrows it directly
+        rather than staging a second load whose timing it would then have to
+        control.
+        """
+        held = threading.Event()
+        release = threading.Event()
+
+        def hold():
+            with self.pm._lock:
+                held.set()
+                release.wait(10)
+
+        thread = threading.Thread(target=hold, daemon=True)
+        thread.start()
+        self.assertTrue(held.wait(5), "could not take the player lock")
+        try:
+            yield
+        finally:
+            release.set()
+            thread.join(timeout=5)
+
     def _show_a_page(self, zoom=None):
         """A comic page: `show_picture` loads it straight into the VO, which
         is a path `_play_media` never runs, so nothing it writes is undone by
@@ -216,6 +244,72 @@ class RestoresMpvStateTest(_Base):
         self._return_to_the_library()
         self._assert_restored(before, "forcing a 4:3 aspect from the gear "
                                       "menu")
+
+    def test_a_force_deferred_by_a_busy_player_does_not_outlive_the_door(self):
+        """The gear menu pressed while a playback start holds the lock.
+
+        `run_action` defers only when `_lock` is contended, and a start holds
+        it for up to `playback_timeout` -- so the press is still on
+        `evt_queue` when the viewer gives up and goes back. The door clears
+        an override that has not been set yet, and the drain then installs
+        the force onto the library, where the gear menu that would undo it
+        is not reachable. Both gear-menu forces take this route, so both are
+        asserted here rather than one standing in for the rule.
+        """
+        from jellyfin_mpv_shim.mpvtk_browser.gateway.hud import HudMixin
+
+        before = self._baseline()
+        self.play()
+        with self._player_busy():
+            with mock.patch("jellyfin_mpv_shim.player.playerManager",
+                            self.pm):
+                hud = HudMixin()
+                hud.set_aspect("4:3")
+                hud.toggle_deinterlace()
+            self.assertFalse(
+                self.pm.evt_queue.empty(),
+                "nothing was deferred, so this is not exercising the "
+                "ordering it is named after -- the lock was free")
+        self._return_to_the_library()
+        # What the action thread does with what the HUD left behind.
+        self.pm.update()
+        self._assert_restored(before, "a gear-menu force deferred past the "
+                                      "door")
+
+    def test_a_configured_aspect_survives_a_session_that_never_forces_one(
+            self):
+        """Somebody whose own `mpv.conf` carries `video-aspect-override`.
+
+        There is no aspect SETTING, so a value at that property can only be
+        theirs. Writing a default at every item, and again on the way out,
+        is this client overriding a config it was never asked about -- the
+        rule `_render_written` is there to state, at a property that is not
+        one of its own.
+        """
+        self._return_to_the_library()
+        self.pm._player.video_aspect_override = 2.35
+        before = self._snapshot()
+        self.play()
+        self._return_to_the_library()
+        self._assert_restored(before, "playing under a configured aspect")
+
+    def test_clearing_a_force_hands_back_the_configured_value(self):
+        """...and once we HAVE written, -1 is still not what to put back.
+
+        The distinction the branch could not make: `None` meant both "mpv's
+        own answer" and "auto", so the way out of a force was a guess that
+        happened to be right only for a default mpv.
+        """
+        from jellyfin_mpv_shim.mpvtk_browser.gateway.hud import HudMixin
+
+        self._return_to_the_library()
+        self.pm._player.video_aspect_override = 2.35
+        before = self._snapshot()
+        self.play()
+        with mock.patch("jellyfin_mpv_shim.player.playerManager", self.pm):
+            HudMixin().set_aspect("4:3")
+        self._return_to_the_library()
+        self._assert_restored(before, "forcing 4:3 over a configured aspect")
 
     def test_the_gear_menus_deinterlace_force(self):
         """The sibling control that got this right, as the contrast: it has

--- a/tests/integration/test_mpv_state_restored.py
+++ b/tests/integration/test_mpv_state_restored.py
@@ -1,0 +1,152 @@
+"""Play media, do things to it, and put mpv back the way it came in.
+
+**One test shape for a whole class of bug.** mpv is not re-created between
+items or between UI modes, so every feature that writes a property is
+borrowing something the next feature will inherit. This session found six of
+those one at a time -- `image_display_duration`, `keepaspect`, `video-zoom`,
+`loop-file`, `background-color`, the geometry option -- each caught by a test
+written after somebody noticed the symptom. That does not scale, and it
+cannot catch the seventh.
+
+So this asserts the *property* instead of the instances: **after a feature
+has had its turn and the library is back, mpv looks the way it did before.**
+A new leak fails here without anybody predicting it, which is the whole
+point. `ALLOWED` below is the executable form of the "deliberately global"
+list -- every entry is a decision with a reason attached, and adding one is
+how you say a difference is intended rather than accidental.
+
+Against the FakeMPV rather than a real one: what is under test is what the
+SHIM writes, and the fake records exactly that. A real mpv also changes
+properties on its own (a VO reconfig, a codec's answer), which would make
+the comparison noisy about things nobody wrote.
+"""
+
+import os
+import sys
+import threading
+import unittest
+from unittest import mock
+
+sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+sys.path.insert(0, os.path.dirname(os.path.dirname(
+    os.path.dirname(os.path.abspath(__file__)))))
+
+import _harness as h  # noqa: E402
+
+player_module = h.import_player_with_fake_mpv()
+
+from test_picture_options import _Base  # noqa: E402
+
+
+#: Properties that legitimately differ after a round trip, each with the
+#: reason. **This is the list to read before "fixing" a diff**: an entry here
+#: is a decision somebody made, and several of them are fixes for bugs that
+#: a naive restore would re-create.
+ALLOWED = {
+    # Ratified: a viewer who slows an episode down means the next episode
+    # too, so the queue advancing must not fight the choice [iw]. Pinned by
+    # tests/e2e/test_type_seams.py.
+    "speed": "per session by design, not per item",
+    # The title of what is playing, cleared on the way back to the library
+    # by `clear_media_title` -- but only once something HAS played, so it is
+    # not equal to its pristine value mid-scenario.
+    "force_media_title": "cleared by clear_media_title, asserted separately",
+    # Written for every item from the user's settings; identical across a
+    # round trip only by coincidence of the defaults.
+    "deinterlace": "written per item from the setting",
+    "hwdec": "written per item, and pinned by the shader-pack tests",
+    # The queue's end-of-file behaviour, owned by `upd_player_hide`.
+    "keep_open": "owned by the queue, not by the window",
+    # Bookkeeping the fake exposes that mpv would not.
+    "playback_abort": "the fake's idle flag",
+    # Reported BY mpv rather than written by the shim: the fake's
+    # `fire_property` answers the duration wait, and nothing clears it.
+    "duration": "mpv reports it; the shim never writes it",
+    # `_sync_window_geometry` arms the option at the window's live size, on
+    # purpose and permanently: clearing it is what made the window jump.
+    # See tests/test_window_geometry.py.
+    "geometry": "armed at the live size deliberately, and kept",
+}
+
+
+class RestoresMpvStateTest(_Base):
+    """Each scenario: snapshot, do the thing, come back, compare."""
+
+    def _baseline(self):
+        """Snapshot **the library**, not a pristine player.
+
+        The round trip is library -> feature -> library, and arriving at the
+        library legitimately paints the browse window (`force_window`, the
+        background, the endless still). Comparing against a never-used player
+        would report all of that as drift and drown the leak this is for --
+        measured, it did.
+        """
+        self._return_to_the_library()
+        return self._snapshot()
+
+    def _snapshot(self):
+        """Every public property the fake is holding.
+
+        Read off `__dict__` rather than a hand-listed set, deliberately: a
+        property nobody thought to list is exactly the one a new feature
+        will leak, and a hand-written list can only ever catch what its
+        author already suspected.
+        """
+        return {k: v for k, v in self.pm._player.__dict__.items()
+                if not k.startswith("_") and not callable(v)
+                and k not in ("init_options",)}
+
+    def _return_to_the_library(self):
+        from jellyfin_mpv_shim.mpvtk_browser.gateway.playback import (
+            PlaybackMixin)
+
+        with mock.patch("jellyfin_mpv_shim.player.playerManager", self.pm):
+            PlaybackMixin().on_browse_enter()
+
+    def _assert_restored(self, before, what):
+        after = self._snapshot()
+        drift = {k: (before.get(k, "<absent>"), after[k])
+                 for k in after
+                 if k not in ALLOWED and after[k] != before.get(k, "<absent>")}
+        self.assertEqual(
+            drift, {},
+            "%s left mpv changed after the library came back. Each entry is "
+            "property: (before, after). Either the feature should put it "
+            "back, or it belongs in ALLOWED with the reason why not." % what)
+
+    # -- the scenarios -----------------------------------------------------
+
+    def test_playing_an_item_and_coming_back(self):
+        """The baseline round trip. If this drifts, every scenario below is
+        measuring that drift as well as its own."""
+        before = self._baseline()
+        self.play()
+        self._return_to_the_library()
+        self._assert_restored(before, "playing one item")
+
+    def test_the_gear_menus_aspect_override(self):
+        """The HUD's Aspect Ratio control, which corrects a badly flagged
+        file -- a per-item judgement if ever there was one."""
+        from jellyfin_mpv_shim.mpvtk_browser.gateway.hud import HudMixin
+
+        before = self._baseline()
+        self.play()
+        with mock.patch("jellyfin_mpv_shim.player.playerManager", self.pm):
+            HudMixin().set_aspect("4:3")
+        self._return_to_the_library()
+        self._assert_restored(before, "forcing a 4:3 aspect from the gear "
+                                      "menu")
+
+    def test_the_gear_menus_deinterlace_force(self):
+        """The sibling control that got this right, as the contrast: it has
+        an override flag, a per-item re-write and two clear doors."""
+        before = self._baseline()
+        self.play()
+        self.pm.set_deinterlace(True)
+        self._return_to_the_library()
+        self._assert_restored(before, "forcing deinterlace from the gear "
+                                      "menu")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/integration/test_picture_options.py
+++ b/tests/integration/test_picture_options.py
@@ -277,6 +277,32 @@ class DeinterlacePerItemTest(_Base):
             self.assertEqual(self.pm._player.deinterlace, "auto")
         self.assertFalse(self.pm.deinterlace_forced())
 
+    def test_choosing_auto_is_not_a_force(self):
+        """The aspect row's way back, which is a VALUE and not a None.
+
+        `_ASPECTS` sends mpv's own spelling, so Auto arrives as the string
+        "-1". Stored, it made `aspect_forced()` answer yes to the row whose
+        whole job is turning forcing off -- and, with the per-item write,
+        kept re-asserting a number at a property this client owns no default
+        for. Driven through the gateway, because that is where the string
+        comes from.
+        """
+        from jellyfin_mpv_shim.mpvtk_browser.gateway.hud import HudMixin
+
+        self.play()
+        gw = HudMixin()
+        with mock.patch("jellyfin_mpv_shim.player.playerManager", self.pm):
+            gw.set_aspect("4:3")
+            self.assertTrue(self.pm.aspect_forced())
+            self.assertEqual(self.pm._player.video_aspect_override, "4:3")
+            gw.set_aspect("-1")                         # the Auto row
+        self.assertFalse(
+            self.pm.aspect_forced(),
+            "Auto was recorded as a force, so the gear row would offer a "
+            "way back from the setting that IS the way back")
+        self.assertEqual(self.pm._player.video_aspect_override, -1.0,
+                         "and mpv should be back to what it came in with")
+
     def test_the_force_can_turn_deinterlacing_off_as_well_as_on(self):
         """`False` was unreachable: the toggle mapped "off" onto "let the
         setting decide", so with `deinterlace_auto` on there was no way to

--- a/tools/audit_act_targets.py
+++ b/tools/audit_act_targets.py
@@ -93,12 +93,6 @@ DECLARED = {
         "halves at once, and it is a player change rather than a gateway "
         "one."
     ),
-    "hud.py:set_aspect:A:video_aspect_override": (
-        "No `PlayerManager.set_aspect` in this tree to route through. One "
-        "exists on the `enrich-e2e-tests` branch, where giving the aspect "
-        "override an owner is the single production change; that commit is "
-        "the repair for this row and it is not merged."
-    ),
     "hud.py:toggle_mute:A:mute": (
         "`PlayerManager.set_mute` EXISTS (player.py) and this does not call "
         "it. Read-modify-write on the handle, so it also decides the new "
@@ -120,8 +114,12 @@ DECLARED = {
         "both."
     ),
     "hud.py:get_aspect:B:video_aspect_override": (
-        "Paired with the `set_aspect` write above -- one accessor answers "
-        "both."
+        "The write half went through `PlayerManager.set_aspect`; this did "
+        "not follow it, because the two ask different questions. The "
+        "manager stores the FORCE, and the gear row ticks whatever mpv is "
+        "showing -- which with no force is the file's own aspect, or the "
+        "user's mpv.conf. `aspect_forced()` answers the manager's question "
+        "and is not what this row draws."
     ),
     "hud.py:chapters:B:chapter_list": (
         "Reads mpv's chapter list to draw the chapter row. Read-only, and "


### PR DESCRIPTION
This fix prevents aspect ratio overrides from persisting throughout the entire rest of the application lifecycle, instead changing it to get restored when playback ends.